### PR TITLE
Address #7: factor the channel-binding reverify loop (+ tests)

### DIFF
--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -23,6 +23,21 @@ use super::{
     CHANNEL_BINDING_REVERIFY_ATTEMPTS, CHAT_COMPLETIONS_PATH,
 };
 
+/// Outcome of [`AciService::forward_with_binding_reverify`]. The caller maps
+/// each non-success variant to its own policy — abort (single forward) or fail
+/// over to the next candidate (middleware).
+pub(super) enum ReverifyOutcome<R> {
+    /// Forwarding succeeded, after zero or more transparent reverify rounds.
+    Forwarded(R),
+    /// A reverify (cached-event refresh) attempt itself failed.
+    RefreshFailed(ServiceError),
+    /// Forwarding failed: either a terminal channel-binding mismatch (after the
+    /// verifier cache was invalidated per policy) or an unrelated upstream
+    /// error. Both map to the caller's failure path; the helper has already
+    /// applied any mismatch invalidation.
+    Failed(UpstreamError),
+}
+
 impl AciService {
     pub async fn forward_chat_completion(
         &self,
@@ -78,31 +93,25 @@ impl AciService {
             )
             .await?;
 
-        let mut reverify_attempts = 0;
-        let upstream_response = loop {
-            match self
-                .upstream
-                .forward_verified_prepared(prepared.clone(), &recorded_event)
-                .await
-            {
-                Ok(response) => break response,
-                Err(UpstreamError::ChannelBindingMismatch(_))
-                    if !caller_supplied_upstream_event
-                        && reverify_attempts < CHANNEL_BINDING_REVERIFY_ATTEMPTS =>
-                {
-                    reverify_attempts += 1;
-                    recorded_event = self
-                        .refresh_upstream_event(&prepared, req.upstream_required)
-                        .await?;
-                }
-                Err(err @ UpstreamError::ChannelBindingMismatch(_))
-                    if !caller_supplied_upstream_event =>
-                {
-                    self.invalidate_upstream_event(&prepared, req.upstream_required);
-                    return Err(err.into());
-                }
-                Err(err) => return Err(err.into()),
-            }
+        let upstream_response = match self
+            .forward_with_binding_reverify(
+                &prepared,
+                &mut recorded_event,
+                req.upstream_required,
+                caller_supplied_upstream_event,
+                // Single forward: only flush the cache for an event we own.
+                false,
+                |prepared, event| async move {
+                    self.upstream
+                        .forward_verified_prepared(prepared, &event)
+                        .await
+                },
+            )
+            .await
+        {
+            ReverifyOutcome::Forwarded(response) => response,
+            ReverifyOutcome::RefreshFailed(err) => return Err(err),
+            ReverifyOutcome::Failed(err) => return Err(err.into()),
         };
         let response_model =
             accepted_response_model(upstream_response.status_code, &upstream_response.body);
@@ -221,31 +230,25 @@ impl AciService {
             )
             .await?;
 
-        let mut reverify_attempts = 0;
-        let upstream_response = loop {
-            match self
-                .upstream
-                .forward_stream_verified_prepared(prepared.clone(), &recorded_event)
-                .await
-            {
-                Ok(response) => break response,
-                Err(UpstreamError::ChannelBindingMismatch(_))
-                    if !caller_supplied_upstream_event
-                        && reverify_attempts < CHANNEL_BINDING_REVERIFY_ATTEMPTS =>
-                {
-                    reverify_attempts += 1;
-                    recorded_event = self
-                        .refresh_upstream_event(&prepared, req.upstream_required)
-                        .await?;
-                }
-                Err(err @ UpstreamError::ChannelBindingMismatch(_))
-                    if !caller_supplied_upstream_event =>
-                {
-                    self.invalidate_upstream_event(&prepared, req.upstream_required);
-                    return Err(err.into());
-                }
-                Err(err) => return Err(err.into()),
-            }
+        let upstream_response = match self
+            .forward_with_binding_reverify(
+                &prepared,
+                &mut recorded_event,
+                req.upstream_required,
+                caller_supplied_upstream_event,
+                // Single forward: only flush the cache for an event we own.
+                false,
+                |prepared, event| async move {
+                    self.upstream
+                        .forward_stream_verified_prepared(prepared, &event)
+                        .await
+                },
+            )
+            .await
+        {
+            ReverifyOutcome::Forwarded(response) => response,
+            ReverifyOutcome::RefreshFailed(err) => return Err(err),
+            ReverifyOutcome::Failed(err) => return Err(err.into()),
         };
         // Match dstack-vllm-proxy compatibility behavior: streaming
         // requests whose upstream response is not exactly HTTP 200
@@ -389,6 +392,67 @@ impl AciService {
         // event. The opt-out path records a synthesized failed event
         // so downstream verifiers see the actual state.
         Ok(event)
+    }
+
+    /// Forward `prepared` against `recorded_event`, transparently reverifying
+    /// (refreshing the cached upstream event) and retrying on a channel-binding
+    /// mismatch up to [`CHANNEL_BINDING_REVERIFY_ATTEMPTS`] times. A successful
+    /// refresh is written back through `recorded_event`, so the caller sees the
+    /// event actually forwarded with.
+    ///
+    /// `caller_supplied_event` (the gateway does not own the event) suppresses
+    /// reverify entirely. On a *terminal* mismatch the gateway's verifier cache
+    /// is invalidated when the gateway owns the event (`!caller_supplied_event`),
+    /// or unconditionally when `always_invalidate_on_mismatch` is set — the
+    /// failover path's conservative "flush a possibly-stale binding" default.
+    pub(super) async fn forward_with_binding_reverify<R, Fwd, Fut>(
+        &self,
+        prepared: &PreparedUpstreamRequest,
+        recorded_event: &mut UpstreamVerifiedEvent,
+        upstream_required: Option<bool>,
+        caller_supplied_event: bool,
+        always_invalidate_on_mismatch: bool,
+        mut forward: Fwd,
+    ) -> ReverifyOutcome<R>
+    where
+        Fwd: FnMut(PreparedUpstreamRequest, UpstreamVerifiedEvent) -> Fut,
+        Fut: std::future::Future<Output = Result<R, UpstreamError>>,
+    {
+        let mut reverify_attempts = 0;
+        loop {
+            // `recorded_event` is cloned per attempt because the forwarded future
+            // owns its inputs. Bounded to CHANNEL_BINDING_REVERIFY_ATTEMPTS + 1,
+            // and `prepared` was already cloned per attempt before this refactor.
+            match forward(prepared.clone(), recorded_event.clone()).await {
+                Ok(response) => return ReverifyOutcome::Forwarded(response),
+                Err(UpstreamError::ChannelBindingMismatch(_))
+                    if !caller_supplied_event
+                        && reverify_attempts < CHANNEL_BINDING_REVERIFY_ATTEMPTS =>
+                {
+                    reverify_attempts += 1;
+                    match self
+                        .refresh_upstream_event(prepared, upstream_required)
+                        .await
+                    {
+                        Ok(event) => *recorded_event = event,
+                        Err(err) => return ReverifyOutcome::RefreshFailed(err),
+                    }
+                }
+                Err(err) => {
+                    // Reached on a terminal channel-binding mismatch (retries
+                    // exhausted, or suppressed because the event is
+                    // caller-supplied) OR any other upstream error. Only a
+                    // mismatch flushes the cache, and only when we own the event
+                    // or the failover path asks us to always flush.
+                    if matches!(err, UpstreamError::ChannelBindingMismatch(_))
+                        && (always_invalidate_on_mismatch || !caller_supplied_event)
+                    {
+                        self.invalidate_upstream_event(prepared, upstream_required);
+                    }
+                    return ReverifyOutcome::Failed(err);
+                }
+            }
+        }
     }
 
     pub(super) async fn refresh_upstream_event(

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -3,6 +3,7 @@
 //!
 
 use super::e2ee_crypto::{encrypt_e2ee_final_response, is_sse_content_type};
+use super::forward::ReverifyOutcome;
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
 };
@@ -16,7 +17,6 @@ use super::{
     MiddlewareGeneratedFinalization, MiddlewareReceiptDraft, MiddlewareReceiptFinalization,
     MiddlewareReceiptJournal, MiddlewareStreamFinalization, MiddlewareStreamingForwarded,
     ReceiptOwner, ServiceError, ServiceResponseStream, StreamingUpstreamError,
-    CHANNEL_BINDING_REVERIFY_ATTEMPTS,
 };
 use crate::aci::receipt::{ReceiptBuilder, TransparencyEventKind, UpstreamVerifiedEvent};
 use crate::aci::upstream::{UpstreamError, UpstreamRequest};
@@ -171,47 +171,39 @@ impl AciService {
             let forwarded_body = prepared.request.body.clone();
 
             if stream {
-                let mut reverify_attempts = 0;
-                let upstream_response = loop {
-                    match self
-                        .upstream
-                        .forward_stream_verified_prepared(prepared.clone(), &recorded_event)
-                        .await
-                    {
-                        Ok(response) => break Some(response),
-                        Err(UpstreamError::ChannelBindingMismatch(_))
-                            if !caller_supplied_upstream_event
-                                && reverify_attempts < CHANNEL_BINDING_REVERIFY_ATTEMPTS =>
-                        {
-                            reverify_attempts += 1;
-                            match self
-                                .refresh_upstream_event(&prepared, candidate_required)
+                let upstream_response = match self
+                    .forward_with_binding_reverify(
+                        &prepared,
+                        &mut recorded_event,
+                        candidate_required,
+                        caller_supplied_upstream_event,
+                        // Failover path: flush a possibly-stale binding on any
+                        // terminal mismatch so the next candidate/request re-verifies.
+                        true,
+                        |prepared, event| async move {
+                            self.upstream
+                                .forward_stream_verified_prepared(prepared, &event)
                                 .await
-                            {
-                                Ok(event) => recorded_event = event,
-                                // A reverify failure must fail over to the
-                                // next candidate, not abort the whole list.
-                                Err(err) => {
-                                    let priority =
-                                        if matches!(err, ServiceError::UpstreamVerification(_)) {
-                                            3
-                                        } else {
-                                            2
-                                        };
-                                    upgrade_err(&mut aggregated_err, priority, err);
-                                    break None;
-                                }
-                            }
-                        }
-                        Err(err @ UpstreamError::ChannelBindingMismatch(_)) => {
-                            self.invalidate_upstream_event(&prepared, candidate_required);
-                            upgrade_err(&mut aggregated_err, 2, err.into());
-                            break None;
-                        }
-                        Err(err) => {
-                            upgrade_err(&mut aggregated_err, 2, err.into());
-                            break None;
-                        }
+                        },
+                    )
+                    .await
+                {
+                    ReverifyOutcome::Forwarded(response) => Some(response),
+                    ReverifyOutcome::RefreshFailed(err) => {
+                        let priority = if matches!(err, ServiceError::UpstreamVerification(_)) {
+                            3
+                        } else {
+                            2
+                        };
+                        upgrade_err(&mut aggregated_err, priority, err);
+                        None
+                    }
+                    ReverifyOutcome::Failed(err) => {
+                        // Terminal binding mismatch and transport errors
+                        // intentionally share failover priority 2 (a failed
+                        // reverify outranks them at 3).
+                        upgrade_err(&mut aggregated_err, 2, err.into());
+                        None
                     }
                 };
                 let Some(upstream_response) = upstream_response else {
@@ -286,47 +278,39 @@ impl AciService {
             }
 
             // Buffered forward.
-            let mut reverify_attempts = 0;
-            let upstream_response = loop {
-                match self
-                    .upstream
-                    .forward_verified_prepared(prepared.clone(), &recorded_event)
-                    .await
-                {
-                    Ok(response) => break Some(response),
-                    Err(UpstreamError::ChannelBindingMismatch(_))
-                        if !caller_supplied_upstream_event
-                            && reverify_attempts < CHANNEL_BINDING_REVERIFY_ATTEMPTS =>
-                    {
-                        reverify_attempts += 1;
-                        match self
-                            .refresh_upstream_event(&prepared, candidate_required)
+            let upstream_response = match self
+                .forward_with_binding_reverify(
+                    &prepared,
+                    &mut recorded_event,
+                    candidate_required,
+                    caller_supplied_upstream_event,
+                    // Failover path: flush a possibly-stale binding on any
+                    // terminal mismatch so the next candidate/request re-verifies.
+                    true,
+                    |prepared, event| async move {
+                        self.upstream
+                            .forward_verified_prepared(prepared, &event)
                             .await
-                        {
-                            Ok(event) => recorded_event = event,
-                            // A reverify failure must fail over to the next
-                            // candidate, not abort the whole list.
-                            Err(err) => {
-                                let priority =
-                                    if matches!(err, ServiceError::UpstreamVerification(_)) {
-                                        3
-                                    } else {
-                                        2
-                                    };
-                                upgrade_err(&mut aggregated_err, priority, err);
-                                break None;
-                            }
-                        }
-                    }
-                    Err(err @ UpstreamError::ChannelBindingMismatch(_)) => {
-                        self.invalidate_upstream_event(&prepared, candidate_required);
-                        upgrade_err(&mut aggregated_err, 2, err.into());
-                        break None;
-                    }
-                    Err(err) => {
-                        upgrade_err(&mut aggregated_err, 2, err.into());
-                        break None;
-                    }
+                    },
+                )
+                .await
+            {
+                ReverifyOutcome::Forwarded(response) => Some(response),
+                ReverifyOutcome::RefreshFailed(err) => {
+                    let priority = if matches!(err, ServiceError::UpstreamVerification(_)) {
+                        3
+                    } else {
+                        2
+                    };
+                    upgrade_err(&mut aggregated_err, priority, err);
+                    None
+                }
+                ReverifyOutcome::Failed(err) => {
+                    // Terminal binding mismatch and transport errors
+                    // intentionally share failover priority 2 (a failed
+                    // reverify outranks them at 3).
+                    upgrade_err(&mut aggregated_err, 2, err.into());
+                    None
                 }
             };
             let Some(upstream_response) = upstream_response else {

--- a/tests/forward_binding_reverify.rs
+++ b/tests/forward_binding_reverify.rs
@@ -1,0 +1,355 @@
+//! Pins the channel-binding reverify/retry loop in
+//! `AciService::forward_with_binding_reverify` and its invalidate-vs-not policy
+//! at the two public entry points (`forward_chat_completion_request` and
+//! `forward_chat_completion_for_middleware`).
+//!
+//! `CHANNEL_BINDING_REVERIFY_ATTEMPTS == 2`, so a gateway-owned event that keeps
+//! mismatching does: 1 initial verify + 2 reverify rounds, each round
+//! invalidating-then-verifying, then a terminal invalidate.
+
+mod common;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use private_ai_gateway::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
+use private_ai_gateway::aci::upstream::{
+    PreparedUpstreamRequest, UpstreamBackend, UpstreamError, UpstreamRequest, UpstreamResponse,
+    UpstreamStreamResponse,
+};
+use private_ai_gateway::aggregator::service::{
+    AciService, AciServiceConfig, ChatCompletionRequest, FixedClock, ForwardCandidate,
+    GatewayRequestContext, InMemoryReceiptStore, MiddlewareReceiptJournal,
+    UpstreamVerificationRequest, UpstreamVerifier,
+};
+
+use common::{StaticKeyProvider, StubQuoter};
+
+const UPSTREAM_NAME: &str = "mismatch-upstream";
+const UPSTREAM_ORIGIN: &str = "https://mismatch-upstream.example";
+const CHAT_BODY: &[u8] = br#"{"model":"model-a","messages":[]}"#;
+
+/// Recording `UpstreamVerifier`.
+///
+/// `verify` returns a canned *passing* event (so the flow reaches the forward
+/// step) and bumps `verify_calls`. `invalidate` bumps `invalidate_calls`.
+/// `refresh` is left as the trait default (invalidate-then-verify), so a single
+/// reverify round shows up as one bump on each counter.
+#[derive(Default)]
+struct RecordingVerifier {
+    verify_calls: AtomicUsize,
+    invalidate_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl UpstreamVerifier for RecordingVerifier {
+    async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        self.verify_calls.fetch_add(1, Ordering::SeqCst);
+        UpstreamVerifiedEvent {
+            upstream_name: request.upstream_name,
+            provider: None,
+            model_id: request.model_id,
+            url_origin: request.url_origin,
+            verifier_id: "recording-verifier/v1".to_string(),
+            result: VerificationResult::Verified,
+            required: request.required,
+            reason: None,
+            evidence: None,
+            // No channel bindings: the canned event itself never makes the
+            // backend's default fail-closed guard fire; the mock backend below
+            // raises the mismatch deterministically instead.
+            channel_bindings: Vec::new(),
+            provider_claims: None,
+        }
+    }
+
+    fn invalidate(&self, _request: &UpstreamVerificationRequest) {
+        self.invalidate_calls.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl RecordingVerifier {
+    fn verify_calls(&self) -> usize {
+        self.verify_calls.load(Ordering::SeqCst)
+    }
+
+    fn invalidate_calls(&self) -> usize {
+        self.invalidate_calls.load(Ordering::SeqCst)
+    }
+}
+
+/// Mock `UpstreamBackend` that returns `ChannelBindingMismatch` for the first
+/// `mismatches_remaining` verified-forward calls, then succeeds.
+///
+/// `usize::MAX` means "always mismatch". The same counter governs the buffered
+/// and streaming verified-forward entry points.
+struct MismatchingBackend {
+    mismatches_remaining: AtomicUsize,
+}
+
+impl MismatchingBackend {
+    fn always_mismatch() -> Self {
+        Self {
+            mismatches_remaining: AtomicUsize::new(usize::MAX),
+        }
+    }
+
+    fn mismatch_times(n: usize) -> Self {
+        Self {
+            mismatches_remaining: AtomicUsize::new(n),
+        }
+    }
+
+    /// Consume one "mismatch budget" unit; returns true while the budget lasts.
+    fn take_mismatch(&self) -> bool {
+        loop {
+            let current = self.mismatches_remaining.load(Ordering::SeqCst);
+            if current == 0 {
+                return false;
+            }
+            // Saturate at MAX so "always mismatch" never decrements to success.
+            let next = if current == usize::MAX {
+                usize::MAX
+            } else {
+                current - 1
+            };
+            if self
+                .mismatches_remaining
+                .compare_exchange(current, next, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    fn ok_response() -> UpstreamResponse {
+        UpstreamResponse {
+            status_code: 200,
+            body: br#"{"id":"chat-ok","object":"chat.completion","model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}"#.to_vec(),
+            headers: std::collections::HashMap::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl UpstreamBackend for MismatchingBackend {
+    fn name(&self) -> &str {
+        UPSTREAM_NAME
+    }
+
+    fn url_origin(&self) -> Option<&str> {
+        Some(UPSTREAM_ORIGIN)
+    }
+
+    // Default `prepare` derives `model_id` from the request body and copies the
+    // backend `name`/`url_origin`, so `recorded_upstream_event` and the
+    // verification request build consistently against this backend.
+
+    async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        Ok(Self::ok_response())
+    }
+
+    async fn forward_verified_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+        _event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        if self.take_mismatch() {
+            return Err(UpstreamError::ChannelBindingMismatch(
+                "mock channel binding mismatch".to_string(),
+            ));
+        }
+        Ok(Self::ok_response())
+    }
+
+    async fn forward_stream_verified_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+        _event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        if self.take_mismatch() {
+            return Err(UpstreamError::ChannelBindingMismatch(
+                "mock channel binding mismatch".to_string(),
+            ));
+        }
+        let response = Self::ok_response();
+        let body = bytes::Bytes::from(response.body);
+        Ok(UpstreamStreamResponse {
+            status_code: response.status_code,
+            headers: response.headers,
+            body: Box::pin(futures_util::stream::once(async move { Ok(body) })),
+        })
+    }
+}
+
+fn build_service(
+    backend: Arc<MismatchingBackend>,
+    verifier: Arc<RecordingVerifier>,
+) -> Arc<AciService> {
+    Arc::new(
+        AciService::new_with_upstream_verifier(
+            Arc::new(StaticKeyProvider::default()),
+            Arc::new(StubQuoter::default()),
+            backend,
+            verifier,
+            Arc::new(InMemoryReceiptStore::default()),
+            AciServiceConfig::for_test("forward-binding-reverify-test"),
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap(),
+    )
+}
+
+/// Canned passing event the caller "owns" — mirrors what the recording verifier
+/// would have produced, so the fail-closed gate (upstream_required defaults to
+/// true) is satisfied and the flow reaches the forward step.
+fn caller_event() -> UpstreamVerifiedEvent {
+    UpstreamVerifiedEvent {
+        upstream_name: UPSTREAM_NAME.to_string(),
+        provider: None,
+        model_id: "model-a".to_string(),
+        url_origin: Some(UPSTREAM_ORIGIN.to_string()),
+        verifier_id: "caller-supplied/v1".to_string(),
+        result: VerificationResult::Verified,
+        required: true,
+        reason: None,
+        evidence: None,
+        channel_bindings: Vec::new(),
+        provider_claims: None,
+    }
+}
+
+fn forward_request(
+    upstream_verification_event: Option<UpstreamVerifiedEvent>,
+) -> ChatCompletionRequest<'static> {
+    ChatCompletionRequest {
+        context: GatewayRequestContext::default(),
+        endpoint_path: "/v1/chat/completions",
+        received_body: CHAT_BODY,
+        forwarded_body: None,
+        upstream_required: Some(true),
+        upstream_verification_event,
+        requester: None,
+        e2ee: None,
+    }
+}
+
+// Test 1: single forward, caller-supplied event, backend always mismatches.
+// Caller-supplied suppresses reverify entirely (no verify, no refresh) and the
+// single-forward path never flushes an event it does not own.
+#[tokio::test]
+async fn forward_caller_supplied_always_mismatch_no_verify_no_invalidate() {
+    let backend = Arc::new(MismatchingBackend::always_mismatch());
+    let verifier = Arc::new(RecordingVerifier::default());
+    let service = build_service(backend, verifier.clone());
+
+    let result = service
+        .forward_chat_completion_request(forward_request(Some(caller_event())))
+        .await;
+
+    assert!(result.is_err(), "always-mismatch forward must fail");
+    assert_eq!(
+        verifier.verify_calls(),
+        0,
+        "caller-supplied event suppresses verify and reverify"
+    );
+    assert_eq!(
+        verifier.invalidate_calls(),
+        0,
+        "single forward must not flush an event it does not own"
+    );
+}
+
+// Test 2: single forward, gateway-owned event, backend always mismatches.
+// The loop reverifies CHANNEL_BINDING_REVERIFY_ATTEMPTS (2) times, then flushes
+// on the terminal mismatch because the gateway owns the event.
+//   verify_calls     = 1 initial + 2 reverify rounds            = 3
+//   invalidate_calls = 2 reverify rounds + 1 terminal flush     = 3
+#[tokio::test]
+async fn forward_gateway_owned_always_mismatch_reverifies_then_flushes() {
+    let backend = Arc::new(MismatchingBackend::always_mismatch());
+    let verifier = Arc::new(RecordingVerifier::default());
+    let service = build_service(backend, verifier.clone());
+
+    let result = service
+        .forward_chat_completion_request(forward_request(None))
+        .await;
+
+    assert!(result.is_err(), "always-mismatch forward must fail");
+    assert_eq!(
+        verifier.verify_calls(),
+        3,
+        "1 initial verify + 2 reverify rounds"
+    );
+    assert!(
+        verifier.verify_calls() > 1,
+        "retries must have happened (reverify loop ran)"
+    );
+    assert_eq!(
+        verifier.invalidate_calls(),
+        3,
+        "2 reverify-round invalidations + 1 terminal flush"
+    );
+    assert!(
+        verifier.invalidate_calls() >= 1,
+        "terminal mismatch must flush the gateway-owned cached event"
+    );
+}
+
+// Test 3: single forward, gateway-owned event, mismatch once then OK (N=1).
+// Exactly one reverify round happens, then the retry succeeds.
+//   verify_calls = 1 initial + 1 reverify round = 2
+#[tokio::test]
+async fn forward_gateway_owned_mismatch_once_then_ok() {
+    let backend = Arc::new(MismatchingBackend::mismatch_times(1));
+    let verifier = Arc::new(RecordingVerifier::default());
+    let service = build_service(backend, verifier.clone());
+
+    let result = service
+        .forward_chat_completion_request(forward_request(None))
+        .await;
+
+    assert!(result.is_ok(), "second attempt should succeed");
+    assert_eq!(
+        verifier.verify_calls(),
+        2,
+        "1 initial verify + exactly 1 reverify round"
+    );
+}
+
+// Test 4 (security-relevant): middleware path, single candidate, caller-supplied
+// event, backend always mismatches. The single candidate is exhausted (Err),
+// and the failover path's `always_invalidate_on_mismatch = true` flushes the
+// possibly-stale binding even though the event was caller-supplied.
+#[tokio::test]
+async fn middleware_single_candidate_caller_supplied_always_mismatch_flushes() {
+    let backend = Arc::new(MismatchingBackend::always_mismatch());
+    let verifier = Arc::new(RecordingVerifier::default());
+    let service = build_service(backend, verifier.clone());
+
+    let candidates = vec![ForwardCandidate {
+        route_id: "route-a".to_string(),
+        body: CHAT_BODY.to_vec(),
+    }];
+    let journal = MiddlewareReceiptJournal::default();
+
+    let result = service
+        .forward_chat_completion_for_middleware(
+            forward_request(Some(caller_event())),
+            candidates,
+            false,
+            journal,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "single candidate that always mismatches must be exhausted into an error"
+    );
+    assert!(
+        verifier.invalidate_calls() >= 1,
+        "middleware path must flush a possibly-stale binding even for a caller-supplied event"
+    );
+}


### PR DESCRIPTION
Slice of #7. The retry-on-`ChannelBindingMismatch` loop (forward → refresh cached event → retry up to N → invalidate on terminal mismatch) was copy-pasted across all four forward paths: buffered + streaming single (`forward.rs`) and buffered + streaming candidate (`middleware.rs`). Factor it into one async helper, `forward_with_binding_reverify`.

**Behavior is preserved exactly** (this revision walks back the normalization the first version snuck in). The one spot the four copies had drifted — whether to flush the verifier cache on a *terminal* mismatch for a **caller-supplied** event — is now an explicit `always_invalidate_on_mismatch` parameter:
- single-forward paths pass `false` → flush only an event the gateway owns;
- failover/middleware paths pass `true` → flush a possibly-stale binding on any terminal mismatch.

Each matches its prior behavior, so middleware keeps its conservative "flush a stale binding" default.

**Tests:** adds `tests/forward_binding_reverify.rs` (4 cases) pinning the reverify/exhaustion arms and the invalidate-vs-not policy at both public entry points — this loop was previously untested. The middleware-flush test was verified to **fail** if the flush is dropped (flag flipped to `false`), so it actually guards the behavior.

Addresses the review on the first revision: restore middleware invalidate (now tested), collapse the outcome enum (callers no longer split `BindingExhausted | Failed`), and own the documented per-attempt clone.

Independent of the other #7 slices; no overlap with main.