### PR TITLE
Address #5: type session channel bindings + content_id material

### DIFF
--- a/src/aci/canonical.rs
+++ b/src/aci/canonical.rs
@@ -47,6 +47,9 @@ pub enum CanonicalError {
     /// through a non-standard path.
     #[error("JCS: object key must be a string")]
     NonStringKey,
+    /// A typed value could not be serialized to JSON before canonicalisation.
+    #[error("JCS: value could not be serialized to JSON: {0}")]
+    Serialize(#[from] serde_json::Error),
 }
 
 /// Canonicalise an arbitrary [`serde_json::Value`] subtree.

--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -5,6 +5,7 @@
 //! signs the canonical bytes of the receipt minus `signature.value`
 //! with a key listed in the established workload keyset.
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::canonical::{self, CanonicalError};
@@ -81,7 +82,14 @@ impl VerificationResult {
 
 /// Channel binding material verified before the aggregator forwards
 /// sensitive bytes to an upstream.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `tag = "type"` serializes this as a flat, self-describing object — e.g.
+/// `{"type":"tls_spki_sha256","origin":..,"spki_sha256":..}` — rather than
+/// serde's default externally tagged `{"TlsSpkiSha256":{..}}`, which would
+/// leak Rust variant names; `rename_all` keeps the discriminator in the
+/// snake_case ACI JSON convention.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChannelBinding {
     TlsSpkiSha256 {
         origin: String,
@@ -93,6 +101,7 @@ pub enum ChannelBinding {
     },
     E2eePublicKeySha256 {
         provider: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         key_id: Option<String>,
         algorithm: String,
         public_key_sha256: String,
@@ -105,39 +114,6 @@ impl ChannelBinding {
             Self::TlsSpkiSha256 { origin, .. } => origin,
             Self::TlsCertificateSha256 { origin, .. } => origin,
             Self::E2eePublicKeySha256 { .. } => "",
-        }
-    }
-
-    pub fn to_value(&self) -> Value {
-        match self {
-            Self::TlsSpkiSha256 {
-                origin,
-                spki_sha256,
-            } => serde_json::json!({
-                "type": "tls_spki_sha256",
-                "origin": origin,
-                "spki_sha256": spki_sha256,
-            }),
-            Self::TlsCertificateSha256 {
-                origin,
-                certificate_sha256,
-            } => serde_json::json!({
-                "type": "tls_certificate_sha256",
-                "origin": origin,
-                "certificate_sha256": certificate_sha256,
-            }),
-            Self::E2eePublicKeySha256 {
-                provider,
-                key_id,
-                algorithm,
-                public_key_sha256,
-            } => serde_json::json!({
-                "type": "e2ee_public_key_sha256",
-                "provider": provider,
-                "key_id": key_id,
-                "algorithm": algorithm,
-                "public_key_sha256": public_key_sha256,
-            }),
         }
     }
 }
@@ -174,11 +150,7 @@ impl UpstreamVerifiedEvent {
             "required": self.required,
             "reason": self.reason,
             "evidence": self.evidence.clone(),
-            "channel_bindings": self
-                .channel_bindings
-                .iter()
-                .map(ChannelBinding::to_value)
-                .collect::<Vec<_>>(),
+            "channel_bindings": self.channel_bindings,
             "provider_claims": self.provider_claims.clone(),
         })
     }

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -450,7 +450,6 @@ impl AciService {
         // validity one (the forwarding path only ever uses a fresh lease).
         let expires_at = now.saturating_add(self.config.receipt_ttl_seconds);
 
-        let channel_binding = AttestedSession::bindings_to_values(&event.channel_bindings);
         let claims = session_claims_for_event(event);
 
         // Lift the response-signing address into the verified identity when present.
@@ -473,7 +472,7 @@ impl AciService {
             event.url_origin.clone(),
             event.verifier_id.clone(),
             identity,
-            channel_binding,
+            event.channel_bindings.clone(),
             claims.clone(),
             evidence,
             now,

--- a/src/aggregator/session.rs
+++ b/src/aggregator/session.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::aci::canonical::{self, CanonicalError};
 use crate::aci::receipt::ChannelBinding;
@@ -227,18 +227,13 @@ pub struct AttestedSession {
     pub expires_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identity: Option<WorkloadIdentityRef>,
-    /// Enforceable channel binding(s), serialized via [`ChannelBinding::to_value`].
-    pub channel_binding: Vec<Value>,
+    /// Enforceable channel binding(s).
+    pub channel_binding: Vec<ChannelBinding>,
     pub claims: SessionClaims,
     pub evidence: EvidenceRef,
 }
 
 impl AttestedSession {
-    /// Serialize channel bindings to their canonical wire values.
-    pub fn bindings_to_values(bindings: &[ChannelBinding]) -> Vec<Value> {
-        bindings.iter().map(ChannelBinding::to_value).collect()
-    }
-
     /// Seal an immutable session, computing its content-addressed id over the
     /// verified material. Timestamps are excluded from the id so identical
     /// material dedups to one session.
@@ -248,7 +243,7 @@ impl AttestedSession {
         endpoint: Option<String>,
         verifier_id: impl Into<String>,
         identity: Option<WorkloadIdentityRef>,
-        channel_binding: Vec<Value>,
+        channel_binding: Vec<ChannelBinding>,
         claims: SessionClaims,
         evidence: EvidenceRef,
         established_at: u64,
@@ -278,15 +273,28 @@ impl AttestedSession {
     /// contents; that recomputation, not any stored signature, is what makes the
     /// record tamper-evident.
     pub fn content_id(&self) -> Result<String, CanonicalError> {
-        let material = json!({
-            "provider": self.provider,
-            "endpoint": self.endpoint,
-            "verifier_id": self.verifier_id,
-            "identity": self.identity,
-            "channel_binding": self.channel_binding,
-            "claims": self.claims,
-            "evidence_digest": self.evidence.digest,
-        });
+        /// The immutable subset the content id commits to. Timestamps are
+        /// excluded so identical material dedups to one session; field names
+        /// here are load-bearing (they feed the canonical hash).
+        #[derive(Serialize)]
+        struct ContentMaterial<'a> {
+            provider: &'a str,
+            endpoint: &'a Option<String>,
+            verifier_id: &'a str,
+            identity: &'a Option<WorkloadIdentityRef>,
+            channel_binding: &'a [ChannelBinding],
+            claims: &'a SessionClaims,
+            evidence_digest: &'a Option<String>,
+        }
+        let material = serde_json::to_value(ContentMaterial {
+            provider: &self.provider,
+            endpoint: &self.endpoint,
+            verifier_id: &self.verifier_id,
+            identity: &self.identity,
+            channel_binding: &self.channel_binding,
+            claims: &self.claims,
+            evidence_digest: &self.evidence.digest,
+        })?;
         let digest = canonical::jcs_sha256_hex(&material)?;
         Ok(format!(
             "as_{}",
@@ -298,13 +306,13 @@ impl AttestedSession {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
-    fn binding(spki: &str) -> Value {
+    fn binding(spki: &str) -> ChannelBinding {
         ChannelBinding::TlsSpkiSha256 {
             origin: "https://node-7.example.net".to_string(),
             spki_sha256: spki.repeat(32),
         }
-        .to_value()
     }
 
     fn seal_with(endpoint: &str, spki: &str, claims: SessionClaims) -> AttestedSession {

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -258,8 +258,10 @@ async fn verified_upstream_binding_creates_attested_session() {
         Some("fixture")
     );
     assert_eq!(session.channel_binding.len(), 1);
+    let binding = serde_json::to_value(&session.channel_binding[0]).unwrap();
+    assert_eq!(binding["type"], "tls_spki_sha256");
     assert_eq!(
-        session.channel_binding[0]["spki_sha256"],
+        binding["spki_sha256"],
         serde_json::Value::String("aa".repeat(32))
     );
 


### PR DESCRIPTION
Closes #5. Types the remaining claim-bearing `serde_json::Value` in the session layer.

- `AttestedSession.channel_binding: Vec<Value>` → `Vec<ChannelBinding>`. `ChannelBinding` derives serde as a `type`-tagged enum; its E2ee `key_id` now follows the codebase skip-None convention. Removes the redundant `to_value` and `bindings_to_values`.
- `content_id` builds a typed `#[derive(Serialize)]` struct instead of a stringly-keyed `json!`, so the hashed field set is compiler-checked. Adds `CanonicalError::Serialize`.

Left `Value` deliberately (free-form provider bags): `UpstreamVerifiedEvent.{provider_claims,evidence}` and `EvidenceRef::from_value`.

Tests green; fmt + clippy `-D warnings` clean.