### PR TITLE
Address #7: dedupe the two streaming receipt finalizers

### DIFF
--- a/src/aggregator/service/streaming.rs
+++ b/src/aggregator/service/streaming.rs
@@ -130,9 +130,11 @@ impl MiddlewareProviderResponseDraftingStream {
     }
 }
 
-pub(super) struct MiddlewareResponseFinalizingStream {
-    inner: ServiceResponseStream,
-    journal: MiddlewareReceiptJournal,
+/// State shared by the two streaming receipt finalizers. The streams differ
+/// only in their inner source (and its error type) and how the receipt is
+/// drafted; the hashing, SSE chat-id parsing, optional E2EE re-encryption, and
+/// the receipt-store/metrics plumbing are identical and live here.
+struct FinalizerShared {
     cleartext_hasher: Sha256,
     wire_hasher: Sha256,
     keys: Arc<dyn KeyProvider>,
@@ -145,9 +147,159 @@ pub(super) struct MiddlewareResponseFinalizingStream {
     endpoint_path: String,
     sse_parser: SseChatIdParser,
     e2ee_transformer: Option<E2eeSseTransformer>,
-    response_modified_by_wire: bool,
     upstream_ended: bool,
     finished: bool,
+}
+
+impl FinalizerShared {
+    fn new(
+        service: &AciService,
+        requester: Option<ReceiptOwner>,
+        endpoint_path: String,
+        e2ee_transformer: Option<E2eeSseTransformer>,
+    ) -> Self {
+        Self {
+            cleartext_hasher: Sha256::new(),
+            wire_hasher: Sha256::new(),
+            keys: service.keys.clone(),
+            receipt_store: service.receipt_store.clone(),
+            key_id: service.default_receipt_key_id.clone(),
+            requester,
+            receipt_ttl_seconds: service.config.receipt_ttl_seconds,
+            clock: service.clock.clone(),
+            metrics: service.metrics.clone(),
+            endpoint_path,
+            sse_parser: SseChatIdParser::default(),
+            e2ee_transformer,
+            upstream_ended: false,
+            finished: false,
+        }
+    }
+
+    /// `sha256:` hex digests of the cleartext and wire bytes seen so far.
+    fn hashes(&self) -> (String, String) {
+        (
+            format!(
+                "sha256:{}",
+                hex::encode(self.cleartext_hasher.clone().finalize())
+            ),
+            format!(
+                "sha256:{}",
+                hex::encode(self.wire_hasher.clone().finalize())
+            ),
+        )
+    }
+
+    /// Sign the receipt and store it under the configured retention window.
+    fn sign_and_store(&self, builder: ReceiptBuilder) -> Result<(), ServiceError> {
+        let receipt = builder.finalize(self.keys.as_ref(), &self.key_id)?;
+        let expires_at = self
+            .clock
+            .now_secs()
+            .saturating_add(self.receipt_ttl_seconds);
+        self.receipt_store
+            .put(receipt, self.requester.clone(), expires_at);
+        Ok(())
+    }
+}
+
+/// Per-stream behavior the shared [`poll_finalizing_stream`] loop needs: access
+/// to the shared state, how to pull the next inner chunk (mapping its error into
+/// [`ServiceError`]), and how to finalize the receipt at end of stream.
+trait FinalizingStream {
+    fn shared(&mut self) -> &mut FinalizerShared;
+    fn poll_inner(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, ServiceError>>>;
+    fn finalize_receipt(&mut self) -> Result<(), ServiceError>;
+}
+
+/// Drive a finalizing stream: hash each cleartext chunk, optionally re-encrypt
+/// it for E2EE while hashing the wire bytes, and on end of stream flush the E2EE
+/// tail then finalize the receipt. Shared by both finalizers, which vary only
+/// through the [`FinalizingStream`] trait.
+fn poll_finalizing_stream<F: FinalizingStream>(
+    f: &mut F,
+    cx: &mut Context<'_>,
+) -> Poll<Option<Result<Bytes, ServiceError>>> {
+    if f.shared().finished {
+        return Poll::Ready(None);
+    }
+
+    loop {
+        if f.shared().upstream_ended {
+            if let Some(mut transformer) = f.shared().e2ee_transformer.take() {
+                let wire = match transformer.finish() {
+                    Ok(wire) => wire,
+                    Err(err) => {
+                        let s = f.shared();
+                        s.metrics
+                            .record_stream_error(&s.endpoint_path, StreamErrorKind::E2ee);
+                        s.finished = true;
+                        return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
+                    }
+                };
+                if !wire.is_empty() {
+                    f.shared().wire_hasher.update(&wire);
+                    return Poll::Ready(Some(Ok(Bytes::from(wire))));
+                }
+            }
+            f.shared().finished = true;
+            return match f.finalize_receipt() {
+                Ok(()) => Poll::Ready(None),
+                Err(err) => {
+                    let s = f.shared();
+                    s.metrics
+                        .record_stream_error(&s.endpoint_path, StreamErrorKind::ReceiptFinalize);
+                    Poll::Ready(Some(Err(err)))
+                }
+            };
+        }
+
+        match f.poll_inner(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Some(Ok(chunk))) => {
+                let s = f.shared();
+                s.cleartext_hasher.update(&chunk);
+                s.sse_parser.observe(&chunk);
+
+                if let Some(transformer) = s.e2ee_transformer.as_mut() {
+                    let wire = match transformer.push_chunk(&chunk) {
+                        Ok(wire) => wire,
+                        Err(err) => {
+                            s.metrics
+                                .record_stream_error(&s.endpoint_path, StreamErrorKind::E2ee);
+                            s.finished = true;
+                            return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
+                        }
+                    };
+                    if wire.is_empty() {
+                        continue;
+                    }
+                    s.wire_hasher.update(&wire);
+                    return Poll::Ready(Some(Ok(Bytes::from(wire))));
+                }
+
+                s.wire_hasher.update(&chunk);
+                return Poll::Ready(Some(Ok(chunk)));
+            }
+            Poll::Ready(Some(Err(err))) => {
+                let s = f.shared();
+                s.metrics
+                    .record_stream_error(&s.endpoint_path, StreamErrorKind::UpstreamRead);
+                s.finished = true;
+                return Poll::Ready(Some(Err(err)));
+            }
+            Poll::Ready(None) => {
+                f.shared().upstream_ended = true;
+            }
+        }
+    }
+}
+
+pub(super) struct MiddlewareResponseFinalizingStream {
+    inner: ServiceResponseStream,
+    journal: MiddlewareReceiptJournal,
+    response_modified_by_wire: bool,
+    shared: FinalizerShared,
 }
 
 impl Unpin for MiddlewareResponseFinalizingStream {}
@@ -156,80 +308,47 @@ impl Stream for MiddlewareResponseFinalizingStream {
     type Item = Result<Bytes, ServiceError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        if this.finished {
-            return Poll::Ready(None);
+        poll_finalizing_stream(self.get_mut(), cx)
+    }
+}
+
+impl FinalizingStream for MiddlewareResponseFinalizingStream {
+    fn shared(&mut self) -> &mut FinalizerShared {
+        &mut self.shared
+    }
+
+    fn poll_inner(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, ServiceError>>> {
+        // The middleware response stream already yields `ServiceError`.
+        self.inner.as_mut().poll_next(cx)
+    }
+
+    fn finalize_receipt(&mut self) -> Result<(), ServiceError> {
+        let Some(mut draft) = self.journal.take() else {
+            return Ok(());
+        };
+        let (cleartext_hash, wire_hash) = self.shared.hashes();
+
+        if self.shared.sse_parser.chat_id.is_some() {
+            draft
+                .builder
+                .set_chat_id(self.shared.sse_parser.chat_id.clone());
         }
-
-        loop {
-            if this.upstream_ended {
-                if let Some(mut transformer) = this.e2ee_transformer.take() {
-                    let wire = match transformer.finish() {
-                        Ok(wire) => wire,
-                        Err(err) => {
-                            this.metrics
-                                .record_stream_error(&this.endpoint_path, StreamErrorKind::E2ee);
-                            this.finished = true;
-                            return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
-                        }
-                    };
-                    if !wire.is_empty() {
-                        this.wire_hasher.update(&wire);
-                        return Poll::Ready(Some(Ok(Bytes::from(wire))));
-                    }
-                }
-                this.finished = true;
-                return match this.finalize_receipt() {
-                    Ok(()) => Poll::Ready(None),
-                    Err(err) => {
-                        this.metrics.record_stream_error(
-                            &this.endpoint_path,
-                            StreamErrorKind::ReceiptFinalize,
-                        );
-                        Poll::Ready(Some(Err(err)))
-                    }
-                };
-            }
-
-            match this.inner.as_mut().poll_next(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Some(Ok(chunk))) => {
-                    this.cleartext_hasher.update(&chunk);
-                    this.sse_parser.observe(&chunk);
-
-                    if let Some(transformer) = this.e2ee_transformer.as_mut() {
-                        let wire = match transformer.push_chunk(&chunk) {
-                            Ok(wire) => wire,
-                            Err(err) => {
-                                this.metrics.record_stream_error(
-                                    &this.endpoint_path,
-                                    StreamErrorKind::E2ee,
-                                );
-                                this.finished = true;
-                                return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
-                            }
-                        };
-                        if wire.is_empty() {
-                            continue;
-                        }
-                        this.wire_hasher.update(&wire);
-                        return Poll::Ready(Some(Ok(Bytes::from(wire))));
-                    }
-
-                    this.wire_hasher.update(&chunk);
-                    return Poll::Ready(Some(Ok(chunk)));
-                }
-                Poll::Ready(Some(Err(err))) => {
-                    this.metrics
-                        .record_stream_error(&this.endpoint_path, StreamErrorKind::UpstreamRead);
-                    this.finished = true;
-                    return Poll::Ready(Some(Err(err)));
-                }
-                Poll::Ready(None) => {
-                    this.upstream_ended = true;
-                }
-            }
+        if draft.provider_response_hash != cleartext_hash || self.response_modified_by_wire {
+            draft
+                .builder
+                .add_transparency_event(TransparencyEventKind::ResponseModified)?;
         }
+        draft
+            .builder
+            .add_response_returned_hashes(cleartext_hash, wire_hash)?;
+        self.shared.sign_and_store(draft.builder)?;
+
+        self.shared.metrics.record_receipt_issued(
+            &draft.endpoint_path,
+            draft.request_mode,
+            draft.response_model.as_deref(),
+        );
+        Ok(())
     }
 }
 
@@ -246,82 +365,17 @@ impl MiddlewareResponseFinalizingStream {
         Self {
             inner,
             journal,
-            cleartext_hasher: Sha256::new(),
-            wire_hasher: Sha256::new(),
-            keys: service.keys.clone(),
-            receipt_store: service.receipt_store.clone(),
-            key_id: service.default_receipt_key_id.clone(),
-            requester,
-            receipt_ttl_seconds: service.config.receipt_ttl_seconds,
-            clock: service.clock.clone(),
-            metrics: service.metrics.clone(),
-            endpoint_path,
-            sse_parser: SseChatIdParser::default(),
-            e2ee_transformer,
             response_modified_by_wire,
-            upstream_ended: false,
-            finished: false,
+            shared: FinalizerShared::new(service, requester, endpoint_path, e2ee_transformer),
         }
-    }
-
-    fn finalize_receipt(&mut self) -> Result<(), ServiceError> {
-        let Some(mut draft) = self.journal.take() else {
-            return Ok(());
-        };
-        let cleartext_hash = format!(
-            "sha256:{}",
-            hex::encode(self.cleartext_hasher.clone().finalize())
-        );
-        let wire_hash = format!(
-            "sha256:{}",
-            hex::encode(self.wire_hasher.clone().finalize())
-        );
-
-        if self.sse_parser.chat_id.is_some() {
-            draft.builder.set_chat_id(self.sse_parser.chat_id.clone());
-        }
-        if draft.provider_response_hash != cleartext_hash || self.response_modified_by_wire {
-            draft
-                .builder
-                .add_transparency_event(TransparencyEventKind::ResponseModified)?;
-        }
-        draft
-            .builder
-            .add_response_returned_hashes(cleartext_hash, wire_hash)?;
-        let receipt = draft.builder.finalize(self.keys.as_ref(), &self.key_id)?;
-
-        let now = self.clock.now_secs();
-        let expires_at = now.saturating_add(self.receipt_ttl_seconds);
-        self.receipt_store
-            .put(receipt, self.requester.clone(), expires_at);
-
-        self.metrics.record_receipt_issued(
-            &draft.endpoint_path,
-            draft.request_mode,
-            draft.response_model.as_deref(),
-        );
-        Ok(())
     }
 }
 
 pub(super) struct ReceiptFinalizingStream {
     inner: UpstreamBodyStream,
     builder: Option<ReceiptBuilder>,
-    cleartext_hasher: Sha256,
-    wire_hasher: Sha256,
-    keys: Arc<dyn KeyProvider>,
-    receipt_store: Arc<dyn ReceiptStore>,
-    key_id: String,
-    requester: Option<ReceiptOwner>,
-    receipt_ttl_seconds: u64,
-    clock: Arc<dyn Clock>,
-    metrics: Arc<ServiceMetrics>,
-    endpoint_path: String,
-    sse_parser: SseChatIdParser,
-    e2ee_transformer: Option<E2eeSseTransformer>,
     response_modified: bool,
-    upstream_ended: bool,
-    finished: bool,
+    shared: FinalizerShared,
 }
 
 impl Unpin for ReceiptFinalizingStream {}
@@ -330,80 +384,49 @@ impl Stream for ReceiptFinalizingStream {
     type Item = Result<Bytes, ServiceError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        if this.finished {
-            return Poll::Ready(None);
+        poll_finalizing_stream(self.get_mut(), cx)
+    }
+}
+
+impl FinalizingStream for ReceiptFinalizingStream {
+    fn shared(&mut self) -> &mut FinalizerShared {
+        &mut self.shared
+    }
+
+    fn poll_inner(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, ServiceError>>> {
+        // The upstream body stream yields `UpstreamError`; lift it to `ServiceError`.
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Ok(chunk))) => Poll::Ready(Some(Ok(chunk))),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(ServiceError::Upstream(err)))),
         }
+    }
 
-        loop {
-            if this.upstream_ended {
-                if let Some(mut transformer) = this.e2ee_transformer.take() {
-                    let wire = match transformer.finish() {
-                        Ok(wire) => wire,
-                        Err(err) => {
-                            this.metrics
-                                .record_stream_error(&this.endpoint_path, StreamErrorKind::E2ee);
-                            this.finished = true;
-                            return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
-                        }
-                    };
-                    if !wire.is_empty() {
-                        this.wire_hasher.update(&wire);
-                        return Poll::Ready(Some(Ok(Bytes::from(wire))));
-                    }
-                }
-                this.finished = true;
-                return match this.finalize_receipt() {
-                    Ok(()) => Poll::Ready(None),
-                    Err(err) => {
-                        this.metrics.record_stream_error(
-                            &this.endpoint_path,
-                            StreamErrorKind::ReceiptFinalize,
-                        );
-                        Poll::Ready(Some(Err(err)))
-                    }
-                };
-            }
-
-            match this.inner.as_mut().poll_next(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Some(Ok(chunk))) => {
-                    this.cleartext_hasher.update(&chunk);
-                    this.sse_parser.observe(&chunk);
-
-                    if let Some(transformer) = this.e2ee_transformer.as_mut() {
-                        let wire = match transformer.push_chunk(&chunk) {
-                            Ok(wire) => wire,
-                            Err(err) => {
-                                this.metrics.record_stream_error(
-                                    &this.endpoint_path,
-                                    StreamErrorKind::E2ee,
-                                );
-                                this.finished = true;
-                                return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
-                            }
-                        };
-                        if wire.is_empty() {
-                            continue;
-                        }
-                        this.wire_hasher.update(&wire);
-                        return Poll::Ready(Some(Ok(Bytes::from(wire))));
-                    }
-
-                    this.wire_hasher.update(&chunk);
-                    return Poll::Ready(Some(Ok(chunk)));
-                }
-                Poll::Ready(Some(Err(err))) => {
-                    this.metrics
-                        .record_stream_error(&this.endpoint_path, StreamErrorKind::UpstreamRead);
-                    this.finished = true;
-                    return Poll::Ready(Some(Err(ServiceError::Upstream(err))));
-                }
-                Poll::Ready(None) => {
-                    this.upstream_ended = true;
-                }
-            }
+    fn finalize_receipt(&mut self) -> Result<(), ServiceError> {
+        let (cleartext_hash, wire_hash) = self.shared.hashes();
+        let mut builder = self.builder.take().ok_or(ReceiptError::EmptyReceipt)?;
+        builder.set_chat_id(self.shared.sse_parser.chat_id.clone());
+        builder.set_upstream_verified_model_id(self.shared.sse_parser.model_id.clone());
+        if self.response_modified {
+            builder.add_transparency_event(TransparencyEventKind::ResponseModified)?;
         }
+        builder.add_response_returned_hashes(cleartext_hash, wire_hash)?;
+        self.shared.sign_and_store(builder)?;
+
+        self.shared.metrics.record_upstream_response(
+            &self.shared.endpoint_path,
+            RequestMode::Streaming,
+            200,
+            self.shared.sse_parser.model_id.as_deref(),
+        );
+        self.shared.metrics.record_receipt_issued(
+            &self.shared.endpoint_path,
+            RequestMode::Streaming,
+            self.shared.sse_parser.model_id.as_deref(),
+        );
+
+        Ok(())
     }
 }
 
@@ -420,60 +443,9 @@ impl ReceiptFinalizingStream {
         Self {
             inner,
             builder: Some(builder),
-            cleartext_hasher: Sha256::new(),
-            wire_hasher: Sha256::new(),
-            keys: service.keys.clone(),
-            receipt_store: service.receipt_store.clone(),
-            key_id: service.default_receipt_key_id.clone(),
-            requester,
-            receipt_ttl_seconds: service.config.receipt_ttl_seconds,
-            clock: service.clock.clone(),
-            metrics: service.metrics.clone(),
-            endpoint_path,
-            sse_parser: SseChatIdParser::default(),
-            e2ee_transformer,
             response_modified,
-            upstream_ended: false,
-            finished: false,
+            shared: FinalizerShared::new(service, requester, endpoint_path, e2ee_transformer),
         }
-    }
-
-    fn finalize_receipt(&mut self) -> Result<(), ServiceError> {
-        let cleartext_hash = format!(
-            "sha256:{}",
-            hex::encode(self.cleartext_hasher.clone().finalize())
-        );
-        let wire_hash = format!(
-            "sha256:{}",
-            hex::encode(self.wire_hasher.clone().finalize())
-        );
-        let mut builder = self.builder.take().ok_or(ReceiptError::EmptyReceipt)?;
-        builder.set_chat_id(self.sse_parser.chat_id.clone());
-        builder.set_upstream_verified_model_id(self.sse_parser.model_id.clone());
-        if self.response_modified {
-            builder.add_transparency_event(TransparencyEventKind::ResponseModified)?;
-        }
-        builder.add_response_returned_hashes(cleartext_hash, wire_hash)?;
-        let receipt = builder.finalize(self.keys.as_ref(), &self.key_id)?;
-
-        let now = self.clock.now_secs();
-        let expires_at = now.saturating_add(self.receipt_ttl_seconds);
-        self.receipt_store
-            .put(receipt, self.requester.clone(), expires_at);
-
-        self.metrics.record_upstream_response(
-            &self.endpoint_path,
-            RequestMode::Streaming,
-            200,
-            self.sse_parser.model_id.as_deref(),
-        );
-        self.metrics.record_receipt_issued(
-            &self.endpoint_path,
-            RequestMode::Streaming,
-            self.sse_parser.model_id.as_deref(),
-        );
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
The last item on the #7 cleanup list. `MiddlewareResponseFinalizingStream` and `ReceiptFinalizingStream` carried a byte-identical ~75-line `poll_next` loop, shared 14 of their fields, and shared most of their constructor and `finalize_receipt`. They differ only in the inner stream type (and whether its error needs lifting to `ServiceError`) and how the receipt is drafted (a middleware journal vs a held `ReceiptBuilder`).

This pulls the common state into a `FinalizerShared` struct and the loop into one `poll_finalizing_stream`, driven by a small `FinalizingStream` trait — `shared()`, `poll_inner()` (the per-stream error mapping), and `finalize_receipt()`. Each stream now holds only its `inner`, its draft source, and the `response_modified` flag.

Behavior is unchanged (the only real difference between the loops — the upstream-read error mapping — is now `poll_inner`'s job). 227 tests pass, clippy + fmt clean.