### PR TITLE
Per-router attested sessions: near.ai and Tinfoil

### DIFF
--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -202,9 +202,9 @@ mapping. A `failed` result asserts nothing.
   per model, with the served model recorded on the receipt. The verifier attests
   exactly that channel — its `AttestationScope` is `PerRouter`, enforced
   fail-closed at the binding seam — and does *not* fetch or re-verify the nested
-  per-model TDs: the gateway does not re-verify those quotes and nothing binds
-  them to the instance that served a given request, so gating on them would be
-  attestation theater and could only ever describe one model, not the channel. So
+  per-model TDs: the gateway does not re-verify those quotes and they are not
+  bound to the instance that served a given request, so they cannot stand as a
+  sound per-model attestation and are not part of the channel evidence. So
   `tee_attested` there means "bound to a verified gateway TEE," not end-to-end to
   the model TD serving the tokens. A request-bound, per-instance model attestation
   would be its own scoped evidence on the receipt and is a roadmap item (see

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -199,16 +199,16 @@ mapping. A `failed` result asserts nothing.
   genuine TEE quote was verified and the request channel bound to it. For NEAR AI
   this is the **gateway** TD — a router that fronts many models behind one TEE,
   so its attested session is the gateway *channel*: one session per router, not
-  per model, with the served model recorded on the receipt. The nested per-model
-  TDs behind it are *not* re-verified by this gateway. Their quotes are
-  shallow-checked at verify time (valid TDX bytes, nonce match, not debug-mode)
-  as a safety gate, but are deliberately kept **out of** the session evidence and
-  claims: they are not bound to the instance that serves a given request, so
-  folding them in would imply a per-model attestation the gateway did not perform
-  and split one channel into a session per model. So `tee_attested` there means
-  "bound to a verified gateway TEE," not end-to-end to the model TD serving the
-  tokens. Surfacing a request-bound, per-instance model attestation is a roadmap
-  item (see [roadmap.md](roadmap.md)).
+  per model, with the served model recorded on the receipt. The verifier attests
+  exactly that channel — its `AttestationScope` is `PerRouter`, enforced
+  fail-closed at the binding seam — and does *not* fetch or re-verify the nested
+  per-model TDs: the gateway does not re-verify those quotes and nothing binds
+  them to the instance that served a given request, so gating on them would be
+  attestation theater and could only ever describe one model, not the channel. So
+  `tee_attested` there means "bound to a verified gateway TEE," not end-to-end to
+  the model TD serving the tokens. A request-bound, per-instance model attestation
+  would be its own scoped evidence on the receipt and is a roadmap item (see
+  [roadmap.md](roadmap.md)).
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status
   **refutes** (the quote proves a stale TCB — the gateway records the bad claim

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -201,13 +201,12 @@ mapping. A `failed` result asserts nothing.
   so its attested session is the gateway *channel*: one session per router, not
   per model, with the served model recorded on the receipt. The verifier attests
   exactly that channel — its `AttestationScope` is `PerRouter`, enforced
-  fail-closed at the binding seam — and does *not* fetch or re-verify the nested
-  per-model TDs: the gateway does not re-verify those quotes and they are not
-  bound to the instance that served a given request, so they cannot stand as a
-  sound per-model attestation and are not part of the channel evidence. So
-  `tee_attested` there means "bound to a verified gateway TEE," not end-to-end to
-  the model TD serving the tokens. A request-bound, per-instance model attestation
-  would be its own scoped evidence on the receipt and is a roadmap item (see
+  fail-closed at the binding seam. Per-model TEE coverage is delegated to the
+  verified gateway, which verifies its backend model TDs before serving them;
+  because the gateway's own integrity and source provenance are verified, that
+  delegation is sound without re-verifying each backend quote here. The remaining
+  roadmap item is finer: binding the exact backend instance to a specific request
+  (a per-instance, request-bound model attestation on the receipt — see
   [roadmap.md](roadmap.md)).
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -197,11 +197,18 @@ mapping. A `failed` result asserts nothing.
 
 - For the four real provider verifiers `tee_attested` is `HardwareProven`: a
   genuine TEE quote was verified and the request channel bound to it. For NEAR AI
-  this is the **gateway** TD (the request channel binds to the verified gateway
-  TEE); the nested per-model TDs behind it are *not* re-verified by this gateway
-  (honestly recorded as `nested_model_attestations_checked_by_gateway: false` in
-  `claims.extra`). So `tee_attested` there means "bound to a verified gateway
-  TEE," not end-to-end to the model TD serving the tokens.
+  this is the **gateway** TD — a router that fronts many models behind one TEE,
+  so its attested session is the gateway *channel*: one session per router, not
+  per model, with the served model recorded on the receipt. The nested per-model
+  TDs behind it are *not* re-verified by this gateway. Their quotes are
+  shallow-checked at verify time (valid TDX bytes, nonce match, not debug-mode)
+  as a safety gate, but are deliberately kept **out of** the session evidence and
+  claims: they are not bound to the instance that serves a given request, so
+  folding them in would imply a per-model attestation the gateway did not perform
+  and split one channel into a session per model. So `tee_attested` there means
+  "bound to a verified gateway TEE," not end-to-end to the model TD serving the
+  tokens. Surfacing a request-bound, per-instance model attestation is a roadmap
+  item (see [roadmap.md](roadmap.md)).
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status
   **refutes** (the quote proves a stale TCB — the gateway records the bad claim

--- a/docs/live-e2e-test-suite.md
+++ b/docs/live-e2e-test-suite.md
@@ -189,12 +189,14 @@ Provider-specific rules:
   and vendored Tinfoil model/router metadata. The accepted binding is the TLS
   SPKI digest committed in the attestation report data.
 - NEAR AI: request attestation with TLS fingerprint binding, verify the
-  gateway workload through `DSTACK_VERIFIER_URL`, enforce the gateway TLS SPKI,
-  then fetch a model-scoped attestation report over that verified channel and
-  require non-empty `model_attestations[]`. The nested model attestations are
-  hashed and recorded as gateway-owned model evidence; Private AI Gateway does not need to
-  re-verify them in the normal lease path. External-provider models that cannot
-  produce model evidence are skipped unless a test explicitly expects
+  gateway workload through `DSTACK_VERIFIER_URL`, and enforce the gateway TLS
+  SPKI. NEAR AI is a router (`PerRouter`): the attested session is the verified
+  gateway channel, shared by every model. The report is fetched with a model
+  parameter only because that is the shape of NEAR's endpoint; the nested
+  `model_attestations[]` it carries are not required, checked, or recorded —
+  they are not bound to the request's instance — and the served model is a
+  receipt-level identifier. External-provider models that cannot produce
+  gateway-backed evidence are skipped unless a test explicitly expects
   rejection.
 - Chutes: verify the TDX report data binds `nonce || e2e_pubkey`, verify DCAP,
   verify the public measurement profile against a reviewed reference, verify

--- a/docs/providers/audit-criteria.md
+++ b/docs/providers/audit-criteria.md
@@ -110,10 +110,10 @@ Required behavior:
   the verified workload
 - prevent aliases from bypassing the verified model identity
 
-For gateway providers, verifying the gateway channel is preferred over trusting
-static catalog metadata. NEAR AI is the reference example — it is a router, so
-the authoritative check is the verified gateway channel itself; the model is only
-the shape of NEAR's `/v1/attestation/report` endpoint, and the gateway
+For gateway providers, the verified gateway channel is the authoritative check;
+static catalog metadata is never trusted. NEAR AI is the reference example — it
+is a router, so the verified gateway channel itself is authoritative; the model
+is only the shape of NEAR's `/v1/attestation/report` endpoint, and the gateway
 attestation it returns is the same for every model:
 
 ```text
@@ -121,8 +121,9 @@ verified gateway channel
 (workload identity + source provenance + runtime policy + TLS SPKI binding)
 ```
 
-The nested `model_attestations[]` are not required or checked: a router attests
-the channel, not the model that serves a given request.
+Per-model TEE coverage is delegated to the verified gateway, which attests its
+own backends; the nested `model_attestations[]` are not re-verified here. The
+gateway is trusted because it is itself verified for integrity and provenance.
 
 The review must call out aliasing and actual served weights. If the provider
 cannot prove the exact backend model or quantization, receipts must be honest

--- a/docs/providers/audit-criteria.md
+++ b/docs/providers/audit-criteria.md
@@ -110,14 +110,19 @@ Required behavior:
   the verified workload
 - prevent aliases from bypassing the verified model identity
 
-For gateway providers, a model-scoped probe is preferred over trusting static
-catalog metadata. The NEAR AI rule is the reference example:
+For gateway providers, verifying the gateway channel is preferred over trusting
+static catalog metadata. NEAR AI is the reference example — it is a router, so
+the authoritative check is the verified gateway channel itself; the model is only
+the shape of NEAR's `/v1/attestation/report` endpoint, and the gateway
+attestation it returns is the same for every model:
 
 ```text
 verified gateway channel
-+ /v1/attestation/report?model=<canonical-model>
-+ non-empty model_attestations[]
+(workload identity + source provenance + runtime policy + TLS SPKI binding)
 ```
+
+The nested `model_attestations[]` are not required or checked: a router attests
+the channel, not the model that serves a given request.
 
 The review must call out aliasing and actual served weights. If the provider
 cannot prove the exact backend model or quantization, receipts must be honest
@@ -374,6 +379,7 @@ Every provider adapter should return the same class of result to Rust:
   "provider": "near-ai",
   "model_id": "canonical-model",
   "verifier_id": "provider-verifier/version",
+  "attested_scope": "router",
   "evidence": {
     "digest": "sha256:...",
     "data": "data:application/json;base64,<exact-verifier-input-bytes>"
@@ -388,10 +394,10 @@ Every provider adapter should return the same class of result to Rust:
     }
   ],
   "provider_claims": {
-    "trust_boundary": "gateway",
-    "evidence_scope": "model",
+    "trust_boundary": "near-ai-gateway",
     "gateway_verified": true,
-    "model_evidence_present": true
+    "gateway_tls_spki_sha256": "...",
+    "tcb_status": "UpToDate"
   }
 }
 ```

--- a/docs/providers/audit-criteria.md
+++ b/docs/providers/audit-criteria.md
@@ -438,7 +438,7 @@ forward the request, and record the receipt.
 
 | Provider | Trust boundary | Decision | Blocking TODOs |
 | --- | --- | --- | --- |
-| NEAR AI | Verified gateway workload | Acceptable with conditions | Pin accepted gateway provenance/runtime policy; define pre-production measurement publication process; confirm no off-TEE TLS termination; keep model-scoped attestation probe mandatory; finish privacy/log/storage review. |
+| NEAR AI | Verified gateway workload | Acceptable with conditions | Pin accepted gateway provenance/runtime policy; define pre-production measurement publication process; confirm no off-TEE TLS termination; finish privacy/log/storage review. |
 | Tinfoil | Verified confidential router | Acceptable with conditions | Pin audited router compose/image digest; define pre-production measurement publication process; decide runtime config update policy; record selected `Tinfoil-Enclave`; finish strict release pins. |
 | Chutes | Verified E2EE model instances | Accepted for limited traffic | Pin exact `chute_id` or unique slug for production models; resolve nonce-throughput limit before general production; document served-model alias limitations. |
 | SecretAI | Verified single SEV-SNP VM | Acceptable with conditions | Pin reviewed `artifacts_ver` allowlist (`secretvm-verify/.../sev.json`); pin `secret-ai-caddy` compose / image; confirm production journal stays inside the trust boundary; define SCRT pre-production measurement publication; treat TLS-cert renewal as forced lease refresh (binding is to cert SHA-256, not SPKI). |

--- a/docs/providers/near-ai/review.md
+++ b/docs/providers/near-ai/review.md
@@ -68,9 +68,9 @@ P0 adapter requirements:
 - Treat catalog flags as advisory only.
 - Enforce the verified gateway SPKI on every request.
 - Record compact, channel-scoped provider claims in receipts (e.g.
-  `gateway_verified`, `gateway_tls_spki_sha256`, `tcb_status`). No model
-  attestation: the session is the gateway channel, and the served model is a
-  receipt-level identifier.
+  `gateway_verified`, `gateway_tls_spki_sha256`, `tcb_status`). The attested
+  session is the gateway channel; per-model TEE coverage is delegated to the
+  verified gateway, with the served model recorded as a receipt-level identifier.
 
 P0 TODOs before strict-release inclusion:
 
@@ -224,10 +224,12 @@ or pinned:
   should otherwise prove the allowed backend image/compose set.
 - The lease is refreshed often enough that model catalog changes, provider
   refreshes, and backend key rotation do not outlive Private AI Gateway's cached trust.
-- Receipts claim only what the channel attestation proves: a verified gateway
-  channel with the served model as a bare identifier. Whether a given model is
-  genuinely TEE-backed (vs an external provider behind the gateway) is not proven
-  by the channel attestation, so receipts do not imply per-model TEE protection.
+- Per-model TEE coverage is delegated to the verified gateway: the gateway
+  verifies its backend model TDs and only serves verified backends, and we verify
+  the gateway's own integrity and source provenance — so the gateway is trusted
+  because it is itself verifiable, not blindly. The served model is recorded on
+  the receipt as an identifier; binding the exact backend instance to a specific
+  request is a roadmap refinement.
 
 ## Privacy and Operations Caveats
 
@@ -337,46 +339,36 @@ Live probes during review:
 - Existing gateway live artifact:
   `/tmp/private-ai-gateway-live-e2e/20260518-053819`.
 
-## Required Adapter Changes
+## Adapter Behavior
 
-P0:
+- NEAR verification is a gateway-soundness lease: the gateway identity, source
+  provenance, runtime policy, and TLS SPKI binding are verified. NEAR AI is a
+  router, so the verified gateway channel is the attested session; the
+  model-scoped report is only the shape of NEAR's endpoint.
+- Per-model TEE coverage is delegated to the verified gateway, which verifies its
+  backend model TDs and only serves verified backends; because the gateway is
+  itself verified for integrity and provenance, that delegation is sound. The
+  nested `model_attestations[]` are not re-verified or recorded here, and the
+  served model is a receipt-level identifier.
+- `/v1/model/list` catalog flags are never trusted; the lease is authorized by
+  the verified gateway channel.
 
-- Move NEAR verification to gateway-soundness lease establishment: verify
-  gateway identity/provenance/TLS binding. NEAR AI is a router, so the verified
-  gateway channel is the attested session; the model-scoped report is only the
-  shape of NEAR's endpoint.
-- Do not fetch, verify, or record the nested `model_attestations[]`: the gateway
-  does not re-verify them and nothing binds them to the request's instance
-  (router scope). Rust enforces only the verified gateway lease and channel
-  binding.
-- Treat `/v1/model/list` catalog flags as hints. They may help choose models to
-  probe, but the lease is authorized by the verified gateway channel, not by any
-  per-model claim.
-- Whether a configured model is genuinely TEE-backed (vs an external provider
-  behind the gateway) is not proven by the channel attestation, so do not imply
-  per-model TEE protection in receipts. A request-bound, per-instance model
-  attestation is the roadmap path to surface that distinction.
+## Remaining
 
-P1:
-
-- Surface and pin the gateway compose/image digest in the NEAR verifier result.
-  The allowlist should map audited source/release evidence to accepted
-  deployment digests.
-- Record the served model id on the receipt as an identifier only — no model
-  attestation digest (router scope).
+- Surface and pin the gateway compose/image digest in the NEAR verifier result,
+  mapping audited source/release evidence to accepted deployment digests.
+- Bind the exact backend instance to a specific request (a per-instance,
+  request-bound model attestation on the receipt), tightening today's delegation
+  to the gateway.
 - Decide how to represent the gateway runtime-policy assumptions, especially
   upstream image/compose allowlists, without adding a generic policy DSL.
 - Ask NEAR to expose stable bucket/backend/cache-hit evidence, for example
   `X-NearAI-Bucket`, `X-NearAI-Backend`, and cache-hit metadata.
-
-P2:
-
-- Add a live external-provider sentinel test: choose a known external model if
-  one is public, verify `model_attestations[]` is empty, and assert the
-  gateway refuses to forward it in verified mode.
-- Add an opt-in prefix-cache locality probe using a large stable prompt prefix
-  and a short changing suffix. Treat timing-only evidence as weak unless NEAR
-  exposes backend or cache metadata.
+- Add a sentinel test that the verified gateway refuses to serve a known
+  external (non-TEE) model, confirming the delegation assumption holds.
+- Add an opt-in prefix-cache locality probe (large stable prompt prefix + short
+  changing suffix); treat timing-only evidence as weak unless NEAR exposes
+  backend or cache metadata.
 - Track whether live NEAR enables strict image-hash and TCB freshness policy,
   then fold those expectations into the verifier bridge.
 

--- a/docs/providers/near-ai/review.md
+++ b/docs/providers/near-ai/review.md
@@ -186,8 +186,7 @@ Adapter rule:
 
 ```text
 /v1/model/list flags are advisory.
-The model-scoped attestation report over the verified gateway channel is
-authoritative for lease establishment.
+The verified gateway channel is authoritative for lease establishment.
 ```
 
 ## `model_attestations[]` Semantics
@@ -225,8 +224,10 @@ or pinned:
   should otherwise prove the allowed backend image/compose set.
 - The lease is refreshed often enough that model catalog changes, provider
   refreshes, and backend key rotation do not outlive Private AI Gateway's cached trust.
-- Private AI Gateway treats external providers as not verified unless the verified gateway
-  can produce model-scoped attestation evidence for that model.
+- Receipts claim only what the channel attestation proves: a verified gateway
+  channel with the served model as a bare identifier. Whether a given model is
+  genuinely TEE-backed (vs an external provider behind the gateway) is not proven
+  by the channel attestation, so receipts do not imply per-model TEE protection.
 
 ## Privacy and Operations Caveats
 

--- a/docs/providers/near-ai/review.md
+++ b/docs/providers/near-ai/review.md
@@ -34,10 +34,10 @@ shared by every model behind it. Private AI Gateway verifies the gateway
 workload identity, source provenance, runtime policy, and TLS SPKI binding — and
 nothing about the served model. It does **not** fetch, parse, or check the
 nested `model_attestations[]`: the gateway does not re-verify those quotes and
-nothing binds them to the instance that serves a given request, so requiring them
-would imply a per-model attestation we did not perform (and would split one
-channel into a session per model). The served model is recorded on the receipt as
-an identifier; a request-bound, per-instance model attestation is a roadmap item.
+they are not bound to the instance that serves a given request, so they cannot
+stand as a sound per-model attestation. The served model is recorded on the
+receipt as an identifier; a request-bound, per-instance model attestation is a
+roadmap item.
 
 The main loophole is catalog metadata. `verifiable` and
 `attestationSupported` are DB/admin-controlled fields. They are useful hints,
@@ -205,12 +205,11 @@ TLS channel.
 ```
 
 That is enough for gateway-soundness mode if Private AI Gateway has accepted the gateway
-as the trust boundary. Private AI Gateway does not consume the nested entries at
-all: they are not bound to the instance that serves a given request, so hashing
-or recording them in the attested session would imply a per-model attestation we
-did not perform. They remain a roadmap input for a future request-bound,
-per-instance model attestation surfaced on the receipt — not in the channel
-session.
+as the trust boundary. Private AI Gateway does not consume the nested entries: they are
+not bound to the instance that serves a given request, so they cannot stand as a
+sound per-model attestation and are not recorded in the attested session. A
+future request-bound, per-instance model attestation would surface them on the
+receipt — not in the channel session.
 
 ## Required Gateway Assumptions
 

--- a/docs/providers/near-ai/review.md
+++ b/docs/providers/near-ai/review.md
@@ -28,20 +28,16 @@ Source reports:
 NEAR AI gateway mode is acceptable as a gateway-soundness provider when the
 verification lease is established through the verified gateway.
 
-Private AI Gateway does not need to re-verify every nested `model_attestations[]` entry.
-The NEAR gateway is the trust boundary. Once Private AI Gateway verifies the gateway
-workload identity, source provenance, runtime policy, and TLS SPKI binding, a
-model-scoped attestation response from that same verified gateway can be
-treated as the gateway's statement that the requested model has attested
-backend evidence.
-
-The model evidence is still required, but its role changes:
-
-- It is not a standalone proof that Private AI Gateway must parse and re-verify.
-- It is the verified gateway's model-scoped claim that this model currently has
-  an attested backend.
-- It must be fetched over the verified gateway channel during lease
-  establishment.
+NEAR AI is a router (`AttestationScope::PerRouter`): the NEAR gateway is the
+trust boundary, and the attested session is that one verified gateway channel,
+shared by every model behind it. Private AI Gateway verifies the gateway
+workload identity, source provenance, runtime policy, and TLS SPKI binding — and
+nothing about the served model. It does **not** fetch, parse, or check the
+nested `model_attestations[]`: the gateway does not re-verify those quotes and
+nothing binds them to the instance that serves a given request, so requiring them
+would imply a per-model attestation we did not perform (and would split one
+channel into a session per model). The served model is recorded on the receipt as
+an identifier; a request-bound, per-instance model attestation is a roadmap item.
 
 The main loophole is catalog metadata. `verifiable` and
 `attestationSupported` are DB/admin-controlled fields. They are useful hints,
@@ -49,8 +45,7 @@ but they are not sufficient proof. The authoritative check for Private AI Gatewa
 
 ```text
 verified gateway channel
-+ model-scoped /v1/attestation/report
-+ non-empty model_attestations[]
+(workload identity + source provenance + runtime policy + TLS SPKI binding)
 ```
 
 ## Criteria Status
@@ -70,13 +65,12 @@ Passed:
 P0 adapter requirements:
 
 - Verify the gateway workload identity and gateway TLS SPKI binding.
-- Fetch model-scoped attestation over the verified gateway channel.
-- Require non-empty `model_attestations[]` for the requested model.
 - Treat catalog flags as advisory only.
 - Enforce the verified gateway SPKI on every request.
-- Record compact provider claims in receipts:
-  `gateway_verified`, `model_evidence_present`,
-  `model_attestation_count`, and a digest of the model evidence.
+- Record compact, channel-scoped provider claims in receipts (e.g.
+  `gateway_verified`, `gateway_tls_spki_sha256`, `tcb_status`). No model
+  attestation: the session is the gateway channel, and the served model is a
+  receipt-level identifier.
 
 P0 TODOs before strict-release inclusion:
 
@@ -102,8 +96,8 @@ P1 TODOs:
 
 ## Lease Contract
 
-The NEAR provider adapter should establish one verification lease per accepted
-model.
+The NEAR provider adapter establishes one verification lease per gateway channel
+(router scope): every accepted model behind the gateway shares it.
 
 Lease establishment:
 
@@ -115,10 +109,13 @@ Lease establishment:
 4. Pin that gateway SPKI for the lease window.
 5. Fetch
    `/v1/attestation/report?model=<canonical-model>&include_tls_fingerprint=true`
-   over the pinned gateway channel.
-6. Require HTTP 200 and at least one `model_attestations[]` entry.
-7. Record the model-attestation digest and compact gateway claim in the lease
-   and receipt.
+   over the pinned gateway channel. The model is only the shape of NEAR AI's
+   endpoint; the gateway attestation it returns is the same for every model.
+6. Require HTTP 200 and a verified gateway component. The nested
+   `model_attestations[]` are neither required nor checked (see
+   [`model_attestations[]` Semantics](#model_attestations-semantics)).
+7. Record the channel-scoped gateway claim in the lease and receipt; the served
+   model is a receipt-level identifier only.
 
 Request forwarding:
 
@@ -208,9 +205,12 @@ TLS channel.
 ```
 
 That is enough for gateway-soundness mode if Private AI Gateway has accepted the gateway
-as the trust boundary. The nested entries are useful audit artifacts and should
-be hashed or recorded, but Private AI Gateway does not need to re-verify them during lease
-establishment.
+as the trust boundary. Private AI Gateway does not consume the nested entries at
+all: they are not bound to the instance that serves a given request, so hashing
+or recording them in the attested session would imply a per-model attestation we
+did not perform. They remain a roadmap input for a future request-bound,
+per-instance model attestation surfaced on the receipt — not in the channel
+session.
 
 ## Required Gateway Assumptions
 
@@ -341,26 +341,29 @@ Live probes during review:
 
 P0:
 
-- Move NEAR verification to gateway-soundness lease establishment:
-  verify gateway identity/provenance/TLS binding, then require a model-scoped
-  attestation report over the verified gateway channel.
-- Stop treating nested `model_attestations[]` verification as a Rust
-  gateway responsibility. The provider verifier may record the nested
-  evidence digest, but Rust should enforce only the verified gateway lease and
-  channel binding.
+- Move NEAR verification to gateway-soundness lease establishment: verify
+  gateway identity/provenance/TLS binding. NEAR AI is a router, so the verified
+  gateway channel is the attested session; the model-scoped report is only the
+  shape of NEAR's endpoint.
+- Do not fetch, verify, or record the nested `model_attestations[]`: the gateway
+  does not re-verify them and nothing binds them to the request's instance
+  (router scope). Rust enforces only the verified gateway lease and channel
+  binding.
 - Treat `/v1/model/list` catalog flags as hints. They may help choose models to
-  probe, but they must not authorize a lease without a successful model-scoped
-  attestation response.
-- Reject or do not configure model IDs that cannot produce non-empty
-  `model_attestations[]` through the verified gateway.
+  probe, but the lease is authorized by the verified gateway channel, not by any
+  per-model claim.
+- Whether a configured model is genuinely TEE-backed (vs an external provider
+  behind the gateway) is not proven by the channel attestation, so do not imply
+  per-model TEE protection in receipts. A request-bound, per-instance model
+  attestation is the roadmap path to surface that distinction.
 
 P1:
 
 - Surface and pin the gateway compose/image digest in the NEAR verifier result.
   The allowlist should map audited source/release evidence to accepted
   deployment digests.
-- Record `model_attestations_sha256` and model canonical id in the lease and
-  receipt.
+- Record the served model id on the receipt as an identifier only — no model
+  attestation digest (router scope).
 - Decide how to represent the gateway runtime-policy assumptions, especially
   upstream image/compose allowlists, without adding a generic policy DSL.
 - Ask NEAR to expose stable bucket/backend/cache-hit evidence, for example

--- a/docs/providers/near-ai/verification.md
+++ b/docs/providers/near-ai/verification.md
@@ -57,9 +57,12 @@ connection before forwarding.
 
 ## Notes
 
-- Only the **gateway** component is verified here; NEAR AI's nested model attestations
-  are recorded as gateway-owned evidence (`model_attestations_sha256`) but not
-  re-verified on the lease path.
+- Only the **gateway** component is verified here, and NEAR AI is treated as a
+  router (`AttestationScope::PerRouter`): its nested per-model TD quotes are
+  **not** fetched or checked. The gateway does not re-verify them and nothing
+  binds them to the instance that served a given request, so the attested session
+  is the gateway *channel* only. A request-bound, per-instance model attestation
+  is a roadmap item, recorded on the receipt rather than in the session.
 - Requires a reachable dstack-verifier at `DSTACK_VERIFIER_URL` (default `:18080`).
 - NVIDIA NRAS JWT-signature hardening is a tracked defense-in-depth follow-up.
 

--- a/docs/providers/tinfoil/verification.md
+++ b/docs/providers/tinfoil/verification.md
@@ -69,9 +69,9 @@ connection before forwarding.
   (`tinfoilsh/confidential-model-router`). Tinfoil is a router
   (`AttestationScope::PerRouter`): the attested session is that one verified
   enclave channel, shared by every model behind it, so verification is keyed on
-  the channel and the served model is a receipt-level identifier. Per-model
-  identity within the router is a separate concern. Override the repo via
-  `provider_options.tinfoil_repo`.
+  the channel and the served model is a receipt-level identifier. Per-model TEE
+  coverage is delegated to the verified router, which attests the model enclaves
+  it fronts. Override the repo via `provider_options.tinfoil_repo`.
 - Pin the dependency deliberately; the SDK is the source of truth for the check set,
   so upgrades should be reviewed.
 

--- a/docs/providers/tinfoil/verification.md
+++ b/docs/providers/tinfoil/verification.md
@@ -66,8 +66,12 @@ connection before forwarding.
   (`<host>/.well-known/tinfoil-attestation`), `kds-proxy.tinfoil.sh` (AMD VCEK),
   the GitHub attestation proxy, and Sigstore's TUF root.
 - Router mode: by default this verifies the **router** enclave
-  (`tinfoilsh/confidential-model-router`); per-model identity within the router is a
-  separate concern. Override the repo via `provider_options.tinfoil_repo`.
+  (`tinfoilsh/confidential-model-router`). Tinfoil is a router
+  (`AttestationScope::PerRouter`): the attested session is that one verified
+  enclave channel, shared by every model behind it, so verification is keyed on
+  the channel and the served model is a receipt-level identifier. Per-model
+  identity within the router is a separate concern. Override the repo via
+  `provider_options.tinfoil_repo`.
 - Pin the dependency deliberately; the SDK is the source of truth for the check set,
   so upgrades should be reviewed.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,12 +71,13 @@ served model stays a receipt-level fact (see
 Remaining:
 
 - **Request-bound, per-instance model attestation on the receipt.** A router
-  attests the channel, not the model that serves a given request. Today the
-  served model is recorded on the receipt as an identifier only; we do not fetch
-  or verify the per-model TD that handled it, because the gateway does not
-  re-verify those quotes and nothing binds them to the request's instance —
-  gating on them would be attestation theater. Once an upstream can attest the
-  exact instance that served a request, surface that as its own scoped,
+  attests the channel, not the model that serves a given request. The served
+  model is recorded on the receipt as an identifier. The per-model TD quotes a
+  router exposes are not part of the channel attestation: the gateway does not
+  re-verify them and they are not bound to the specific instance that serves a
+  request, so they cannot stand as a sound per-model attestation. Once an upstream
+  can attest the exact instance that served a request, surface that as its own
+  scoped,
   request-bound attestation on the receipt — never folded into the channel
   session.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,32 @@ concept.
 - Keep the implementation small: reuse the existing upstream lease lifecycle
   where possible, and avoid introducing a policy DSL.
 
+### Router Upstreams: Model Attestation and One Session per Channel
+
+An attested session is a verified secure channel, and we never create more than
+one session per channel. The channel boundary differs by provider: per E2EE
+instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
+(NEAR AI), where one gateway fronts many models. For NEAR AI the session is the
+verified gateway channel; the per-model TD quotes are shallow-checked at verify
+time but deliberately kept out of the session (see
+[attested-session-system.md](attested-session-system.md)). Two improvements
+remain:
+
+- **Request-bound, per-instance model attestation on the receipt.** A router's
+  per-model TD quotes are fetched at verify time and only shallow-checked (valid
+  TDX bytes, nonce, not debug-mode); they are not re-verified, and nothing binds
+  them to the specific instance that served a given request. They are kept out of
+  the attested session to avoid implying a per-model attestation the gateway did
+  not perform. Once an upstream can attest the exact instance that served a
+  request, surface that as a verified, request-bound reference on the receipt —
+  not in the channel session.
+- **One session per router channel.** Verification is currently keyed per model
+  (the report endpoint is `?model=`, and the verifier cache and refresh targets
+  include the model id), so a router still produces one channel session per
+  configured model. Key verification and the session on the channel for router
+  providers so a router yields exactly one session, with the served model staying
+  a receipt-level fact.
+
 ### P0: Multi-Domain Downstream TLS Binding
 
 The gateway currently assumes one downstream TLS identity. Production deployments

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,9 +77,8 @@ Remaining:
   re-verify them and they are not bound to the specific instance that serves a
   request, so they cannot stand as a sound per-model attestation. Once an upstream
   can attest the exact instance that served a request, surface that as its own
-  scoped,
-  request-bound attestation on the receipt — never folded into the channel
-  session.
+  scoped, request-bound attestation on the receipt — never folded into the
+  channel session.
 
 ### P0: Multi-Domain Downstream TLS Binding
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,14 +70,13 @@ served model stays a receipt-level fact (see
 
 Remaining:
 
-- **Request-bound, per-instance model attestation on the receipt.** A router
-  attests the channel, not the model that serves a given request. The served
-  model is recorded on the receipt as an identifier. The per-model TD quotes a
-  router exposes are not part of the channel attestation: the gateway does not
-  re-verify them and they are not bound to the specific instance that serves a
-  request, so they cannot stand as a sound per-model attestation. Once an upstream
-  can attest the exact instance that served a request, surface that as its own
-  scoped, request-bound attestation on the receipt — never folded into the
+- **Request-bound, per-instance model attestation on the receipt.** Today,
+  per-model TEE coverage is delegated to the verified router: the router attests
+  its backend model TEEs, and we verify the router's own integrity and source
+  provenance, so the delegation is sound. What it does not yet establish is which
+  *specific* backend instance served a *given* request. Once an upstream can
+  attest that exact instance, surface it as its own scoped, request-bound model
+  attestation on the receipt — tightening the delegation, never folded into the
   channel session.
 
 ### P0: Multi-Domain Downstream TLS Binding

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,25 +59,23 @@ An attested session is a verified secure channel, and we never create more than
 one session per channel. The channel boundary differs by provider: per E2EE
 instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
 (NEAR AI), where one gateway fronts many models. For NEAR AI the session is the
-verified gateway channel; the per-model TD quotes are shallow-checked at verify
-time but deliberately kept out of the session (see
-[attested-session-system.md](attested-session-system.md)). Two improvements
-remain:
+verified gateway channel: the per-model TD quotes are shallow-checked at verify
+time but deliberately kept out of the session, and verification is keyed on the
+channel (`UpstreamProvider::is_router`), so every model resolves to one verified
+channel and one attested session — the served model staying a receipt-level fact
+(see [attested-session-system.md](attested-session-system.md)).
+
+Remaining:
 
 - **Request-bound, per-instance model attestation on the receipt.** A router's
   per-model TD quotes are fetched at verify time and only shallow-checked (valid
   TDX bytes, nonce, not debug-mode); they are not re-verified, and nothing binds
   them to the specific instance that served a given request. They are kept out of
   the attested session to avoid implying a per-model attestation the gateway did
-  not perform. Once an upstream can attest the exact instance that served a
-  request, surface that as a verified, request-bound reference on the receipt —
-  not in the channel session.
-- **One session per router channel.** Verification is currently keyed per model
-  (the report endpoint is `?model=`, and the verifier cache and refresh targets
-  include the model id), so a router still produces one channel session per
-  configured model. Key verification and the session on the channel for router
-  providers so a router yields exactly one session, with the served model staying
-  a receipt-level fact.
+  not perform. Because verification is now channel-keyed, that shallow check also
+  only covers the model that populated the channel cache, not every model. Once an
+  upstream can attest the exact instance that served a request, surface that as a
+  verified, request-bound reference on the receipt — not in the channel session.
 
 ### P0: Multi-Domain Downstream TLS Binding
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,26 +56,29 @@ concept.
 ### Router Upstreams: Model Attestation and One Session per Channel
 
 An attested session is a verified secure channel, and we never create more than
-one session per channel. The channel boundary differs by provider: per E2EE
+one session per channel. The channel boundary a provider attests is a first-class
+property, `UpstreamProvider::attestation_scope()` → `AttestationScope`: per E2EE
 instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
-(NEAR AI), where one gateway fronts many models. For NEAR AI the session is the
-verified gateway channel: the per-model TD quotes are shallow-checked at verify
-time but deliberately kept out of the session, and verification is keyed on the
-channel (`UpstreamProvider::is_router`), so every model resolves to one verified
-channel and one attested session — the served model staying a receipt-level fact
-(see [attested-session-system.md](attested-session-system.md)).
+(NEAR AI) or model router (Tinfoil), where one channel fronts many models. The
+scope is the single source of truth: it drives channel-keyed verification (the
+model is dropped from the verifier cache key for routers, so every model resolves
+to one verified channel and one attested session) and is enforced fail-closed at
+the verifier seam — a verifier must attest the scope its provider is declared to
+use, so a router channel can never be sealed from model-scoped evidence. The
+served model stays a receipt-level fact (see
+[attested-session-system.md](attested-session-system.md)).
 
 Remaining:
 
-- **Request-bound, per-instance model attestation on the receipt.** A router's
-  per-model TD quotes are fetched at verify time and only shallow-checked (valid
-  TDX bytes, nonce, not debug-mode); they are not re-verified, and nothing binds
-  them to the specific instance that served a given request. They are kept out of
-  the attested session to avoid implying a per-model attestation the gateway did
-  not perform. Because verification is now channel-keyed, that shallow check also
-  only covers the model that populated the channel cache, not every model. Once an
-  upstream can attest the exact instance that served a request, surface that as a
-  verified, request-bound reference on the receipt — not in the channel session.
+- **Request-bound, per-instance model attestation on the receipt.** A router
+  attests the channel, not the model that serves a given request. Today the
+  served model is recorded on the receipt as an identifier only; we do not fetch
+  or verify the per-model TD that handled it, because the gateway does not
+  re-verify those quotes and nothing binds them to the request's instance —
+  gating on them would be attestation theater. Once an upstream can attest the
+  exact instance that served a request, surface that as its own scoped,
+  request-bound attestation on the receipt — never folded into the channel
+  session.
 
 ### P0: Multi-Domain Downstream TLS Binding
 

--- a/scripts/live_e2e/router_refresh_smoke.py
+++ b/scripts/live_e2e/router_refresh_smoke.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Live check that a router upstream's attested session is refreshed.
+
+Boots the gateway with one router upstream (NEAR AI or Tinfoil) and a short
+`verification_refresh_seconds`, then — making NO inference request — confirms:
+
+  1. the boot prewarm writes the channel session (it appears in /v1/aci/sessions), and
+  2. the background refresh re-verifies it: a session with a newer `established_at`
+     appears, with no inference traffic.
+
+We do NOT require the session id to stay constant. A session is an immutable,
+content-addressed record of one verification; a refresh is a new (fresh,
+nonce-bound) verification, so a provider whose attestation carries a freshness
+nonce (NEAR AI) correctly mints a new immutable session each cycle, while one
+whose attestation is static (Tinfoil) re-seals the same id. Both are "refreshed".
+Superseded sessions are retained until their TTL so receipts can still resolve
+them.
+
+Usage (from scripts/, with the provider key in the environment):
+    uv run python live_e2e/router_refresh_smoke.py tinfoil
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import requests  # noqa: E402
+
+from live_e2e.common import (  # noqa: E402
+    DEFAULT_DSTACK_ENDPOINT,
+    DEFAULT_DSTACK_VERIFIER_URL,
+    ROOT,
+)
+
+PORT = 18086
+BASE = f"http://127.0.0.1:{PORT}"
+PRESETS = {
+    "near-ai": ("https://cloud-api.near.ai", "NEARAI_API_KEY", "google/gemma-4-31B-it"),
+    "tinfoil": ("https://inference.tinfoil.sh", "TINFOIL_API_KEY", "kimi-k2-6"),
+}
+
+
+def list_sessions(name: str) -> list[dict]:
+    try:
+        r = requests.get(f"{BASE}/v1/aci/sessions", params={"provider": name}, timeout=5)
+        if r.status_code == 200:
+            return (r.json() or {}).get("sessions", [])
+    except Exception:
+        pass
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("provider", choices=sorted(PRESETS), default="tinfoil", nargs="?")
+    args = parser.parse_args()
+    base_url, key_env, model = PRESETS[args.provider]
+
+    token = os.environ.get(key_env)
+    if not token:
+        print(f"missing {key_env}")
+        return 2
+
+    name = f"{args.provider}-router"
+    config = [
+        {
+            "name": name,
+            "provider": args.provider,
+            "base_url": base_url,
+            "models": {"router-model": model},
+            "bearer_token": token,
+            "verification_refresh_seconds": 5,
+            "connect_timeout_seconds": 10,
+            "read_timeout_seconds": 600,
+            "verifier_request_timeout_seconds": 120,
+        }
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="router-refresh-smoke-") as tmp:
+        cfg_path = Path(tmp) / "upstreams.json"
+        cfg_path.write_text(json.dumps(config))
+        log_path = Path(tmp) / "aggregator.log"
+        env = {
+            **os.environ,
+            "PRIVATE_AI_GATEWAY_BIND": f"127.0.0.1:{PORT}",
+            "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH": str(cfg_path),
+            "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT": DEFAULT_DSTACK_ENDPOINT,
+            "DSTACK_VERIFIER_URL": os.environ.get("DSTACK_VERIFIER_URL", DEFAULT_DSTACK_VERIFIER_URL),
+            "PRIVATE_AI_GATEWAY_REPO_URL": "https://github.com/Dstack-TEE/private-ai-gateway",
+            "PRIVATE_AI_GATEWAY_REPO_COMMIT": "live-e2e",
+            "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": "3600",
+            "RUST_LOG": "warn",
+        }
+        env.pop(key_env, None)
+        log = log_path.open("wb")
+        proc = subprocess.Popen(
+            ["cargo", "run", "--bin", "private-ai-gateway"],
+            cwd=ROOT,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            # Wait for readiness.
+            deadline = time.time() + 240
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    print("gateway exited early; log tail:\n", log_path.read_text()[-1200:])
+                    return 1
+                try:
+                    if requests.get(f"{BASE}/v1/models", timeout=2).status_code == 200:
+                        break
+                except Exception:
+                    pass
+                time.sleep(0.5)
+
+            # 1. Prewarm writes the session (no inference request made).
+            first = None
+            deadline = time.time() + 90
+            while time.time() < deadline:
+                sessions = list_sessions(name)
+                if sessions:
+                    first = sessions
+                    break
+                time.sleep(1)
+            if not first:
+                print("FAIL: prewarm did not write a session; log tail:\n", log_path.read_text()[-1000:])
+                return 1
+            est0 = max(s.get("established_at", 0) for s in first)
+            ids0 = sorted(s.get("session_id") for s in first)
+            print(f"  prewarm: {len(first)} session(s), established_at={est0}, ids={ids0}")
+
+            # 2. The refresh loop re-verifies the channel: a session with a newer
+            #    established_at appears (id rotates for nonce-bound attestation,
+            #    stays for static attestation — both count as refreshed).
+            deadline = time.time() + 90
+            while time.time() < deadline:
+                sessions = list_sessions(name)
+                if sessions and max(s.get("established_at", 0) for s in sessions) > est0:
+                    est1 = max(s.get("established_at", 0) for s in sessions)
+                    ids1 = sorted(s.get("session_id") for s in sessions)
+                    # Is the freshest session the prewarm one re-sealed, or a new
+                    # immutable session (nonce-bound attestation)?
+                    fresh_ids = {s.get("session_id") for s in sessions if s.get("established_at", 0) == est1}
+                    re_sealed = fresh_ids <= set(ids0)
+                    print(f"  refresh: {len(sessions)} session(s), established_at={est1}, ids={ids1}")
+                    print(
+                        f"\nPASS: router channel re-verified by the background refresh "
+                        f"(established_at {est0} -> {est1}; "
+                        f"{'same id, re-sealed' if re_sealed else 'fresh immutable session, prior retained'})."
+                    )
+                    return 0
+                time.sleep(1)
+            print("FAIL: channel was not re-verified within the window")
+            return 1
+        finally:
+            if proc.poll() is None:
+                os.killpg(proc.pid, signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    os.killpg(proc.pid, signal.SIGKILL)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live_e2e/router_session_smoke.py
+++ b/scripts/live_e2e/router_session_smoke.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Live check for router channel-keying.
+
+Boots the gateway with ONE NEAR AI upstream mapping two models, sends a request
+to each, and asserts both receipts cite the SAME `upstream.verified.session_id`
+— i.e. a router yields one attested session per channel, not one per model.
+
+Run from scripts/ with NEARAI_API_KEY in the environment.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import requests  # noqa: E402
+
+from live_e2e.common import (  # noqa: E402
+    DEFAULT_DSTACK_ENDPOINT,
+    DEFAULT_DSTACK_VERIFIER_URL,
+    ROOT,
+)
+
+PORT = 18086
+BASE = f"http://127.0.0.1:{PORT}"
+MODELS = {
+    "router-gemma": "google/gemma-4-31B-it",
+    "router-deepseek": "deepseek-ai/DeepSeek-V4-Flash",
+}
+
+
+def session_id_for(model: str) -> tuple[int, str | None, str | None]:
+    body = {"model": model, "messages": [{"role": "user", "content": "hi"}], "max_tokens": 16}
+    resp = requests.post(f"{BASE}/v1/chat/completions", json=body, timeout=180)
+    rid = resp.headers.get("x-receipt-id")
+    if resp.status_code != 200 or not rid:
+        print(f"    {model}: status={resp.status_code} body={resp.text[:300]}")
+        return resp.status_code, None, None
+    rc = requests.get(f"{BASE}/v1/aci/receipts/{rid}", timeout=30).json()
+    receipt = rc.get("receipt") if "event_log" not in rc else rc
+    uv = next(
+        (e for e in (receipt or {}).get("event_log", []) if e.get("type") == "upstream.verified"),
+        {},
+    )
+    return resp.status_code, uv.get("session_id"), uv.get("model_id")
+
+
+def main() -> int:
+    token = os.environ.get("NEARAI_API_KEY")
+    if not token:
+        print("missing NEARAI_API_KEY")
+        return 2
+
+    config = [
+        {
+            "name": "near-router",
+            "provider": "near-ai",
+            "base_url": "https://cloud-api.near.ai",
+            "models": MODELS,
+            "bearer_token": token,
+            "connect_timeout_seconds": 10,
+            "read_timeout_seconds": 600,
+            "verifier_request_timeout_seconds": 120,
+        }
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="router-session-smoke-") as tmp:
+        cfg_path = Path(tmp) / "upstreams.json"
+        cfg_path.write_text(json.dumps(config))
+        log_path = Path(tmp) / "aggregator.log"
+        env = {
+            **os.environ,
+            "PRIVATE_AI_GATEWAY_BIND": f"127.0.0.1:{PORT}",
+            "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH": str(cfg_path),
+            "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT": DEFAULT_DSTACK_ENDPOINT,
+            "DSTACK_VERIFIER_URL": os.environ.get("DSTACK_VERIFIER_URL", DEFAULT_DSTACK_VERIFIER_URL),
+            "PRIVATE_AI_GATEWAY_REPO_URL": "https://github.com/Dstack-TEE/private-ai-gateway",
+            "PRIVATE_AI_GATEWAY_REPO_COMMIT": "live-e2e",
+            "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": "3600",
+            "RUST_LOG": "warn",
+        }
+        env.pop("NEARAI_API_KEY", None)  # lives in the config file, not the env
+        log = log_path.open("wb")
+        proc = subprocess.Popen(
+            ["cargo", "run", "--bin", "private-ai-gateway"],
+            cwd=ROOT,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            deadline = time.time() + 240
+            ready = False
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    print("gateway exited early; log tail:\n", log_path.read_text()[-1200:])
+                    return 1
+                try:
+                    r = requests.get(f"{BASE}/v1/models", timeout=2)
+                    if r.status_code == 200:
+                        ids = {m.get("id") for m in r.json().get("data", [])}
+                        if set(MODELS) <= ids:
+                            ready = True
+                            break
+                except Exception:
+                    pass
+                time.sleep(0.75)
+            if not ready:
+                print("gateway not ready; log tail:\n", log_path.read_text()[-1200:])
+                return 1
+
+            results = {}
+            for model in MODELS:
+                status, sid, model_id = session_id_for(model)
+                print(f"  {model}: status={status} session_id={sid} model_id={model_id}")
+                if status != 200 or not sid:
+                    return 1
+                results[model] = sid
+
+            sids = set(results.values())
+            if len(sids) == 1:
+                print(f"\nPASS: both models resolved to ONE channel session: {sids.pop()}")
+                return 0
+            print(f"\nFAIL: models produced different sessions: {results}")
+            return 1
+        finally:
+            if proc.poll() is None:
+                os.killpg(proc.pid, signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    os.killpg(proc.pid, signal.SIGKILL)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live_e2e/router_session_smoke.py
+++ b/scripts/live_e2e/router_session_smoke.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """Live check for router channel-keying.
 
-Boots the gateway with ONE NEAR AI upstream mapping two models, sends a request
-to each, and asserts both receipts cite the SAME `upstream.verified.session_id`
-— i.e. a router yields one attested session per channel, not one per model.
+Boots the gateway with ONE router upstream (NEAR AI or Tinfoil) mapping two
+models, sends a request to each, and asserts both receipts cite the SAME
+`upstream.verified.session_id` — i.e. a router yields one attested session per
+channel, not one per model, while each receipt records its own model.
 
-Run from scripts/ with NEARAI_API_KEY in the environment.
+Usage (from scripts/, with the provider key in the environment):
+    uv run python live_e2e/router_session_smoke.py near-ai
+    uv run python live_e2e/router_session_smoke.py tinfoil
 """
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import signal
@@ -30,9 +34,18 @@ from live_e2e.common import (  # noqa: E402
 
 PORT = 18086
 BASE = f"http://127.0.0.1:{PORT}"
-MODELS = {
-    "router-gemma": "google/gemma-4-31B-it",
-    "router-deepseek": "deepseek-ai/DeepSeek-V4-Flash",
+
+PRESETS = {
+    "near-ai": {
+        "base_url": "https://cloud-api.near.ai",
+        "api_key_env": "NEARAI_API_KEY",
+        "models": ["google/gemma-4-31B-it", "deepseek-ai/DeepSeek-V4-Flash"],
+    },
+    "tinfoil": {
+        "base_url": "https://inference.tinfoil.sh",
+        "api_key_env": "TINFOIL_API_KEY",
+        "models": ["kimi-k2-6", "llama3-3-70b"],
+    },
 }
 
 
@@ -53,17 +66,24 @@ def session_id_for(model: str) -> tuple[int, str | None, str | None]:
 
 
 def main() -> int:
-    token = os.environ.get("NEARAI_API_KEY")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("provider", choices=sorted(PRESETS), default="near-ai", nargs="?")
+    args = parser.parse_args()
+    preset = PRESETS[args.provider]
+
+    token = os.environ.get(preset["api_key_env"])
     if not token:
-        print("missing NEARAI_API_KEY")
+        print(f"missing {preset['api_key_env']}")
         return 2
 
+    # public alias -> upstream model
+    public = {f"router-{i}": m for i, m in enumerate(preset["models"])}
     config = [
         {
-            "name": "near-router",
-            "provider": "near-ai",
-            "base_url": "https://cloud-api.near.ai",
-            "models": MODELS,
+            "name": f"{args.provider}-router",
+            "provider": args.provider,
+            "base_url": preset["base_url"],
+            "models": public,
             "bearer_token": token,
             "connect_timeout_seconds": 10,
             "read_timeout_seconds": 600,
@@ -86,7 +106,7 @@ def main() -> int:
             "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": "3600",
             "RUST_LOG": "warn",
         }
-        env.pop("NEARAI_API_KEY", None)  # lives in the config file, not the env
+        env.pop(preset["api_key_env"], None)  # lives in the config file, not the env
         log = log_path.open("wb")
         proc = subprocess.Popen(
             ["cargo", "run", "--bin", "private-ai-gateway"],
@@ -107,7 +127,7 @@ def main() -> int:
                     r = requests.get(f"{BASE}/v1/models", timeout=2)
                     if r.status_code == 200:
                         ids = {m.get("id") for m in r.json().get("data", [])}
-                        if set(MODELS) <= ids:
+                        if set(public) <= ids:
                             ready = True
                             break
                 except Exception:
@@ -118,12 +138,12 @@ def main() -> int:
                 return 1
 
             results = {}
-            for model in MODELS:
-                status, sid, model_id = session_id_for(model)
-                print(f"  {model}: status={status} session_id={sid} model_id={model_id}")
+            for alias in public:
+                status, sid, model_id = session_id_for(alias)
+                print(f"  {alias} ({public[alias]}): status={status} session_id={sid} model_id={model_id}")
                 if status != 200 or not sid:
                     return 1
-                results[model] = sid
+                results[alias] = sid
 
             sids = set(results.values())
             if len(sids) == 1:

--- a/scripts/live_e2e/streaming_smoke.py
+++ b/scripts/live_e2e/streaming_smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Live streaming smoke for the receipt-hashing path.
+
+The standard live_e2e cases are all buffered, so they never exercise
+`ReceiptFinalizingStream`. This drives a real provider's *streaming* chat
+through the gateway and checks that the receipt's `response.returned` event
+hashes the exact wire bytes we received back.
+
+Usage (run from scripts/, with the provider's API key in the env):
+    uv run python live_e2e/streaming_smoke.py near-ai-live
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import requests  # noqa: E402
+
+from live_e2e.common import load_providers  # noqa: E402
+from live_e2e.launch_aggregator import AggregatorProcess  # noqa: E402
+
+PROVIDERS_FILE = Path(__file__).resolve().parent / "providers.json"
+
+
+def main() -> int:
+    name = sys.argv[1] if len(sys.argv) > 1 else "near-ai-live"
+    providers = load_providers(PROVIDERS_FILE, [name])
+    if not providers:
+        print(f"provider {name!r} not found in {PROVIDERS_FILE}")
+        return 2
+    provider = providers[0]
+    if not os.environ.get(provider.api_key_env):
+        print(f"missing {provider.api_key_env} in environment")
+        return 2
+
+    port = 18086
+    with AggregatorProcess([provider], port=port) as agg:
+        base = agg.base_url
+        body = {
+            "model": provider.public_model,
+            "messages": [
+                {"role": "user", "content": "Reply with exactly: hello from the smoke test."}
+            ],
+            "stream": True,
+            "max_tokens": 64,
+        }
+        print(f"POST {base}/v1/chat/completions  (stream=true, model={provider.public_model})")
+        resp = requests.post(
+            f"{base}/v1/chat/completions", json=body, stream=True, timeout=180
+        )
+        raw = bytearray()
+        for chunk in resp.iter_content(chunk_size=None):
+            if chunk:
+                raw += chunk
+        content_type = resp.headers.get("content-type", "")
+        receipt_id = resp.headers.get("x-receipt-id")
+        print(
+            f"  status={resp.status_code} content-type={content_type!r} "
+            f"x-receipt-id={receipt_id} wire_bytes={len(raw)}"
+        )
+        if resp.status_code != 200:
+            print("  body:", bytes(raw[:600]))
+            return 1
+        if "text/event-stream" not in content_type:
+            print("  FAIL: response was not an SSE stream")
+            return 1
+        if not receipt_id:
+            print("  FAIL: no x-receipt-id header")
+            return 1
+
+        r2 = requests.get(f"{base}/v1/aci/receipts/{receipt_id}", timeout=30)
+        if r2.status_code != 200:
+            print(f"  FAIL: receipt fetch {r2.status_code}: {r2.text[:300]}")
+            return 1
+        payload = r2.json() or {}
+        # The receipt endpoint returns the receipt object directly (event_log at
+        # top level); tolerate a {"receipt": {...}} envelope too.
+        receipt = payload.get("receipt") if "event_log" not in payload else payload
+        events = (receipt or {}).get("event_log", [])
+
+        # Per-router check: the upstream.verified event (which feeds the attested
+        # session) must be the gateway *channel* only — no model attestation
+        # folded in. (NEAR AI fix: model TD quotes stay out of the session.)
+        import base64 as _b64
+        import json as _json
+
+        uv = next((e for e in events if isinstance(e, dict) and e.get("type") == "upstream.verified"), None)
+        if uv is not None:
+            model_keys = {
+                "model_attestations_sha256",
+                "model_attestation_count",
+                "model_evidence_present",
+                "nested_model_attestations_checked_by_gateway",
+                "canonical_model_id",
+                "model_attestations_nonce_matched",
+            }
+            pc = uv.get("provider_claims") or {}
+            leaked_claims = model_keys & set(pc)
+            ev = uv.get("evidence") or {}
+            data_uri = ev.get("data") or ""
+            ev_obj = {}
+            if ";base64," in data_uri:
+                try:
+                    ev_obj = _json.loads(_b64.b64decode(data_uri.split(";base64,", 1)[1]))
+                except Exception:
+                    ev_obj = {}
+            ev_has_model = "model_attestations" in ev_obj or "model_id" in ev_obj
+            print(f"  [per-router] provider_claims keys: {sorted(pc)}")
+            print(f"  [per-router] evidence top-level keys: {sorted(ev_obj)}")
+            if leaked_claims or ev_has_model:
+                print(f"  PER-ROUTER FAIL: model attestation leaked into session "
+                      f"(claims={sorted(leaked_claims)}, evidence_has_model={ev_has_model})")
+                return 1
+            print("  [per-router] OK: session evidence/claims are gateway-channel only")
+        types = [e.get("type") for e in events if isinstance(e, dict)]
+        rr = next((e for e in events if isinstance(e, dict) and e.get("type") == "response.returned"), None)
+        if not rr:
+            print(f"  FAIL: receipt has no response.returned event; events={types}")
+            return 1
+
+        cleartext_hash = rr.get("cleartext_hash")
+        wire_hash = rr.get("wire_hash")
+        observed = "sha256:" + hashlib.sha256(bytes(raw)).hexdigest()
+        has_upstream_verified = "upstream.verified" in types
+        print(f"  receipt.cleartext_hash = {cleartext_hash}")
+        print(f"  receipt.wire_hash      = {wire_hash}")
+        print(f"  sha256(received wire)  = {observed}")
+        print(f"  upstream.verified present = {has_upstream_verified}")
+
+        ok = observed == wire_hash and has_upstream_verified
+        if ok:
+            print(
+                "\nPASS: the streamed wire bytes hash to the receipt's wire_hash, "
+                "and the receipt carries upstream.verified."
+            )
+            print(f"  (cleartext_hash == wire_hash: {cleartext_hash == wire_hash})")
+            return 0
+        print("\nFAIL: streamed bytes do not match the receipt hash")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/provider_verifier/nearai.py
+++ b/scripts/provider_verifier/nearai.py
@@ -13,7 +13,6 @@ from .common import (
     failed,
     json_evidence_bundle,
     model_dump,
-    sha256_json_prefixed,
     tdx_debug_enabled,
     verifier_id_for,
 )
@@ -125,7 +124,17 @@ async def verify_nearai(request: dict[str, Any]) -> None:
             )
             return
 
-    model_attestations_sha256 = sha256_json_prefixed(model_attestations)
+    # The attested session is the verified *gateway* TEE channel, which is the
+    # same for every model behind the router. NEAR AI's per-model TD quotes
+    # (model_attestations) are shallow-checked above as a safety gate (valid TDX
+    # bytes, nonce match, not debug-mode) but are deliberately NOT folded into
+    # the session evidence or claims: the gateway does not re-verify them, and
+    # they are not bound to the instance that serves a given request, so putting
+    # them in the session would imply a per-model attestation we did not perform
+    # and split one channel into a session per model. The served model is
+    # recorded on the receipt instead. Surfacing a request-bound, per-instance
+    # model attestation is a roadmap item (docs/roadmap.md).
+    #
     # Surface the granular gateway TDX TCB status (e.g. "UpToDate", "OutOfDate")
     # so the session layer can populate a tri-state `tcb_up_to_date` claim. The
     # dstack verifier reports TCB freshness separately from its overall is_valid
@@ -133,25 +142,28 @@ async def verify_nearai(request: dict[str, Any]) -> None:
     # freshness), so a stale TCB surfaces here without failing the gateway.
     gateway_dstack = (gateway_result.get("details") or {}).get("dstack") or {}
     gateway_tcb_status = (gateway_dstack.get("details") or {}).get("tcb_status")
+
+    # Channel-scoped, model-independent evidence: the gateway TD attestation and
+    # the TLS binding the dstack verifier checked, nonce-bound for freshness.
+    channel_evidence = {
+        "provider": "nearai",
+        "trust_boundary": "near-ai-gateway",
+        "request_nonce": report.request_nonce,
+        "tls_cert_fingerprint": spki,
+        "gateway_attestation": gateway,
+    }
     provider_claims = {
         "trust_boundary": "near-ai-gateway",
         "gateway_verified": True,
         "gateway_tls_spki_sha256": spki,
-        "model_evidence_present": True,
-        "model_attestation_count": len(model_attestations),
-        "model_attestations_sha256": model_attestations_sha256,
-        "nested_model_attestations_checked_by_gateway": False,
-        "canonical_model_id": report.model_id,
         "tcb_status": gateway_tcb_status,
     }
-    if all(isinstance(item, dict) and item.get("request_nonce") for item in model_attestations):
-        provider_claims["model_attestations_nonce_matched"] = True
 
     emit(
         {
             "result": "verified",
             "verifier_id": verifier_id,
-            "evidence": json_evidence_bundle(report_obj, attestation_url),
+            "evidence": json_evidence_bundle(channel_evidence, attestation_url),
             "channel_bindings": [
                 {
                     "type": "tls_spki_sha256",

--- a/scripts/provider_verifier/nearai.py
+++ b/scripts/provider_verifier/nearai.py
@@ -73,15 +73,11 @@ async def verify_nearai(request: dict[str, Any]) -> None:
         )
         return
 
-    # NEAR AI is a router: this verifier attests the gateway TEE channel, which
-    # is the same for every model behind it (attested_scope = "router" below).
-    # The model is only a fetch parameter for the model-scoped report endpoint —
-    # it is recorded on the receipt, never folded into the channel session. We
-    # deliberately do NOT fetch-and-check NEAR AI's per-model TD quotes here: the
-    # gateway does not re-verify them, they are not bound to the instance that
-    # serves a given request, and gating on them would be attestation theater.
-    # A request-bound, per-instance model attestation is a roadmap item
-    # (docs/roadmap.md) and would be its own scoped evidence on the receipt.
+    # NEAR AI is a router: this verifier attests the gateway TEE channel
+    # (attested_scope = "router"), shared by every model. Per-model TEE coverage
+    # is delegated to the verified gateway, which attests its own backends; the
+    # model is only a fetch parameter and is recorded on the receipt as an
+    # identifier.
     #
     # Surface the granular gateway TDX TCB status (e.g. "UpToDate", "OutOfDate")
     # so the session layer can populate a tri-state `tcb_up_to_date` claim. The

--- a/scripts/provider_verifier/nearai.py
+++ b/scripts/provider_verifier/nearai.py
@@ -13,7 +13,6 @@ from .common import (
     failed,
     json_evidence_bundle,
     model_dump,
-    tdx_debug_enabled,
     verifier_id_for,
 )
 
@@ -74,66 +73,15 @@ async def verify_nearai(request: dict[str, Any]) -> None:
         )
         return
 
-    raw_report = report.raw or {}
-    model_attestations = raw_report.get("model_attestations") or []
-    if not isinstance(model_attestations, list) or not model_attestations:
-        failed(
-            provider,
-            "NEAR AI model-scoped report did not include model_attestations",
-            evidence=json_evidence_bundle(report_obj, attestation_url),
-            verifier_id=verifier_id,
-        )
-        return
-
-    for index, item in enumerate(model_attestations):
-        if not isinstance(item, dict) or not item.get("intel_quote"):
-            failed(
-                provider,
-                f"NEAR AI model_attestations[{index}] did not include intel_quote",
-                evidence=json_evidence_bundle(report_obj, attestation_url),
-                verifier_id=verifier_id,
-            )
-            return
-        item_nonce = item.get("request_nonce")
-        if item_nonce is not None and str(item_nonce).lower() != str(report.request_nonce).lower():
-            failed(
-                provider,
-                f"NEAR AI model_attestations[{index}] nonce did not match request nonce",
-                evidence=json_evidence_bundle(report_obj, attestation_url),
-                verifier_id=verifier_id,
-            )
-            return
-        # The gateway does not re-verify these nested model quotes through the
-        # dstack verifier, so check the TD debug bit here: a debug-mode model TD
-        # would otherwise be accepted on the gateway's word alone.
-        try:
-            if tdx_debug_enabled(bytes.fromhex(item["intel_quote"])):
-                failed(
-                    provider,
-                    f"NEAR AI model_attestations[{index}] TDX quote is in debug mode",
-                    evidence=json_evidence_bundle(report_obj, attestation_url),
-                    verifier_id=verifier_id,
-                )
-                return
-        except ValueError as exc:
-            failed(
-                provider,
-                f"NEAR AI model_attestations[{index}] intel_quote is not valid TDX bytes: {exc}",
-                evidence=json_evidence_bundle(report_obj, attestation_url),
-                verifier_id=verifier_id,
-            )
-            return
-
-    # The attested session is the verified *gateway* TEE channel, which is the
-    # same for every model behind the router. NEAR AI's per-model TD quotes
-    # (model_attestations) are shallow-checked above as a safety gate (valid TDX
-    # bytes, nonce match, not debug-mode) but are deliberately NOT folded into
-    # the session evidence or claims: the gateway does not re-verify them, and
-    # they are not bound to the instance that serves a given request, so putting
-    # them in the session would imply a per-model attestation we did not perform
-    # and split one channel into a session per model. The served model is
-    # recorded on the receipt instead. Surfacing a request-bound, per-instance
-    # model attestation is a roadmap item (docs/roadmap.md).
+    # NEAR AI is a router: this verifier attests the gateway TEE channel, which
+    # is the same for every model behind it (attested_scope = "router" below).
+    # The model is only a fetch parameter for the model-scoped report endpoint —
+    # it is recorded on the receipt, never folded into the channel session. We
+    # deliberately do NOT fetch-and-check NEAR AI's per-model TD quotes here: the
+    # gateway does not re-verify them, they are not bound to the instance that
+    # serves a given request, and gating on them would be attestation theater.
+    # A request-bound, per-instance model attestation is a roadmap item
+    # (docs/roadmap.md) and would be its own scoped evidence on the receipt.
     #
     # Surface the granular gateway TDX TCB status (e.g. "UpToDate", "OutOfDate")
     # so the session layer can populate a tri-state `tcb_up_to_date` claim. The
@@ -163,6 +111,7 @@ async def verify_nearai(request: dict[str, Any]) -> None:
         {
             "result": "verified",
             "verifier_id": verifier_id,
+            "attested_scope": "router",
             "evidence": json_evidence_bundle(channel_evidence, attestation_url),
             "channel_bindings": [
                 {

--- a/scripts/provider_verifier/tinfoil.py
+++ b/scripts/provider_verifier/tinfoil.py
@@ -115,6 +115,7 @@ async def verify_tinfoil(request: dict[str, Any]) -> None:
         {
             "result": "verified",
             "verifier_id": "tinfoil-verifier/v1",
+            "attested_scope": "router",
             "evidence": evidence,
             "channel_bindings": [
                 {

--- a/scripts/provider_verifier/tinfoil.py
+++ b/scripts/provider_verifier/tinfoil.py
@@ -96,6 +96,21 @@ async def verify_tinfoil(request: dict[str, Any]) -> None:
     used_router = bool(getattr(doc, "selected_router_endpoint", "")) or repo.endswith(
         "confidential-model-router"
     )
+    # Tinfoil is a router upstream: we request the router attestation (the
+    # confidential-model-router enclave) explicitly rather than inferring the
+    # scope from the response. The verified channel is that router enclave,
+    # shared by every model, so the attested session is per router (like NEAR
+    # AI) and the served model is recorded on the receipt, not in the session.
+    # Fail closed if the verification was not router-scoped, so a non-router
+    # deployment can never be treated as one channel for many models.
+    if not used_router:
+        failed(
+            provider,
+            "Tinfoil verification was not router-scoped; expected the "
+            f"confidential-model-router enclave (repo={repo!r})",
+            evidence=evidence,
+        )
+        return
     emit(
         {
             "result": "verified",
@@ -109,10 +124,12 @@ async def verify_tinfoil(request: dict[str, Any]) -> None:
                 }
             ],
             "provider_claims": {
-                "trust_boundary": "router" if used_router else "model",
-                "evidence_scope": "router" if used_router else "model",
-                "canonical_model_id": request["model_id"],
-                "used_router": used_router,
+                # Router channel scope — model-independent. The served model is
+                # deliberately NOT folded in: it would split one verified channel
+                # into a session per model, and it is recorded on the receipt.
+                "trust_boundary": "router",
+                "evidence_scope": "router",
+                "used_router": True,
                 "config_repo": doc.config_repo,
                 "release_digest": doc.release_digest,
                 "code_fingerprint": doc.code_fingerprint,

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -20,7 +20,7 @@ use super::{current_unix_secs, decode_hex_32};
 use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use crate::aci::upstream::{ChutesSessionStore, ChutesVerifiedDiscovery};
 use crate::aggregator::service::UpstreamVerificationRequest;
-use crate::aggregator::upstream_config::{attestation_scope_for_provider, AttestationScope};
+use crate::aggregator::upstream_config::AttestationScope;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderVerifierConfigError {
@@ -31,6 +31,10 @@ pub enum ProviderVerifierConfigError {
 #[derive(Debug, Clone)]
 pub(super) struct ExternalProviderVerifier {
     provider: &'static str,
+    /// The channel boundary this provider attests, resolved once from
+    /// `UpstreamProvider::attestation_scope`. Drives channel-keying and the
+    /// fail-closed scope seam.
+    scope: AttestationScope,
     command: Vec<String>,
     current_dir: Option<PathBuf>,
     env: Vec<(String, String)>,
@@ -45,6 +49,7 @@ pub(super) struct ExternalProviderVerifier {
 impl ExternalProviderVerifier {
     pub(super) fn private_inference(
         provider: &'static str,
+        scope: AttestationScope,
         timeout_seconds: u64,
         cache_ttl_seconds: u64,
     ) -> Self {
@@ -60,6 +65,7 @@ impl ExternalProviderVerifier {
         ];
         Self {
             provider,
+            scope,
             command,
             // Run `uv run` in the gateway project so the bridge uses the gateway's
             // own uv environment and the vendored `scripts/confidential_verifier`
@@ -81,6 +87,7 @@ impl ExternalProviderVerifier {
     #[cfg(test)]
     pub(super) fn with_command(
         provider: &'static str,
+        scope: AttestationScope,
         command: Vec<String>,
         timeout_seconds: u64,
     ) -> Result<Self, ProviderVerifierConfigError> {
@@ -89,6 +96,7 @@ impl ExternalProviderVerifier {
         }
         Ok(Self {
             provider,
+            scope,
             command,
             current_dir: None,
             env: Vec::new(),
@@ -104,11 +112,12 @@ impl ExternalProviderVerifier {
     #[cfg(test)]
     pub(super) fn with_command_and_cache(
         provider: &'static str,
+        scope: AttestationScope,
         command: Vec<String>,
         timeout_seconds: u64,
         cache_ttl_seconds: u64,
     ) -> Result<Self, ProviderVerifierConfigError> {
-        let mut verifier = Self::with_command(provider, command, timeout_seconds)?;
+        let mut verifier = Self::with_command(provider, scope, command, timeout_seconds)?;
         verifier.cache_ttl_seconds = cache_ttl_seconds;
         Ok(verifier)
     }
@@ -141,7 +150,7 @@ impl ExternalProviderVerifier {
     /// (docs/roadmap.md) and would live on the receipt, not the channel session.
     fn cache_key(&self, request: &UpstreamVerificationRequest) -> ExternalProviderVerifierCacheKey {
         let mut key = ExternalProviderVerifierCacheKey::from_request(request);
-        if attestation_scope_for_provider(self.provider).is_per_router() {
+        if self.scope.is_per_router() {
             key.model_id = String::new();
         }
         key
@@ -380,7 +389,7 @@ impl ExternalProviderVerifier {
     /// model). The served model is the gateway's request/receipt fact, never a
     /// channel claim.
     fn enforce_attested_scope(&self, declared: Option<&str>) -> Result<(), String> {
-        let expected = attestation_scope_for_provider(self.provider);
+        let expected = self.scope;
         match declared {
             Some(token) => match AttestationScope::from_declared(token) {
                 Some(scope) if scope == expected => Ok(()),

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -20,6 +20,7 @@ use super::{current_unix_secs, decode_hex_32};
 use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use crate::aci::upstream::{ChutesSessionStore, ChutesVerifiedDiscovery};
 use crate::aggregator::service::UpstreamVerificationRequest;
+use crate::aggregator::upstream_config::{attestation_scope_for_provider, AttestationScope};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderVerifierConfigError {
@@ -125,24 +126,22 @@ impl ExternalProviderVerifier {
         self
     }
 
-    /// Cache / channel-identity key for a verification. Router providers (e.g.
-    /// NEAR AI) verify one gateway TEE channel shared by every model behind it,
-    /// so the model is omitted from the key: a request for any model resolves to
-    /// that one verified channel, and the channel-addressed session dedups to one
-    /// per router. Per-model (Phala-direct) and per-instance (Chutes) providers
-    /// keep the model in the key, so each really is its own channel.
+    /// Cache / channel-identity key for a verification, derived from the
+    /// provider's [`AttestationScope`]. A per-router provider (e.g. NEAR AI)
+    /// verifies one gateway TEE channel shared by every model behind it, so the
+    /// model is omitted from the key: a request for any model resolves to that
+    /// one verified channel, and the channel-addressed session dedups to one per
+    /// router. Per-model (Phala-direct) and per-instance (Chutes) providers keep
+    /// the model in the key, so each really is its own channel.
     ///
     /// A router-cached event is still tagged with the requesting model by
     /// `CachedExternalProviderEvent::event_for`, so the receipt reports the right
-    /// per-request model. The tradeoff: a request for a model other than the one
-    /// that populated the cache reuses the gateway verification without fetching
-    /// that model's report, so the per-model debug-TD shallow-check (see
-    /// `scripts/provider_verifier/nearai.py`) only covers the cache-populating
-    /// model. That is consistent with attesting the gateway channel rather than
-    /// the model; full per-model model-TD verification is a roadmap item.
+    /// per-request model. The model itself is never attested by a router channel;
+    /// a request-bound, per-instance model attestation is a roadmap item
+    /// (docs/roadmap.md) and would live on the receipt, not the channel session.
     fn cache_key(&self, request: &UpstreamVerificationRequest) -> ExternalProviderVerifierCacheKey {
         let mut key = ExternalProviderVerifierCacheKey::from_request(request);
-        if provider_is_router(self.provider) {
+        if attestation_scope_for_provider(self.provider).is_per_router() {
             key.model_id = String::new();
         }
         key
@@ -352,6 +351,9 @@ impl ExternalProviderVerifier {
                     .to_string(),
             );
         }
+        if result == VerificationResult::Verified {
+            self.enforce_attested_scope(output.attested_scope.as_deref())?;
+        }
         Ok(UpstreamVerifiedEvent {
             upstream_name: request.upstream_name,
             provider: Some(self.provider.to_string()),
@@ -368,6 +370,37 @@ impl ExternalProviderVerifier {
             channel_bindings,
             provider_claims: output.provider_claims.clone(),
         })
+    }
+
+    /// Fail-closed scope seam: a provider must attest the channel boundary it is
+    /// declared to use ([`AttestationScope`]). A per-router provider that returns
+    /// anything but router-scoped evidence — or declares no scope at all — is
+    /// rejected, so a router's attested session can never be sealed from
+    /// model-scoped evidence (which would split one channel into a session per
+    /// model). The served model is the gateway's request/receipt fact, never a
+    /// channel claim.
+    fn enforce_attested_scope(&self, declared: Option<&str>) -> Result<(), String> {
+        let expected = attestation_scope_for_provider(self.provider);
+        match declared {
+            Some(token) => match AttestationScope::from_declared(token) {
+                Some(scope) if scope == expected => Ok(()),
+                Some(scope) => Err(format!(
+                    "provider verifier attested {} scope but {} is a per-{} provider",
+                    scope.as_declared(),
+                    self.provider,
+                    expected.as_declared(),
+                )),
+                None => Err(format!(
+                    "provider verifier returned an unrecognized attestation scope {token:?}"
+                )),
+            },
+            None if expected.is_per_router() => Err(format!(
+                "router provider {} did not declare its attestation scope; refusing to \
+                 seal a channel session from undeclared evidence",
+                self.provider,
+            )),
+            None => Ok(()),
+        }
     }
 
     fn record_provider_session(
@@ -436,14 +469,6 @@ impl ExternalProviderVerifierCacheKey {
     }
 }
 
-/// Whether a provider is a router: one verified TEE channel (a gateway TD or a
-/// confidential model router) fronts many models, so the attested session is the
-/// channel, not per model. Keep in sync with `UpstreamProvider::is_router` —
-/// these two name the same set by the provider's wire string vs its config enum.
-fn provider_is_router(provider: &str) -> bool {
-    matches!(provider, "near-ai" | "tinfoil")
-}
-
 #[derive(Clone, Debug)]
 struct CachedExternalProviderEvent {
     expires_at: u64,
@@ -471,6 +496,10 @@ struct ExternalProviderVerifierOutput {
     channel_bindings: Vec<ExternalChannelBinding>,
     #[serde(default)]
     provider_claims: Option<serde_json::Value>,
+    /// The channel boundary the verifier attests ("router" / "model" /
+    /// "instance"), enforced fail-closed against the provider's expected scope.
+    #[serde(default)]
+    attested_scope: Option<String>,
     #[serde(default)]
     chutes_session: Option<ChutesVerifiedDiscovery>,
 }

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -125,11 +125,34 @@ impl ExternalProviderVerifier {
         self
     }
 
+    /// Cache / channel-identity key for a verification. Router providers (e.g.
+    /// NEAR AI) verify one gateway TEE channel shared by every model behind it,
+    /// so the model is omitted from the key: a request for any model resolves to
+    /// that one verified channel, and the channel-addressed session dedups to one
+    /// per router. Per-model (Phala-direct) and per-instance (Chutes) providers
+    /// keep the model in the key, so each really is its own channel.
+    ///
+    /// A router-cached event is still tagged with the requesting model by
+    /// `CachedExternalProviderEvent::event_for`, so the receipt reports the right
+    /// per-request model. The tradeoff: a request for a model other than the one
+    /// that populated the cache reuses the gateway verification without fetching
+    /// that model's report, so the per-model debug-TD shallow-check (see
+    /// `scripts/provider_verifier/nearai.py`) only covers the cache-populating
+    /// model. That is consistent with attesting the gateway channel rather than
+    /// the model; full per-model model-TD verification is a roadmap item.
+    fn cache_key(&self, request: &UpstreamVerificationRequest) -> ExternalProviderVerifierCacheKey {
+        let mut key = ExternalProviderVerifierCacheKey::from_request(request);
+        if provider_is_router(self.provider) {
+            key.model_id = String::new();
+        }
+        key
+    }
+
     pub(super) async fn verify(
         &self,
         request: UpstreamVerificationRequest,
     ) -> UpstreamVerifiedEvent {
-        let cache_key = ExternalProviderVerifierCacheKey::from_request(&request);
+        let cache_key = self.cache_key(&request);
         if let Some(event) = self.cached_event(&cache_key, &request) {
             return event;
         }
@@ -144,7 +167,7 @@ impl ExternalProviderVerifier {
         &self,
         request: UpstreamVerificationRequest,
     ) -> UpstreamVerifiedEvent {
-        let cache_key = ExternalProviderVerifierCacheKey::from_request(&request);
+        let cache_key = self.cache_key(&request);
         let _verify_guard = self.verify_lock.lock().await;
         self.verify_uncached(request, cache_key).await
     }
@@ -408,6 +431,14 @@ impl ExternalProviderVerifierCacheKey {
             model_id: request.model_id.clone(),
         }
     }
+}
+
+/// Whether a provider is a router: one verified gateway TEE channel fronts many
+/// models, so the attested session is the channel (not per model). Keep in sync
+/// with `UpstreamProvider::is_router` — these two name the same set by the
+/// provider's wire string vs its config enum.
+fn provider_is_router(provider: &str) -> bool {
+    matches!(provider, "near-ai")
 }
 
 #[derive(Clone, Debug)]

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -269,10 +269,13 @@ impl ExternalProviderVerifier {
     }
 
     pub(super) fn invalidate(&self, request: &UpstreamVerificationRequest) {
+        // Must use the same key as `verify`/`refresh` (channel-keyed for routers),
+        // otherwise invalidation would target a different entry than the one
+        // cached and a router's verification could never be flushed.
         self.cache
             .write()
             .expect("external provider verifier cache poisoned")
-            .remove(&ExternalProviderVerifierCacheKey::from_request(request));
+            .remove(&self.cache_key(request));
     }
 
     async fn run(&self, input: Vec<u8>) -> Result<Vec<u8>, String> {
@@ -433,12 +436,12 @@ impl ExternalProviderVerifierCacheKey {
     }
 }
 
-/// Whether a provider is a router: one verified gateway TEE channel fronts many
-/// models, so the attested session is the channel (not per model). Keep in sync
-/// with `UpstreamProvider::is_router` — these two name the same set by the
-/// provider's wire string vs its config enum.
+/// Whether a provider is a router: one verified TEE channel (a gateway TD or a
+/// confidential model router) fronts many models, so the attested session is the
+/// channel, not per model. Keep in sync with `UpstreamProvider::is_router` —
+/// these two name the same set by the provider's wire string vs its config enum.
 fn provider_is_router(provider: &str) -> bool {
-    matches!(provider, "near-ai")
+    matches!(provider, "near-ai" | "tinfoil")
 }
 
 #[derive(Clone, Debug)]

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -12,6 +12,7 @@ use super::external::ProviderVerifierConfigError;
 use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
 use crate::aci::upstream::ChutesSessionStore;
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
+use crate::aggregator::upstream_config::UpstreamProvider;
 
 #[derive(Debug, Clone)]
 pub struct ChutesProviderVerifier {
@@ -27,6 +28,7 @@ impl ChutesProviderVerifier {
         Self {
             verifier: ExternalProviderVerifier::private_inference(
                 "chutes",
+                UpstreamProvider::Chutes.attestation_scope(),
                 timeout_seconds,
                 cache_ttl_seconds,
             ),
@@ -41,6 +43,7 @@ impl ChutesProviderVerifier {
         Self {
             verifier: ExternalProviderVerifier::private_inference(
                 "chutes",
+                UpstreamProvider::Chutes.attestation_scope(),
                 timeout_seconds,
                 cache_ttl_seconds,
             )
@@ -88,7 +91,12 @@ impl ChutesProviderVerifier {
         timeout_seconds: u64,
     ) -> Result<Self, ProviderVerifierConfigError> {
         Ok(Self {
-            verifier: ExternalProviderVerifier::with_command("chutes", command, timeout_seconds)?,
+            verifier: ExternalProviderVerifier::with_command(
+                "chutes",
+                UpstreamProvider::Chutes.attestation_scope(),
+                command,
+                timeout_seconds,
+            )?,
         })
     }
 
@@ -99,8 +107,13 @@ impl ChutesProviderVerifier {
         session_store: Arc<ChutesSessionStore>,
     ) -> Result<Self, ProviderVerifierConfigError> {
         Ok(Self {
-            verifier: ExternalProviderVerifier::with_command("chutes", command, timeout_seconds)?
-                .with_chutes_session_store(session_store),
+            verifier: ExternalProviderVerifier::with_command(
+                "chutes",
+                UpstreamProvider::Chutes.attestation_scope(),
+                command,
+                timeout_seconds,
+            )?
+            .with_chutes_session_store(session_store),
         })
     }
 }
@@ -134,6 +147,7 @@ impl TinfoilProviderVerifier {
         Self {
             verifier: ExternalProviderVerifier::private_inference(
                 "tinfoil",
+                UpstreamProvider::Tinfoil.attestation_scope(),
                 timeout_seconds,
                 cache_ttl_seconds,
             ),
@@ -146,7 +160,12 @@ impl TinfoilProviderVerifier {
         timeout_seconds: u64,
     ) -> Result<Self, ProviderVerifierConfigError> {
         Ok(Self {
-            verifier: ExternalProviderVerifier::with_command("tinfoil", command, timeout_seconds)?,
+            verifier: ExternalProviderVerifier::with_command(
+                "tinfoil",
+                UpstreamProvider::Tinfoil.attestation_scope(),
+                command,
+                timeout_seconds,
+            )?,
         })
     }
 }
@@ -180,6 +199,7 @@ impl NearAiProviderVerifier {
         Self {
             verifier: ExternalProviderVerifier::private_inference(
                 "near-ai",
+                UpstreamProvider::NearAi.attestation_scope(),
                 timeout_seconds,
                 cache_ttl_seconds,
             ),
@@ -192,7 +212,12 @@ impl NearAiProviderVerifier {
         timeout_seconds: u64,
     ) -> Result<Self, ProviderVerifierConfigError> {
         Ok(Self {
-            verifier: ExternalProviderVerifier::with_command("near-ai", command, timeout_seconds)?,
+            verifier: ExternalProviderVerifier::with_command(
+                "near-ai",
+                UpstreamProvider::NearAi.attestation_scope(),
+                command,
+                timeout_seconds,
+            )?,
         })
     }
 }
@@ -235,6 +260,7 @@ impl PhalaDirectProviderVerifier {
         Self {
             verifier: ExternalProviderVerifier::private_inference(
                 "phala-direct",
+                UpstreamProvider::PhalaDirect.attestation_scope(),
                 timeout_seconds,
                 cache_ttl_seconds,
             ),
@@ -258,6 +284,7 @@ impl PhalaDirectProviderVerifier {
         Ok(Self {
             verifier: ExternalProviderVerifier::with_command(
                 "phala-direct",
+                UpstreamProvider::PhalaDirect.attestation_scope(),
                 command,
                 timeout_seconds,
             )?,

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -9,13 +9,14 @@ use super::dstack::verify_dstack_kms_identity_custody;
 use super::external::ExternalProviderVerifier;
 use super::*;
 use crate::aci::keys::ALGO_ECDSA_SECP256K1;
-use crate::aci::receipt::{ChannelBinding, VerificationResult};
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use crate::aci::types::{
     AttestationEnvelope, AttestationReport, Freshness, KeysetEndorsement, KeysetEpoch,
     PublicKeyMaterial, ServiceCapabilities, SourceProvenance, WorkloadIdentity, WorkloadKeyset,
 };
 use crate::aci::upstream::ChutesSessionStore;
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
+use crate::aggregator::upstream_config::AttestationScope;
 
 fn signing_key(byte: u8) -> SigningKey {
     SigningKey::from_slice(&[byte; 32]).unwrap()
@@ -90,21 +91,20 @@ fn custody_report(identity: &SigningKey, signature_chain: Vec<String>) -> Attest
     }
 }
 
-/// The attestation scope a stub verifier should declare to satisfy the
-/// fail-closed scope seam — mirrors `attestation_scope_for_provider`.
-fn declared_scope(provider: &str) -> &'static str {
+/// The scope token a stub verifier declares. Only routers declare a scope in
+/// production (near.ai / Tinfoil); per-model and per-instance verifiers omit it
+/// and the seam accepts `None`. Stubs mirror that so the real accept paths run.
+fn declared_scope(provider: &str) -> Option<&'static str> {
     match provider {
-        "near-ai" | "tinfoil" => "router",
-        "chutes" => "instance",
-        _ => "model",
+        "near-ai" | "tinfoil" => Some("router"),
+        _ => None,
     }
 }
 
 fn provider_script(provider: &str, verifier_id: &str, binding: Value) -> Vec<String> {
-    let output = json!({
+    let mut output = json!({
         "result": "verified",
         "verifier_id": verifier_id,
-        "attested_scope": declared_scope(provider),
         "evidence": {
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJvdmlkZXItbW9kZWwifQ==",
@@ -114,8 +114,11 @@ fn provider_script(provider: &str, verifier_id: &str, binding: Value) -> Vec<Str
             "fixture_provider": provider,
             "model_evidence_present": true,
         },
-    })
-    .to_string();
+    });
+    if let Some(scope) = declared_scope(provider) {
+        output["attested_scope"] = json!(scope);
+    }
+    let output = output.to_string();
     let script = format!(
         r#"payload="$(cat)"
 case "$payload" in
@@ -132,17 +135,19 @@ fn counting_provider_script(
     verifier_id: &str,
     binding: Value,
 ) -> Vec<String> {
-    let output = json!({
+    let mut output = json!({
         "result": "verified",
         "verifier_id": verifier_id,
-        "attested_scope": declared_scope(provider),
         "evidence": {
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJvdmlkZXItbW9kZWwifQ==",
         },
         "channel_bindings": [binding],
-    })
-    .to_string();
+    });
+    if let Some(scope) = declared_scope(provider) {
+        output["attested_scope"] = json!(scope);
+    }
+    let output = output.to_string();
     let script = format!(
         r#"payload="$(cat)"
 case "$payload" in
@@ -392,6 +397,7 @@ async fn external_provider_verifier_caches_verified_bindings() {
     let _ = std::fs::remove_file(&counter_path);
     let verifier = ExternalProviderVerifier::with_command_and_cache(
         "tinfoil",
+        AttestationScope::PerRouter,
         counting_provider_script(
             &counter_path,
             "tinfoil",
@@ -447,12 +453,15 @@ async fn router_shares_one_channel_verification_across_models() {
     // model, so verifying a second model reuses the first model's verification
     // (one external run) and event_for re-tags it with the requesting model. A
     // per-model provider must NOT share — each model is its own channel.
-    for (provider, expected_runs) in [("near-ai", "1"), ("phala-direct", "2")] {
-        // Each provider declares its own scope so the fail-closed seam accepts it.
-        let output = json!({
+    for (provider, scope, expected_runs) in [
+        ("near-ai", AttestationScope::PerRouter, "1"),
+        ("phala-direct", AttestationScope::PerModel, "2"),
+    ] {
+        // The stub declares the provider's scope (routers) or omits it (per-model)
+        // just like production, so the fail-closed seam accepts it.
+        let mut output = json!({
             "result": "verified",
             "verifier_id": "router-cache-test/v1",
-            "attested_scope": declared_scope(provider),
             "evidence": {
                 "digest": format!("sha256:{}", "11".repeat(32)),
                 "data": "data:application/json;base64,eyJmaXh0dXJlIjoicm91dGVyIn0=",
@@ -462,8 +471,11 @@ async fn router_shares_one_channel_verification_across_models() {
                 "origin": "https://router.example",
                 "spki_sha256": "AA".repeat(32),
             }],
-        })
-        .to_string();
+        });
+        if let Some(token) = declared_scope(provider) {
+            output["attested_scope"] = json!(token);
+        }
+        let output = output.to_string();
         // Counts every external run and verifies any model (unlike
         // counting_provider_script, which is pinned to one model_id).
         let script = format!(
@@ -480,6 +492,7 @@ printf '%s' '{output}'"#
         let _ = std::fs::remove_file(&counter_path);
         let verifier = ExternalProviderVerifier::with_command_and_cache(
             provider,
+            scope,
             vec![
                 "/bin/sh".to_string(),
                 "-c".to_string(),
@@ -520,6 +533,81 @@ printf '%s' '{output}'"#
 }
 
 #[tokio::test]
+async fn scope_seam_rejects_mismatched_missing_and_unknown_scopes() {
+    // The fail-closed seam: a Verified result must attest the scope its provider
+    // is declared to use. A router that comes back model-scoped, undeclared, or
+    // with a garbage token is rejected before the event is trusted or cached;
+    // a non-router that omits the scope (the production path) is accepted.
+    async fn verify_with_scope(
+        provider: &'static str,
+        scope: AttestationScope,
+        declared: Option<&str>,
+    ) -> UpstreamVerifiedEvent {
+        let mut output = json!({
+            "result": "verified",
+            "verifier_id": "scope-seam-test/v1",
+            "channel_bindings": [{
+                "type": "tls_spki_sha256",
+                "origin": "https://provider.example",
+                "spki_sha256": "AA".repeat(32),
+            }],
+        });
+        if let Some(token) = declared {
+            output["attested_scope"] = json!(token);
+        }
+        let script = format!("cat >/dev/null; printf '%s' '{}'", output);
+        let verifier = ExternalProviderVerifier::with_command(
+            provider,
+            scope,
+            vec!["/bin/sh".to_string(), "-c".to_string(), script],
+            5,
+        )
+        .unwrap();
+        verifier
+            .verify(UpstreamVerificationRequest {
+                upstream_name: "scope-seam-upstream".to_string(),
+                url_origin: Some("https://provider.example".to_string()),
+                model_id: "model-a".to_string(),
+                forwarded_body_hash: format!("sha256:{}", "22".repeat(32)),
+                required: true,
+            })
+            .await
+    }
+
+    // Router declaring the wrong (model) scope → rejected.
+    let mismatch = verify_with_scope("near-ai", AttestationScope::PerRouter, Some("model")).await;
+    assert_eq!(mismatch.result, VerificationResult::Failed);
+    assert!(mismatch.reason.unwrap().contains("per-router"));
+
+    // Router declaring no scope at all → rejected (it must declare).
+    let missing = verify_with_scope("near-ai", AttestationScope::PerRouter, None).await;
+    assert_eq!(missing.result, VerificationResult::Failed);
+    assert!(missing.reason.unwrap().contains("did not declare"));
+
+    // Any verifier returning a garbage token → rejected.
+    let unknown = verify_with_scope("near-ai", AttestationScope::PerRouter, Some("galaxy")).await;
+    assert_eq!(unknown.result, VerificationResult::Failed);
+    assert!(unknown.reason.unwrap().contains("unrecognized"));
+
+    // Per-instance provider declaring its matching scope → accepted.
+    let instance =
+        verify_with_scope("chutes", AttestationScope::PerInstance, Some("instance")).await;
+    assert_eq!(instance.result, VerificationResult::Verified);
+
+    // Per-instance provider declaring router scope → rejected (mismatch the other
+    // direction, so the seam isn't router-only).
+    let instance_mismatch =
+        verify_with_scope("chutes", AttestationScope::PerInstance, Some("router")).await;
+    assert_eq!(instance_mismatch.result, VerificationResult::Failed);
+    assert!(instance_mismatch.reason.unwrap().contains("per-instance"));
+
+    // Per-model provider that omits the scope → accepted (Phala-direct / Chutes
+    // don't declare one).
+    let omitted = verify_with_scope("phala-direct", AttestationScope::PerModel, None).await;
+    assert_eq!(omitted.result, VerificationResult::Verified);
+}
+
+#[tokio::test]
 async fn external_provider_refresh_keeps_existing_cache_on_failure() {
     let counter_path = std::env::temp_dir().join(format!(
         "private-ai-gateway-provider-refresh-cache-test-{}",
@@ -555,6 +643,7 @@ fi"#
     );
     let verifier = ExternalProviderVerifier::with_command_and_cache(
         "tinfoil",
+        AttestationScope::PerRouter,
         vec![
             "/bin/sh".to_string(),
             "-c".to_string(),

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -90,10 +90,21 @@ fn custody_report(identity: &SigningKey, signature_chain: Vec<String>) -> Attest
     }
 }
 
+/// The attestation scope a stub verifier should declare to satisfy the
+/// fail-closed scope seam — mirrors `attestation_scope_for_provider`.
+fn declared_scope(provider: &str) -> &'static str {
+    match provider {
+        "near-ai" | "tinfoil" => "router",
+        "chutes" => "instance",
+        _ => "model",
+    }
+}
+
 fn provider_script(provider: &str, verifier_id: &str, binding: Value) -> Vec<String> {
     let output = json!({
         "result": "verified",
         "verifier_id": verifier_id,
+        "attested_scope": declared_scope(provider),
         "evidence": {
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJvdmlkZXItbW9kZWwifQ==",
@@ -124,6 +135,7 @@ fn counting_provider_script(
     let output = json!({
         "result": "verified",
         "verifier_id": verifier_id,
+        "attested_scope": declared_scope(provider),
         "evidence": {
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJvdmlkZXItbW9kZWwifQ==",
@@ -435,30 +447,32 @@ async fn router_shares_one_channel_verification_across_models() {
     // model, so verifying a second model reuses the first model's verification
     // (one external run) and event_for re-tags it with the requesting model. A
     // per-model provider must NOT share — each model is its own channel.
-    let output = json!({
-        "result": "verified",
-        "verifier_id": "router-cache-test/v1",
-        "evidence": {
-            "digest": format!("sha256:{}", "11".repeat(32)),
-            "data": "data:application/json;base64,eyJmaXh0dXJlIjoicm91dGVyIn0=",
-        },
-        "channel_bindings": [{
-            "type": "tls_spki_sha256",
-            "origin": "https://router.example",
-            "spki_sha256": "AA".repeat(32),
-        }],
-    })
-    .to_string();
-    // Counts every external run and verifies any model (unlike
-    // counting_provider_script, which is pinned to one model_id).
-    let script = format!(
-        r#"cat >/dev/null
+    for (provider, expected_runs) in [("near-ai", "1"), ("phala-direct", "2")] {
+        // Each provider declares its own scope so the fail-closed seam accepts it.
+        let output = json!({
+            "result": "verified",
+            "verifier_id": "router-cache-test/v1",
+            "attested_scope": declared_scope(provider),
+            "evidence": {
+                "digest": format!("sha256:{}", "11".repeat(32)),
+                "data": "data:application/json;base64,eyJmaXh0dXJlIjoicm91dGVyIn0=",
+            },
+            "channel_bindings": [{
+                "type": "tls_spki_sha256",
+                "origin": "https://router.example",
+                "spki_sha256": "AA".repeat(32),
+            }],
+        })
+        .to_string();
+        // Counts every external run and verifies any model (unlike
+        // counting_provider_script, which is pinned to one model_id).
+        let script = format!(
+            r#"cat >/dev/null
 count="$(cat "$1" 2>/dev/null || printf '0')"
 count="$((count + 1))"
 printf '%s' "$count" > "$1"
 printf '%s' '{output}'"#
-    );
-    for (provider, expected_runs) in [("near-ai", "1"), ("phala-direct", "2")] {
+        );
         let counter_path = std::env::temp_dir().join(format!(
             "private-ai-gateway-router-cache-test-{}-{provider}",
             std::process::id(),
@@ -469,7 +483,7 @@ printf '%s' '{output}'"#
             vec![
                 "/bin/sh".to_string(),
                 "-c".to_string(),
-                script.clone(),
+                script,
                 "router-cache-test".to_string(),
                 counter_path.display().to_string(),
             ],
@@ -515,6 +529,7 @@ async fn external_provider_refresh_keeps_existing_cache_on_failure() {
     let output = json!({
         "result": "verified",
         "verifier_id": "tinfoil/external-test/v1",
+        "attested_scope": "router",
         "evidence": {
             "digest": format!("sha256:{}", "11".repeat(32)),
             "data": "data:application/json;base64,eyJmaXh0dXJlIjoicHJvdmlkZXItbW9kZWwifQ==",

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -430,6 +430,82 @@ async fn external_provider_verifier_caches_verified_bindings() {
 }
 
 #[tokio::test]
+async fn router_shares_one_channel_verification_across_models() {
+    // Security-critical: a router keys its verifier cache on the channel, not the
+    // model, so verifying a second model reuses the first model's verification
+    // (one external run) and event_for re-tags it with the requesting model. A
+    // per-model provider must NOT share — each model is its own channel.
+    let output = json!({
+        "result": "verified",
+        "verifier_id": "router-cache-test/v1",
+        "evidence": {
+            "digest": format!("sha256:{}", "11".repeat(32)),
+            "data": "data:application/json;base64,eyJmaXh0dXJlIjoicm91dGVyIn0=",
+        },
+        "channel_bindings": [{
+            "type": "tls_spki_sha256",
+            "origin": "https://router.example",
+            "spki_sha256": "AA".repeat(32),
+        }],
+    })
+    .to_string();
+    // Counts every external run and verifies any model (unlike
+    // counting_provider_script, which is pinned to one model_id).
+    let script = format!(
+        r#"cat >/dev/null
+count="$(cat "$1" 2>/dev/null || printf '0')"
+count="$((count + 1))"
+printf '%s' "$count" > "$1"
+printf '%s' '{output}'"#
+    );
+    for (provider, expected_runs) in [("near-ai", "1"), ("phala-direct", "2")] {
+        let counter_path = std::env::temp_dir().join(format!(
+            "private-ai-gateway-router-cache-test-{}-{provider}",
+            std::process::id(),
+        ));
+        let _ = std::fs::remove_file(&counter_path);
+        let verifier = ExternalProviderVerifier::with_command_and_cache(
+            provider,
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                script.clone(),
+                "router-cache-test".to_string(),
+                counter_path.display().to_string(),
+            ],
+            5,
+            300,
+        )
+        .unwrap();
+        let base = UpstreamVerificationRequest {
+            upstream_name: "router-upstream".to_string(),
+            url_origin: Some("https://router.example".to_string()),
+            model_id: "model-a".to_string(),
+            forwarded_body_hash: format!("sha256:{}", "22".repeat(32)),
+            required: true,
+        };
+        let _ = verifier.verify(base.clone()).await;
+        let second = verifier
+            .verify(UpstreamVerificationRequest {
+                model_id: "model-b".to_string(),
+                ..base
+            })
+            .await;
+
+        assert_eq!(second.result, VerificationResult::Verified);
+        // The served event always reports the requesting model, even on reuse.
+        assert_eq!(second.model_id, "model-b");
+        assert_eq!(
+            std::fs::read_to_string(&counter_path).unwrap(),
+            expected_runs,
+            "{provider}: external verifier runs (a router reuses one channel \
+             verification across models; a per-model provider verifies each)"
+        );
+        let _ = std::fs::remove_file(counter_path);
+    }
+}
+
+#[tokio::test]
 async fn external_provider_refresh_keeps_existing_cache_on_failure() {
     let counter_path = std::env::temp_dir().join(format!(
         "private-ai-gateway-provider-refresh-cache-test-{}",

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -158,13 +158,83 @@ pub enum UpstreamProvider {
 }
 
 impl UpstreamProvider {
-    /// Whether this provider is a router: one verified TEE channel (a gateway TD
-    /// or a confidential model router) fronts many models, so its attested
-    /// session is the channel and it is verified once per channel rather than
-    /// once per model. Keep in sync with `provider_is_router` in the external
-    /// verifier.
-    pub(crate) fn is_router(self) -> bool {
-        matches!(self, UpstreamProvider::NearAi | UpstreamProvider::Tinfoil)
+    /// The provider's stable wire string — the kebab name shared by this enum's
+    /// serde and the external verifier's `provider` field.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            UpstreamProvider::OpenAiCompatible => "openai-compatible",
+            UpstreamProvider::AciDcap => "aci-dcap",
+            UpstreamProvider::Chutes => "chutes",
+            UpstreamProvider::Tinfoil => "tinfoil",
+            UpstreamProvider::NearAi => "near-ai",
+            UpstreamProvider::PhalaDirect => "phala-direct",
+        }
+    }
+
+    /// The channel boundary this provider attests; see [`AttestationScope`].
+    pub(crate) fn attestation_scope(self) -> AttestationScope {
+        attestation_scope_for_provider(self.as_str())
+    }
+}
+
+/// The channel boundary a provider's attestation proves — and therefore what
+/// identifies its attested session.
+///
+/// A *per-router* provider verifies one TEE channel (a gateway TD or a
+/// confidential model router) that fronts many models, so the model is not part
+/// of the channel identity and one session is shared across models. *Per-model*
+/// and *per-instance* providers verify a distinct channel for each model or
+/// serving instance, so the model participates in the channel identity.
+///
+/// This is the single axis that decides channel-keyed verification (the model
+/// is dropped from the verifier cache key for routers) and is enforced
+/// fail-closed at the verifier seam: a verifier must attest the scope its
+/// provider is declared to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttestationScope {
+    PerRouter,
+    PerModel,
+    PerInstance,
+}
+
+impl AttestationScope {
+    /// Routers share one channel across models, so verification is keyed on the
+    /// channel alone (model dropped from the cache key).
+    pub(crate) fn is_per_router(self) -> bool {
+        matches!(self, AttestationScope::PerRouter)
+    }
+
+    /// Parse the scope token a provider verifier emits in its result.
+    pub(crate) fn from_declared(token: &str) -> Option<Self> {
+        match token {
+            "router" => Some(Self::PerRouter),
+            "model" => Some(Self::PerModel),
+            "instance" => Some(Self::PerInstance),
+            _ => None,
+        }
+    }
+
+    /// The wire token for this scope (matches [`Self::from_declared`]).
+    pub(crate) fn as_declared(self) -> &'static str {
+        match self {
+            Self::PerRouter => "router",
+            Self::PerModel => "model",
+            Self::PerInstance => "instance",
+        }
+    }
+}
+
+/// The attestation scope for a provider's wire string — the single source of
+/// truth, consulted by both [`UpstreamProvider::attestation_scope`] and the
+/// external verifier (for channel-keying and the fail-closed scope seam).
+///
+/// Unrecognized providers default to per-model: never collapse models onto one
+/// channel without a positive reason to.
+pub(crate) fn attestation_scope_for_provider(provider: &str) -> AttestationScope {
+    match provider {
+        "near-ai" | "tinfoil" => AttestationScope::PerRouter,
+        "chutes" => AttestationScope::PerInstance,
+        _ => AttestationScope::PerModel,
     }
 }
 

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -166,9 +166,17 @@ impl UpstreamProvider {
         match self {
             UpstreamProvider::NearAi | UpstreamProvider::Tinfoil => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
-            UpstreamProvider::OpenAiCompatible
-            | UpstreamProvider::AciDcap
-            | UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
+            UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
+            // OpenAI-compatible has no verifier (no attestation), and ACI/DCAP
+            // uses its own verifier rather than the channel-keying here — so for
+            // both this scope only affects prewarm probe granularity, never the
+            // cache key or the seam. Per-model is the conservative default: it
+            // verifies every model and never collapses distinct channels. ACI can
+            // be router- or model-based depending on the ACI service; resolving
+            // that dynamically is deferred until ACI is a first-party router.
+            UpstreamProvider::OpenAiCompatible | UpstreamProvider::AciDcap => {
+                AttestationScope::PerModel
+            }
         }
     }
 }

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -158,22 +158,18 @@ pub enum UpstreamProvider {
 }
 
 impl UpstreamProvider {
-    /// The provider's stable wire string — the kebab name shared by this enum's
-    /// serde and the external verifier's `provider` field.
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            UpstreamProvider::OpenAiCompatible => "openai-compatible",
-            UpstreamProvider::AciDcap => "aci-dcap",
-            UpstreamProvider::Chutes => "chutes",
-            UpstreamProvider::Tinfoil => "tinfoil",
-            UpstreamProvider::NearAi => "near-ai",
-            UpstreamProvider::PhalaDirect => "phala-direct",
-        }
-    }
-
-    /// The channel boundary this provider attests; see [`AttestationScope`].
+    /// The channel boundary this provider attests — the single source of truth
+    /// for [`AttestationScope`]. Exhaustive by design: adding a provider is a
+    /// compile error here until it declares a scope, so a new variant can never
+    /// silently inherit a default.
     pub(crate) fn attestation_scope(self) -> AttestationScope {
-        attestation_scope_for_provider(self.as_str())
+        match self {
+            UpstreamProvider::NearAi | UpstreamProvider::Tinfoil => AttestationScope::PerRouter,
+            UpstreamProvider::Chutes => AttestationScope::PerInstance,
+            UpstreamProvider::OpenAiCompatible
+            | UpstreamProvider::AciDcap
+            | UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
+        }
     }
 }
 
@@ -189,7 +185,8 @@ impl UpstreamProvider {
 /// This is the single axis that decides channel-keyed verification (the model
 /// is dropped from the verifier cache key for routers) and is enforced
 /// fail-closed at the verifier seam: a verifier must attest the scope its
-/// provider is declared to use.
+/// provider is declared to use. It is resolved once via
+/// [`UpstreamProvider::attestation_scope`] and carried on the verifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttestationScope {
     PerRouter,
@@ -221,20 +218,6 @@ impl AttestationScope {
             Self::PerModel => "model",
             Self::PerInstance => "instance",
         }
-    }
-}
-
-/// The attestation scope for a provider's wire string — the single source of
-/// truth, consulted by both [`UpstreamProvider::attestation_scope`] and the
-/// external verifier (for channel-keying and the fail-closed scope seam).
-///
-/// Unrecognized providers default to per-model: never collapse models onto one
-/// channel without a positive reason to.
-pub(crate) fn attestation_scope_for_provider(provider: &str) -> AttestationScope {
-    match provider {
-        "near-ai" | "tinfoil" => AttestationScope::PerRouter,
-        "chutes" => AttestationScope::PerInstance,
-        _ => AttestationScope::PerModel,
     }
 }
 

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -157,6 +157,16 @@ pub enum UpstreamProvider {
     PhalaDirect,
 }
 
+impl UpstreamProvider {
+    /// Whether this provider is a router: one verified gateway TEE channel fronts
+    /// many models, so its attested session is the channel and it is verified
+    /// once per channel rather than once per model. Keep in sync with
+    /// `provider_is_router` in the external verifier.
+    pub(crate) fn is_router(self) -> bool {
+        matches!(self, UpstreamProvider::NearAi)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum UpstreamVerifierMode {
     None,

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -158,12 +158,13 @@ pub enum UpstreamProvider {
 }
 
 impl UpstreamProvider {
-    /// Whether this provider is a router: one verified gateway TEE channel fronts
-    /// many models, so its attested session is the channel and it is verified
-    /// once per channel rather than once per model. Keep in sync with
-    /// `provider_is_router` in the external verifier.
+    /// Whether this provider is a router: one verified TEE channel (a gateway TD
+    /// or a confidential model router) fronts many models, so its attested
+    /// session is the channel and it is verified once per channel rather than
+    /// once per model. Keep in sync with `provider_is_router` in the external
+    /// verifier.
     pub(crate) fn is_router(self) -> bool {
-        matches!(self, UpstreamProvider::NearAi)
+        matches!(self, UpstreamProvider::NearAi | UpstreamProvider::Tinfoil)
     }
 }
 

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -40,6 +40,43 @@ fn test_upstream_config(
     }
 }
 
+#[test]
+fn router_provider_verifies_once_per_channel() {
+    // A router (NEAR AI) with several models yields ONE verification target — the
+    // shared gateway channel — so it seals one session per channel, not one per
+    // model. A per-model provider keeps one target per model.
+    let mut router = test_upstream_config("near-router", UpstreamProvider::NearAi, "pub-a", "up-a");
+    router
+        .models
+        .insert("pub-b".to_string(), "up-b".to_string());
+    assert_eq!(
+        super::validation::verification_targets(std::slice::from_ref(&router)).len(),
+        1,
+        "router collapses its models to one channel target"
+    );
+
+    let mut per_model =
+        test_upstream_config("phala", UpstreamProvider::PhalaDirect, "pub-a", "up-a");
+    per_model
+        .models
+        .insert("pub-b".to_string(), "up-b".to_string());
+    assert_eq!(
+        super::validation::verification_targets(std::slice::from_ref(&per_model)).len(),
+        2,
+        "per-model provider verifies every model"
+    );
+}
+
+#[test]
+fn only_near_ai_is_a_router() {
+    assert!(UpstreamProvider::NearAi.is_router());
+    assert!(!UpstreamProvider::PhalaDirect.is_router());
+    assert!(!UpstreamProvider::Chutes.is_router());
+    assert!(!UpstreamProvider::Tinfoil.is_router());
+    assert!(!UpstreamProvider::OpenAiCompatible.is_router());
+    assert!(!UpstreamProvider::AciDcap.is_router());
+}
+
 #[async_trait]
 impl UpstreamVerifier for CountingVerifier {
     async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -68,16 +68,23 @@ fn router_provider_verifies_once_per_channel() {
 }
 
 #[test]
-fn routers_are_near_ai_and_tinfoil() {
-    // Both front many models behind one verified channel (NEAR AI gateway TD,
-    // Tinfoil confidential-model-router), so they are per-router. Per-model
-    // (Phala-direct) and per-instance (Chutes) providers are not.
-    assert!(UpstreamProvider::NearAi.is_router());
-    assert!(UpstreamProvider::Tinfoil.is_router());
-    assert!(!UpstreamProvider::PhalaDirect.is_router());
-    assert!(!UpstreamProvider::Chutes.is_router());
-    assert!(!UpstreamProvider::OpenAiCompatible.is_router());
-    assert!(!UpstreamProvider::AciDcap.is_router());
+fn provider_attestation_scopes() {
+    // NEAR AI (gateway TD) and Tinfoil (confidential-model-router) front many
+    // models behind one verified channel, so they are per-router. Phala-direct
+    // verifies a TEE per model; Chutes a key per instance; the rest default to
+    // per-model. Only per-router drops the model from the channel identity.
+    use AttestationScope::*;
+    assert_eq!(UpstreamProvider::NearAi.attestation_scope(), PerRouter);
+    assert_eq!(UpstreamProvider::Tinfoil.attestation_scope(), PerRouter);
+    assert_eq!(UpstreamProvider::PhalaDirect.attestation_scope(), PerModel);
+    assert_eq!(UpstreamProvider::Chutes.attestation_scope(), PerInstance);
+    assert_eq!(
+        UpstreamProvider::OpenAiCompatible.attestation_scope(),
+        PerModel
+    );
+    assert_eq!(UpstreamProvider::AciDcap.attestation_scope(), PerModel);
+    assert!(UpstreamProvider::NearAi.attestation_scope().is_per_router());
+    assert!(!UpstreamProvider::Chutes.attestation_scope().is_per_router());
 }
 
 #[async_trait]

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -68,11 +68,14 @@ fn router_provider_verifies_once_per_channel() {
 }
 
 #[test]
-fn only_near_ai_is_a_router() {
+fn routers_are_near_ai_and_tinfoil() {
+    // Both front many models behind one verified channel (NEAR AI gateway TD,
+    // Tinfoil confidential-model-router), so they are per-router. Per-model
+    // (Phala-direct) and per-instance (Chutes) providers are not.
     assert!(UpstreamProvider::NearAi.is_router());
+    assert!(UpstreamProvider::Tinfoil.is_router());
     assert!(!UpstreamProvider::PhalaDirect.is_router());
     assert!(!UpstreamProvider::Chutes.is_router());
-    assert!(!UpstreamProvider::Tinfoil.is_router());
     assert!(!UpstreamProvider::OpenAiCompatible.is_router());
     assert!(!UpstreamProvider::AciDcap.is_router());
 }
@@ -190,7 +193,9 @@ async fn prewarm_verification_deduplicates_upstream_models() {
     let invalidations = Arc::new(AtomicUsize::new(0));
     let config = vec![UpstreamConfig {
         name: "provider-a".to_string(),
-        provider: UpstreamProvider::Tinfoil,
+        // Per-model provider (not a router): two public models sharing one
+        // upstream model dedup to one target; a third yields a second.
+        provider: UpstreamProvider::PhalaDirect,
         base_url: "https://provider-a.example/".to_string(),
         path: None,
         models: BTreeMap::from([

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -46,7 +46,7 @@ fn verification_targets_for_configs<'a>(
         // probe it once (a single representative model — `models` is a BTreeMap,
         // so `.take(1)` is deterministic); per-model requests reuse that channel
         // verification. Per-model / per-instance providers verify every model.
-        let model_ids: Vec<&String> = if cfg.provider.is_router() {
+        let model_ids: Vec<&String> = if cfg.provider.attestation_scope().is_per_router() {
             cfg.models.values().take(1).collect()
         } else {
             cfg.models.values().collect()

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -42,10 +42,12 @@ fn verification_targets_for_configs<'a>(
     let mut targets = Vec::new();
     for cfg in configs {
         let url_origin = Some(cfg.base_url.trim_end_matches('/').to_string());
-        // Router providers verify one gateway channel shared by every model, so
-        // probe it once (a single representative model — `models` is a BTreeMap,
-        // so `.take(1)` is deterministic); per-model requests reuse that channel
-        // verification. Per-model / per-instance providers verify every model.
+        // A router's attestation is of the gateway/enclave channel itself, which
+        // is identical for every model it fronts — every model resolves to the
+        // same channel-keyed verification. So probing a second model would only
+        // re-verify the same channel (a cache hit); we probe once with one
+        // representative model (`models` is a BTreeMap, so `.take(1)` is
+        // deterministic). Per-model / per-instance providers verify every model.
         let model_ids: Vec<&String> = if cfg.provider.attestation_scope().is_per_router() {
             cfg.models.values().take(1).collect()
         } else {

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -42,7 +42,16 @@ fn verification_targets_for_configs<'a>(
     let mut targets = Vec::new();
     for cfg in configs {
         let url_origin = Some(cfg.base_url.trim_end_matches('/').to_string());
-        for model_id in cfg.models.values() {
+        // Router providers verify one gateway channel shared by every model, so
+        // probe it once (a single representative model — `models` is a BTreeMap,
+        // so `.take(1)` is deterministic); per-model requests reuse that channel
+        // verification. Per-model / per-instance providers verify every model.
+        let model_ids: Vec<&String> = if cfg.provider.is_router() {
+            cfg.models.values().take(1).collect()
+        } else {
+            cfg.models.values().collect()
+        };
+        for model_id in model_ids {
             let target = UpstreamVerificationTarget {
                 upstream_name: cfg.name.clone(),
                 model_id: model_id.clone(),


### PR DESCRIPTION
A session is one verified secure channel, and we never allow more than one per channel. The boundary differs by provider — per E2EE instance (Chutes), per model TEE (Phala-direct), per **router** for the two providers where one verified TEE fronts many models: near.ai's gateway TD and Tinfoil's confidential-model-router. Both were treated as per-model (in session content *and* count). This makes both genuinely per-router.

## What "per-router" means here
- **Session content** is the channel only — no per-model attestation folded in. near.ai stopped emitting `model_attestations`; Tinfoil stopped emitting `canonical_model_id`. The served model is recorded on the receipt (`upstream.verified.model_id`).
- **Session count** is one per channel — `UpstreamProvider::is_router` (near.ai, Tinfoil) keys the verifier cache on the channel (model omitted), so every model resolves to one verified channel and one content-addressed session. Refresh verifies a router once (a probe model). `event_for` tags the reused event with the requesting model.

## We request the router scope, we don't infer it
Per review feedback: the Tinfoil verifier now **requires** the router attestation (the confidential-model-router enclave) and **fails closed** if the verification wasn't router-scoped, rather than reading `used_router` heuristically. A non-router Tinfoil deployment can never be silently treated as one channel for many models.

## Bug caught along the way
`invalidate` used the model-keyed cache key while `verify`/`refresh` used the channel key — so for a router the cache could never be flushed (a verified channel would be pinned). An existing test caught it; all three now use the same key.

## Roadmap (`docs/roadmap.md`)
Request-bound, per-instance model attestation on the receipt — gated on an upstream being able to attest the exact instance that served a request.

## Validation
- Unit: `verification_targets` collapses a router's models to one channel target (per-model providers keep one per model); `is_router` covers exactly near.ai + Tinfoil.
- **Live, both routers** (`scripts/live_e2e/router_session_smoke.py {near-ai,tinfoil}`): two models on one upstream resolve to one `session_id`, each receipt recording its own model. near.ai's session evidence/claims are gateway-channel only; the streamed receipt hashes still match.