### PR TITLE
feat: BYOK auth-passthrough — forward per-caller credentials to upstreams

### DIFF
--- a/examples/live_chutes_embedding.rs
+++ b/examples/live_chutes_embedding.rs
@@ -132,6 +132,7 @@ async fn run() -> Result<(), String> {
         headers: HashMap::new(),
         path: Some("/v1/embeddings".to_string()),
         target_route_id: None,
+        client_authorization: Default::default(),
     };
     let prepared = backend
         .prepare(request)

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -43,12 +43,30 @@ use openai::request_model_id;
 pub const DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS: u64 = 10;
 pub const DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS: u64 = 600;
 
+/// Per-request upstream credential carried through the forwarding path
+/// for BYOK auth-passthrough. Holds the caller's token in memory only and
+/// redacts on `Debug` so a raw key can never land in logs or receipts.
+#[derive(Clone, Default)]
+pub struct ClientAuthorization(pub Option<String>);
+
+impl std::fmt::Debug for ClientAuthorization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(_) => f.write_str("ClientAuthorization(<redacted>)"),
+            None => f.write_str("ClientAuthorization(None)"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct UpstreamRequest {
     pub body: Vec<u8>,
     pub headers: HashMap<String, String>,
     pub path: Option<String>,
     pub target_route_id: Option<String>,
+    /// Caller credential for BYOK auth-passthrough upstreams. Ignored by
+    /// backends that are not configured for passthrough.
+    pub client_authorization: ClientAuthorization,
 }
 
 #[derive(Debug, Clone)]

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -28,6 +28,11 @@ pub struct OpenAICompatibleBackend {
     base_url: String,
     path: String,
     bearer_token: Option<String>,
+    /// When true, the caller's per-request credential
+    /// ([`UpstreamRequest::client_authorization`]) is forwarded as the
+    /// upstream `Authorization` and the static `bearer_token` is never used
+    /// (BYOK). Set from `UpstreamConfig::auth_passthrough`.
+    auth_passthrough: bool,
     client: reqwest::Client,
     connect_timeout_seconds: u64,
     read_timeout_seconds: u64,
@@ -61,6 +66,7 @@ impl OpenAICompatibleBackend {
             base_url: base,
             path: "/v1/chat/completions".to_string(),
             bearer_token: None,
+            auth_passthrough: false,
             client,
             connect_timeout_seconds,
             read_timeout_seconds,
@@ -83,6 +89,13 @@ impl OpenAICompatibleBackend {
 
     pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
         self.bearer_token = Some(token.into());
+        self
+    }
+
+    /// Enable BYOK auth-passthrough: forward the caller's per-request
+    /// credential to the upstream instead of a statically-configured token.
+    pub fn with_auth_passthrough(mut self, enabled: bool) -> Self {
+        self.auth_passthrough = enabled;
         self
     }
 }
@@ -325,7 +338,15 @@ impl OpenAICompatibleBackend {
         for (k, v) in req.headers.iter() {
             builder = builder.header(k, v);
         }
-        if let Some(t) = &self.bearer_token {
+        if self.auth_passthrough {
+            // BYOK: forward only the caller's credential; never fall back to
+            // a static token for a passthrough upstream. Absent credential =>
+            // no auth header (the upstream rejects, which is the correct,
+            // visible failure).
+            if let Some(t) = &req.client_authorization.0 {
+                builder = builder.header("authorization", format!("Bearer {t}"));
+            }
+        } else if let Some(t) = &self.bearer_token {
             builder = builder.header("authorization", format!("Bearer {t}"));
         }
         builder

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -4,7 +4,9 @@ use crate::aci::receipt::{
     ReceiptBuilder, ReceiptError, TransparencyEventKind, UpstreamVerifiedEvent, VerificationResult,
 };
 use crate::aci::types::Receipt;
-use crate::aci::upstream::{PreparedUpstreamRequest, UpstreamError, UpstreamRequest};
+use crate::aci::upstream::{
+    ClientAuthorization, PreparedUpstreamRequest, UpstreamError, UpstreamRequest,
+};
 use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
 use crate::aggregator::session::{
     AttestedSession, EvidenceRef, SessionClaims, WorkloadIdentityRef,
@@ -40,6 +42,7 @@ impl AciService {
             upstream_verification_event,
             requester: None,
             e2ee: None,
+            client_authorization: ClientAuthorization(None),
         })
         .await
     }
@@ -66,6 +69,7 @@ impl AciService {
             body: backend_input_body,
             path: Some(endpoint_path.to_string()),
             target_route_id: target_route_id.clone(),
+            client_authorization: req.client_authorization.clone(),
             ..Default::default()
         })?;
         let forwarded_body = prepared.request.body.clone();
@@ -209,6 +213,7 @@ impl AciService {
             body: backend_input_body,
             path: Some(endpoint_path.to_string()),
             target_route_id: target_route_id.clone(),
+            client_authorization: req.client_authorization.clone(),
             ..Default::default()
         })?;
         let forwarded_body = prepared.request.body.clone();

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -124,6 +124,7 @@ impl AciService {
                 body: candidate.body.clone(),
                 path: Some(endpoint_path.to_string()),
                 target_route_id: Some(route_id.clone()),
+                client_authorization: req.client_authorization.clone(),
                 ..Default::default()
             }) {
                 Ok(prepared) => prepared,

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -8,6 +8,7 @@ use futures_util::Stream;
 use super::{ReceiptOwner, ServiceError};
 use crate::aci::receipt::{ReceiptBuilder, UpstreamVerifiedEvent};
 use crate::aci::types::Receipt;
+use crate::aci::upstream::ClientAuthorization;
 use crate::aggregator::metrics::RequestMode;
 
 pub struct E2eeRequestParts<'a> {
@@ -228,6 +229,11 @@ pub struct ChatCompletionRequest<'a> {
     /// receipt that any caller can retrieve.
     pub requester: Option<ReceiptOwner>,
     pub e2ee: Option<E2eeRequestContext>,
+    /// Caller credential to forward to a BYOK auth-passthrough upstream.
+    /// Empty for non-passthrough upstreams (the static token is used).
+    /// Typed as [`ClientAuthorization`] so the raw secret redacts on `Debug`
+    /// end-to-end, not just at the final hop.
+    pub client_authorization: ClientAuthorization,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -82,6 +82,23 @@ fn provider_is_tee(provider: UpstreamProvider) -> bool {
     }
 }
 
+/// Whether a provider's backend honours BYOK `auth_passthrough`. Only the
+/// providers served by `OpenAICompatibleBackend` (wired with
+/// `with_auth_passthrough` below) forward the caller credential. Chutes uses a
+/// dedicated E2EE transport that ignores it, so enabling passthrough there
+/// would be a silent no-op — rejected at validation instead. Keep this in sync
+/// with the backend match arms in `build_provider_backend`.
+pub(super) fn provider_supports_auth_passthrough(provider: UpstreamProvider) -> bool {
+    match provider {
+        UpstreamProvider::Chutes => false,
+        UpstreamProvider::OpenAiCompatible
+        | UpstreamProvider::AciDcap
+        | UpstreamProvider::Tinfoil
+        | UpstreamProvider::NearAi
+        | UpstreamProvider::PhalaDirect => true,
+    }
+}
+
 fn build_provider_backend(
     cfg: &UpstreamConfig,
     options: &UpstreamRuntimeOptions,
@@ -118,7 +135,8 @@ fn build_provider_backend(
                 read_timeout_seconds,
             )
             .map_err(|e| UpstreamConfigError::InvalidConfig(e.to_string()))?
-            .with_name(cfg.name.clone());
+            .with_name(cfg.name.clone())
+            .with_auth_passthrough(cfg.auth_passthrough);
             if let Some(token) = &cfg.bearer_token {
                 backend = backend.with_bearer_token(token.clone());
             }

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -48,6 +48,11 @@ pub struct UpstreamConfig {
     pub models: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bearer_token: Option<String>,
+    /// BYOK: forward each caller's own `Authorization` to the upstream
+    /// instead of a static `bearer_token`. Mutually exclusive with
+    /// `bearer_token` (rejected at config validation).
+    #[serde(default)]
+    pub auth_passthrough: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accepted_workload_ids: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -87,6 +92,7 @@ pub struct PublicUpstreamConfig {
     pub path: Option<String>,
     pub models: BTreeMap<String, String>,
     pub bearer_token_configured: bool,
+    pub auth_passthrough: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_workload_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,6 +132,7 @@ impl UpstreamConfig {
             path: self.path.clone(),
             models: self.models.clone(),
             bearer_token_configured: self.bearer_token.is_some(),
+            auth_passthrough: self.auth_passthrough,
             accepted_workload_ids: self.accepted_workload_ids.clone(),
             accepted_image_digests: self.accepted_image_digests.clone(),
             accepted_dstack_kms_root_public_keys: self.accepted_dstack_kms_root_public_keys.clone(),

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -23,6 +23,7 @@ fn test_upstream_config(
         path: None,
         models: BTreeMap::from([(public_model.to_string(), upstream_model.to_string())]),
         bearer_token: None,
+        auth_passthrough: false,
         accepted_workload_ids: None,
         accepted_image_digests: None,
         accepted_dstack_kms_root_public_keys: None,
@@ -87,6 +88,82 @@ fn parse_config_allows_same_public_model_on_distinct_route_ids() {
     .expect("same public model can have multiple route ids");
 
     assert_eq!(config.len(), 2);
+}
+
+#[test]
+fn byok_auth_passthrough_parses_and_defaults_off() {
+    let config = parse_config_text(
+        r#"
+            [
+              {
+                "name": "near-ai",
+                "provider": "near-ai",
+                "base_url": "https://cloud-api.near.ai",
+                "models": {"openai/gpt-oss-120b": "near-model"},
+                "auth_passthrough": true
+              },
+              {
+                "name": "plain",
+                "provider": "openai-compatible",
+                "base_url": "https://plain.example",
+                "models": {"m": "u"}
+              }
+            ]
+            "#,
+    )
+    .expect("auth_passthrough upstream is valid without a static token");
+
+    assert!(config[0].auth_passthrough);
+    assert!(!config[1].auth_passthrough, "defaults off when omitted");
+}
+
+#[test]
+fn byok_auth_passthrough_rejects_static_bearer_token() {
+    let err = parse_config_text(
+        r#"
+            [
+              {
+                "name": "near-ai",
+                "provider": "near-ai",
+                "base_url": "https://cloud-api.near.ai",
+                "models": {"openai/gpt-oss-120b": "near-model"},
+                "auth_passthrough": true,
+                "bearer_token": "should-not-be-here"
+              }
+            ]
+            "#,
+    )
+    .expect_err("auth_passthrough + bearer_token must be rejected");
+
+    assert!(
+        matches!(err, UpstreamConfigError::InvalidConfig(msg) if msg.contains("auth_passthrough")),
+        "error should name the offending field",
+    );
+}
+
+#[test]
+fn byok_auth_passthrough_rejects_providers_that_do_not_support_it() {
+    // Chutes uses a dedicated E2EE transport that ignores auth_passthrough,
+    // so enabling it there is a silent no-op and must be rejected.
+    let err = parse_config_text(
+        r#"
+            [
+              {
+                "name": "chutes-provider",
+                "provider": "chutes",
+                "base_url": "https://chutes.example",
+                "models": {"m": "u"},
+                "auth_passthrough": true
+              }
+            ]
+            "#,
+    )
+    .expect_err("auth_passthrough on an unsupported provider must be rejected");
+
+    assert!(
+        matches!(err, UpstreamConfigError::InvalidConfig(msg) if msg.contains("does not")),
+        "error should explain the provider does not support passthrough",
+    );
 }
 
 #[test]
@@ -166,6 +243,7 @@ async fn prewarm_verification_deduplicates_upstream_models() {
             ("public-c".to_string(), "upstream-c".to_string()),
         ]),
         bearer_token: None,
+        auth_passthrough: false,
         accepted_workload_ids: None,
         accepted_image_digests: None,
         accepted_dstack_kms_root_public_keys: None,

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -156,6 +156,22 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
                 upstream.name
             )));
         }
+        if upstream.auth_passthrough && upstream.bearer_token.is_some() {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} sets both auth_passthrough and bearer_token; \
+                 a passthrough upstream must not configure a static token",
+                upstream.name
+            )));
+        }
+        if upstream.auth_passthrough
+            && !super::builders::provider_supports_auth_passthrough(upstream.provider)
+        {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} sets auth_passthrough but provider {:?} does not \
+                 support it (only OpenAI-compatible-forwarded providers do)",
+                upstream.name, upstream.provider
+            )));
+        }
         for (field, value) in [
             ("connect_timeout_seconds", upstream.connect_timeout_seconds),
             ("read_timeout_seconds", upstream.read_timeout_seconds),

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -13,7 +13,7 @@ use futures_util::StreamExt;
 use rand::RngCore;
 use serde_json::Value;
 
-use crate::aci::upstream::UpstreamError;
+use crate::aci::upstream::{ClientAuthorization, UpstreamError};
 use crate::aggregator::service::{
     AciService, ChatCompletionRequest, E2eeRequestContext, E2eeResponseInfo, GatewayRequestContext,
     MiddlewareForwardResult, ReceiptOwner, ServiceError, StreamingForwardResult,
@@ -34,6 +34,10 @@ pub(super) struct BackendForwardInput {
     pub(super) upstream_required: bool,
     pub(super) requester: Option<ReceiptOwner>,
     pub(super) e2ee: Option<E2eeRequestContext>,
+    /// Caller credential for BYOK auth-passthrough upstreams. Forwarded to the
+    /// backend in memory only; the [`ClientAuthorization`] newtype redacts on
+    /// `Debug` so the raw secret cannot be logged or persisted.
+    pub(super) client_authorization: ClientAuthorization,
     pub(super) stream: bool,
 }
 
@@ -52,6 +56,7 @@ pub(super) async fn forward_to_backend(
                 upstream_verification_event: None,
                 requester: input.requester,
                 e2ee: input.e2ee,
+                client_authorization: input.client_authorization,
             })
             .await;
         return match result {
@@ -104,6 +109,7 @@ pub(super) async fn forward_to_backend(
             upstream_verification_event: None,
             requester: input.requester,
             e2ee: input.e2ee,
+            client_authorization: input.client_authorization,
         })
         .await;
     match result {
@@ -181,6 +187,11 @@ pub(super) async fn internal_forward(
                 upstream_verification_event: None,
                 requester: stored.requester,
                 e2ee: stored.e2ee,
+                // Middleware mode deliberately does not carry the raw caller
+                // credential (the request store keeps only a hashed requester),
+                // so BYOK passthrough is unsupported on this path by design
+                // (and rejected at startup when middleware is enabled).
+                client_authorization: ClientAuthorization(None),
             },
             candidates,
             stream,

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -17,6 +17,7 @@ use crate::aci::keys::{
     ethereum_address_from_uncompressed_public_key, KeyError, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
 };
 use crate::aci::types::AttestationReport;
+use crate::aci::upstream::ClientAuthorization;
 use crate::aggregator::service::{
     E2eeRequestParts, GatewayRequestContext, MiddlewareReceiptJournal, ReceiptOwner, ServiceError,
     CHAT_COMPLETIONS_PATH, COMPLETIONS_PATH, EMBEDDINGS_PATH, MESSAGES_PATH, RESPONSES_PATH,
@@ -481,6 +482,9 @@ pub(super) async fn openai_completion_endpoint(
             upstream_required,
             requester,
             e2ee,
+            // BYOK passthrough: the backend forwards this only for
+            // auth_passthrough upstreams; ignored otherwise.
+            client_authorization: ClientAuthorization(extract_bearer(&headers)),
             stream,
         },
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -544,6 +544,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     spawn_upstream_lifecycle(upstream_config.clone());
 
     let app = if let Some(executor_uds_path) = executor_uds_path {
+        // BYOK auth-passthrough cannot work in middleware mode: the request
+        // store keeps only a hashed requester, so the caller credential is not
+        // available on the middleware finalize path. Fail closed at startup
+        // rather than silently 401 every passthrough request at runtime.
+        if upstream_config
+            .snapshot()
+            .upstreams
+            .iter()
+            .any(|u| u.auth_passthrough)
+        {
+            return Err(
+                "auth_passthrough upstreams are not supported in middleware mode; \
+                 disable middleware (unset the executor UDS path) or remove auth_passthrough"
+                    .into(),
+            );
+        }
         let request_store = GatewayRequestStore::default();
         let backend_app = build_internal_backend_router(service.clone(), request_store.clone());
         let backend_listener = bind_unix_listener(&backend_uds_path)?;

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -674,6 +674,7 @@ async fn request_rewrite_is_recorded_by_hash_without_retaining_the_body() {
             }),
             requester: Some(ReceiptOwner::from_bearer("requester-a")),
             e2ee: None,
+            client_authorization: Default::default(),
         })
         .await
         .unwrap();

--- a/tests/dstack_live.rs
+++ b/tests/dstack_live.rs
@@ -328,6 +328,7 @@ async fn dstack_live_aci_report_and_receipt_chain_verify() {
             upstream_verification_event: None,
             requester: None,
             e2ee: None,
+            client_authorization: Default::default(),
         })
         .await
         .unwrap();

--- a/tests/provider_e2e.rs
+++ b/tests/provider_e2e.rs
@@ -474,6 +474,36 @@ async fn call(
     (status, headers, body)
 }
 
+/// Like [`call`] but sets (or omits) an inbound `Authorization` header, so a
+/// test can exercise BYOK auth-passthrough where the caller credential is what
+/// reaches the upstream.
+async fn call_with_auth(
+    app: Router,
+    method: &str,
+    uri: &str,
+    body: impl Into<Vec<u8>>,
+    authorization: Option<&str>,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(value) = authorization {
+        builder = builder.header("authorization", value);
+    }
+    let response = app
+        .oneshot(builder.body(Body::from(body.into())).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .to_vec();
+    (status, headers, body)
+}
+
 fn service_for_manager(manager: Arc<UpstreamConfigManager>) -> Arc<AciService> {
     Arc::new(
         AciService::new_with_upstream_verifier(
@@ -639,6 +669,7 @@ async fn openai_compatible_provider_e2e_via_runtime_config() {
             path: None,
             models: BTreeMap::from([("public-model".to_string(), "provider-model".to_string())]),
             bearer_token: Some("provider-secret".to_string()),
+            auth_passthrough: false,
             accepted_workload_ids: None,
             accepted_image_digests: None,
             accepted_dstack_kms_root_public_keys: None,
@@ -708,6 +739,74 @@ async fn openai_compatible_provider_e2e_via_runtime_config() {
 }
 
 #[tokio::test]
+async fn byok_auth_passthrough_forwards_caller_credential_not_a_static_token() {
+    let (base_url, provider_calls) = serve_openai_provider_fixture().await;
+    let path = temp_config_path();
+    let manager = Arc::new(
+        UpstreamConfigManager::load(&path, runtime_options(UpstreamVerifierMode::Preverified))
+            .unwrap(),
+    );
+    manager
+        .replace(vec![UpstreamConfig {
+            name: "byok-provider".to_string(),
+            provider: UpstreamProvider::OpenAiCompatible,
+            base_url: base_url.clone(),
+            path: None,
+            models: BTreeMap::from([("public-model".to_string(), "provider-model".to_string())]),
+            bearer_token: None,
+            auth_passthrough: true,
+            accepted_workload_ids: None,
+            accepted_image_digests: None,
+            accepted_dstack_kms_root_public_keys: None,
+            pccs_url: None,
+            verifier_cache_seconds: None,
+            connect_timeout_seconds: None,
+            read_timeout_seconds: None,
+            verifier_request_timeout_seconds: None,
+            verification_refresh_seconds: None,
+            session_refresh_seconds: None,
+            chutes_e2ee_api_base: None,
+            chutes_chute_ids: None,
+            chutes_e2ee_discovery_rounds: None,
+            chutes_e2ee_discovery_interval_seconds: None,
+        }])
+        .unwrap();
+    let service = service_for_manager(manager);
+    let app = build_router(service);
+
+    // (a) The caller's own credential — not any static token — reaches upstream.
+    let (status, _, body) = call_with_auth(
+        app.clone(),
+        "POST",
+        "/v1/chat/completions",
+        CHAT_REQUEST,
+        Some("Bearer caller-byok-key"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+    // (b) Absent caller credential => no Authorization header forwarded (a
+    // visible upstream decision), never a silent fallback.
+    let (status, _, body) =
+        call_with_auth(app, "POST", "/v1/chat/completions", CHAT_REQUEST, None).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+    let calls = provider_calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(
+        calls[0].authorization.as_deref(),
+        Some("Bearer caller-byok-key"),
+        "passthrough must forward the caller credential verbatim",
+    );
+    assert_eq!(
+        calls[1].authorization, None,
+        "absent caller credential must not fall back to any token",
+    );
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
 async fn openai_compatible_provider_routes_embeddings_via_runtime_config() {
     let (base_url, provider_calls) = serve_openai_provider_fixture().await;
     let path = temp_config_path();
@@ -729,6 +828,7 @@ async fn openai_compatible_provider_routes_embeddings_via_runtime_config() {
                 ),
             ]),
             bearer_token: Some("provider-secret".to_string()),
+            auth_passthrough: false,
             accepted_workload_ids: None,
             accepted_image_digests: None,
             accepted_dstack_kms_root_public_keys: None,
@@ -813,6 +913,7 @@ async fn dynamic_runtime_config_delegates_verified_forwarding_to_selected_backen
             path: None,
             models: BTreeMap::from([("public-model".to_string(), "provider-model".to_string())]),
             bearer_token: None,
+            auth_passthrough: false,
             accepted_workload_ids: None,
             accepted_image_digests: None,
             accepted_dstack_kms_root_public_keys: None,
@@ -836,6 +937,7 @@ async fn dynamic_runtime_config_delegates_verified_forwarding_to_selected_backen
             headers: Default::default(),
             path: None,
             target_route_id: None,
+            client_authorization: Default::default(),
         })
         .unwrap();
     let event = UpstreamVerifiedEvent {


### PR DESCRIPTION
Closes #11.

## Summary

Adds an opt-in **`auth_passthrough`** mode to upstream config. When enabled, the gateway forwards **each caller's own `Authorization` credential** to the upstream instead of a statically-configured `bearer_token`.

This enables **BYOK (bring-your-own-key)**: a fronting service can let each end user supply their own upstream provider API key, which the gateway relays per-request — without the operator holding a shared key for that upstream. Attestation, verification, channel binding, and receipts are unchanged.

## Motivation

Today an upstream authenticates with a single operator-configured `bearer_token` (`OpenAICompatibleBackend`), and the caller's inbound `Authorization` is consumed only as a hashed receipt-owner tag — it never reaches the upstream. That's correct for a gateway fronting one account, but it blocks multi-tenant BYOK, where the gateway should relay each user's own provider key (e.g. a per-user NEAR AI key) while still doing the attested-confidential-inference work it exists for.

## What this does

- New `UpstreamConfig.auth_passthrough: bool` (default `false`, serde-defaulted so existing configs are unchanged).
- When set, `OpenAICompatibleBackend` forwards the caller credential as the upstream `Authorization` and **never** uses a static token.
- The caller credential is threaded handler → service → backend via a new `UpstreamRequest.client_authorization`.

## Security / design notes

This change moves a raw secret (the caller's bearer) along new code paths, so the handling is deliberately conservative:

- **Redaction is structural, end-to-end.** The credential is wrapped in a `ClientAuthorization` newtype whose hand-written `Debug` redacts, and it is carried as that type across every hop (`ChatCompletionRequest`, `BackendForwardInput`, `UpstreamRequest`). No struct carrying it derives `Serialize`, and none is logged. The raw key cannot reach logs, receipts, or the request store.
- **Fail-closed precedence.** In passthrough mode the static `bearer_token` is *never* sent. Config validation rejects setting both `auth_passthrough` and `bearer_token` on the same upstream, and an absent caller credential yields **no** `Authorization` header (a visible upstream rejection), never a silent fallback.
- **Provider support is validated.** `auth_passthrough` is only honored by providers served through `OpenAICompatibleBackend` (`openai-compatible`, `aci-dcap`, `tinfoil`, `near-ai`, `phala-direct`). Enabling it on a provider that ignores it (`chutes`, which uses its own E2EE transport) is rejected at config validation rather than silently no-op'ing.
- **Middleware mode is unsupported, and fails closed.** The middleware request store keeps only a hashed requester, so the raw credential isn't available on that path. The gateway now **refuses to start** if middleware mode is enabled together with any `auth_passthrough` upstream, rather than 401-ing every request at runtime.
- **Credential normalization.** `extract_bearer` strips/trims the `Bearer ` scheme and the backend re-wraps it, so only a well-formed `Bearer <token>` is forwarded (no header-shape passthrough).

## Scope / limitations

- Applies to the forwarding (POST) path. Server-initiated upstream GETs (e.g. model listing) are unaffected — under config-driven routing the model list is synthesized locally, so no per-caller credential exists there.
- In BYOK mode the receipt-owner tag becomes `sha256(caller credential)` (same as today's hashing of the inbound bearer); ownership semantics therefore bind to the provider key in this mode.
- Not wired for the Chutes E2EE transport (rejected at validation, see above).

## Testing

- `tests/provider_e2e.rs`: new end-to-end test asserting the load-bearing properties against the mock-upstream harness — the caller credential reaches the upstream **verbatim**, and an absent credential results in **no** `Authorization` header (no static-token fallback).
- `src/aggregator/upstream_config.rs`: unit tests for the new validation rules (`auth_passthrough` defaults off and parses; rejected with a static `bearer_token`; rejected for an unsupported provider).
- `cargo check --all-targets`, `cargo clippy --all-targets`, and `cargo fmt -- --check` are clean. Full suite passes (lib + `provider_e2e` + `aci_service_surface`).

## Backward compatibility

`auth_passthrough` is serde-defaulted to `false`; existing upstream configs and behavior are unchanged. `PublicUpstreamConfig` gains the field so the admin/read API reflects it.