### PR TITLE
Address #7: Default for UpstreamVerifiedEvent + reduce literals

### DIFF
--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -43,7 +43,13 @@ pub enum ReceiptError {
 }
 
 /// An aggregator verifier event suitable for `upstream.verified`.
-#[derive(Debug, Clone)]
+///
+/// `Default` is provided so constructions can set only the fields they care
+/// about and `..Default::default()` the rest — adding a field then doesn't
+/// ripple across every call site. The default `result` is fail-closed
+/// ([`VerificationResult::Failed`]), so an event is never accidentally
+/// "verified" by omission.
+#[derive(Debug, Clone, Default)]
 pub struct UpstreamVerifiedEvent {
     /// The operator's per-endpoint upstream config `name` (e.g.
     /// "tinfoil-glm51") — a label chosen by whoever wrote the config.
@@ -65,9 +71,11 @@ pub struct UpstreamVerifiedEvent {
     pub provider_claims: Option<Value>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VerificationResult {
     Verified,
+    /// Fail-closed default: an event with no explicit result is not "verified".
+    #[default]
     Failed,
 }
 

--- a/src/aci/verifier/dcap.rs
+++ b/src/aci/verifier/dcap.rs
@@ -163,16 +163,14 @@ impl CachedAciDcapVerification {
     ) -> UpstreamVerifiedEvent {
         UpstreamVerifiedEvent {
             upstream_name: self.vendor.clone(),
-            provider: None,
             model_id: request.model_id,
             url_origin: request.url_origin,
             verifier_id: verifier_id.to_string(),
             result: VerificationResult::Verified,
             required: request.required,
-            reason: None,
             evidence: self.evidence.clone(),
             channel_bindings: self.channel_bindings.clone(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 }
@@ -415,16 +413,13 @@ impl UpstreamVerifier for AciDcapUpstreamVerifier {
             }
             Err(err) => UpstreamVerifiedEvent {
                 upstream_name: request.upstream_name,
-                provider: None,
                 model_id: request.model_id,
                 url_origin: request.url_origin,
                 verifier_id: self.verifier_id.clone(),
                 result: VerificationResult::Failed,
                 required: request.required,
                 reason: Some(err.to_string()),
-                evidence: None,
-                channel_bindings: Vec::new(),
-                provider_claims: None,
+                ..Default::default()
             },
         }
     }

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -374,9 +374,7 @@ impl ExternalProviderVerifier {
             result: VerificationResult::Failed,
             required: request.required,
             reason: Some(reason.into()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 }

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -331,16 +331,13 @@ impl UpstreamVerifier for RoutingUpstreamVerifier {
         }
         UpstreamVerifiedEvent {
             upstream_name: request.upstream_name,
-            provider: None,
             model_id: request.model_id,
             url_origin: request.url_origin,
             verifier_id: "routing-upstream-verifier/v1".to_string(),
             result: VerificationResult::Failed,
             required: request.required,
             reason: Some("no verifier configured for selected upstream".to_string()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 
@@ -355,16 +352,13 @@ impl UpstreamVerifier for RoutingUpstreamVerifier {
         }
         UpstreamVerifiedEvent {
             upstream_name: request.upstream_name,
-            provider: None,
             model_id: request.model_id,
             url_origin: request.url_origin,
             verifier_id: "routing-upstream-verifier/v1".to_string(),
             result: VerificationResult::Failed,
             required: request.required,
             reason: Some("no verifier configured for selected upstream".to_string()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 

--- a/src/aci/verifier/simple.rs
+++ b/src/aci/verifier/simple.rs
@@ -23,16 +23,11 @@ impl StaticUpstreamVerifier {
     pub fn verified(verifier_id: impl Into<String>) -> Self {
         Self::new(UpstreamVerifiedEvent {
             upstream_name: String::new(),
-            provider: None,
             model_id: String::new(),
-            url_origin: None,
             verifier_id: verifier_id.into(),
             result: VerificationResult::Verified,
             required: true,
-            reason: None,
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         })
     }
 
@@ -40,16 +35,12 @@ impl StaticUpstreamVerifier {
     pub fn failed(verifier_id: impl Into<String>, reason: impl Into<String>) -> Self {
         Self::new(UpstreamVerifiedEvent {
             upstream_name: String::new(),
-            provider: None,
             model_id: String::new(),
-            url_origin: None,
             verifier_id: verifier_id.into(),
             result: VerificationResult::Failed,
             required: true,
             reason: Some(reason.into()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         })
     }
 }
@@ -98,16 +89,12 @@ impl UpstreamVerifier for PreverifiedUpstreamVerifier {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
         UpstreamVerifiedEvent {
             upstream_name: request.upstream_name,
-            provider: None,
             model_id: request.model_id,
             url_origin: request.url_origin,
             verifier_id: self.verifier_id.clone(),
             result: VerificationResult::Verified,
             required: request.required,
-            reason: None,
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 }

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -249,13 +249,12 @@ mod claim_mapping_tests {
             verifier_id: "vid/v1".to_string(),
             result,
             required: true,
-            reason: None,
-            evidence: None,
             channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
                 origin: "https://up".to_string(),
                 spki_sha256: "aa".repeat(32),
             }],
             provider_claims,
+            ..Default::default()
         }
     }
 

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -357,16 +357,13 @@ impl AciService {
         let missing_verifier_result = upstream_verification_event.is_none();
         let event = upstream_verification_event.unwrap_or_else(|| UpstreamVerifiedEvent {
             upstream_name: prepared.upstream_name.clone(),
-            provider: None,
             model_id: prepared.model_id.clone(),
             url_origin: prepared.url_origin.clone(),
             verifier_id: "none".to_string(),
             result: VerificationResult::Failed,
             required: upstream_required,
             reason: Some("no upstream verifier configured".to_string()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         });
         self.metrics.record_upstream_verification(&event);
 

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -150,16 +150,13 @@ impl UpstreamVerifier for DynamicUpstreamVerifier {
             Some(verifier) => verifier.verify(request).await,
             None => UpstreamVerifiedEvent {
                 upstream_name: request.upstream_name,
-                provider: None,
                 model_id: request.model_id,
                 url_origin: request.url_origin,
                 verifier_id: "none".to_string(),
                 result: VerificationResult::Failed,
                 required: request.required,
                 reason: Some("no upstream verifier configured".to_string()),
-                evidence: None,
-                channel_bindings: Vec::new(),
-                provider_claims: None,
+                ..Default::default()
             },
         }
     }
@@ -175,16 +172,13 @@ impl UpstreamVerifier for DynamicUpstreamVerifier {
             Some(verifier) => verifier.refresh(request).await,
             None => UpstreamVerifiedEvent {
                 upstream_name: request.upstream_name,
-                provider: None,
                 model_id: request.model_id,
                 url_origin: request.url_origin,
                 verifier_id: "none".to_string(),
                 result: VerificationResult::Failed,
                 required: request.required,
                 reason: Some("no upstream verifier configured".to_string()),
-                evidence: None,
-                channel_bindings: Vec::new(),
-                provider_claims: None,
+                ..Default::default()
             },
         }
     }

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -46,16 +46,12 @@ impl UpstreamVerifier for CountingVerifier {
         self.verifications.fetch_add(1, Ordering::SeqCst);
         UpstreamVerifiedEvent {
             upstream_name: request.upstream_name,
-            provider: None,
             model_id: request.model_id,
             url_origin: request.url_origin,
             verifier_id: "counting-verifier/v1".to_string(),
             result: VerificationResult::Verified,
             required: request.required,
-            reason: None,
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..Default::default()
         }
     }
 

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -41,7 +41,7 @@ use private_ai_gateway::http::build_router;
 use serde_json::Value;
 use tower::ServiceExt;
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{event_from_request, verified_event, StaticKeyProvider, StubQuoter};
 
 const CHAT_REQUEST: &[u8] =
     br#"{"model":"aci-model","messages":[{"role":"user","content":"hello"}]}"#;
@@ -201,20 +201,12 @@ struct AlwaysVerified;
 impl UpstreamVerifier for AlwaysVerified {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
         UpstreamVerifiedEvent {
-            upstream_name: request.upstream_name,
-            provider: None,
-            model_id: request.model_id,
-            url_origin: request.url_origin,
             verifier_id: "surface-verifier/v1".to_string(),
-            result: VerificationResult::Verified,
-            required: request.required,
-            reason: None,
             evidence: Some(serde_json::json!({
                 "digest": format!("sha256:{}", "11".repeat(32)),
                 "data": "data:application/json;base64,eyJmaXh0dXJlIjoic3VyZmFjZS1ldmlkZW5jZSJ9",
             })),
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..event_from_request(&request, VerificationResult::Verified)
         }
     }
 }
@@ -657,20 +649,13 @@ async fn request_rewrite_is_recorded_by_hash_without_retaining_the_body() {
             forwarded_body: Some(forwarded.to_vec()),
             upstream_required: Some(true),
             upstream_verification_event: Some(UpstreamVerifiedEvent {
-                upstream_name: "surface-upstream".to_string(),
-                provider: None,
-                model_id: "private-upstream".to_string(),
                 url_origin: Some("https://surface-upstream.example".to_string()),
                 verifier_id: "surface-verifier/v1".to_string(),
-                result: VerificationResult::Verified,
-                required: true,
-                reason: None,
                 evidence: Some(serde_json::json!({
                     "digest": format!("sha256:{}", "11".repeat(32)),
                     "data": "data:application/json;base64,eyJmaXh0dXJlIjoic3VyZmFjZS1ldmlkZW5jZSJ9",
                 })),
-                channel_bindings: Vec::new(),
-                provider_claims: None,
+                ..verified_event("surface-upstream", "private-upstream")
             }),
             requester: Some(ReceiptOwner::from_bearer("requester-a")),
             e2ee: None,

--- a/tests/aggregator_scenarios.rs
+++ b/tests/aggregator_scenarios.rs
@@ -54,7 +54,7 @@ use serde_json::Value;
 use tokio::sync::Notify;
 use tower::ServiceExt;
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{event_from_request, verified_event, StaticKeyProvider, StubQuoter};
 
 const CHAT_REQUEST: &[u8] =
     br#"{"model":"gpt-test","messages":[{"role":"user","content":"hello"}],"temperature":0}"#;
@@ -185,17 +185,10 @@ impl UpstreamVerifier for ScriptedVerifier {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
         self.calls.lock().unwrap().push(request.clone());
         UpstreamVerifiedEvent {
-            upstream_name: request.upstream_name,
-            provider: None,
-            model_id: request.model_id,
-            url_origin: request.url_origin,
             verifier_id: "mock-verifier/v1".to_string(),
-            result: self.result,
-            required: request.required,
             reason: self.reason.clone(),
             evidence: self.evidence.clone(),
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..event_from_request(&request, self.result)
         }
     }
 }
@@ -1553,20 +1546,13 @@ async fn request_rewrite_receipt_distinguishes_received_and_forwarded_bytes() {
     let received = br#"{"model":"public-name","messages":[]}"#;
     let forwarded = br#"{"model":"private-upstream-name","messages":[]}"#;
     let verifier_event = UpstreamVerifiedEvent {
-        upstream_name: "mock-upstream".to_string(),
-        provider: None,
-        model_id: "private-upstream-name".to_string(),
         url_origin: Some("https://mock-upstream.example".to_string()),
         verifier_id: "mock-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(serde_json::json!({
             "digest": format!("sha256:{}", "cd".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJpdmF0ZS11cHN0cmVhbS1uYW1lIn0=",
         })),
-        channel_bindings: Vec::new(),
-        provider_claims: None,
+        ..verified_event("mock-upstream", "private-upstream-name")
     };
 
     let result = service
@@ -1933,22 +1919,15 @@ struct KeyedVerifier {
 impl UpstreamVerifier for KeyedVerifier {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
         let verified = request.upstream_name != self.fail_for;
+        let result = if verified {
+            VerificationResult::Verified
+        } else {
+            VerificationResult::Failed
+        };
         UpstreamVerifiedEvent {
-            upstream_name: request.upstream_name.clone(),
-            provider: None,
-            model_id: request.model_id,
-            url_origin: request.url_origin,
             verifier_id: "keyed-verifier/v1".to_string(),
-            result: if verified {
-                VerificationResult::Verified
-            } else {
-                VerificationResult::Failed
-            },
-            required: request.required,
             reason: (!verified).then(|| "verification failed".to_string()),
-            evidence: None,
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..event_from_request(&request, result)
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,51 @@ use private_ai_gateway::aci::keys::{
     ethereum_address_from_uncompressed_public_key, KeyError, KeyProvider, LegacySignature, Quote,
     Quoter, ALGO_ECDSA_SECP256K1, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
 };
+use private_ai_gateway::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
 use private_ai_gateway::aci::types::{KeyedPublicKey, PublicKeyMaterial, TlsSpki};
+use private_ai_gateway::aggregator::service::UpstreamVerificationRequest;
+
+/// A `verified` upstream event with only identity fields and the required flag
+/// set; everything else takes the struct default. Tests override individual
+/// fields with struct-update syntax (`..verified_event("x", "y")`).
+pub fn verified_event(upstream_name: &str, model_id: &str) -> UpstreamVerifiedEvent {
+    UpstreamVerifiedEvent {
+        upstream_name: upstream_name.to_string(),
+        model_id: model_id.to_string(),
+        result: VerificationResult::Verified,
+        required: true,
+        ..Default::default()
+    }
+}
+
+/// Like [`verified_event`] but fail-closed (`result: Failed`).
+pub fn failed_event(upstream_name: &str, model_id: &str) -> UpstreamVerifiedEvent {
+    UpstreamVerifiedEvent {
+        upstream_name: upstream_name.to_string(),
+        model_id: model_id.to_string(),
+        result: VerificationResult::Failed,
+        required: true,
+        ..Default::default()
+    }
+}
+
+/// Builds an event the way a mock `UpstreamVerifier` does: copying
+/// `upstream_name` / `model_id` / `url_origin` / `required` straight off the
+/// request, with the given `result`. The caller fills `verifier_id` and any
+/// `reason` / `evidence` via struct-update syntax.
+pub fn event_from_request(
+    request: &UpstreamVerificationRequest,
+    result: VerificationResult,
+) -> UpstreamVerifiedEvent {
+    UpstreamVerifiedEvent {
+        upstream_name: request.upstream_name.clone(),
+        model_id: request.model_id.clone(),
+        url_origin: request.url_origin.clone(),
+        required: request.required,
+        result,
+        ..Default::default()
+    }
+}
 
 pub struct StaticKeyProvider {
     identity: K256SigningKey,

--- a/tests/forward_binding_reverify.rs
+++ b/tests/forward_binding_reverify.rs
@@ -24,7 +24,7 @@ use private_ai_gateway::aggregator::service::{
     UpstreamVerificationRequest, UpstreamVerifier,
 };
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{event_from_request, verified_event, StaticKeyProvider, StubQuoter};
 
 const UPSTREAM_NAME: &str = "mismatch-upstream";
 const UPSTREAM_ORIGIN: &str = "https://mismatch-upstream.example";
@@ -46,21 +46,12 @@ struct RecordingVerifier {
 impl UpstreamVerifier for RecordingVerifier {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
         self.verify_calls.fetch_add(1, Ordering::SeqCst);
+        // No channel bindings (left at default): the canned event itself never
+        // makes the backend's default fail-closed guard fire; the mock backend
+        // below raises the mismatch deterministically instead.
         UpstreamVerifiedEvent {
-            upstream_name: request.upstream_name,
-            provider: None,
-            model_id: request.model_id,
-            url_origin: request.url_origin,
             verifier_id: "recording-verifier/v1".to_string(),
-            result: VerificationResult::Verified,
-            required: request.required,
-            reason: None,
-            evidence: None,
-            // No channel bindings: the canned event itself never makes the
-            // backend's default fail-closed guard fire; the mock backend below
-            // raises the mismatch deterministically instead.
-            channel_bindings: Vec::new(),
-            provider_claims: None,
+            ..event_from_request(&request, VerificationResult::Verified)
         }
     }
 
@@ -207,17 +198,9 @@ fn build_service(
 /// true) is satisfied and the flow reaches the forward step.
 fn caller_event() -> UpstreamVerifiedEvent {
     UpstreamVerifiedEvent {
-        upstream_name: UPSTREAM_NAME.to_string(),
-        provider: None,
-        model_id: "model-a".to_string(),
         url_origin: Some(UPSTREAM_ORIGIN.to_string()),
         verifier_id: "caller-supplied/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
-        channel_bindings: Vec::new(),
-        provider_claims: None,
+        ..verified_event(UPSTREAM_NAME, "model-a")
     }
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use private_ai_gateway::aci::keys::{verify_receipt_signature, KeyProvider};
 use private_ai_gateway::aci::receipt::{
-    canonical_bytes_for_signing, ChannelBinding, UpstreamVerifiedEvent, VerificationResult,
+    canonical_bytes_for_signing, ChannelBinding, UpstreamVerifiedEvent,
 };
 use private_ai_gateway::aci::types::{Receipt, ServiceCapabilities, TlsSpki};
 use private_ai_gateway::aci::upstream::{
@@ -26,7 +26,7 @@ use private_ai_gateway::aggregator::service::{
 use private_ai_gateway::http::build_router;
 use tower::ServiceExt;
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{verified_event, StaticKeyProvider, StubQuoter};
 
 const RESPONSE_BODY: &[u8] = br#"{"id":"chat-xyz","object":"chat.completion"}"#;
 
@@ -396,14 +396,8 @@ async fn chat_x_request_hash_is_ignored() {
 async fn attested_session_lookup_returns_audit_record() {
     let h = make_harness();
     let event = UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("https://stub-upstream".to_string()),
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(serde_json::json!({
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoic3R1Yi11cHN0cmVhbS1hdHRlc3RhdGlvbiJ9",
@@ -412,7 +406,7 @@ async fn attested_session_lookup_returns_audit_record() {
             origin: "https://stub-upstream".to_string(),
             spki_sha256: "aa".repeat(32),
         }],
-        provider_claims: None,
+        ..verified_event("stub-upstream", "x")
     };
     let result = h
         .service

--- a/tests/provider_e2e.rs
+++ b/tests/provider_e2e.rs
@@ -35,8 +35,7 @@ use ml_kem::{
 };
 use private_ai_gateway::aci::canonical::sha256_hex;
 use private_ai_gateway::aci::receipt::{
-    ChannelBinding, UpstreamVerifiedEvent, VerificationResult, EVENT_REQUEST_FORWARDED,
-    EVENT_UPSTREAM_VERIFIED,
+    ChannelBinding, UpstreamVerifiedEvent, EVENT_REQUEST_FORWARDED, EVENT_UPSTREAM_VERIFIED,
 };
 use private_ai_gateway::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
@@ -56,7 +55,7 @@ use serde_json::{json, Value};
 use sha2::Digest;
 use tower::ServiceExt;
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{verified_event, StaticKeyProvider, StubQuoter};
 
 const CHAT_REQUEST: &[u8] =
     br#"{"model":"public-model","messages":[{"role":"user","content":"hello"}]}"#;
@@ -839,20 +838,14 @@ async fn dynamic_runtime_config_delegates_verified_forwarding_to_selected_backen
         })
         .unwrap();
     let event = UpstreamVerifiedEvent {
-        upstream_name: "openai-compatible-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url.clone()),
         verifier_id: "fixture-spki-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("attestation")),
         channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
             origin: base_url,
             spki_sha256: "aa".repeat(32),
         }],
-        provider_claims: None,
+        ..verified_event("openai-compatible-provider", "provider-model")
     };
 
     let err = backend
@@ -876,14 +869,8 @@ async fn openai_compatible_provider_refuses_unenforceable_tls_binding() {
         .unwrap()
         .with_name("openai-compatible-provider");
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "openai-compatible-provider".to_string(),
-        provider: None,
-        model_id: "public-model".to_string(),
         url_origin: Some(base_url.clone()),
         verifier_id: "fixture-spki-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("attestation")),
         channel_bindings: vec![
             private_ai_gateway::aci::receipt::ChannelBinding::TlsSpkiSha256 {
@@ -891,7 +878,7 @@ async fn openai_compatible_provider_refuses_unenforceable_tls_binding() {
                 spki_sha256: "aa".repeat(32),
             },
         ],
-        provider_claims: None,
+        ..verified_event("openai-compatible-provider", "public-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -928,17 +915,11 @@ async fn chutes_provider_uses_e2ee_transport_for_buffered_requests() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(&e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -995,17 +976,11 @@ async fn chutes_provider_requires_exact_catalog_match() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1051,17 +1026,11 @@ async fn chutes_provider_uses_configured_chute_id_pin() {
             CHUTES_CHUTE_ID.to_string(),
         )]));
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1100,17 +1069,11 @@ async fn chutes_provider_pools_verified_single_use_nonces() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(&e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1187,17 +1150,11 @@ async fn chutes_provider_consumes_verifier_prewarmed_nonce_pool() {
         .with_e2ee_api_base(base_url.clone())
         .with_session_store(store);
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(&e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1243,17 +1200,11 @@ async fn chutes_provider_refreshes_verified_nonce_pool_without_forwarding() {
         .with_e2ee_api_base(base_url.clone())
         .with_session_store(store);
     let event = UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(&e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     };
 
     let refreshed = backend
@@ -1313,14 +1264,8 @@ async fn chutes_provider_interleaves_nonces_across_verified_instances() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![
             chutes_key_binding_for(
@@ -1332,7 +1277,7 @@ async fn chutes_provider_interleaves_nonces_across_verified_instances() {
                 e2e_pubkeys.get(CHUTES_INSTANCE_ID_B).unwrap(),
             ),
         ],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1389,17 +1334,11 @@ async fn chutes_provider_decrypts_streaming_e2ee_response() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![chutes_key_binding(&e2e_pubkey)],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -1437,14 +1376,8 @@ async fn chutes_provider_refuses_unverified_e2ee_key() {
         .with_bearer_token("chutes-secret")
         .with_e2ee_api_base(base_url.clone());
     let verifier = StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
-        upstream_name: "chutes-provider".to_string(),
-        provider: None,
-        model_id: "provider-model".to_string(),
         url_origin: Some(base_url),
         verifier_id: "fixture-chutes-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(provider_evidence_fixture("chutes-attestation")),
         channel_bindings: vec![
             private_ai_gateway::aci::receipt::ChannelBinding::E2eePublicKeySha256 {
@@ -1454,7 +1387,7 @@ async fn chutes_provider_refuses_unverified_e2ee_key() {
                 public_key_sha256: "aa".repeat(32),
             },
         ],
-        provider_claims: None,
+        ..verified_event("chutes-provider", "provider-model")
     });
     let service = Arc::new(
         AciService::new_with_upstream_verifier(

--- a/tests/receipt.rs
+++ b/tests/receipt.rs
@@ -7,11 +7,10 @@ use private_ai_gateway::aci::canonical;
 use private_ai_gateway::aci::keys::{verify_receipt_signature, KeyProvider};
 use private_ai_gateway::aci::receipt::{
     canonical_bytes_for_signing, ChannelBinding, ReceiptBuilder, ReceiptError,
-    TransparencyEventKind, UpstreamVerifiedEvent, VerificationResult,
-    EVENT_TRANSPARENCY_REQUEST_MODIFIED,
+    TransparencyEventKind, UpstreamVerifiedEvent, EVENT_TRANSPARENCY_REQUEST_MODIFIED,
 };
 
-use common::StaticKeyProvider;
+use common::{verified_event, StaticKeyProvider};
 
 fn keys() -> StaticKeyProvider {
     StaticKeyProvider::default()
@@ -81,17 +80,9 @@ fn event_seqs_strictly_increasing_and_first_is_request_received() {
     b.add_request_received(b"a").unwrap();
     b.add_request_forwarded(b"a").unwrap();
     b.add_upstream_verified(UpstreamVerifiedEvent {
-        upstream_name: "openai-compatible".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("http://upstream".to_string()),
         verifier_id: "verifier-stub-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
-        channel_bindings: Vec::new(),
-        provider_claims: None,
+        ..verified_event("openai-compatible", "x")
     })
     .unwrap();
     b.add_response_returned(b"b", b"b").unwrap();
@@ -113,15 +104,8 @@ fn upstream_verified_event_records_channel_bindings() {
     b.add_request_received(b"a").unwrap();
     b.add_request_forwarded(b"a").unwrap();
     b.add_upstream_verified(UpstreamVerifiedEvent {
-        upstream_name: "openai-compatible".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("https://upstream.example".to_string()),
         verifier_id: "external/verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
         channel_bindings: vec![
             ChannelBinding::TlsSpkiSha256 {
                 origin: "https://upstream.example".to_string(),
@@ -142,6 +126,7 @@ fn upstream_verified_event_records_channel_bindings() {
             "trust_boundary": "fixture",
             "model_evidence_present": true,
         })),
+        ..verified_event("openai-compatible", "x")
     })
     .unwrap();
     b.add_response_returned(b"b", b"b").unwrap();

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 mod common;
 
 use async_trait::async_trait;
-use private_ai_gateway::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
+use private_ai_gateway::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent};
 use private_ai_gateway::aci::types::{ServiceCapabilities, SourceProvenance};
 use private_ai_gateway::aci::upstream::{
     PreparedUpstreamRequest, UpstreamBackend, UpstreamError, UpstreamRequest, UpstreamResponse,
@@ -18,7 +18,7 @@ use private_ai_gateway::aggregator::service::{
 use private_ai_gateway::aggregator::session::ClaimStatus;
 use private_ai_gateway::aggregator::upstream_config::UpstreamSessionSink;
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{failed_event, verified_event, StaticKeyProvider, StubQuoter};
 
 type ReceivedBody = Arc<Mutex<Option<Vec<u8>>>>;
 
@@ -170,17 +170,9 @@ async fn x_request_hash_header_value_does_not_enter_request_received_hash() {
 async fn verifier_event_result_verified_emits_upstream_verified() {
     let (svc, _) = make_service(br#"{"id":"chat-xyz"}"#, true);
     let event = UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("http://stub-upstream".to_string()),
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
-        channel_bindings: Vec::new(),
-        provider_claims: None,
+        ..verified_event("stub-upstream", "x")
     };
     let result = svc
         .forward_chat_completion(br#"{"model":"x","messages":[]}"#, None, None, Some(event))
@@ -206,14 +198,8 @@ async fn verifier_event_result_verified_emits_upstream_verified() {
 async fn verified_upstream_binding_creates_attested_session() {
     let (svc, _) = make_service(br#"{"id":"chat-xyz","model":"x"}"#, true);
     let event = UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("https://stub-upstream".to_string()),
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(serde_json::json!({
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoic3R1Yi11cHN0cmVhbS1hdHRlc3RhdGlvbiJ9",
@@ -226,6 +212,7 @@ async fn verified_upstream_binding_creates_attested_session() {
             "release": "fixture",
             "verified_claims": ["source-verified"]
         })),
+        ..verified_event("stub-upstream", "x")
     };
 
     let result = svc
@@ -293,20 +280,13 @@ async fn session_is_per_tee_channel_not_per_model() {
     // served is recorded on the receipt, never on the session.
     let (svc, _) = make_service(br#"{"id":"chat-xyz"}"#, true);
     let event = |model: &str| UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: model.to_string(),
         url_origin: Some("https://stub-upstream".to_string()),
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
         channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
             origin: "https://stub-upstream".to_string(),
             spki_sha256: "aa".repeat(32),
         }],
-        provider_claims: None,
+        ..verified_event("stub-upstream", model)
     };
     let session_id_of = |result: &private_ai_gateway::aggregator::service::ForwardResult| {
         result
@@ -351,14 +331,8 @@ async fn session_is_per_tee_channel_not_per_model() {
 async fn attested_session_id_changes_when_verification_material_changes() {
     let (svc, _) = make_service(br#"{"id":"chat-xyz","model":"x"}"#, true);
     let make_event = |digest_byte: &str| UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
         url_origin: Some("https://stub-upstream".to_string()),
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
         evidence: Some(serde_json::json!({
             "digest": format!("sha256:{}", digest_byte.repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoic3R1Yi11cHN0cmVhbS1hdHRlc3RhdGlvbiJ9",
@@ -370,6 +344,7 @@ async fn attested_session_id_changes_when_verification_material_changes() {
         provider_claims: Some(serde_json::json!({
             "release": "fixture",
         })),
+        ..verified_event("stub-upstream", "x")
     };
 
     let first = svc
@@ -431,17 +406,9 @@ async fn attested_session_id_changes_when_verification_material_changes() {
 async fn verifier_event_failed_with_required_fails_before_forwarding() {
     let (svc, received) = make_service(br#"{"id":"chat-xyz"}"#, true);
     let event = UpstreamVerifiedEvent {
-        upstream_name: "stub-upstream".to_string(),
-        provider: None,
-        model_id: "x".to_string(),
-        url_origin: None,
         verifier_id: "stub-verifier-1".to_string(),
-        result: VerificationResult::Failed,
-        required: true,
         reason: Some("quote did not match expected app-id".to_string()),
-        evidence: None,
-        channel_bindings: Vec::new(),
-        provider_claims: None,
+        ..failed_event("stub-upstream", "x")
     };
     let err = svc
         .forward_chat_completion(
@@ -552,20 +519,15 @@ async fn attestation_report_does_not_advertise_unwired_e2ee_by_default() {
 async fn background_verification_writes_inspectable_session_into_the_store() {
     let (service, _) = make_service(b"{}", true);
     let event = UpstreamVerifiedEvent {
-        upstream_name: "preflight-upstream".to_string(),
         provider: Some("tinfoil".to_string()),
-        model_id: "preflight-model".to_string(),
         url_origin: Some("https://preflight-upstream".to_string()),
         verifier_id: "preflight-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
         channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
             origin: "https://preflight-upstream".to_string(),
             spki_sha256: "bb".repeat(32),
         }],
         provider_claims: Some(serde_json::json!({ "tcb_status": "UpToDate" })),
+        ..verified_event("preflight-upstream", "preflight-model")
     };
 
     // Nothing verified yet — nothing to inspect.

--- a/tests/upstream_verifier.rs
+++ b/tests/upstream_verifier.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use private_ai_gateway::aci::receipt::{ChannelBinding, VerificationResult};
+use private_ai_gateway::aci::receipt::ChannelBinding;
 use private_ai_gateway::aci::upstream::{
     UpstreamBackend, UpstreamError, UpstreamRequest, UpstreamResponse,
 };
@@ -13,7 +13,7 @@ use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
 };
 
-use common::{StaticKeyProvider, StubQuoter};
+use common::{verified_event, StaticKeyProvider, StubQuoter};
 
 struct NoopUpstream;
 
@@ -107,20 +107,13 @@ async fn aci_report_binding_validation_rejects_bad_keyset_endorsement() {
 #[tokio::test]
 async fn service_fails_if_selected_backend_cannot_enforce_channel_binding() {
     let event = private_ai_gateway::aci::receipt::UpstreamVerifiedEvent {
-        upstream_name: "noop-upstream".to_string(),
-        provider: None,
-        model_id: "model-a".to_string(),
         url_origin: Some("https://noop-upstream.example".to_string()),
         verifier_id: "fixture-verifier/v1".to_string(),
-        result: VerificationResult::Verified,
-        required: true,
-        reason: None,
-        evidence: None,
         channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
             origin: "https://noop-upstream.example".to_string(),
             spki_sha256: "aa".repeat(32),
         }],
-        provider_claims: None,
+        ..verified_event("noop-upstream", "model-a")
     };
     let err = service()
         .forward_chat_completion(


### PR DESCRIPTION
Slice of #7. `UpstreamVerifiedEvent` had no `Default`, forcing 44 full struct literals across the verifier code and tests — a new field rippled to all of them.

- `UpstreamVerifiedEvent` and `VerificationResult` now `#[derive(Default)]`; the default `result` is fail-closed (`Failed`), so an event is never accidentally "verified" by omission.
- Tests use new `tests/common` helpers: `verified_event(name, model)` / `failed_event(name, model)` / `event_from_request(req, result)`.
- Production verifier constructions adopt `..Default::default()` but **drop only default-valued fields** (`provider`/`url_origin`/`reason`/`evidence`/`channel_bindings`/`provider_claims` when `None`/empty); `result` and every non-default field stay explicit. **Pure no-op** — no emitted event changes.

Net −174 lines; 226 tests pass, clippy + fmt clean. Every production-site change was reviewed for value-preservation.