### PR TITLE
fix(clippy): restore dropped allow + gate CI on clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,14 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --all-targets

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -37,6 +37,7 @@ fn upgrade_err(slot: &mut Option<(u8, ServiceError)>, priority: u8, err: Service
 }
 
 impl AciService {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn build_middleware_receipt_prefix(
         &self,
         receipt_id: &str,


### PR DESCRIPTION
Restore the `#[allow(clippy::too_many_arguments)]` that #9 dropped when it moved `build_middleware_receipt_prefix` into `service/middleware.rs`, and add a `cargo clippy --all-targets -- -D warnings` step to CI (which ran fmt+tests but not clippy) so the next dropped lint can't reach main.