### PR TITLE
Review cleanups (#7): evidence digest-vs-data hardening, single-pass log write

### DIFF
--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -196,7 +196,12 @@ mapping. A `failed` result asserts nothing.
 | `model_weights_provenance` | unknown | unknown | unknown | unknown | unknown |
 
 - For the four real provider verifiers `tee_attested` is `HardwareProven`: a
-  genuine TEE quote was verified and the request channel bound to it.
+  genuine TEE quote was verified and the request channel bound to it. For NEAR AI
+  this is the **gateway** TD (the request channel binds to the verified gateway
+  TEE); the nested per-model TDs behind it are *not* re-verified by this gateway
+  (honestly recorded as `nested_model_attestations_checked_by_gateway: false` in
+  `claims.extra`). So `tee_attested` there means "bound to a verified gateway
+  TEE," not end-to-end to the model TD serving the tokens.
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status
   **refutes** (the quote proves a stale TCB — the gateway records the bad claim

--- a/src/aggregator/session.rs
+++ b/src/aggregator/session.rs
@@ -20,6 +20,7 @@
 
 use std::collections::BTreeMap;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -158,6 +159,27 @@ impl EvidenceRef {
                 .get("data")
                 .and_then(Value::as_str)
                 .map(str::to_string),
+        }
+    }
+
+    /// True when there is nothing to verify (no `data_uri`, or a `data_uri` shape
+    /// we do not produce) or the `data_uri`'s decoded bytes hash to `digest`.
+    /// The content id commits to `digest`, not the bytes, so this guards against
+    /// a persisted record whose evidence `data` was substituted for bytes that
+    /// do not match the digest the receipt is signed over.
+    pub fn digest_matches_data(&self) -> bool {
+        let (Some(digest), Some(data_uri)) = (self.digest.as_deref(), self.data_uri.as_deref())
+        else {
+            return true;
+        };
+        // We only ever emit `data:<content-type>;base64,<b64>`; any other shape
+        // is not ours, so there is nothing to check against our digest.
+        let Some((_, b64)) = data_uri.split_once(";base64,") else {
+            return true;
+        };
+        match BASE64.decode(b64.as_bytes()) {
+            Ok(bytes) => canonical::sha256_hex(&bytes) == digest,
+            Err(_) => false, // claims a digest but the data is not decodable
         }
     }
 }
@@ -383,6 +405,29 @@ mod tests {
                 "reason": "hard-coded known measurements",
             })
         );
+    }
+
+    #[test]
+    fn evidence_digest_matches_data_guards_a_swapped_payload() {
+        let digest = canonical::sha256_hex(b"abc"); // "sha256:..."
+                                                    // base64("abc") = "YWJj" — matches the digest.
+        let ok = EvidenceRef {
+            digest: Some(digest.clone()),
+            data_uri: Some("data:text/plain;base64,YWJj".to_string()),
+        };
+        assert!(ok.digest_matches_data());
+        // base64("xyz") = "eHl6" — does NOT match the digest of "abc".
+        let swapped = EvidenceRef {
+            digest: Some(digest.clone()),
+            data_uri: Some("data:text/plain;base64,eHl6".to_string()),
+        };
+        assert!(!swapped.digest_matches_data());
+        // No data to check against ⇒ nothing to verify.
+        let no_data = EvidenceRef {
+            digest: Some(digest),
+            data_uri: None,
+        };
+        assert!(no_data.digest_matches_data());
     }
 
     #[test]

--- a/src/aggregator/session_store.rs
+++ b/src/aggregator/session_store.rs
@@ -36,7 +36,7 @@ use super::session::AttestedSession;
 /// Record type tag for a session line.
 const RECORD_TYPE_SESSION: &str = "session";
 
-/// One line in the append-only session log.
+/// One line in the append-only session log, as read back on replay.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionLogRecord {
     pub seq: u64,
@@ -44,6 +44,17 @@ pub struct SessionLogRecord {
     #[serde(rename = "type")]
     pub record_type: String,
     pub payload: Value,
+}
+
+/// Write-side view of a log record that borrows the session, so a line is
+/// serialized in one pass instead of building an intermediate `Value` tree.
+#[derive(Serialize)]
+struct SessionLogRecordRef<'a> {
+    seq: u64,
+    ts: u64,
+    #[serde(rename = "type")]
+    record_type: &'a str,
+    payload: &'a AttestedSession,
 }
 
 /// The session registry behind the audit endpoints.
@@ -106,8 +117,13 @@ impl JsonlSessionStore {
                         // Enforce content-addressing on replay: a record whose
                         // session_id does not match a fresh hash of its own
                         // contents was tampered with (or written by an
-                        // incompatible version). Skip it rather than serve it.
-                        if session.content_id().ok().as_deref() == Some(&session.session_id) {
+                        // incompatible version). Also require the evidence
+                        // `data` to hash to its `digest` — the content id commits
+                        // to the digest, not the bytes, so this catches a swapped
+                        // evidence payload. Skip either way rather than serve it.
+                        if session.content_id().ok().as_deref() == Some(&session.session_id)
+                            && session.evidence.digest_matches_data()
+                        {
                             by_id.insert(session.session_id.clone(), session);
                         }
                     }
@@ -128,18 +144,15 @@ impl JsonlSessionStore {
 
 impl SessionStore for JsonlSessionStore {
     fn put_session(&self, session: AttestedSession, ts: u64) -> io::Result<u64> {
-        let payload = serde_json::to_value(&session)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let mut guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let seq = guard.next_seq;
-        let record = SessionLogRecord {
+        let mut line = serde_json::to_string(&SessionLogRecordRef {
             seq,
             ts,
-            record_type: RECORD_TYPE_SESSION.to_string(),
-            payload,
-        };
-        let mut line = serde_json::to_string(&record)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            record_type: RECORD_TYPE_SESSION,
+            payload: &session,
+        })
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         line.push('\n');
         guard.writer.write_all(line.as_bytes())?;
         guard.writer.flush()?;
@@ -392,6 +405,47 @@ mod tests {
         let store = JsonlSessionStore::open(&path).unwrap();
         assert_eq!(store.get_session(&good.session_id, 2_000), Some(good));
         assert_eq!(store.list_sessions(None, 2_000).len(), 1);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn evidence_data_not_matching_its_digest_is_skipped_on_replay() {
+        use crate::aci::canonical;
+
+        // Seal a session whose evidence digest covers "abc" (base64 "YWJj").
+        let mut s = AttestedSession::seal(
+            "phala-direct",
+            Some("https://node-7.example.net".to_string()),
+            "phala-direct/1",
+            None,
+            vec![],
+            SessionClaims::default(),
+            EvidenceRef {
+                digest: Some(canonical::sha256_hex(b"abc")),
+                data_uri: Some("data:text/plain;base64,YWJj".to_string()),
+            },
+            1_000,
+            9_000,
+        )
+        .unwrap();
+        assert!(s.evidence.digest_matches_data());
+
+        // Swap the evidence bytes but keep the digest — the content id is over
+        // the digest, so the session_id still "matches" while the data does not.
+        s.evidence.data_uri = Some("data:text/plain;base64,eHl6".to_string()); // "xyz"
+        assert_eq!(s.content_id().unwrap(), s.session_id);
+        assert!(!s.evidence.digest_matches_data());
+
+        let path = temp_path();
+        JsonlSessionStore::open(&path)
+            .unwrap()
+            .put_session(s.clone(), 1_000)
+            .unwrap();
+
+        // On replay the swapped-evidence record is rejected.
+        let reopened = JsonlSessionStore::open(&path).unwrap();
+        assert!(reopened.get_session(&s.session_id, 2_000).is_none());
 
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
First slice of #7 (deferred cleanups from the multi-angle review of #3). Focused on session-store soundness/robustness so it stays reviewable.

## Changes
- **Soundness hardening (the main item).** `content_id` commits to `evidence.digest`, not the bytes, so a persisted record whose evidence `data` was swapped for something that doesn't match its digest used to pass content-addressing. `EvidenceRef::digest_matches_data` now recomputes `sha256(decode(data_uri))` and the JSONL replay rejects any record where it doesn't match the digest. Today's producers always match — this is defense in depth against a hand-edited/substituted log line.
- **Single-pass log write.** `JsonlSessionStore::put_session` serialized to a `Value` tree and then to a string; now it serializes once via a borrowing `SessionLogRecordRef`.
- **Doc.** Make the NEAR AI gateway-vs-model-TD boundary explicit: `tee_attested` binds the verified *gateway* TD, not the nested model TDs (honestly recorded as `nested_model_attestations_checked_by_gateway: false` in `claims.extra`).

## Tests
`EvidenceRef::digest_matches_data` unit test + a replay test proving a swapped-evidence record is skipped. 222 tests + fmt + clippy clean.

## Remaining in #7 (not here)
- Stream/reverify-loop de-duplication — its own PR (a structural refactor).
- `service.rs` god-file split — already in flight on `refactor/modularize-long-files`.
- `BTreeMap` store eviction — negligible at realistic store size; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)