### PR TITLE
Support static gateway config and domain TLS binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2311,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2958,6 +2969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3580,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3744,6 +3762,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,6 +3853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +3925,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ futures-util = "0.3"
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio", "service"] }
 
-# HTTP client (upstream forwarding). rustls-tls so we don't depend on
-# a system OpenSSL inside the launcher image.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+# HTTP client (upstream forwarding). Rustls with native roots keeps TLS
+# validation normal without linking against system OpenSSL.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "stream"] }
 
 # Errors and logging.
 thiserror = "1"

--- a/Dockerfile.smoke
+++ b/Dockerfile.smoke
@@ -4,8 +4,15 @@ COPY . .
 RUN cargo build --release --locked --bin private-ai-gateway
 
 FROM debian:bookworm-slim
+ARG SOURCE_REPO_URL
+ARG SOURCE_COMMIT
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
  && rm -rf /var/lib/apt/lists/*
+RUN test -n "$SOURCE_REPO_URL" \
+ && test -n "$SOURCE_COMMIT" \
+ && mkdir -p /etc/git-launcher \
+ && printf 'REPO_URL=%s\nCOMMIT_SHA=%s\nWORK_DIR=/src\n' "$SOURCE_REPO_URL" "$SOURCE_COMMIT" \
+    > /etc/git-launcher/gateway.conf
 COPY --from=builder /src/target/release/private-ai-gateway /usr/local/bin/private-ai-gateway
 ENTRYPOINT ["/usr/local/bin/private-ai-gateway"]

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Use this checklist before treating a deployment as private inference.
 
 | Check | Evidence |
 | --- | --- |
-| Gateway identity is real | `GET /v1/attestation/report?nonce=<fresh nonce>` proves the TEE quote, workload id, and keyset. The report also carries source provenance that must match the reviewed deployment. |
+| Gateway identity is real | `GET /v1/attestation/report?nonce=<fresh nonce>` proves the TEE quote, workload id, and keyset. When source provenance is present, it must match the reviewed deployment. |
 | Keys are bound to the workload | The keyset in the report lists identity, receipt-signing, E2EE, and optional TLS SPKI keys endorsed by the workload identity. |
 | Client session is bound | For direct TLS, verify the server certificate SPKI matches the attested keyset. For ACI E2EE, verify the E2EE public key from the keyset. |
 | Upstream is verified | Receipt event `upstream.verified` must be `verified` for the provider and canonical model id. |
 | Channel binding is enforceable | The upstream verification event must include a binding the backend can enforce on the actual request path. |
-| Upstream session is auditable | `upstream.verified.session_id`, when present, points to `GET /v1/audit/sessions/{session_id}`. The id is derived from the target, verifier, evidence digest, provider claims, and binding material. |
+| Upstream session is auditable | `upstream.verified.session_id`, when present, points to `GET /v1/aci/sessions/{session_id}`. The id is derived from the target, verifier, evidence digest, provider claims, and binding material. |
 | Middleware is in boundary | If middleware is enabled, audit its source/config and confirm it runs inside the same attested deployment. |
 | Response is bound | Verify the receipt signature under the attested receipt key and compare the response hash in `response.returned`. |
 | Provider is admissible | Review the provider's `docs/providers/<provider>/review.md` against `docs/providers/audit-criteria.md`. |
@@ -122,7 +122,7 @@ additional ACI artifacts are:
   to.
 - `x-receipt-id`: returned on provider-backed inference responses.
 - `GET /v1/aci/receipts/{id}`: fetches the signed receipt by chat id or receipt id.
-- `GET /v1/audit/sessions/{session_id}`: fetches an attested-session audit
+- `GET /v1/aci/sessions/{session_id}`: fetches an attested-session audit
   record referenced by a receipt.
 - Optional ACI E2EE headers: encrypt selected request/response fields when the
   client wants application-level encryption in addition to TLS.
@@ -192,8 +192,8 @@ and it uses the same SDK for TDX quotes.
 ## Quick Start For New Users
 
 This repository expects a dstack SDK endpoint. By default the gateway uses
-`/var/run/dstack.sock`. For local development, point
-`PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT` at a forwarded dstack socket.
+`/var/run/dstack.sock`. For local development, set `dstack_endpoint` in the
+gateway config to a forwarded dstack socket.
 
 Prerequisites:
 
@@ -213,12 +213,17 @@ cargo clippy --all-targets -- -D warnings
 Start an identity-only gateway:
 
 ```bash
-printf '[]\n' >/tmp/private-ai-gateway-upstreams.json
+mkdir -p /tmp/private-ai-gateway-state
+printf '[]\n' >/tmp/private-ai-gateway-upstreams.seed.json
+cat >/tmp/private-ai-gateway.config.json <<EOF
+{
+  "state_dir": "/tmp/private-ai-gateway-state",
+  "upstream_config_seed_path": "/tmp/private-ai-gateway-upstreams.seed.json",
+  "dstack_endpoint": "unix:/tmp/aci-dstack-sock-dev.dstack.sock"
+}
+EOF
 
-PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT=unix:/tmp/aci-dstack-sock-dev.dstack.sock \
-PRIVATE_AI_GATEWAY_REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git \
-PRIVATE_AI_GATEWAY_REPO_COMMIT="$(git rev-parse HEAD)" \
-PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH=/tmp/private-ai-gateway-upstreams.json \
+PRIVATE_AI_GATEWAY_CONFIG_PATH=/tmp/private-ai-gateway.config.json \
 cargo run --release --bin private-ai-gateway
 ```
 
@@ -277,9 +282,9 @@ cargo run --quiet --example verify_aci_artifacts -- \
 
 ## Configure Upstreams
 
-The gateway has one mutable upstream config file. Set
-`PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH`; if unset, the default is
-`/var/lib/private-ai-gateway/upstreams.json`.
+The gateway owns one mutable state directory. Set `state_dir` in the static
+gateway config; if omitted, the default is `/var/lib/private-ai-gateway`.
+The active upstream config is always `upstreams.json` inside that directory.
 
 A missing, empty, or whitespace-only file is valid and means no upstreams are
 configured yet. Inference routes require a JSON array with at least one
@@ -311,33 +316,28 @@ Supported `provider` values:
 
 | Provider | Use |
 | --- | --- |
-| `openai-compatible` | Generic OpenAI-compatible upstream. Verification is controlled by `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER`; the upstream config does not currently accept static TLS pin fields. |
+| `openai-compatible` | Generic OpenAI-compatible upstream with no provider-owned verifier. |
 | `aci-dcap` | Upstream ACI service that exposes ACI attestation and dstack/DCAP evidence. |
 | `tinfoil` | Tinfoil provider adapter using provider-owned verification through `private-ai-verifier`. |
 | `near-ai` | NEAR AI gateway adapter with TLS binding from the provider report. |
 | `chutes` | Chutes adapter with provider E2EE key verification and encrypted `/e2e/invoke` transport. |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint (one per model) with TLS SPKI binding from the version-2 attestation report. See [docs/providers/phala-direct/verification.md](docs/providers/phala-direct/verification.md). |
 
-ACI/DCAP verification policy can be set globally with
-`PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_WORKLOAD_IDS`,
-`PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_IMAGE_DIGESTS`,
-`PRIVATE_AI_GATEWAY_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS`, and
-`PRIVATE_AI_GATEWAY_UPSTREAM_PCCS_URL`, or per upstream with
+ACI/DCAP verification policy is set on the upstream entry with
 `accepted_workload_ids`, `accepted_image_digests`,
 `accepted_dstack_kms_root_public_keys`, and `pccs_url`.
 
-Tinfoil, NEAR AI, Chutes, and PhalaDirect use the provider verifier bridge in
-`scripts/private_ai_provider_verifier.py`. Install `uv` and set
-`PRIVATE_AI_VERIFIER_DIR` to a `private-ai-verifier` checkout, or keep that
-checkout as a sibling directory of this repo.
+Tinfoil, NEAR AI, Chutes, and PhalaDirect use the vendored provider verifier
+bridge. Set `PRIVATE_AI_VERIFIER_DIR` only when you need to override the
+vendored verifier package with an external checkout.
 
-For one-command Compose deployments, set
-`PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH` to a read-only seed file. The
-gateway copies the seed only when the mutable config path is missing or empty.
-An existing admin-updated config is never overwritten.
+For one-command Compose deployments, set `upstream_config_seed_path` in the
+static gateway config to a read-only seed file. The gateway validates and
+copies the seed to `<state_dir>/upstreams.json` only when the active config is
+missing or empty. An existing admin-updated config is never overwritten.
 
-When `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` is set, operators can inspect and replace
-the live config:
+When `admin_token` is set in the gateway config, operators can inspect and
+replace the live config:
 
 ```bash
 curl -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
@@ -364,6 +364,12 @@ The recommended dstack deployment path uses `git-launcher`:
 4. The built binary runs with runtime config from Compose environment, mounted
    files, dstack encrypted secrets, and dstack KMS.
 
+Source provenance in attestation reports is derived from the git-launcher pin,
+not from gateway JSON. If the launcher config is absent, the report omits
+source provenance and the value is unknown. In production, compare the report's
+source provenance with `REPO_URL` and `COMMIT_SHA` in the attested launcher
+config.
+
 The launcher stays generic. Build, install, and run logic belongs to this repo.
 For production, prefer a Rust-capable gateway image so the toolchain is covered
 by a gateway-owned image digest instead of installing Rust at boot.
@@ -377,13 +383,9 @@ Deployment files:
 
 ## Middleware
 
-Middleware mode is enabled by a middleware Unix socket path. The gateway also
-starts an internal backend socket for middleware to call:
-
-```bash
-PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH=/run/private-ai-gateway/executor.sock
-PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH=/run/private-ai-gateway/backend.sock
-```
+The current binary deployment runs in no-middleware mode. Middleware router
+helpers exist for future executor integration, but the static gateway config
+does not expose middleware socket fields.
 
 In middleware mode:
 
@@ -411,7 +413,7 @@ writing middleware.
 | `POST /v1/chat/completions` | OpenAI-compatible chat completions. |
 | `POST /v1/completions` | OpenAI-compatible legacy completions. |
 | `POST /v1/embeddings` | OpenAI-compatible buffered embeddings. |
-| `GET /v1/aci/attestation/report?nonce=<n>` | Gateway workload identity and keyset evidence. |
+| `GET /v1/aci/attestation?nonce=<n>` | Gateway workload identity and keyset evidence. |
 | `GET /v1/aci/receipts/{id}` | Signed ACI receipt by chat id or receipt id. |
 | `GET /v1/aci/sessions/{session_id}` | Attested-session record referenced by a receipt. |
 | `GET /v1/aci/sessions?provider=&model=` | List a provider's imported attested sessions. |
@@ -422,59 +424,75 @@ writing middleware.
 
 ## Runtime Configuration
 
-Use `PRIVATE_AI_GATEWAY_*` variables. Older `DSTACK_LLM_ROUTER_*` aliases are
-still accepted for compatibility; the `PRIVATE_AI_GATEWAY_*` value wins when
-both are set.
+The full field and environment-variable reference is
+[docs/configuration-reference.md](docs/configuration-reference.md).
 
-| Setting | Variable | Default |
+The gateway consumes one read-only JSON config and one writable state directory:
+
+| Item | Path | Mutability |
 | --- | --- | --- |
-| Public bind address | `PRIVATE_AI_GATEWAY_BIND` | `127.0.0.1:8086` |
-| Upstream config path | `PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH` | `/var/lib/private-ai-gateway/upstreams.json` |
-| Initial upstream config seed | `PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH` | unset |
-| Admin bearer token | `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | unset; admin API returns `404` |
-| Source-provenance repo URL | `PRIVATE_AI_GATEWAY_REPO_URL` | required |
-| Source-provenance commit | `PRIVATE_AI_GATEWAY_REPO_COMMIT` | required |
-| Body retention seconds | `PRIVATE_AI_GATEWAY_BODY_RETENTION_SECONDS` | `0` |
-| Receipt TTL seconds | `PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS` | `3600` |
-| TLS certificate paths | `PRIVATE_AI_GATEWAY_TLS_CERT_PATHS` | unset |
-| TLS SPKI SHA-256 list | `PRIVATE_AI_GATEWAY_TLS_SPKI_SHA256` | unset |
-| Domain TLS certificate map | `PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS` | unset |
-| Domain TLS SPKI SHA-256 map | `PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256` | unset |
-| Upstream verifier mode | `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER` | `none` |
-| Accepted upstream workload IDs | `PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_WORKLOAD_IDS` | unset |
-| Accepted upstream image digests | `PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_IMAGE_DIGESTS` | unset |
-| Accepted upstream dstack KMS root public keys | `PRIVATE_AI_GATEWAY_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS` | unset |
-| Upstream verifier PCCS URL | `PRIVATE_AI_GATEWAY_UPSTREAM_PCCS_URL` | default verifier PCCS |
-| Upstream verifier cache seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_CACHE_SECONDS` | `300` |
-| Upstream connect timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | `10` |
-| Upstream read idle timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS` | `600` |
-| Upstream verifier request timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS` | `60` |
-| dstack SDK endpoint | `PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT` | dstack SDK default socket |
-| Executor UDS path | `PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH` | unset; executor disabled |
-| Internal backend UDS path | `PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH` | `/run/private-ai-gateway/backend.sock` |
+| Static gateway config | `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Read at startup. |
+| Gateway state directory | `state_dir` inside the gateway config, default `/var/lib/private-ai-gateway` | Gateway-owned writable files. |
 
-Prefer certificate-path variables for client-facing TLS binding. The gateway
-reads each mounted leaf certificate, computes `sha256(SPKI)`, and publishes
-that digest in the attested keyset. Use SPKI variables only for manual or test
-deployments.
+The gateway derives its writable files from `state_dir`: `upstreams.json` for
+the active upstream database and `sessions.jsonl` for the attested-session log.
+Deployment-owned read-only inputs, such as an upstream seed file or TLS
+certificates, stay explicit paths in the static config.
 
-Use `PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS` when the gateway serves multiple
-custom domains:
+Unknown config fields are rejected at startup. See
+[docs/configuration-reference.md](docs/configuration-reference.md) for the
+minimal config example and the full field reference.
 
-```bash
-PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS=api.example.com=/run/certs/api.pem,chat.example.com=/run/certs/chat.pem
+For client-facing TLS binding, set `tls.domain_certificates` with one mounted
+leaf certificate per public hostname. The gateway reads each certificate,
+computes `sha256(SPKI)`, and publishes that digest in the attested keyset. Raw
+SPKI configuration is not supported; all TLS bindings are derived from mounted
+certificate material.
+
+### Multi-Domain Listening
+
+The gateway process still has one `bind` listener. Multi-domain support means
+the same gateway workload can answer attestation requests for multiple public
+hostnames and select the correct downstream TLS binding from the request host.
+TLS termination, certificate issuance, DNS, SNI routing, and reverse-proxy
+configuration are deployment-owned and out of scope for this repo.
+
+For each public hostname, mount the leaf certificate that the external
+TLS-terminating component serves for that hostname, then list it in
+`tls.domain_certificates`:
+
+```json
+{
+  "tls": {
+    "domain_certificates": [
+      {
+        "domain": "api.example.com",
+        "certificate_path": "/run/certs/api.pem"
+      },
+      {
+        "domain": "chat.example.com",
+        "certificate_path": "/run/certs/chat.pem"
+      }
+    ]
+  }
+}
 ```
 
-The equivalent manual form is
-`PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256=api.example.com=<hex>,chat.example.com=<hex>`.
-Set only one TLS binding source among the service-wide and domain-mapped
-variables. When domain bindings are configured,
+The component in front of the gateway must forward the original HTTP `Host`.
+Clients should request the attestation report through the same public hostname
+they will use for gateway traffic. For example, a frontend pinned to
+`https://chat.example.com` should fetch
+`https://chat.example.com/v1/attestation/report`; the gateway will bind
+`chat.example.com` to the SPKI derived from `/run/certs/chat.pem`.
+
+When domain bindings are configured,
 `GET /v1/attestation/report` uses the request `Host` to add the matching
 `attestation.evidence.downstream_tls_binding` entry while keeping all configured
-TLS keys in the attested keyset.
+TLS keys in the attested keyset. Requests whose `Host` does not match a
+configured domain binding fail closed instead of returning an unbound report.
 
-`PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT` accepts HTTP(S) endpoints and Unix socket
-endpoints such as `unix:/var/run/dstack.sock`.
+`dstack_endpoint` accepts HTTP(S) endpoints and Unix socket endpoints such as
+`unix:/var/run/dstack.sock`.
 
 ## Test And Smoke Suites
 
@@ -503,7 +521,7 @@ uv run python scripts/live_e2e/run.py --profile quick --port 0
 The live smoke verifies every configured upstream in
 `scripts/live_e2e/providers.json`, sends one request per supported surface, then
 checks each receipt's `upstream.verified.session_id` against
-`GET /v1/audit/sessions/{session_id}`.
+`GET /v1/aci/sessions/{session_id}`.
 
 Run the slower Phala deployment smoke when you need to validate the deployment
 surface:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,11 +11,9 @@ generic; install, build, run, and ACI policy live in this repo.
 
 The checked-in compose runs in no-middleware mode: the public ACI frontend and
 verified-provider backend are the same process, and traffic is forwarded
-directly from frontend to backend. The binary can also run with a plaintext
-HTTP-over-UDS middleware slot by setting
-`PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH` and
-`PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH`; this compose does not yet include a
-middleware container or shared socket volume. See
+directly from frontend to backend. Middleware router helpers exist for future
+executor integration, but this deploy path does not expose middleware socket
+fields in the static gateway config. See
 [`../docs/frontend-middleware-backend.md`](../docs/frontend-middleware-backend.md)
 and
 [`../docs/middleware-integration.md`](../docs/middleware-integration.md).
@@ -46,10 +44,17 @@ shell, and run the same `phala-h4xuser deploy` command. For production, pass
 secrets such as admin tokens through the deployment secret mechanism rather
 than keeping them in a plaintext env file.
 
-`compose.yaml` inlines the launcher config, non-secret runtime environment, and
+`compose.yaml` inlines the launcher config, the static gateway config, and the
 initial upstream config. dstack therefore measures the whole launch policy into
 `compose_hash`.
 After deployment, the gateway listens on port `8086`.
+
+The gateway consumes two JSON files:
+
+| File | Compose config | Runtime role |
+| --- | --- | --- |
+| Static gateway config | `gateway-config` | Startup policy: bind address, TLS certificate bindings, dstack endpoint, admin token, gateway state directory, and read-only seed paths. |
+| Upstream seed config | `gateway-upstreams` seed copied to `<state_dir>/upstreams.json` on first boot | Initial provider/model routing policy. The live file is replaced by the admin API. |
 
 The checked-in compose starts with an empty upstream seed:
 
@@ -78,13 +83,14 @@ Everything after step 4 is gateway-owned:
 | Concern | Owner | Location |
 | --- | --- | --- |
 | Workload source pin | Launcher config | `gateway-pin` in `compose.yaml` |
-| Non-secret runtime env | Deployment compose | service `environment:` in `compose.yaml` |
+| Static gateway config | Deployment compose | `gateway-config` in `compose.yaml` |
+| Runtime bootstrap env | Deployment compose | service `environment:` in `compose.yaml` points at the static gateway config and cache directory |
 | Initial upstream config | Deployment compose | `gateway-upstreams` in `compose.yaml` |
 | Toolchain bootstrap | Gateway repo | `../entrypoint.sh` |
 | Build and exec | Gateway repo | `../entrypoint.sh` |
 | Downstream ACI frontend | Gateway binary | `../src` |
 | Verified-provider backend | Gateway binary | `../src` |
-| Optional routing middleware | Gateway deployment | Runtime-supported; not wired in this compose yet |
+| Optional routing middleware | Gateway deployment | Router helpers exist, but this compose and static config do not wire middleware |
 
 The public gateway repo root contains `entrypoint.sh`, so the launcher config
 does not set `REPO_SUBDIR`.
@@ -96,22 +102,40 @@ The compose uses two persistent volumes with different meanings:
 | Volume | Mount | Meaning |
 | --- | --- | --- |
 | `gateway-checkout` | `/var/lib/git-launcher` | Source checkout cache owned by `git-launcher`. Scrubbed on every boot with `git reset --hard` and `git clean -ffdx`. |
-| `gateway-state` | `/var/lib/private-ai-gateway` | Gateway-owned mutable state: upstream config, receipt/body retention, and Rust build cache. |
+| `gateway-state` | `/var/lib/private-ai-gateway` | Gateway-owned mutable state: active upstream config, attested-session log, and Rust build cache. |
 
-Do not put SQLite databases, retained bodies, uploaded files, or build artefacts
-under `WORK_DIR`. The source checkout is allowed to disappear and reclone. By
-default `entrypoint.sh` stores Cargo/Rustup/target state under
+Do not put gateway state or build artefacts under `WORK_DIR`. The source
+checkout is allowed to disappear and reclone. By default `entrypoint.sh` stores
+Cargo/Rustup/target state under
 `PRIVATE_AI_GATEWAY_CACHE_DIR=/var/lib/private-ai-gateway/cache`, so restarts
 can reuse the toolchain and crate/build cache without making the source checkout
 mutable.
 
-## Upstream Config Seed
+## Gateway And Upstream Config
 
-The active upstream config path is mutable:
+The complete config and environment-variable reference is
+[`../docs/configuration-reference.md`](../docs/configuration-reference.md).
+
+The static gateway config is mounted read-only:
 
 ```text
-/var/lib/private-ai-gateway/upstreams.json
+/etc/private-ai-gateway/gateway.config.json
 ```
+
+It is selected by the only gateway config-path env variable in the compose:
+
+```text
+PRIVATE_AI_GATEWAY_CONFIG_PATH=/etc/private-ai-gateway/gateway.config.json
+```
+
+The gateway config names the writable state directory:
+
+```text
+/var/lib/private-ai-gateway
+```
+
+Inside that directory, the gateway owns `upstreams.json` and `sessions.jsonl`.
+Operators do not configure those writable file paths individually.
 
 The compose-mounted seed is read-only:
 
@@ -119,14 +143,49 @@ The compose-mounted seed is read-only:
 /etc/private-ai-gateway/upstreams.seed.json
 ```
 
-The runtime env variable is:
+The state directory and seed path are configured inside `gateway-config`:
 
-```text
-PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH=/etc/private-ai-gateway/upstreams.seed.json
+```json
+{
+  "state_dir": "/var/lib/private-ai-gateway",
+  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json"
+}
 ```
 
-At startup, if the active config path is missing or whitespace-only, the
-gateway validates the seed and copies it into the active config path. If the
+### Multi-Domain Listener Usage
+
+The compose keeps a single gateway listener on port `8086`. To serve multiple
+public domains, configure DNS, TLS termination, SNI routing, and reverse proxying
+outside this repo, and forward each public hostname to that listener with the
+original HTTP `Host` intact.
+
+Mount the leaf certificate used for each public hostname and list those
+hostnames in the static gateway config:
+
+```json
+{
+  "tls": {
+    "domain_certificates": [
+      {
+        "domain": "api.example.com",
+        "certificate_path": "/run/certs/api.pem"
+      },
+      {
+        "domain": "chat.example.com",
+        "certificate_path": "/run/certs/chat.pem"
+      }
+    ]
+  }
+}
+```
+
+When a client requests `/v1/attestation/report` through `chat.example.com`, the
+gateway selects the `chat.example.com` certificate SPKI for
+`attestation.evidence.downstream_tls_binding`. A request with an unknown `Host`
+returns `404 not_found` instead of an attestation report.
+
+At startup, if `<state_dir>/upstreams.json` is missing or whitespace-only, the
+gateway validates the seed and copies it into that active config file. If the
 active config already contains anything, the seed is ignored and the active
 config wins. This lets a single compose boot a complete initial deployment
 without blocking later admin updates.
@@ -135,11 +194,16 @@ Changing `gateway-upstreams` in a later compose revision does not overwrite an
 existing active config volume. Use the admin API to replace the config, or
 delete the `gateway-state` volume intentionally before redeploying.
 
-The seed and non-secret runtime env are part of the attested compose. API keys
-in the seed are therefore part of the deployment input and must be handled as
-secrets by the deployment environment. For production, pass secrets through
-dstack encrypted secrets, KMS, or mounted secret files rather than inline
-compose values.
+The static gateway config, seed, and bootstrap env are part of the attested
+compose. API keys in the seed and secrets interpolated into the static config
+are therefore part of the deployment input and must be handled as secrets by
+the deployment environment. For production, pass secrets through dstack
+encrypted secrets, KMS, or mounted secret files rather than inline compose
+values.
+
+Source provenance is not set in the gateway config. The gateway reports the
+`REPO_URL` and `COMMIT_SHA` from the git-launcher config, which is also covered
+by the attested compose.
 
 Example seed:
 
@@ -158,12 +222,17 @@ Example seed:
 ```
 
 Supported provider values are `openai-compatible`, `aci-dcap`, `tinfoil`,
-`near-ai`, and `chutes`.
+`near-ai`, `chutes`, and `phala-direct`.
+
+For `aci-dcap`, `base_url` is the HTTPS origin used for both model traffic and
+`/v1/attestation/report`. The router fetches the report through normal TLS,
+derives the attested TLS SPKI binding from that report, then pins that SPKI for
+the actual upstream model request.
 
 ## Runtime Admin API
 
-When `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` is set, the same active config can be
-inspected and replaced:
+When `admin_token` is set in the static gateway config, the same active config
+can be inspected and replaced:
 
 ```bash
 curl -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
@@ -186,9 +255,10 @@ A verifier checks:
 | --- | --- |
 | Launcher image | The image digest in the attested compose equals `sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b` and verifies through the `git-launcher-v0.3.0` Sigstore provenance. |
 | Launcher config | `REPO_URL` and `COMMIT_SHA` in `gateway-pin` match the audited gateway commit. |
-| Runtime env | Service `environment:` matches the non-secret deployment policy, including source-provenance fields, config paths, and cache location. |
+| Gateway config | `gateway-config` matches the reviewed startup policy, including TLS certificate bindings, state directory, dstack endpoint, admin token, and read-only input paths. |
+| Runtime env | Service `environment:` points at the reviewed gateway config and cache location. |
 | Upstream seed | `gateway-upstreams` is the reviewed initial provider policy. |
-| Gateway report | `/v1/attestation/report` binds the dstack KMS identity, ACI keyset, TLS SPKI if configured, and source provenance. |
+| Gateway report | `/v1/attestation/report` binds the dstack KMS identity, ACI keyset, TLS SPKI if configured, and the git-launcher source provenance when present. |
 
 The launcher image digest alone does not identify the workload; the compose
 config is part of the trust surface.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -6,11 +6,11 @@
 #   PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-token> \
 #   phala-h4xuser deploy -n private-ai-gateway -c compose.yaml
 #
-# The compose inlines the launcher pin, non-secret runtime env, and initial
+# The compose inlines the launcher pin, static gateway config, and initial
 # upstream config so dstack's compose_hash covers the complete launch policy.
-# The gateway copies the read-only upstream seed into its mutable state path
-# only when no mutable config exists yet; later admin updates replace the
-# mutable file without changing this attested compose.
+# The gateway copies the read-only upstream seed into its mutable state path only
+# when no mutable config exists yet; later admin updates replace the mutable file
+# without changing this attested compose.
 
 services:
   private-ai-gateway:
@@ -21,28 +21,13 @@ services:
     configs:
       - source: gateway-pin
         target: /etc/git-launcher/gateway.conf
+      - source: gateway-config
+        target: /etc/private-ai-gateway/gateway.config.json
       - source: gateway-upstreams
         target: /etc/private-ai-gateway/upstreams.seed.json
     environment:
-      PRIVATE_AI_GATEWAY_BIND: "0.0.0.0:8086"
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /var/lib/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH: /etc/private-ai-gateway/upstreams.seed.json
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
       PRIVATE_AI_GATEWAY_CACHE_DIR: /var/lib/private-ai-gateway/cache
-      PRIVATE_AI_GATEWAY_ADMIN_TOKEN: ${PRIVATE_AI_GATEWAY_ADMIN_TOKEN:?set PRIVATE_AI_GATEWAY_ADMIN_TOKEN}
-      PRIVATE_AI_GATEWAY_REPO_URL: https://github.com/Dstack-TEE/private-ai-gateway.git
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
-      # PRIVATE_AI_GATEWAY_BODY_RETENTION_SECONDS: "0"
-      # PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS: "3600"
-      # PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS: "10"
-      # PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS: "600"
-      # PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS: "60"
-      # PRIVATE_AI_GATEWAY_TLS_CERT_PATHS: /etc/tls/aci-endpoint.crt
-      # PRIVATE_AI_GATEWAY_TLS_SPKI_SHA256: <64-hex-spki-sha256>[,<64-hex-spki-sha256>]
-      # PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT: unix:/var/run/dstack.sock
-      # Middleware mode is optional and requires a middleware service in the
-      # same attested compose with a shared socket volume.
-      # PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH: /run/private-ai-gateway/executor.sock
-      # PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH: /run/private-ai-gateway/backend.sock
     volumes:
       - gateway-checkout:/var/lib/git-launcher
       - gateway-state:/var/lib/private-ai-gateway
@@ -55,6 +40,16 @@ configs:
       REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
       COMMIT_SHA=${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
       WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+
+  gateway-config:
+    content: |
+      {
+        "bind": "0.0.0.0:8086",
+        "state_dir": "/var/lib/private-ai-gateway",
+        "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+        "admin_token": "${PRIVATE_AI_GATEWAY_ADMIN_TOKEN:?set PRIVATE_AI_GATEWAY_ADMIN_TOKEN}",
+        "dstack_endpoint": "unix:/var/run/dstack.sock"
+      }
 
   gateway-upstreams:
     content: |

--- a/deploy/gateway.config.example.json
+++ b/deploy/gateway.config.example.json
@@ -1,0 +1,7 @@
+{
+  "bind": "0.0.0.0:8086",
+  "state_dir": "/var/lib/private-ai-gateway",
+  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+  "admin_token": "<long-random-admin-token>",
+  "dstack_endpoint": "unix:/var/run/dstack.sock"
+}

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -232,8 +232,8 @@ mapping. A `failed` result asserts nothing.
   Absent or unverified GPU evidence leaves it `unknown` (we do not refute on an
   ambiguous negative). The raw `gpu_verified` / `gpu_arch` facts also stay in
   `extra`.
-- "generic" is the static / preverified / DCAP path with no provider identity:
-  it asserts only `tee_attested` (`VerifierDerived`), nothing else.
+- "generic" is a verifier path with no provider-specific identity: it asserts
+  only `tee_attested` (`VerifierDerived`), nothing else.
 
 ## Configuration
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,0 +1,165 @@
+# Configuration Reference
+
+Private AI Gateway uses one read-only static config file and one writable state
+directory. Operators must choose the config file with
+`PRIVATE_AI_GATEWAY_CONFIG_PATH` and put gateway policy in that file.
+
+## Runtime Files
+
+| Item | Owner | Runtime path |
+| --- | --- | --- |
+| Static gateway config | Deployment | Required. Selected by `PRIVATE_AI_GATEWAY_CONFIG_PATH`. |
+| Upstream seed config | Deployment | Selected by `upstream_config_seed_path` in the static gateway config. |
+| Active upstream config | Gateway | `<state_dir>/upstreams.json` |
+| Attested-session log | Gateway | `<state_dir>/sessions.jsonl` |
+
+Operators configure `state_dir`, not the individual writable files inside it.
+The gateway creates `state_dir` on startup, seeds `upstreams.json` from the
+read-only upstream seed only when the active file is missing or empty, and
+updates `upstreams.json` through `PUT /v1/admin/upstreams`.
+
+Unknown fields in the static gateway config are rejected at startup.
+
+## Minimal Config
+
+This is the smallest practical container config.
+
+```json
+{
+  "bind": "0.0.0.0:8086",
+  "state_dir": "/var/lib/private-ai-gateway",
+  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+  "admin_token": "<long-random-admin-token>",
+  "dstack_endpoint": "unix:/var/run/dstack.sock"
+}
+```
+
+## Config Fields
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `bind` | `127.0.0.1:8086` | Public HTTP listener address. Use `0.0.0.0:8086` in containers that expose the gateway port. |
+| `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
+| `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
+| `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
+| `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
+
+## Source Provenance
+
+Source provenance is not a gateway config field. The gateway reports source
+provenance from the dstack git-launcher pin at
+`/etc/git-launcher/gateway.conf`:
+
+```text
+REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+COMMIT_SHA=<audited-full-40-or-64-hex-commit-sha>
+WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+```
+
+When the launcher config is absent, source provenance is unknown and the
+gateway omits `source_provenance` from attestation reports. Production
+deployments should use `git-launcher`; relying parties should compare reported
+source provenance, when present, with the `REPO_URL` and `COMMIT_SHA` covered by
+the attested dstack compose.
+
+If the launcher config exists, `COMMIT_SHA` must be a full 40- or 64-character
+hexadecimal commit hash. Branch names, tags, and short hashes are rejected at
+startup.
+
+## TLS Binding
+
+TLS binding is optional. Configure it only when clients verify the gateway's
+public TLS certificate SPKI from the attested keyset.
+
+| Field | Use |
+| --- | --- |
+| `tls.domain_certificates` | One mounted leaf certificate per public hostname. |
+
+For multi-domain listening, use `tls.domain_certificates`:
+
+```json
+{
+  "tls": {
+    "domain_certificates": [
+      {
+        "domain": "api.example.com",
+        "certificate_path": "/run/certs/api.pem"
+      },
+      {
+        "domain": "chat.example.com",
+        "certificate_path": "/run/certs/chat.pem"
+      }
+    ]
+  }
+}
+```
+
+Raw SPKI digest inputs are not supported. The gateway reads mounted leaf
+certificates, computes `sha256(SPKI)`, and publishes those digests in the
+attested keyset. When `tls.domain_certificates` is configured, the request
+`Host` selects the matching downstream TLS binding for
+`/v1/attestation/report`. Unknown hosts return `404 not_found`.
+
+## Upstream Config
+
+The upstream seed file and active upstream database use the same JSON shape: an
+array of upstream entries. The seed file is deployment-owned and read-only. The
+active file at `<state_dir>/upstreams.json` is gateway-owned and is replaced by
+the admin API.
+
+```json
+[
+  {
+    "name": "route-a",
+    "provider": "aci-dcap",
+    "base_url": "https://upstream-a.example",
+    "models": {
+      "public-model": "provider-model"
+    },
+    "accepted_workload_ids": ["<workload-id>"],
+    "accepted_dstack_kms_root_public_keys": ["<kms-root-public-key>"]
+  }
+]
+```
+
+Supported `provider` values:
+
+| Provider | Use |
+| --- | --- |
+| `openai-compatible` | Generic OpenAI-compatible upstream with no provider-owned verifier. |
+| `aci-dcap` | ACI service that exposes dstack/DCAP evidence. |
+| `tinfoil` | Tinfoil provider adapter. |
+| `near-ai` | NEAR AI provider adapter. |
+| `chutes` | Chutes provider adapter. |
+| `phala-direct` | Direct Phala dstack-vllm-proxy endpoint. |
+
+Provider verification policy belongs on the upstream entry. For ACI/DCAP
+routes, configure accepted workload ids, image digests, or dstack KMS root
+public keys on that entry.
+
+For `aci-dcap`, `base_url` is the HTTPS origin used for both model traffic and
+`/v1/attestation/report`. The router fetches the report through normal TLS,
+derives the attested TLS SPKI binding from that report, then pins that SPKI for
+the actual upstream model request.
+
+## Environment Variables
+
+The gateway runtime reads only these environment variables. Provider verifier
+bridges may consume provider-specific environment variables such as
+`DSTACK_VERIFIER_URL` or `PRIVATE_AI_VERIFIER_DIR`.
+
+| Variable | Use |
+| --- | --- |
+| `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Selects the static gateway config file. |
+| `RUST_LOG` | Tracing filter consumed by `tracing_subscriber`. |
+
+Deployment tooling also uses these variables:
+
+| Variable | Use |
+| --- | --- |
+| `PRIVATE_AI_GATEWAY_CACHE_DIR` | `entrypoint.sh` build and toolchain cache root. Defaults to `/var/lib/private-ai-gateway/cache`. |
+| `CARGO_HOME` | Optional override for Cargo cache. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
+| `RUSTUP_HOME` | Optional override for Rustup state. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
+| `CARGO_TARGET_DIR` | Optional override for Cargo build output. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
+| `PRIVATE_AI_GATEWAY_REPO_COMMIT` | Used by `deploy/compose.yaml` interpolation for the git-launcher `COMMIT_SHA` pin. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Used by `deploy/compose.yaml` interpolation for the static config's `admin_token`. |

--- a/docs/frontend-middleware-backend.md
+++ b/docs/frontend-middleware-backend.md
@@ -124,20 +124,15 @@ headers or claims.
 
 ## Config Sketch
 
-Disabled mode stays the default. If no middleware socket path is configured,
-the frontend calls the backend directly in-process.
+Disabled mode is the current binary behavior. The static gateway config has no
+middleware socket fields, so the frontend calls the backend directly in-process.
 
 ```text
 # no middleware variables required
 ```
 
-Middleware mode is enabled by one Unix socket path. The gateway also starts an
-internal backend Unix socket for the middleware to call:
-
-```text
-PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH=/run/private-ai-gateway/executor.sock
-PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH=/run/private-ai-gateway/backend.sock
-```
+Middleware mode is a router-helper contract for custom embedding and tests. It
+is not exposed by the checked-in static config.
 
 The pending request-context TTL is 300 seconds. A middleware must call
 `POST /internal/forward` before the context expires.

--- a/docs/live-e2e-test-suite.md
+++ b/docs/live-e2e-test-suite.md
@@ -203,7 +203,7 @@ Provider-specific rules:
   NVIDIA evidence when present, and hash the decoded ML-KEM public-key bytes
   for the binding enforced by the transport. Strict production entries should
   pin upstream model ids to concrete `chute_id` UUIDs with `chutes_chute_ids`;
-  the verifier and gateway config use the same pins.
+  the verifier and upstream config use the same pins.
 - ACI/DCAP: verify `/v1/attestation/report?nonce=...`, quote report data,
   dstack KMS identity custody, accepted workload id or image digest, accepted
   KMS root, and attested TLS SPKI.
@@ -218,10 +218,13 @@ Reference updates must be reviewed. The script may print a proposed diff with
 Checks:
 
 - Required API keys are present but never printed.
-- `PRIVATE_AI_VERIFIER_DIR` exists or the sibling verifier checkout exists.
+- The vendored `scripts/confidential_verifier` package exists, or
+  `PRIVATE_AI_VERIFIER_DIR` points at an explicit verifier override.
 - `DSTACK_VERIFIER_URL` responds for NEAR AI and ACI/DCAP tests.
-- `PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT` or a local dstack socket exists for
-  gateway attestation tests.
+- A local dstack socket exists for gateway attestation tests. The runner writes
+  the static gateway config and defaults `dstack_endpoint` to
+  `unix:/tmp/aci-dstack-sock-dev.dstack.sock`; pass `--dstack-endpoint` to use
+  a different endpoint.
 - The gateway binary builds.
 - No live server is already bound to the selected local port.
 
@@ -255,7 +258,8 @@ Checks:
   - keyset endorsement verifies,
   - quote report data binds the ACI attestation statement,
   - dstack KMS custody verifies when using dstack,
-  - source provenance fields match the expected repo/commit or image digest,
+  - source provenance is absent when unknown, or matches the git-launcher
+    repo/commit pin when present,
   - attested TLS SPKI is present when configured.
 
 ### 30 Lifecycle
@@ -473,13 +477,13 @@ Procedure:
    evidence digest, session binding material, and verified claim tags.
 
 The final output should be a human-readable summary plus a machine-readable
-JSON result:
+JSON result. The verifier should omit `source_provenance` when the gateway
+report omits it because the git-launcher pin is unavailable.
 
 ```json
 {
   "verified": true,
   "workload_id": "sha256:...",
-  "source_provenance": {"repo_url": "...", "repo_commit": "..."},
   "receipt": {"chat_id": "...", "signature_valid": true},
   "upstream": {
     "vendor": "chutes-live",
@@ -518,4 +522,4 @@ providers. Our suite should explicitly cover the same classes of behavior:
 7. Tool and structured-output cases.
 8. Multimodal and context cases.
 9. Cache observability.
-10. Strict-release source provenance and launcher/image provenance checks.
+10. Strict-release source provenance from the launcher pin and image provenance checks.

--- a/docs/middleware-integration.md
+++ b/docs/middleware-integration.md
@@ -25,18 +25,10 @@ The gateway frontend owns downstream ACI.
 
 ## Runtime Wiring
 
-Enable middleware by setting the middleware Unix socket path on the gateway.
-The gateway connects to this socket when forwarding public requests to
-middleware:
-
-```bash
-PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH=/run/private-ai-gateway/executor.sock
-PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH=/run/private-ai-gateway/backend.sock
-```
-
-`PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH` is the socket the gateway's internal
-backend serves for middleware. It defaults to
-`/run/private-ai-gateway/backend.sock` when unset.
+The middleware router is available through the Rust HTTP router helpers. The
+checked-in gateway binary and static config do not expose middleware socket
+fields. Current deployments run no-middleware mode unless they embed the
+middleware router wiring in a custom binary.
 
 In this mode the gateway has three HTTP surfaces:
 
@@ -311,14 +303,8 @@ Run it locally:
 uvicorn middleware:app --uds /run/private-ai-gateway/executor.sock
 ```
 
-Start the gateway with middleware enabled:
-
-```bash
-PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH=/run/private-ai-gateway/executor.sock \
-PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH=/run/private-ai-gateway/backend.sock \
-PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH=/path/to/upstreams.json \
-cargo run --bin private-ai-gateway
-```
+The current static gateway config has no middleware fields. Use the integration
+tests as the executable reference for middleware router wiring.
 
 Then call the public gateway as usual:
 

--- a/docs/providers/aci-dcap/verification.md
+++ b/docs/providers/aci-dcap/verification.md
@@ -31,12 +31,18 @@ worker and verifies it natively:
 
 ## What binds the session
 
-The TLS SPKIs come from `workload_keyset.tls_public_keys[].spki_sha256_hex`. The
-`WorkloadKeyset.to_canonical_value()` (`src/aci/types.rs`) **includes** `tls_public_keys`,
-so they are covered by `workload_keyset_digest` — which is, in turn, (a) checked against
-the reported digest, (b) folded into `report_data` (and thus into the verified quote),
-and (c) signed by the keyset endorsement. The TLS-SPKI binding is therefore triple-bound
-to the attested workload.
+The TLS SPKIs are attested through `workload_keyset.tls_public_keys[].spki_sha256_hex`.
+The `WorkloadKeyset.to_canonical_value()` (`src/aci/types.rs`) **includes**
+`tls_public_keys`, so they are covered by `workload_keyset_digest` — which is, in turn,
+(a) checked against the reported digest, (b) folded into `report_data` (and thus into the
+verified quote), and (c) signed by the keyset endorsement. The TLS-SPKI binding is
+therefore triple-bound to the attested workload.
+
+For a domain-scoped keyset, the verifier also requires
+`attestation.evidence.downstream_tls_binding` to name the requested origin host and a
+SPKI present in the attested keyset. Only that selected SPKI becomes the enforced
+`tls_spki_sha256` channel binding. Service-wide keysets without per-domain entries keep
+the previous behavior: every service-wide TLS SPKI is accepted for the origin.
 
 ## What a tamper rejects
 
@@ -81,7 +87,7 @@ separate `review.md`):
 
 ## Reproduce
 
-Driven through the gateway's `aci-dcap` upstream verifier mode against a worker that
-exposes `/v1/attestation/report`; see `scripts/phala_multi_upstream_smoke.sh` and
-`scripts/local_multi_upstream_smoke.sh`
-(`PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: aci-dcap`).
+Driven through upstream entries with `provider: "aci-dcap"` against workers
+that expose `/v1/attestation/report`; see
+`scripts/phala_multi_upstream_smoke.sh` and
+`scripts/local_multi_upstream_smoke.sh`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,9 +84,9 @@ Remaining:
 The gateway currently assumes one downstream TLS identity. Production deployments
 may need multiple custom domains bound to the same gateway workload.
 
-- Add runtime config for a domain-to-certificate mapping. Implemented through
-  `PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS` and
-  `PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256`.
+- Add runtime config for a domain-to-certificate mapping. Implemented as
+  `tls.domain_certificates` in the static gateway config loaded from
+  `PRIVATE_AI_GATEWAY_CONFIG_PATH`. Raw SPKI inputs are not supported.
 - Publish all configured domain SPKI bindings in the attested keyset.
   Implemented.
 - Select the configured downstream domain binding from the HTTP `Host` and
@@ -112,7 +112,8 @@ Source design: [frontend-middleware-backend.md](frontend-middleware-backend.md).
   request context lookup. Implemented as a separate internal router builder and
   runtime listener when middleware is enabled.
 - Add optional UDS middleware mode with a fixture middleware for tests.
-  Implemented through `PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH`.
+  Implemented through router helpers and tests; not exposed by the static
+  gateway config.
 - Ensure external `X-Private-AI-Gateway-*` headers cannot steer the public
   frontend. Implemented by generating internal context server-side; covered by
   tests.
@@ -236,9 +237,9 @@ Source design: [frontend-middleware-backend.md](frontend-middleware-backend.md).
   transport/session binding logic as the gateway backend. The local proxy must
   fail closed when the upstream provider cannot be verified or when the verified
   binding cannot be enforced.
-- Keep the configuration minimal: local bind address, upstream config path, and
-  provider credentials. Avoid adding a separate verifier DSL or local policy
-  system.
+- Keep the configuration minimal: local bind address, provider credentials, and
+  the upstream config as a read-only input. Avoid adding a separate verifier DSL
+  or local policy system.
 - Document the trust model clearly: local proxy mode verifies upstream
   providers for the local user, but it does not claim to provide a TEE-backed
   ACI service identity to downstream clients.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,15 +22,15 @@
 #      failure, not silent dependency drift).
 #   3. exec's the freshly built binary so it becomes the process the TEE
 #      keeps running. The binary itself enforces all of ACI's fail-closed
-#      policy (refuses test-only keys, requires source provenance, etc.);
+#      policy (refuses test-only keys, upstream verification, etc.);
 #      this script does not duplicate that logic.
 #
 # What it deliberately does NOT do
 #   * Set the aggregator's upstream URL, identity subject, or any
-#     trust-bearing policy. Non-secret runtime policy flows in through Docker
-#     Compose `environment:` so a verifier audits it as deployment config, not
-#     as bytes inside this script. Secrets should come from encrypted secrets,
-#     KMS, or mounted secret files.
+#     trust-bearing policy. Runtime policy flows in through the static gateway
+#     config selected by Docker Compose `environment:`, so a verifier audits it
+#     as deployment config, not as bytes inside this script. Secrets should
+#     come from encrypted secrets, KMS, or mounted secret files.
 #   * Fall back if any step fails. Build / install / exec failure is a
 #     hard exit.
 #

--- a/scripts/live_e2e/bfcl_v4.py
+++ b/scripts/live_e2e/bfcl_v4.py
@@ -18,6 +18,7 @@ if __package__ in (None, ""):
 
 from live_e2e.common import (  # noqa: E402
     DEFAULT_ARTIFACT_DIR,
+    DEFAULT_DSTACK_ENDPOINT,
     DEFAULT_ENV_FILE,
     ROOT,
     Provider,
@@ -46,6 +47,7 @@ def main() -> None:
     parser.add_argument("--provider", action="append", default=[])
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--port", type=int, default=18086)
+    parser.add_argument("--dstack-endpoint", default=DEFAULT_DSTACK_ENDPOINT)
     parser.add_argument("--artifacts-dir", type=Path, default=DEFAULT_ARTIFACT_DIR)
     parser.add_argument(
         "--bfcl-dir",
@@ -131,6 +133,7 @@ def main() -> None:
         summary["preflight"] = preflight(
             providers,
             port=args.port,
+            dstack_endpoint=args.dstack_endpoint,
             env_file=args.env_file,
             check_build=not args.no_build,
         )
@@ -142,6 +145,7 @@ def main() -> None:
                 sampled_ids=sample["ids"],
                 sampled_categories=sample["categories"],
                 port=args.port,
+                dstack_endpoint=args.dstack_endpoint,
                 artifact_dir=artifact_dir / provider.name,
                 timeout_seconds=args.timeout_seconds,
                 num_threads=args.num_threads,
@@ -381,6 +385,7 @@ def run_provider_bfcl(
     sampled_ids: dict[str, list[str]],
     sampled_categories: list[str],
     port: int,
+    dstack_endpoint: str,
     artifact_dir: Path,
     timeout_seconds: int,
     num_threads: int,
@@ -394,6 +399,7 @@ def run_provider_bfcl(
     with AggregatorProcess(
         [bfcl_provider],
         port=port,
+        dstack_endpoint=dstack_endpoint,
         env=merged_env(),
         artifact_dir=artifact_dir,
     ) as aggregator:

--- a/scripts/live_e2e/chutes_rate_probe.py
+++ b/scripts/live_e2e/chutes_rate_probe.py
@@ -17,6 +17,7 @@ if __package__ in (None, ""):
 
 from live_e2e.common import (  # noqa: E402
     DEFAULT_ARTIFACT_DIR,
+    DEFAULT_DSTACK_ENDPOINT,
     DEFAULT_ENV_FILE,
     ROOT,
     Provider,
@@ -69,6 +70,7 @@ def main() -> None:
     parser.add_argument("--provider", default="chutes")
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--port", type=int, default=18087)
+    parser.add_argument("--dstack-endpoint", default=DEFAULT_DSTACK_ENDPOINT)
     parser.add_argument("--artifacts-dir", type=Path, default=DEFAULT_ARTIFACT_DIR)
     parser.add_argument("--stage", action="append", type=Stage.parse, default=[])
     parser.add_argument("--warmup", type=int, default=1)
@@ -109,10 +111,16 @@ def main() -> None:
         summary["preflight"] = preflight(
             [provider],
             port=args.port,
+            dstack_endpoint=args.dstack_endpoint,
             env_file=args.env_file,
             check_build=not args.no_build,
         )
-        with AggregatorProcess([provider], port=args.port, artifact_dir=artifact_dir) as agg:
+        with AggregatorProcess(
+            [provider],
+            port=args.port,
+            dstack_endpoint=args.dstack_endpoint,
+            artifact_dir=artifact_dir,
+        ) as agg:
             sequence = 0
             for index in range(args.warmup):
                 sequence += 1

--- a/scripts/live_e2e/launch_aggregator.py
+++ b/scripts/live_e2e/launch_aggregator.py
@@ -26,23 +26,29 @@ class AggregatorProcess:
         providers: list[Provider],
         *,
         port: int,
+        dstack_endpoint: str = DEFAULT_DSTACK_ENDPOINT,
         env: dict[str, str] | None = None,
         artifact_dir: Path | None = None,
     ) -> None:
         self.providers = providers
         self.port = port
         self.base_url = public_base_url(port)
+        self.dstack_endpoint = dstack_endpoint
         self.env = {**os.environ, **(env or {})}
         self.artifact_dir = artifact_dir
         self._tmp: tempfile.TemporaryDirectory[str] | None = None
         self._process: subprocess.Popen[bytes] | None = None
-        self.config_path: Path | None = None
+        self.gateway_config_path: Path | None = None
+        self.upstream_seed_path: Path | None = None
+        self.state_dir: Path | None = None
         self.log_path: Path | None = None
 
     def __enter__(self) -> "AggregatorProcess":
         self._tmp = tempfile.TemporaryDirectory(prefix="private-ai-gateway-live-e2e-")
         tmp_dir = Path(self._tmp.name)
-        self.config_path = tmp_dir / "upstreams.json"
+        self.gateway_config_path = tmp_dir / "gateway.config.json"
+        self.upstream_seed_path = tmp_dir / "upstreams.seed.json"
+        self.state_dir = tmp_dir / "state"
         self.log_path = (
             self.artifact_dir / "aggregator.log"
             if self.artifact_dir
@@ -50,7 +56,17 @@ class AggregatorProcess:
         )
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         config = build_upstream_config(self.providers, self.env)
-        write_json(self.config_path, config, mode=0o600)
+        write_json(self.upstream_seed_path, config, mode=0o600)
+        write_json(
+            self.gateway_config_path,
+            {
+                "bind": f"127.0.0.1:{self.port}",
+                "state_dir": str(self.state_dir),
+                "upstream_config_seed_path": str(self.upstream_seed_path),
+                "dstack_endpoint": self.dstack_endpoint,
+            },
+            mode=0o600,
+        )
         if self.artifact_dir:
             write_json(
                 self.artifact_dir / "aggregator-upstreams.redacted.json",
@@ -58,40 +74,7 @@ class AggregatorProcess:
             )
         child_env = {
             **self.env,
-            "PRIVATE_AI_GATEWAY_BIND": f"127.0.0.1:{self.port}",
-            "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH": str(self.config_path),
-            "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT": self.env.get(
-                "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT",
-                DEFAULT_DSTACK_ENDPOINT,
-            ),
-            "PRIVATE_AI_GATEWAY_REPO_URL": self.env.get(
-                "PRIVATE_AI_GATEWAY_REPO_URL",
-                "https://github.com/Dstack-TEE/private-ai-gateway",
-            ),
-            "PRIVATE_AI_GATEWAY_REPO_COMMIT": self.env.get(
-                "PRIVATE_AI_GATEWAY_REPO_COMMIT",
-                "live-e2e",
-            ),
-            "PRIVATE_AI_GATEWAY_BODY_RETENTION_SECONDS": self.env.get(
-                "PRIVATE_AI_GATEWAY_BODY_RETENTION_SECONDS",
-                "3600",
-            ),
-            "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": self.env.get(
-                "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS",
-                "3600",
-            ),
-            "PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS": self.env.get(
-                "PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS",
-                "10",
-            ),
-            "PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS": self.env.get(
-                "PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS",
-                "600",
-            ),
-            "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS": self.env.get(
-                "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS",
-                "240",
-            ),
+            "PRIVATE_AI_GATEWAY_CONFIG_PATH": str(self.gateway_config_path),
             "RUST_LOG": self.env.get("RUST_LOG", "info"),
         }
         if "DSTACK_VERIFIER_URL" not in child_env:

--- a/scripts/live_e2e/preflight.py
+++ b/scripts/live_e2e/preflight.py
@@ -27,6 +27,7 @@ def preflight(
     providers: list[Provider],
     *,
     port: int,
+    dstack_endpoint: str = DEFAULT_DSTACK_ENDPOINT,
     env_file: Path = DEFAULT_ENV_FILE,
     check_build: bool = True,
 ) -> dict[str, object]:
@@ -58,7 +59,6 @@ def preflight(
         if not (verifier_dir / "__init__.py").exists():
             raise RuntimeError(f"vendored confidential_verifier not found: {verifier_dir}")
 
-    dstack_endpoint = os.getenv("PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT", DEFAULT_DSTACK_ENDPOINT)
     if dstack_endpoint.startswith("unix:"):
         socket_path = Path(dstack_endpoint.removeprefix("unix:"))
         if not socket_path.exists():
@@ -90,6 +90,7 @@ def main() -> None:
     parser.add_argument("--provider", action="append", default=[])
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--port", type=int, default=18086)
+    parser.add_argument("--dstack-endpoint", default=DEFAULT_DSTACK_ENDPOINT)
     parser.add_argument("--no-build", action="store_true")
     args = parser.parse_args()
     load_dotenv(args.env_file)
@@ -97,6 +98,7 @@ def main() -> None:
     summary = preflight(
         providers,
         port=args.port,
+        dstack_endpoint=args.dstack_endpoint,
         env_file=args.env_file,
         check_build=not args.no_build,
     )

--- a/scripts/live_e2e/router_refresh_smoke.py
+++ b/scripts/live_e2e/router_refresh_smoke.py
@@ -86,18 +86,26 @@ def main() -> int:
     ]
 
     with tempfile.TemporaryDirectory(prefix="router-refresh-smoke-") as tmp:
-        cfg_path = Path(tmp) / "upstreams.json"
-        cfg_path.write_text(json.dumps(config))
+        upstream_seed_path = Path(tmp) / "upstreams.seed.json"
+        gateway_config_path = Path(tmp) / "gateway.config.json"
+        state_dir = Path(tmp) / "state"
+        upstream_seed_path.write_text(json.dumps(config))
+        gateway_config_path.write_text(
+            json.dumps(
+                {
+                    "bind": f"127.0.0.1:{PORT}",
+                    "state_dir": str(state_dir),
+                    "upstream_config_seed_path": str(upstream_seed_path),
+                    "dstack_endpoint": DEFAULT_DSTACK_ENDPOINT,
+                    "receipt_ttl_seconds": 3600,
+                }
+            )
+        )
         log_path = Path(tmp) / "aggregator.log"
         env = {
             **os.environ,
-            "PRIVATE_AI_GATEWAY_BIND": f"127.0.0.1:{PORT}",
-            "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH": str(cfg_path),
-            "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT": DEFAULT_DSTACK_ENDPOINT,
+            "PRIVATE_AI_GATEWAY_CONFIG_PATH": str(gateway_config_path),
             "DSTACK_VERIFIER_URL": os.environ.get("DSTACK_VERIFIER_URL", DEFAULT_DSTACK_VERIFIER_URL),
-            "PRIVATE_AI_GATEWAY_REPO_URL": "https://github.com/Dstack-TEE/private-ai-gateway",
-            "PRIVATE_AI_GATEWAY_REPO_COMMIT": "live-e2e",
-            "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": "3600",
             "RUST_LOG": "warn",
         }
         env.pop(key_env, None)

--- a/scripts/live_e2e/router_session_smoke.py
+++ b/scripts/live_e2e/router_session_smoke.py
@@ -92,18 +92,26 @@ def main() -> int:
     ]
 
     with tempfile.TemporaryDirectory(prefix="router-session-smoke-") as tmp:
-        cfg_path = Path(tmp) / "upstreams.json"
-        cfg_path.write_text(json.dumps(config))
+        upstream_seed_path = Path(tmp) / "upstreams.seed.json"
+        gateway_config_path = Path(tmp) / "gateway.config.json"
+        state_dir = Path(tmp) / "state"
+        upstream_seed_path.write_text(json.dumps(config))
+        gateway_config_path.write_text(
+            json.dumps(
+                {
+                    "bind": f"127.0.0.1:{PORT}",
+                    "state_dir": str(state_dir),
+                    "upstream_config_seed_path": str(upstream_seed_path),
+                    "dstack_endpoint": DEFAULT_DSTACK_ENDPOINT,
+                    "receipt_ttl_seconds": 3600,
+                }
+            )
+        )
         log_path = Path(tmp) / "aggregator.log"
         env = {
             **os.environ,
-            "PRIVATE_AI_GATEWAY_BIND": f"127.0.0.1:{PORT}",
-            "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH": str(cfg_path),
-            "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT": DEFAULT_DSTACK_ENDPOINT,
+            "PRIVATE_AI_GATEWAY_CONFIG_PATH": str(gateway_config_path),
             "DSTACK_VERIFIER_URL": os.environ.get("DSTACK_VERIFIER_URL", DEFAULT_DSTACK_VERIFIER_URL),
-            "PRIVATE_AI_GATEWAY_REPO_URL": "https://github.com/Dstack-TEE/private-ai-gateway",
-            "PRIVATE_AI_GATEWAY_REPO_COMMIT": "live-e2e",
-            "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS": "3600",
             "RUST_LOG": "warn",
         }
         env.pop(preset["api_key_env"], None)  # lives in the config file, not the env

--- a/scripts/live_e2e/run.py
+++ b/scripts/live_e2e/run.py
@@ -19,6 +19,7 @@ from live_e2e.cases.fidelity_structured_outputs import (  # noqa: E402
 from live_e2e.cases.lifecycle import run_lifecycle_case  # noqa: E402
 from live_e2e.common import (  # noqa: E402
     DEFAULT_ARTIFACT_DIR,
+    DEFAULT_DSTACK_ENDPOINT,
     DEFAULT_ENV_FILE,
     ROOT,
     find_free_port,
@@ -39,6 +40,7 @@ def main() -> None:
     parser.add_argument("--provider", action="append", default=[])
     parser.add_argument("--env-file", type=Path, default=DEFAULT_ENV_FILE)
     parser.add_argument("--port", type=int, default=18086)
+    parser.add_argument("--dstack-endpoint", default=DEFAULT_DSTACK_ENDPOINT)
     parser.add_argument("--artifacts-dir", type=Path, default=DEFAULT_ARTIFACT_DIR)
     parser.add_argument("--skip-provider-verify", action="store_true")
     parser.add_argument("--no-build", action="store_true")
@@ -61,6 +63,7 @@ def main() -> None:
         summary["phases"]["preflight"] = preflight(
             providers,
             port=args.port,
+            dstack_endpoint=args.dstack_endpoint,
             env_file=args.env_file,
             check_build=not args.no_build,
         )
@@ -81,6 +84,7 @@ def main() -> None:
         with AggregatorProcess(
             providers,
             port=args.port,
+            dstack_endpoint=args.dstack_endpoint,
             env=merged_env(),
             artifact_dir=artifact_dir,
         ) as aggregator:

--- a/scripts/local_multi_upstream_smoke.sh
+++ b/scripts/local_multi_upstream_smoke.sh
@@ -19,11 +19,13 @@ Environment:
   ROUTER_PORT            Host port for router. Default: 18088
   UPSTREAM_A_PORT        Host port for upstream A. Default: 18086
   UPSTREAM_B_PORT        Host port for upstream B. Default: 18087
+  UPSTREAM_A_TLS_PORT    Host port for upstream A TLS proxy. Default: 18446
+  UPSTREAM_B_TLS_PORT    Host port for upstream B TLS proxy. Default: 18447
   READY_ATTEMPTS         HTTP readiness attempts. Default: 60
   KEEP_STACK             Keep compose stack after completion when set to 1.
 
 Requirements:
-  docker compose, curl, jq, cargo, sha256sum, awk
+  docker compose, curl, jq, cargo, sha256sum, awk, openssl
 EOF
 }
 
@@ -42,6 +44,8 @@ IMAGE_REF="${IMAGE_REF:-private-ai-gateway:local-smoke}"
 ROUTER_PORT="${ROUTER_PORT:-18088}"
 UPSTREAM_A_PORT="${UPSTREAM_A_PORT:-18086}"
 UPSTREAM_B_PORT="${UPSTREAM_B_PORT:-18087}"
+UPSTREAM_A_TLS_PORT="${UPSTREAM_A_TLS_PORT:-18446}"
+UPSTREAM_B_TLS_PORT="${UPSTREAM_B_TLS_PORT:-18447}"
 READY_ATTEMPTS="${READY_ATTEMPTS:-60}"
 ADMIN_TOKEN="${ADMIN_TOKEN:-local-admin-secret}"
 KEEP_STACK="${KEEP_STACK:-0}"
@@ -65,6 +69,7 @@ need_cmd jq
 need_cmd cargo
 need_cmd sha256sum
 need_cmd awk
+need_cmd openssl
 
 docker compose version >/dev/null 2>&1 || die "docker compose plugin is required"
 [[ -S "$DSTACK_SOCK" ]] || die "dstack socket not found: $DSTACK_SOCK"
@@ -79,6 +84,8 @@ COMMIT_SHA="$(git rev-parse HEAD)"
 ROUTER_URL="http://127.0.0.1:${ROUTER_PORT}"
 UPSTREAM_A_URL="http://127.0.0.1:${UPSTREAM_A_PORT}"
 UPSTREAM_B_URL="http://127.0.0.1:${UPSTREAM_B_PORT}"
+UPSTREAM_A_TLS_URL="https://upstream-a-tls:${UPSTREAM_A_TLS_PORT}"
+UPSTREAM_B_TLS_URL="https://upstream-b-tls:${UPSTREAM_B_TLS_PORT}"
 
 export DSTACK_SOCK
 export WORK_DIR
@@ -87,6 +94,8 @@ export IMAGE_REF
 export ROUTER_PORT
 export UPSTREAM_A_PORT
 export UPSTREAM_B_PORT
+export UPSTREAM_A_TLS_PORT
+export UPSTREAM_B_TLS_PORT
 
 cleanup() {
   if [[ "$KEEP_STACK" == "1" ]]; then
@@ -103,6 +112,13 @@ sha256_prefixed() {
   printf '%s' "$value" | sha256sum | awk '{print "sha256:" $1}'
 }
 
+receipt_id_from_headers() {
+  local headers="$1"
+
+  awk -F': ' 'tolower($1) == "x-receipt-id" { sub(/\r/, "", $2); print $2; exit }' \
+    "$headers" | tr -d '[:space:]'
+}
+
 wait_for_http_ok() {
   local url="$1"
   local output="$2"
@@ -115,6 +131,70 @@ wait_for_http_ok() {
     sleep 2
   done
   die "endpoint did not become ready: ${url}"
+}
+
+wait_for_https_ok() {
+  local url="$1"
+  local resolve_host="$2"
+  local ca_cert="$3"
+  local output="$4"
+
+  for attempt in $(seq 1 "$READY_ATTEMPTS"); do
+    if curl -fsS --max-time 10 \
+      --noproxy '*' \
+      --cacert "$ca_cert" \
+      --resolve "$resolve_host:127.0.0.1" \
+      "$url" >"$output"; then
+      return 0
+    fi
+    log "waiting for ${url} (${attempt}/${READY_ATTEMPTS})"
+    sleep 2
+  done
+  die "endpoint did not become ready: ${url}"
+}
+
+generate_tls_ca() {
+  local prefix="$1"
+
+  openssl req \
+    -x509 \
+    -newkey rsa:2048 \
+    -nodes \
+    -sha256 \
+    -days 2 \
+    -subj "/CN=private-ai-gateway-local-smoke-ca" \
+    -keyout "${prefix}.key" \
+    -out "${prefix}.crt" \
+    >/dev/null 2>&1
+}
+
+generate_tls_cert() {
+  local domain="$1"
+  local prefix="$2"
+  local ca_prefix="$3"
+  local extfile="${prefix}.ext"
+
+  printf 'subjectAltName=DNS:%s\n' "$domain" >"$extfile"
+
+  openssl req \
+    -newkey rsa:2048 \
+    -nodes \
+    -sha256 \
+    -subj "/CN=${domain}" \
+    -keyout "${prefix}.key" \
+    -out "${prefix}.csr" \
+    >/dev/null 2>&1
+  openssl x509 \
+    -req \
+    -in "${prefix}.csr" \
+    -CA "${ca_prefix}.crt" \
+    -CAkey "${ca_prefix}.key" \
+    -CAcreateserial \
+    -sha256 \
+    -days 2 \
+    -extfile "$extfile" \
+    -out "${prefix}.crt" \
+    >/dev/null 2>&1
 }
 
 post_chat_until_ok() {
@@ -185,27 +265,32 @@ assert_route_receipt() {
   local receipt="$WORK_DIR/router-${suffix}.receipt.json"
   local received_body
   local forwarded_body
-  local chat_id
+  local response_headers="$WORK_DIR/router-${public_model}.headers"
+  local receipt_id
 
   response=$(post_chat_until_ok "$public_model")
   jq -e --arg model "$upstream_model" '.model == $model' "$response" >/dev/null
-  chat_id=$(jq -r '.id' "$response")
-  wait_for_http_ok "${ROUTER_URL}/v1/receipt/${chat_id}" "$receipt"
+  receipt_id=$(receipt_id_from_headers "$response_headers")
+  if [[ -z "$receipt_id" ]]; then
+    cat "$response_headers" >&2
+    die "chat response did not include x-receipt-id"
+  fi
+  wait_for_http_ok "${ROUTER_URL}/v1/aci/receipts/${receipt_id}" "$receipt"
 
   received_body=$(printf '{"model":"%s","messages":[]}' "$public_model")
   forwarded_body=$(printf '{"model":"%s","messages":[]}' "$upstream_model")
 
   jq -e --arg h "$(sha256_prefixed "$received_body")" '
-    .receipt.event_log | any(.type == "request.received" and .body_hash == $h)
+    .event_log | any(.type == "request.received" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e --arg h "$(sha256_prefixed "$forwarded_body")" '
-    .receipt.event_log | any(.type == "request.forwarded" and .body_hash == $h)
+    .event_log | any(.type == "request.forwarded" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e '
-    .receipt.event_log | any(.type == "transparency.request_modified")
+    .event_log | any(.type == "transparency.request_modified")
   ' "$receipt" >/dev/null
   jq -e --arg model "$upstream_model" '
-    .receipt.event_log
+    .event_log
     | any(.type == "upstream.verified" and .result == "verified" and .model_id == $model)
   ' "$receipt" >/dev/null
 }
@@ -225,30 +310,27 @@ assert_embeddings_receipt() {
     (.object == "list") and (.model == $model) and ((.data | length) == 1)
   ' "$response" >/dev/null
 
-  # Embeddings responses carry no `id`; look up the receipt by the
-  # x-receipt-id header instead of /v1/receipt/{chat_id}.
-  receipt_id=$(awk -F': ' 'tolower($1) == "x-receipt-id" { sub(/\r/, "", $2); print $2 }' \
-    "$response_headers" | tr -d '[:space:]')
+  receipt_id=$(receipt_id_from_headers "$response_headers")
   if [[ -z "$receipt_id" ]]; then
     cat "$response_headers" >&2
     die "embeddings response did not include x-receipt-id"
   fi
-  wait_for_http_ok "${ROUTER_URL}/v1/receipt/${receipt_id}" "$receipt"
+  wait_for_http_ok "${ROUTER_URL}/v1/aci/receipts/${receipt_id}" "$receipt"
 
   received_body=$(printf '{"model":"%s","input":"hello"}' "$public_model")
   forwarded_body=$(printf '{"model":"%s","input":"hello"}' "$upstream_model")
 
   jq -e --arg endpoint "/v1/embeddings" '
-    .receipt.endpoint == $endpoint
+    .endpoint == $endpoint
   ' "$receipt" >/dev/null
   jq -e --arg h "$(sha256_prefixed "$received_body")" '
-    .receipt.event_log | any(.type == "request.received" and .body_hash == $h)
+    .event_log | any(.type == "request.received" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e --arg h "$(sha256_prefixed "$forwarded_body")" '
-    .receipt.event_log | any(.type == "request.forwarded" and .body_hash == $h)
+    .event_log | any(.type == "request.forwarded" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e --arg model "$upstream_model" '
-    .receipt.event_log
+    .event_log
     | any(.type == "upstream.verified" and .result == "verified" and .model_id == $model)
   ' "$receipt" >/dev/null
 }
@@ -291,6 +373,76 @@ JSON
 }
 
 write_compose() {
+  cat >"$WORK_DIR/upstream-a.nginx.conf" <<NGINX
+events {}
+http {
+  server {
+    listen 8443 ssl;
+    server_name upstream-a-tls;
+    ssl_certificate /etc/nginx/certs/upstream-a.crt;
+    ssl_certificate_key /etc/nginx/certs/upstream-a.key;
+    location / {
+      proxy_set_header Host \$host;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_pass http://upstream-a:8086;
+    }
+  }
+}
+NGINX
+  cat >"$WORK_DIR/upstream-b.nginx.conf" <<NGINX
+events {}
+http {
+  server {
+    listen 8443 ssl;
+    server_name upstream-b-tls;
+    ssl_certificate /etc/nginx/certs/upstream-b.crt;
+    ssl_certificate_key /etc/nginx/certs/upstream-b.key;
+    location / {
+      proxy_set_header Host \$host;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_pass http://upstream-b:8086;
+    }
+  }
+}
+NGINX
+  cat >"$WORK_DIR/upstream-a.gateway.json" <<JSON
+{
+  "bind": "0.0.0.0:8086",
+  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+  "dstack_endpoint": "unix:/var/run/dstack.sock",
+  "tls": {
+    "domain_certificates": [
+      {
+        "domain": "upstream-a-tls",
+        "certificate_path": "/etc/private-ai-gateway/tls/upstream-a.crt"
+      }
+    ]
+  }
+}
+JSON
+  cat >"$WORK_DIR/upstream-b.gateway.json" <<JSON
+{
+  "bind": "0.0.0.0:8086",
+  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+  "dstack_endpoint": "unix:/var/run/dstack.sock",
+  "tls": {
+    "domain_certificates": [
+      {
+        "domain": "upstream-b-tls",
+        "certificate_path": "/etc/private-ai-gateway/tls/upstream-b.crt"
+      }
+    ]
+  }
+}
+JSON
+  cat >"$WORK_DIR/router.gateway.json" <<JSON
+{
+  "bind": "0.0.0.0:8086",
+  "state_dir": "/var/lib/private-ai-gateway",
+  "admin_token": "${ADMIN_TOKEN}",
+  "dstack_endpoint": "unix:/var/run/dstack.sock"
+}
+JSON
   cat >"$WORK_DIR/compose.yml" <<'YAML'
 services:
   mock-a:
@@ -378,51 +530,70 @@ services:
     depends_on:
       - mock-a
     environment:
-      PRIVATE_AI_GATEWAY_BIND: 0.0.0.0:8086
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /etc/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: preverified
-      PRIVATE_AI_GATEWAY_REPO_URL: local-build://private-ai-gateway
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${COMMIT_SHA}
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
     ports:
       - "${UPSTREAM_A_PORT}:8086"
     volumes:
       - ${DSTACK_SOCK}:/var/run/dstack.sock
-      - ${WORK_DIR}/upstream-a.json:/etc/private-ai-gateway/upstreams.json:ro
+      - ${WORK_DIR}/upstream-a.gateway.json:/etc/private-ai-gateway/gateway.config.json:ro
+      - ${WORK_DIR}/upstream-a.json:/etc/private-ai-gateway/upstreams.seed.json:ro
+      - ${WORK_DIR}/certs/upstream-a.crt:/etc/private-ai-gateway/tls/upstream-a.crt:ro
+
+  upstream-a-tls:
+    image: nginx:1.27-alpine
+    depends_on:
+      - upstream-a
+    ports:
+      - "${UPSTREAM_A_TLS_PORT}:8443"
+    volumes:
+      - ${WORK_DIR}/upstream-a.nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${WORK_DIR}/certs:/etc/nginx/certs:ro
 
   upstream-b:
     image: ${IMAGE_REF}
     depends_on:
       - mock-b
     environment:
-      PRIVATE_AI_GATEWAY_BIND: 0.0.0.0:8086
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /etc/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: preverified
-      PRIVATE_AI_GATEWAY_REPO_URL: local-build://private-ai-gateway
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${COMMIT_SHA}
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
     ports:
       - "${UPSTREAM_B_PORT}:8086"
     volumes:
       - ${DSTACK_SOCK}:/var/run/dstack.sock
-      - ${WORK_DIR}/upstream-b.json:/etc/private-ai-gateway/upstreams.json:ro
+      - ${WORK_DIR}/upstream-b.gateway.json:/etc/private-ai-gateway/gateway.config.json:ro
+      - ${WORK_DIR}/upstream-b.json:/etc/private-ai-gateway/upstreams.seed.json:ro
+      - ${WORK_DIR}/certs/upstream-b.crt:/etc/private-ai-gateway/tls/upstream-b.crt:ro
+
+  upstream-b-tls:
+    image: nginx:1.27-alpine
+    depends_on:
+      - upstream-b
+    ports:
+      - "${UPSTREAM_B_TLS_PORT}:8443"
+    volumes:
+      - ${WORK_DIR}/upstream-b.nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${WORK_DIR}/certs:/etc/nginx/certs:ro
 
   router:
     image: ${IMAGE_REF}
     depends_on:
-      - upstream-a
-      - upstream-b
+      - upstream-a-tls
+      - upstream-b-tls
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        cp /etc/private-ai-gateway/tls/local-smoke-ca.crt /usr/local/share/ca-certificates/local-smoke-ca.crt
+        update-ca-certificates >/dev/null
+        exec /usr/local/bin/private-ai-gateway
     environment:
-      PRIVATE_AI_GATEWAY_BIND: 0.0.0.0:8086
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /var/lib/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_ADMIN_TOKEN: ${ADMIN_TOKEN}
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: aci-dcap
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_CACHE_SECONDS: "300"
-      PRIVATE_AI_GATEWAY_REPO_URL: local-build://private-ai-gateway
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${COMMIT_SHA}
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
     ports:
       - "${ROUTER_PORT}:8086"
     volumes:
       - ${DSTACK_SOCK}:/var/run/dstack.sock
+      - ${WORK_DIR}/router.gateway.json:/etc/private-ai-gateway/gateway.config.json:ro
       - ${WORK_DIR}/router-state:/var/lib/private-ai-gateway
+      - ${WORK_DIR}/certs/local-smoke-ca.crt:/etc/private-ai-gateway/tls/local-smoke-ca.crt:ro
 YAML
 }
 
@@ -431,20 +602,33 @@ export ADMIN_TOKEN
 
 write_upstream_a_config_with_embed routed-upstream-a-model routed-upstream-a-embed-model
 write_upstream_config b routed-upstream-b-model
+mkdir -p "$WORK_DIR/certs"
+generate_tls_ca "$WORK_DIR/certs/local-smoke-ca"
+generate_tls_cert upstream-a-tls "$WORK_DIR/certs/upstream-a" "$WORK_DIR/certs/local-smoke-ca"
+generate_tls_cert upstream-b-tls "$WORK_DIR/certs/upstream-b" "$WORK_DIR/certs/local-smoke-ca"
 write_compose
 
 log "building ${IMAGE_REF}"
-docker build -f Dockerfile.smoke -t "$IMAGE_REF" .
+docker build \
+  -f Dockerfile.smoke \
+  --build-arg SOURCE_REPO_URL=local-build://private-ai-gateway \
+  --build-arg SOURCE_COMMIT="$COMMIT_SHA" \
+  -t "$IMAGE_REF" \
+  .
 
 log "starting local upstream ACI services"
 docker compose -f "$WORK_DIR/compose.yml" -p "$COMPOSE_PROJECT_NAME" up -d \
-  mock-a mock-b upstream-a upstream-b
+  mock-a mock-b upstream-a upstream-b upstream-a-tls upstream-b-tls
 
 wait_for_http_ok "${UPSTREAM_A_URL}/" "$WORK_DIR/upstream-a-root.json"
 wait_for_http_ok "${UPSTREAM_B_URL}/" "$WORK_DIR/upstream-b-root.json"
-wait_for_http_ok "${UPSTREAM_A_URL}/v1/attestation/report?nonce=local-a" \
+wait_for_https_ok "${UPSTREAM_A_TLS_URL}/v1/attestation/report?nonce=local-a" \
+  "upstream-a-tls:${UPSTREAM_A_TLS_PORT}" \
+  "$WORK_DIR/certs/local-smoke-ca.crt" \
   "$WORK_DIR/upstream-a-report.json"
-wait_for_http_ok "${UPSTREAM_B_URL}/v1/attestation/report?nonce=local-b" \
+wait_for_https_ok "${UPSTREAM_B_TLS_URL}/v1/attestation/report?nonce=local-b" \
+  "upstream-b-tls:${UPSTREAM_B_TLS_PORT}" \
+  "$WORK_DIR/certs/local-smoke-ca.crt" \
   "$WORK_DIR/upstream-b-report.json"
 
 cargo run --quiet --example dstack_kms_root_from_report \
@@ -465,7 +649,8 @@ jq -cn \
   '[
     {
       name: "route-a",
-      base_url: "http://upstream-a:8086",
+      provider: "aci-dcap",
+      base_url: "https://upstream-a-tls:8443",
       models: {
         "public-a": "routed-upstream-a-model",
         "public-embed": "routed-upstream-a-embed-model"
@@ -476,7 +661,8 @@ jq -cn \
     },
     {
       name: "route-b",
-      base_url: "http://upstream-b:8086",
+      provider: "aci-dcap",
+      base_url: "https://upstream-b-tls:8443",
       models: {"public-b": "routed-upstream-b-model"},
       accepted_workload_ids: [$wid_b],
       accepted_dstack_kms_root_public_keys: [$kms_b]

--- a/scripts/phala_multi_upstream_smoke.sh
+++ b/scripts/phala_multi_upstream_smoke.sh
@@ -75,6 +75,13 @@ sha256_prefixed() {
   printf '%s' "$value" | sha256sum | awk '{print "sha256:" $1}'
 }
 
+receipt_id_from_headers() {
+  local headers="$1"
+
+  awk -F': ' 'tolower($1) == "x-receipt-id" { sub(/\r/, "", $2); print $2; exit }' \
+    "$headers" | tr -d '[:space:]'
+}
+
 extract_json_object() {
   local input="$1"
   local output="$2"
@@ -150,7 +157,14 @@ post_chat_until_ok() {
 build_image() {
   local digest
   log "building and pushing ${IMAGE_TAG}"
-  docker buildx build --platform linux/amd64 -f Dockerfile.smoke -t "$IMAGE_TAG" --push .
+  docker buildx build \
+    --platform linux/amd64 \
+    -f Dockerfile.smoke \
+    --build-arg SOURCE_REPO_URL=local-build://private-ai-gateway \
+    --build-arg SOURCE_COMMIT="$COMMIT_SHA" \
+    -t "$IMAGE_TAG" \
+    --push \
+    .
   digest=$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')
   printf '%s@%s\n' "${IMAGE_TAG%:24h}" "$digest"
 }
@@ -225,14 +239,12 @@ services:
     depends_on:
       - mock
     environment:
-      PRIVATE_AI_GATEWAY_BIND: 0.0.0.0:8086
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /etc/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: preverified
-      PRIVATE_AI_GATEWAY_REPO_URL: local-build://private-ai-gateway
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${COMMIT_SHA}
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
     configs:
+      - source: gateway-config
+        target: /etc/private-ai-gateway/gateway.config.json
       - source: upstream-config
-        target: /etc/private-ai-gateway/upstreams.json
+        target: /etc/private-ai-gateway/upstreams.seed.json
     ports:
       - "8086:8086"
     volumes:
@@ -240,6 +252,14 @@ services:
     restart: unless-stopped
 
 configs:
+  gateway-config:
+    content: |
+      {
+        "bind": "0.0.0.0:8086",
+        "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+        "dstack_endpoint": "unix:/var/run/dstack.sock"
+      }
+
   upstream-config:
     content: |
       [
@@ -294,12 +314,16 @@ assert_route_receipt() {
   local receipt="$WORK_DIR/router-${suffix}.receipt.json"
   local received_body
   local forwarded_body
-  local chat_id
+  local receipt_id
 
   post_chat_until_ok "$ROUTER_URL" "$public_model" "$headers" "$response" "$ROUTE_READY_ATTEMPTS"
   jq -e --arg model "$upstream_model" '.model == $model' "$response" >/dev/null
-  chat_id=$(jq -r '.id' "$response")
-  wait_for_http_ok "${ROUTER_URL}/v1/receipt/${chat_id}" "$receipt" "$HTTP_READY_ATTEMPTS"
+  receipt_id=$(receipt_id_from_headers "$headers")
+  if [[ -z "$receipt_id" ]]; then
+    cat "$headers" >&2
+    die "chat response did not include x-receipt-id"
+  fi
+  wait_for_http_ok "${ROUTER_URL}/v1/aci/receipts/${receipt_id}" "$receipt" "$HTTP_READY_ATTEMPTS"
 
   received_body=$(printf '{"model":"%s","messages":[]}' "$public_model")
   forwarded_body=$(printf '{"model":"%s","messages":[]}' "$upstream_model")
@@ -309,16 +333,16 @@ assert_route_receipt() {
   forwarded_hash=$(sha256_prefixed "$forwarded_body")
 
   jq -e --arg h "$received_hash" '
-    .receipt.event_log | any(.type == "request.received" and .body_hash == $h)
+    .event_log | any(.type == "request.received" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e --arg h "$forwarded_hash" '
-    .receipt.event_log | any(.type == "request.forwarded" and .body_hash == $h)
+    .event_log | any(.type == "request.forwarded" and .body_hash == $h)
   ' "$receipt" >/dev/null
   jq -e '
-    .receipt.event_log | any(.type == "transparency.request_modified")
+    .event_log | any(.type == "transparency.request_modified")
   ' "$receipt" >/dev/null
   jq -e --arg model "$upstream_model" '
-    .receipt.event_log
+    .event_log
     | any(.type == "upstream.verified" and .result == "verified" and .model_id == $model)
   ' "$receipt" >/dev/null
 }
@@ -380,6 +404,7 @@ routes_json=$(
     '[
       {
         name: "route-a",
+        provider: "aci-dcap",
         base_url: $url_a,
         models: {"public-a": "routed-upstream-a-model"},
         accepted_workload_ids: [$wid_a],
@@ -387,6 +412,7 @@ routes_json=$(
       },
       {
         name: "route-b",
+        provider: "aci-dcap",
         base_url: $url_b,
         models: {"public-b": "routed-upstream-b-model"},
         accepted_workload_ids: [$wid_b],
@@ -402,15 +428,12 @@ services:
   router:
     image: ${IMAGE_REF}
     environment:
-      PRIVATE_AI_GATEWAY_BIND: 0.0.0.0:8086
-      PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH: /etc/private-ai-gateway/upstreams.json
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: aci-dcap
-      PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_CACHE_SECONDS: "300"
-      PRIVATE_AI_GATEWAY_REPO_URL: local-build://private-ai-gateway
-      PRIVATE_AI_GATEWAY_REPO_COMMIT: ${COMMIT_SHA}
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
     configs:
+      - source: gateway-config
+        target: /etc/private-ai-gateway/gateway.config.json
       - source: router-upstream-config
-        target: /etc/private-ai-gateway/upstreams.json
+        target: /etc/private-ai-gateway/upstreams.seed.json
     ports:
       - "8086:8086"
     volumes:
@@ -418,6 +441,14 @@ services:
     restart: unless-stopped
 
 configs:
+  gateway-config:
+    content: |
+      {
+        "bind": "0.0.0.0:8086",
+        "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+        "dstack_endpoint": "unix:/var/run/dstack.sock"
+      }
+
   router-upstream-config:
     content: |
 ${routes_config_yaml}

--- a/src/aci/types.rs
+++ b/src/aci/types.rs
@@ -203,6 +203,15 @@ pub struct SourceProvenance {
     pub image_provenance: Option<Value>,
 }
 
+impl SourceProvenance {
+    pub fn is_unknown(&self) -> bool {
+        self.repo_url.is_none()
+            && self.repo_commit.is_none()
+            && self.image_digest.is_none()
+            && self.image_provenance.is_none()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Freshness {
     pub fetched_at: u64,
@@ -226,6 +235,7 @@ pub struct AttestationEnvelope {
     #[serde(rename = "report_data")]
     pub report_data_hex: String,
     pub keyset_endorsement: KeysetEndorsement,
+    #[serde(default, skip_serializing_if = "SourceProvenance::is_unknown")]
     pub source_provenance: SourceProvenance,
     pub freshness: Freshness,
     pub evidence: Value,
@@ -326,5 +336,79 @@ impl Receipt {
             "event_log": self.event_log.iter().map(ReceiptEvent::to_canonical_value).collect::<Vec<_>>(),
             "signature": sig,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AttestationEnvelope, Freshness, KeysetEndorsement, KeysetEpoch, PublicKeyMaterial,
+        SourceProvenance, WorkloadIdentity, WorkloadKeyset,
+    };
+    use serde_json::json;
+
+    fn minimal_envelope(source_provenance: SourceProvenance) -> AttestationEnvelope {
+        AttestationEnvelope {
+            vendor: "test".to_string(),
+            tee_type: "tdx".to_string(),
+            workload_keyset: WorkloadKeyset {
+                workload_identity: WorkloadIdentity {
+                    public_key: PublicKeyMaterial {
+                        algo: "test".to_string(),
+                        public_key_hex: "00".to_string(),
+                    },
+                    subject: None,
+                },
+                keyset_epoch: KeysetEpoch {
+                    version: 1,
+                    not_after: u64::MAX,
+                },
+                receipt_signing_keys: Vec::new(),
+                e2ee_public_keys: Vec::new(),
+                tls_public_keys: Vec::new(),
+            },
+            report_data_hex: "00".to_string(),
+            keyset_endorsement: KeysetEndorsement {
+                algo: "test".to_string(),
+                value_hex: "00".to_string(),
+            },
+            source_provenance,
+            freshness: Freshness {
+                fetched_at: 0,
+                stale_after: u64::MAX,
+            },
+            evidence: json!({}),
+        }
+    }
+
+    #[test]
+    fn unknown_source_provenance_is_hidden_on_the_wire() {
+        let value = serde_json::to_value(minimal_envelope(SourceProvenance::default())).unwrap();
+
+        assert!(value.get("source_provenance").is_none());
+    }
+
+    #[test]
+    fn known_source_provenance_is_reported_on_the_wire() {
+        let value = serde_json::to_value(minimal_envelope(SourceProvenance {
+            repo_url: Some("https://github.com/Dstack-TEE/private-ai-gateway.git".to_string()),
+            repo_commit: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+            image_digest: None,
+            image_provenance: None,
+        }))
+        .unwrap();
+
+        assert_eq!(
+            value["source_provenance"]["repo_commit"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
+    }
+
+    #[test]
+    fn missing_source_provenance_deserializes_as_unknown() {
+        let value = serde_json::to_value(minimal_envelope(SourceProvenance::default())).unwrap();
+        let envelope: AttestationEnvelope = serde_json::from_value(value).unwrap();
+
+        assert!(envelope.source_provenance.is_unknown());
     }
 }

--- a/src/aci/upstream/tls.rs
+++ b/src/aci/upstream/tls.rs
@@ -73,32 +73,28 @@ impl ServerCertVerifier for SpkiPinVerifier {
     fn verify_server_cert(
         &self,
         end_entity: &CertificateDer<'_>,
-        intermediates: &[CertificateDer<'_>],
-        server_name: &ServerName<'_>,
-        ocsp_response: &[u8],
-        now: UnixTime,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
     ) -> Result<ServerCertVerified, RustlsError> {
-        let verified = self.inner.verify_server_cert(
-            end_entity,
-            intermediates,
-            server_name,
-            ocsp_response,
-            now,
-        )?;
-        if !self.accepted_certificates.is_empty() {
-            let digest = hex::encode(Sha256::digest(end_entity.as_ref()));
-            if !self.accepted_certificates.contains(&digest) {
-                return Err(RustlsError::InvalidCertificate(
-                    CertificateError::ApplicationVerificationFailure,
-                ));
-            }
+        if self.accepted.is_empty() && self.accepted_certificates.is_empty() {
+            return Err(RustlsError::InvalidCertificate(
+                CertificateError::ApplicationVerificationFailure,
+            ));
         }
+
+        let certificate_digest = hex::encode(Sha256::digest(end_entity.as_ref()));
+        let certificate_matches = self.accepted_certificates.contains(&certificate_digest);
+
         let (_, cert) = parse_x509_certificate(end_entity.as_ref())
             .map_err(|_| RustlsError::InvalidCertificate(CertificateError::BadEncoding))?;
         let digest = Sha256::digest(cert.public_key().raw);
         let digest = hex::encode(digest);
-        if self.accepted.is_empty() || self.accepted.contains(&digest) {
-            Ok(verified)
+        let spki_matches = self.accepted.contains(&digest);
+
+        if certificate_matches || spki_matches {
+            Ok(ServerCertVerified::assertion())
         } else {
             Err(RustlsError::InvalidCertificate(
                 CertificateError::ApplicationVerificationFailure,

--- a/src/aci/verifier/dcap.rs
+++ b/src/aci/verifier/dcap.rs
@@ -35,6 +35,8 @@ pub enum AciDcapVerifierConfigError {
     InvalidKmsRootPublicKey(String),
     #[error("upstream attestation report base URL is empty")]
     EmptyBaseUrl,
+    #[error("invalid upstream attestation report base URL: {0}")]
+    InvalidBaseUrl(String),
     #[error("failed to build verifier HTTP client: {0}")]
     Client(String),
 }
@@ -145,6 +147,16 @@ pub(super) enum AciDcapVerificationError {
     KmsRootRejected,
     #[error("verified ACI/dstack upstream report did not publish a TLS SPKI binding")]
     MissingTlsSpkiBinding,
+    #[error("verified ACI/dstack upstream report did not select a downstream TLS binding")]
+    MissingDownstreamTlsBinding,
+    #[error("invalid downstream TLS binding: {0}")]
+    InvalidDownstreamTlsBinding(String),
+    #[error(
+        "selected downstream TLS binding domain {reported:?} does not match upstream host {expected:?}"
+    )]
+    DownstreamTlsBindingHostMismatch { reported: String, expected: String },
+    #[error("selected downstream TLS binding is not present in the attested keyset")]
+    DownstreamTlsBindingNotInKeyset,
 }
 
 #[derive(Debug, Clone)]
@@ -173,6 +185,148 @@ impl CachedAciDcapVerification {
             ..Default::default()
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectedDownstreamTlsBinding {
+    domain: String,
+    spki_sha256: String,
+}
+
+pub(super) fn aci_report_tls_channel_bindings(
+    report: &AttestationReport,
+    origin: &str,
+) -> Result<Vec<ChannelBinding>, AciDcapVerificationError> {
+    let tls_public_keys = &report.attestation.workload_keyset.tls_public_keys;
+    if tls_public_keys.is_empty() {
+        return Err(AciDcapVerificationError::MissingTlsSpkiBinding);
+    }
+
+    let has_domain_scoped_keys = tls_public_keys.iter().any(|key| key.domain.is_some());
+    if !has_domain_scoped_keys {
+        return tls_public_keys
+            .iter()
+            .map(|key| {
+                Ok(ChannelBinding::TlsSpkiSha256 {
+                    origin: origin.to_string(),
+                    spki_sha256: normalize_sha256_hex(&key.spki_sha256_hex).map_err(|e| {
+                        AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+                            "invalid keyset TLS SPKI digest: {e}"
+                        ))
+                    })?,
+                })
+            })
+            .collect();
+    }
+
+    let selected = selected_downstream_tls_binding(&report.attestation.evidence)?;
+    let origin_domain = origin_host_domain(origin)?;
+    if selected.domain != origin_domain {
+        return Err(AciDcapVerificationError::DownstreamTlsBindingHostMismatch {
+            reported: selected.domain,
+            expected: origin_domain,
+        });
+    }
+
+    for key in tls_public_keys {
+        let Some(domain) = key.domain.as_deref() else {
+            continue;
+        };
+        let key_domain = normalize_tls_domain(domain).map_err(|e| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+                "invalid keyset TLS domain {domain:?}: {e}"
+            ))
+        })?;
+        let key_spki = normalize_sha256_hex(&key.spki_sha256_hex).map_err(|e| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+                "invalid keyset TLS SPKI digest: {e}"
+            ))
+        })?;
+        if key_domain == selected.domain && key_spki == selected.spki_sha256 {
+            return Ok(vec![ChannelBinding::TlsSpkiSha256 {
+                origin: origin.to_string(),
+                spki_sha256: selected.spki_sha256,
+            }]);
+        }
+    }
+
+    Err(AciDcapVerificationError::DownstreamTlsBindingNotInKeyset)
+}
+
+fn selected_downstream_tls_binding(
+    evidence: &Value,
+) -> Result<SelectedDownstreamTlsBinding, AciDcapVerificationError> {
+    let binding = evidence
+        .get("downstream_tls_binding")
+        .ok_or(AciDcapVerificationError::MissingDownstreamTlsBinding)?;
+    let domain = binding
+        .get("domain")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(
+                "downstream_tls_binding.domain must be a string".to_string(),
+            )
+        })?;
+    let spki_sha256 = binding
+        .get("spki_sha256")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(
+                "downstream_tls_binding.spki_sha256 must be a string".to_string(),
+            )
+        })?;
+    Ok(SelectedDownstreamTlsBinding {
+        domain: normalize_tls_domain(domain).map_err(|e| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+                "invalid downstream_tls_binding.domain: {e}"
+            ))
+        })?,
+        spki_sha256: normalize_sha256_hex(spki_sha256).map_err(|e| {
+            AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+                "invalid downstream_tls_binding.spki_sha256: {e}"
+            ))
+        })?,
+    })
+}
+
+fn origin_host_domain(origin: &str) -> Result<String, AciDcapVerificationError> {
+    let url = reqwest::Url::parse(origin).map_err(|e| {
+        AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+            "invalid report base URL {origin:?}: {e}"
+        ))
+    })?;
+    let host = url.host_str().ok_or_else(|| {
+        AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+            "report base URL {origin:?} has no host"
+        ))
+    })?;
+    normalize_tls_domain(host).map_err(|e| {
+        AciDcapVerificationError::InvalidDownstreamTlsBinding(format!(
+            "invalid report base URL host {host:?}: {e}"
+        ))
+    })
+}
+
+fn normalize_tls_domain(raw: &str) -> Result<String, String> {
+    let domain = raw.trim().trim_end_matches('.').to_ascii_lowercase();
+    if domain.is_empty()
+        || domain.contains('/')
+        || domain.contains(':')
+        || domain.contains('=')
+        || domain.contains(',')
+        || domain.chars().any(char::is_whitespace)
+    {
+        return Err(format!("invalid TLS domain {raw:?}"));
+    }
+    Ok(domain)
+}
+
+fn normalize_sha256_hex(value: &str) -> Result<String, String> {
+    let value = value.trim();
+    if value.len() != 64 || !value.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err("expected 64 hex characters".to_string());
+    }
+    Ok(value.to_ascii_lowercase())
 }
 
 /// Verifies an upstream ACI/dstack service by fetching its attestation
@@ -303,19 +457,7 @@ impl AciDcapUpstreamVerifier {
         let expires_at = verified_at
             .saturating_add(self.cache_ttl_seconds)
             .min(report.attestation.freshness.stale_after);
-        let channel_bindings: Vec<ChannelBinding> = report
-            .attestation
-            .workload_keyset
-            .tls_public_keys
-            .iter()
-            .map(|key| ChannelBinding::TlsSpkiSha256 {
-                origin: self.report_base_url.clone(),
-                spki_sha256: key.spki_sha256_hex.clone(),
-            })
-            .collect();
-        if channel_bindings.is_empty() {
-            return Err(AciDcapVerificationError::MissingTlsSpkiBinding);
-        }
+        let channel_bindings = aci_report_tls_channel_bindings(&report, &self.report_base_url)?;
 
         Ok(CachedAciDcapVerification {
             expires_at,

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -4,7 +4,7 @@ use k256::ecdsa::SigningKey;
 use serde_json::{json, Value};
 use sha3::{Digest, Keccak256};
 
-use super::dcap::CachedAciDcapVerification;
+use super::dcap::{aci_report_tls_channel_bindings, CachedAciDcapVerification};
 use super::dstack::verify_dstack_kms_identity_custody;
 use super::external::ExternalProviderVerifier;
 use super::*;
@@ -12,7 +12,8 @@ use crate::aci::keys::ALGO_ECDSA_SECP256K1;
 use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use crate::aci::types::{
     AttestationEnvelope, AttestationReport, Freshness, KeysetEndorsement, KeysetEpoch,
-    PublicKeyMaterial, ServiceCapabilities, SourceProvenance, WorkloadIdentity, WorkloadKeyset,
+    PublicKeyMaterial, ServiceCapabilities, SourceProvenance, TlsSpki, WorkloadIdentity,
+    WorkloadKeyset,
 };
 use crate::aci::upstream::ChutesSessionStore;
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
@@ -99,6 +100,13 @@ fn declared_scope(provider: &str) -> Option<&'static str> {
         "near-ai" | "tinfoil" => Some("router"),
         _ => None,
     }
+}
+
+fn tls_binding_report(tls_public_keys: Vec<TlsSpki>, evidence: Value) -> AttestationReport {
+    let mut report = custody_report(&signing_key(7), Vec::new());
+    report.attestation.workload_keyset.tls_public_keys = tls_public_keys;
+    report.attestation.evidence = evidence;
+    report
 }
 
 fn provider_script(provider: &str, verifier_id: &str, binding: Value) -> Vec<String> {
@@ -705,6 +713,136 @@ fn cached_aci_dcap_verification_preserves_channel_bindings() {
 
     assert_eq!(event.result, VerificationResult::Verified);
     assert_eq!(event.channel_bindings, cached.channel_bindings);
+}
+
+#[test]
+fn aci_report_tls_channel_bindings_preserves_service_wide_pins() {
+    let report = tls_binding_report(
+        vec![
+            TlsSpki {
+                domain: None,
+                spki_sha256_hex: "AA".repeat(32),
+            },
+            TlsSpki {
+                domain: None,
+                spki_sha256_hex: "bb".repeat(32),
+            },
+        ],
+        json!({}),
+    );
+
+    let bindings = aci_report_tls_channel_bindings(&report, "https://gateway.example").unwrap();
+
+    assert_eq!(
+        bindings,
+        vec![
+            ChannelBinding::TlsSpkiSha256 {
+                origin: "https://gateway.example".to_string(),
+                spki_sha256: "aa".repeat(32),
+            },
+            ChannelBinding::TlsSpkiSha256 {
+                origin: "https://gateway.example".to_string(),
+                spki_sha256: "bb".repeat(32),
+            },
+        ]
+    );
+}
+
+#[test]
+fn aci_report_tls_channel_bindings_selects_domain_binding_for_origin_host() {
+    let report = tls_binding_report(
+        vec![
+            TlsSpki {
+                domain: Some("api.example.com".to_string()),
+                spki_sha256_hex: "AA".repeat(32),
+            },
+            TlsSpki {
+                domain: Some("chat.example.com".to_string()),
+                spki_sha256_hex: "bb".repeat(32),
+            },
+        ],
+        json!({
+            "downstream_tls_binding": {
+                "domain": "API.EXAMPLE.COM.",
+                "spki_sha256": "AA".repeat(32),
+            }
+        }),
+    );
+
+    let bindings = aci_report_tls_channel_bindings(&report, "https://api.example.com").unwrap();
+
+    assert_eq!(
+        bindings,
+        vec![ChannelBinding::TlsSpkiSha256 {
+            origin: "https://api.example.com".to_string(),
+            spki_sha256: "aa".repeat(32),
+        }]
+    );
+}
+
+#[test]
+fn aci_report_tls_channel_bindings_rejects_domain_keyset_without_selected_binding() {
+    let report = tls_binding_report(
+        vec![TlsSpki {
+            domain: Some("api.example.com".to_string()),
+            spki_sha256_hex: "aa".repeat(32),
+        }],
+        json!({}),
+    );
+
+    let err = aci_report_tls_channel_bindings(&report, "https://api.example.com").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("did not select a downstream TLS binding"));
+}
+
+#[test]
+fn aci_report_tls_channel_bindings_rejects_selected_binding_for_other_host() {
+    let report = tls_binding_report(
+        vec![
+            TlsSpki {
+                domain: Some("api.example.com".to_string()),
+                spki_sha256_hex: "aa".repeat(32),
+            },
+            TlsSpki {
+                domain: Some("chat.example.com".to_string()),
+                spki_sha256_hex: "bb".repeat(32),
+            },
+        ],
+        json!({
+            "downstream_tls_binding": {
+                "domain": "chat.example.com",
+                "spki_sha256": "bb".repeat(32),
+            }
+        }),
+    );
+
+    let err = aci_report_tls_channel_bindings(&report, "https://api.example.com").unwrap_err();
+
+    assert!(err.to_string().contains("does not match upstream host"));
+}
+
+#[test]
+fn aci_report_tls_channel_bindings_rejects_selected_binding_outside_keyset() {
+    let report = tls_binding_report(
+        vec![TlsSpki {
+            domain: Some("api.example.com".to_string()),
+            spki_sha256_hex: "aa".repeat(32),
+        }],
+        json!({
+            "downstream_tls_binding": {
+                "domain": "api.example.com",
+                "spki_sha256": "bb".repeat(32),
+            }
+        }),
+    );
+
+    let err = aci_report_tls_channel_bindings(&report, "https://api.example.com").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("not present in the attested keyset"));
 }
 
 #[test]

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -104,8 +104,8 @@ impl ProviderClaimMapper for TinfoilClaims {
     }
 }
 
-/// Generic verifier (static / preverified / DCAP test path): we only know it
-/// returned Verified with an enforceable channel binding.
+/// Generic verifier path: we only know it returned Verified with an enforceable
+/// channel binding.
 pub(super) struct GenericClaims;
 impl ProviderClaimMapper for GenericClaims {
     fn claims(&self, event: &UpstreamVerifiedEvent) -> SessionClaims {

--- a/src/aggregator/service/config.rs
+++ b/src/aggregator/service/config.rs
@@ -1,8 +1,13 @@
 use super::ServiceError;
 use crate::aci::types::{KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki};
 
-/// Validate ACI §5.2 source-provenance arms.
+/// Validate source provenance before it is serialized in an attestation report.
+/// The binary derives runtime provenance from git-launcher; unknown provenance
+/// is valid and omitted from the wire report.
 pub fn validate_source_provenance(sp: &SourceProvenance) -> Result<(), ServiceError> {
+    if sp.is_unknown() {
+        return Ok(());
+    }
     let has_repo = sp.repo_url.as_deref().is_some_and(|s| !s.is_empty())
         && sp.repo_commit.as_deref().is_some_and(|s| !s.is_empty());
     let has_image = sp.image_digest.as_deref().is_some_and(|s| !s.is_empty());
@@ -31,6 +36,9 @@ pub(super) fn normalize_downstream_domain(raw: &str) -> Option<String> {
 pub struct AciServiceConfig {
     pub vendor: String,
     pub tee_type: String,
+    /// Runtime source provenance. The binary populates this from
+    /// `/etc/git-launcher/gateway.conf`; missing launcher metadata is
+    /// represented by `SourceProvenance::default()`.
     pub source_provenance: SourceProvenance,
     pub keyset_epoch: KeysetEpoch,
     pub identity_subject: Option<String>,

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -61,7 +61,17 @@ impl AciService {
         if !key_custody.is_null() {
             evidence["key_custody"] = key_custody;
         }
-        if let Some(binding) = domain.and_then(|domain| self.downstream_tls_binding(domain)) {
+        if self.requires_host_for_downstream_tls_binding() {
+            // Domain-scoped TLS keys publish one SPKI per public hostname. The
+            // report must therefore be requested through a known Host so the
+            // relying client pins the SPKI for that same hostname.
+            let domain = domain.ok_or(ServiceError::DownstreamTlsDomainMissing)?;
+            let binding = self
+                .downstream_tls_binding(domain)
+                .ok_or_else(|| ServiceError::DownstreamTlsDomainUnknown(domain.to_string()))?;
+            evidence["downstream_tls_binding"] = binding;
+        } else if let Some(binding) = domain.and_then(|domain| self.downstream_tls_binding(domain))
+        {
             evidence["downstream_tls_binding"] = binding;
         }
 
@@ -97,6 +107,13 @@ impl AciService {
                     "spki_sha256": key.spki_sha256_hex,
                 })
             })
+    }
+
+    fn requires_host_for_downstream_tls_binding(&self) -> bool {
+        self.keyset
+            .tls_public_keys
+            .iter()
+            .any(|key| key.domain.is_some())
     }
 
     pub fn prepare_e2ee_v2_request(

--- a/src/aggregator/service/errors.rs
+++ b/src/aggregator/service/errors.rs
@@ -11,8 +11,8 @@ pub enum ServiceError {
     )]
     TestKeysInProduction,
     #[error(
-        "ACI §5.2 requires at least one source provenance arm: \
-         (repo_url + repo_commit) or image_digest"
+        "invalid source provenance: repo provenance must include both repo_url and repo_commit; \
+         runtime source provenance is loaded from git-launcher or omitted when unknown"
     )]
     InvalidSourceProvenance,
     #[error("upstream verification failed: {0}")]
@@ -27,10 +27,16 @@ pub enum ServiceError {
     Receipt(#[from] ReceiptError),
     #[error("upstream error: {0}")]
     Upstream(#[from] UpstreamError),
+    #[error("attested session store error: {0}")]
+    SessionStore(String),
     #[error("metrics error: {0}")]
     Metrics(String),
     #[error("missing receipt signing key in keyset")]
     NoReceiptKey,
+    #[error("downstream TLS domain binding is required but request host is missing")]
+    DownstreamTlsDomainMissing,
+    #[error("no downstream TLS binding configured for request host {0:?}")]
+    DownstreamTlsDomainUnknown(String),
 }
 
 #[derive(Debug, thiserror::Error, Clone)]

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -85,10 +85,12 @@ impl AciService {
         })?;
         let forwarded_body = prepared.request.body.clone();
         let caller_supplied_upstream_event = req.upstream_verification_event.is_some();
+        let upstream_required =
+            self.upstream_required_for_prepared(&prepared, req.upstream_required);
         let mut recorded_event = self
             .recorded_upstream_event(
                 &prepared,
-                req.upstream_required,
+                upstream_required,
                 req.upstream_verification_event,
             )
             .await?;
@@ -97,7 +99,7 @@ impl AciService {
             .forward_with_binding_reverify(
                 &prepared,
                 &mut recorded_event,
-                req.upstream_required,
+                upstream_required,
                 caller_supplied_upstream_event,
                 // Single forward: only flush the cache for an event we own.
                 false,
@@ -222,10 +224,12 @@ impl AciService {
         })?;
         let forwarded_body = prepared.request.body.clone();
         let caller_supplied_upstream_event = req.upstream_verification_event.is_some();
+        let upstream_required =
+            self.upstream_required_for_prepared(&prepared, req.upstream_required);
         let mut recorded_event = self
             .recorded_upstream_event(
                 &prepared,
-                req.upstream_required,
+                upstream_required,
                 req.upstream_verification_event,
             )
             .await?;
@@ -234,7 +238,7 @@ impl AciService {
             .forward_with_binding_reverify(
                 &prepared,
                 &mut recorded_event,
-                req.upstream_required,
+                upstream_required,
                 caller_supplied_upstream_event,
                 // Single forward: only flush the cache for an event we own.
                 false,
@@ -452,6 +456,18 @@ impl AciService {
         }
     }
 
+    pub(super) fn upstream_required_for_prepared(
+        &self,
+        prepared: &PreparedUpstreamRequest,
+        requested: Option<bool>,
+    ) -> Option<bool> {
+        if prepared.is_tee == Some(false) {
+            Some(false)
+        } else {
+            requested
+        }
+    }
+
     pub(super) async fn refresh_upstream_event(
         &self,
         prepared: &PreparedUpstreamRequest,
@@ -541,11 +557,13 @@ impl AciService {
         )?;
 
         let session_id = session.session_id.clone();
-        if let Err(err) = self.session_store.put_session(session, now) {
-            // Persisting the audit record must not break inference; a missing
-            // session simply resolves to "not found" for relying parties.
-            tracing::warn!(error = %err, session_id = %session_id, "failed to persist attested session");
-        }
+        self.session_store
+            .put_session(session, now)
+            .map_err(|err| {
+                ServiceError::SessionStore(format!(
+                    "failed to persist attested session {session_id}: {err}"
+                ))
+            })?;
         Ok(Some((session_id, claims)))
     }
 

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -68,9 +68,9 @@ fn build_model_router(
     Ok(router)
 }
 
-/// Whether a provider performs hardware attestation (TEE). Non-TEE
-/// providers (plain OpenAI-compatible cloud APIs) are forwarded with
-/// TLS endpoint binding only and never fail closed for lack of evidence.
+/// Whether a provider route should participate in the default fail-closed
+/// upstream verification path. Plain OpenAI-compatible cloud APIs are forwarded
+/// with TLS endpoint binding only.
 fn provider_is_tee(provider: UpstreamProvider) -> bool {
     match provider {
         UpstreamProvider::OpenAiCompatible => false,

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -133,6 +133,45 @@ fn parse_config_allows_same_public_model_on_distinct_route_ids() {
 }
 
 #[test]
+fn parse_config_rejects_preverified_provider() {
+    let err = parse_config_text(
+        r#"
+            [
+              {
+                "name": "fixture",
+                "provider": "preverified",
+                "base_url": "https://fixture.example",
+                "models": {"public-model": "upstream-model"}
+              }
+            ]
+            "#,
+    )
+    .expect_err("preverified must not be accepted as upstream config");
+
+    assert!(err.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn parse_config_rejects_attestation_report_base_url() {
+    let err = parse_config_text(
+        r#"
+            [
+              {
+                "name": "aci",
+                "provider": "aci-dcap",
+                "base_url": "https://aci.example",
+                "attestation_report_base_url": "http://aci.internal:8086",
+                "models": {"public-model": "upstream-model"}
+              }
+            ]
+            "#,
+    )
+    .expect_err("attestation report URL must not be configured separately from base_url");
+
+    assert!(err.to_string().contains("unknown field"));
+}
+
+#[test]
 fn global_aci_dcap_does_not_require_policy_for_plain_openai_compatible_upstreams() {
     let config = vec![
         test_upstream_config(

--- a/src/http/app/error_responses.rs
+++ b/src/http/app/error_responses.rs
@@ -121,6 +121,10 @@ pub(super) fn upstream_verification_error_response(err: UpstreamVerificationErro
     )
 }
 
+pub(super) fn unknown_downstream_host_response(err: ServiceError) -> Response {
+    error_response(StatusCode::NOT_FOUND, "not_found", err.to_string())
+}
+
 pub(super) fn error_response(
     status: StatusCode,
     error_type: &str,

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -29,8 +29,8 @@ use super::backend::{
 };
 use super::error_responses::{
     admin_not_found_response, e2ee_error_response, error_response, insert_str_header,
-    internal_error_response, invalid_signing_algo_response, unsupported_e2ee_response,
-    upstream_config_error_response,
+    internal_error_response, invalid_signing_algo_response, unknown_downstream_host_response,
+    unsupported_e2ee_response, upstream_config_error_response,
 };
 use super::proxy::{
     finalize_middleware_http_response, forward_to_middleware, get_from_middleware,
@@ -175,6 +175,10 @@ pub(super) async fn attestation_report(
                 Err(e) => internal_error_response(e),
             }
         }
+        Err(
+            e @ (ServiceError::DownstreamTlsDomainMissing
+            | ServiceError::DownstreamTlsDomainUnknown(_)),
+        ) => unknown_downstream_host_response(e),
         Err(e) => internal_error_response(e),
     }
 }
@@ -193,6 +197,10 @@ pub(super) async fn aci_attestation_report(
         .await
     {
         Ok(report) => Json(report).into_response(),
+        Err(
+            e @ (ServiceError::DownstreamTlsDomainMissing
+            | ServiceError::DownstreamTlsDomainUnknown(_)),
+        ) => unknown_downstream_host_response(e),
         Err(e) => internal_error_response(e),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,38 +4,21 @@
 //! the dstack TDX quote API through the Rust dstack SDK. There is no
 //! ephemeral-key or stub-quote startup path.
 //!
-//! Configuration (env vars). Each setting uses the
-//! `PRIVATE_AI_GATEWAY_*` prefix. The older `DSTACK_LLM_ROUTER_*`
-//! names are still accepted as compatibility aliases; the
-//! `PRIVATE_AI_GATEWAY_*` value wins when both are set.
+//! Configuration. `PRIVATE_AI_GATEWAY_CONFIG_PATH` points at the static gateway
+//! JSON config. Gateway policy belongs in that file, not in environment
+//! fallbacks. See `docs/configuration-reference.md` for the full config and env
+//! reference.
 //!
-//! | Setting | Primary name | Compatibility alias |
-//! | --- | --- | --- |
-//! | Bind address | `PRIVATE_AI_GATEWAY_BIND` | `DSTACK_LLM_ROUTER_BIND` |
-//! | Upstream config path | `PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH` | `DSTACK_LLM_ROUTER_UPSTREAM_CONFIG_PATH` |
-//! | Initial upstream config seed path | `PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH` | `DSTACK_LLM_ROUTER_UPSTREAM_CONFIG_SEED_PATH` |
-//! | Admin API bearer token | `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | `DSTACK_LLM_ROUTER_ADMIN_TOKEN` |
-//! | Source-provenance repo URL | `PRIVATE_AI_GATEWAY_REPO_URL` | `DSTACK_LLM_ROUTER_REPO_URL` |
-//! | Source-provenance commit | `PRIVATE_AI_GATEWAY_REPO_COMMIT` | `DSTACK_LLM_ROUTER_REPO_COMMIT` |
-//! | Receipt TTL seconds | `PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS` | `DSTACK_LLM_ROUTER_RECEIPT_TTL_SECONDS` |
-//! | TLS certificate paths | `PRIVATE_AI_GATEWAY_TLS_CERT_PATHS` | `DSTACK_LLM_ROUTER_TLS_CERT_PATHS` |
-//! | TLS SPKI SHA-256 list | `PRIVATE_AI_GATEWAY_TLS_SPKI_SHA256` | `DSTACK_LLM_ROUTER_TLS_SPKI_SHA256` |
-//! | Domain TLS certificate map (`domain=path`) | `PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS` | `DSTACK_LLM_ROUTER_TLS_DOMAIN_CERT_PATHS` |
-//! | Domain TLS SPKI map (`domain=sha256`) | `PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256` | `DSTACK_LLM_ROUTER_TLS_DOMAIN_SPKI_SHA256` |
-//! | Upstream verifier mode (`none`, `preverified`, `aci-dcap`) | `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER` | `DSTACK_LLM_ROUTER_UPSTREAM_VERIFIER` |
-//! | Accepted upstream workload IDs | `PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_WORKLOAD_IDS` | `DSTACK_LLM_ROUTER_UPSTREAM_ACCEPTED_WORKLOAD_IDS` |
-//! | Accepted upstream image digests | `PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_IMAGE_DIGESTS` | `DSTACK_LLM_ROUTER_UPSTREAM_ACCEPTED_IMAGE_DIGESTS` |
-//! | Accepted upstream dstack KMS root public keys | `PRIVATE_AI_GATEWAY_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS` | `DSTACK_LLM_ROUTER_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS` |
-//! | Upstream verifier PCCS URL | `PRIVATE_AI_GATEWAY_UPSTREAM_PCCS_URL` | `DSTACK_LLM_ROUTER_UPSTREAM_PCCS_URL` |
-//! | Upstream connect timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | `DSTACK_LLM_ROUTER_UPSTREAM_CONNECT_TIMEOUT_SECONDS` |
-//! | Upstream read timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS` | `DSTACK_LLM_ROUTER_UPSTREAM_READ_TIMEOUT_SECONDS` |
-//! | Upstream verifier request timeout seconds | `PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS` | `DSTACK_LLM_ROUTER_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS` |
-//! | dstack endpoint | `PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT` | `DSTACK_LLM_ROUTER_DSTACK_ENDPOINT` |
-//! | Optional executor Unix socket path | `PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH` | none |
-//! | Internal backend Unix socket path for middleware mode | `PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH` | none |
+//! | Setting | Environment variable |
+//! | --- | --- |
+//! | Gateway config path | `PRIVATE_AI_GATEWAY_CONFIG_PATH` |
+//!
+//! Gateway-owned writable files are derived from `state_dir` in the static
+//! config. The active upstream database is `upstreams.json` and the
+//! attested-session log is `sessions.jsonl` inside that directory.
 
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -53,135 +36,164 @@ use private_ai_gateway::aggregator::upstream_config::{
     parse_config_text, UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::dstack::{DstackAciProvider, DstackAciProviderConfig};
-use private_ai_gateway::http::{
-    bind_unix_listener, build_internal_backend_router, build_router_with_admin,
-    build_router_with_admin_and_uds_middleware, serve_unix_listener, GatewayRequestStore,
-};
+use private_ai_gateway::http::build_router_with_admin;
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use x509_parser::prelude::parse_x509_certificate;
 
-/// Read an env var, preferring the current name over the compatibility alias.
-fn env_pref(current: &str, alias: &str) -> Option<String> {
-    std::env::var(current)
+const GIT_LAUNCHER_CONFIG_PATH: &str = "/etc/git-launcher/gateway.conf";
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name)
         .ok()
-        .or_else(|| std::env::var(alias).ok())
-}
-
-fn parse_seconds(setting: &str, value: &str) -> Result<u64, String> {
-    value
-        .parse::<u64>()
-        .map_err(|e| format!("invalid {setting} seconds {value:?}: {e}"))
-}
-
-fn parse_positive_seconds(setting: &str, value: &str) -> Result<u64, String> {
-    let seconds = parse_seconds(setting, value)?;
-    if seconds == 0 {
-        return Err(format!("{setting} seconds must be greater than zero"));
-    }
-    Ok(seconds)
-}
-
-fn parse_comma_list(value: Option<&str>) -> Vec<String> {
-    value
-        .into_iter()
-        .flat_map(|v| v.split(','))
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-        .map(str::to_string)
-        .collect()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn invalid_input(message: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidInput, message.into())
 }
 
-fn parse_tls_spki_list(value: &str) -> Result<Vec<TlsSpki>, String> {
-    let mut keys = Vec::new();
-    for raw in value.split(',') {
-        let item = raw.trim();
-        if item.len() != 64 || !item.as_bytes().iter().all(u8::is_ascii_hexdigit) {
-            return Err(format!(
-                "invalid TLS SPKI SHA-256 digest {item:?}: expected 64 hex characters"
-            ));
-        }
-        keys.push(TlsSpki {
-            domain: None,
-            spki_sha256_hex: item.to_ascii_lowercase(),
-        });
-    }
-    if keys.is_empty() {
-        return Err("TLS SPKI SHA-256 list must not be empty".to_string());
-    }
-    Ok(keys)
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct GatewayConfigFile {
+    bind: Option<String>,
+    state_dir: Option<String>,
+    upstream_config_seed_path: Option<String>,
+    admin_token: Option<String>,
+    tls: GatewayTlsConfig,
+    dstack_endpoint: Option<String>,
 }
 
-fn parse_domain_spki_map(value: &str) -> Result<Vec<TlsSpki>, String> {
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct GatewayTlsConfig {
+    domain_certificates: Vec<TlsDomainCertificateEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TlsDomainCertificateEntry {
+    domain: String,
+    certificate_path: String,
+}
+
+fn load_gateway_config(path: &str) -> Result<GatewayConfigFile, String> {
+    let path = Path::new(path);
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read gateway config {}: {e}", path.display()))?;
+    serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse gateway config {}: {e}", path.display()))
+}
+
+fn resolve_state_dir(config_state_dir: Option<&str>) -> Result<PathBuf, String> {
+    let state_dir = config_state_dir
+        .unwrap_or("/var/lib/private-ai-gateway")
+        .trim();
+    if state_dir.is_empty() {
+        return Err("gateway state_dir must not be empty".to_string());
+    }
+    Ok(PathBuf::from(state_dir))
+}
+
+fn upstream_config_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("upstreams.json")
+}
+
+fn session_log_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("sessions.jsonl")
+}
+
+fn resolve_source_provenance() -> Result<SourceProvenance, String> {
+    Ok(
+        source_provenance_from_git_launcher_config(Path::new(GIT_LAUNCHER_CONFIG_PATH))?
+            .unwrap_or_default(),
+    )
+}
+
+fn source_provenance_from_git_launcher_config(
+    path: &Path,
+) -> Result<Option<SourceProvenance>, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "failed to read git-launcher config {}: {err}",
+                path.display()
+            ));
+        }
+    };
+    let mut repo_url = None;
+    let mut repo_commit = None;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "REPO_URL" if !value.is_empty() => repo_url = Some(value.to_string()),
+            "COMMIT_SHA" if !value.is_empty() => repo_commit = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    let repo_url = repo_url
+        .ok_or_else(|| format!("git-launcher config {} is missing REPO_URL", path.display()))?;
+    let repo_commit = repo_commit.ok_or_else(|| {
+        format!(
+            "git-launcher config {} is missing COMMIT_SHA",
+            path.display()
+        )
+    })?;
+    validate_git_launcher_commit_sha(&repo_commit).map_err(|err| {
+        format!(
+            "git-launcher config {} has invalid COMMIT_SHA: {err}",
+            path.display()
+        )
+    })?;
+    Ok(Some(SourceProvenance {
+        repo_url: Some(repo_url),
+        repo_commit: Some(repo_commit),
+        image_digest: None,
+        image_provenance: None,
+    }))
+}
+
+fn validate_git_launcher_commit_sha(value: &str) -> Result<(), String> {
+    if (value.len() == 40 || value.len() == 64) && value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+    Err("expected a full 40- or 64-character hexadecimal commit hash".to_string())
+}
+
+fn parse_domain_cert_entries(
+    entries: &[TlsDomainCertificateEntry],
+) -> Result<Vec<TlsSpki>, String> {
     let mut keys = Vec::new();
     let mut domains = std::collections::BTreeSet::new();
-    for raw in value.split(',') {
-        let (domain, spki) = parse_domain_value(raw, "TLS domain SPKI")?;
+    for entry in entries {
+        let domain = normalize_config_domain(&entry.domain)?;
         if !domains.insert(domain.clone()) {
             return Err(format!("TLS domain {domain:?} is duplicated"));
         }
-        if spki.len() != 64 || !spki.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        let certificate_path = entry.certificate_path.trim();
+        if certificate_path.is_empty() {
             return Err(format!(
-                "invalid TLS SPKI SHA-256 digest {spki:?}: expected 64 hex characters"
+                "TLS domain certificate entry for {domain:?} has an empty certificate_path"
             ));
         }
-        keys.push(TlsSpki {
-            domain: Some(domain),
-            spki_sha256_hex: spki.to_ascii_lowercase(),
-        });
-    }
-    if keys.is_empty() {
-        return Err("TLS domain SPKI map must not be empty".to_string());
-    }
-    Ok(keys)
-}
-
-fn parse_tls_cert_paths(value: &str) -> Result<Vec<TlsSpki>, String> {
-    let mut keys = Vec::new();
-    for raw in value.split(',') {
-        let path = raw.trim();
-        if path.is_empty() {
-            return Err("TLS certificate path list contains an empty path".to_string());
-        }
-        keys.push(tls_spki_from_cert_path(Path::new(path))?);
-    }
-    if keys.is_empty() {
-        return Err("TLS certificate path list must not be empty".to_string());
-    }
-    Ok(keys)
-}
-
-fn parse_domain_cert_paths(value: &str) -> Result<Vec<TlsSpki>, String> {
-    let mut keys = Vec::new();
-    let mut domains = std::collections::BTreeSet::new();
-    for raw in value.split(',') {
-        let (domain, path) = parse_domain_value(raw, "TLS domain certificate")?;
-        if !domains.insert(domain.clone()) {
-            return Err(format!("TLS domain {domain:?} is duplicated"));
-        }
-        let mut key = tls_spki_from_cert_path(Path::new(&path))?;
+        let mut key = tls_spki_from_cert_path(Path::new(certificate_path))?;
         key.domain = Some(domain);
         keys.push(key);
     }
     if keys.is_empty() {
-        return Err("TLS domain certificate map must not be empty".to_string());
+        return Err("TLS domain config must contain at least one domain".to_string());
     }
     Ok(keys)
-}
-
-fn parse_domain_value(raw: &str, label: &str) -> Result<(String, String), String> {
-    let (domain, value) = raw
-        .split_once('=')
-        .ok_or_else(|| format!("{label} entry must be domain=value, got {raw:?}"))?;
-    let domain = normalize_config_domain(domain)?;
-    let value = value.trim();
-    if value.is_empty() {
-        return Err(format!("{label} entry for {domain:?} has an empty value"));
-    }
-    Ok((domain, value.to_string()))
 }
 
 fn normalize_config_domain(raw: &str) -> Result<String, String> {
@@ -223,40 +235,9 @@ fn leaf_certificate_der(bytes: &[u8]) -> Result<Vec<u8>, String> {
     Ok(bytes.to_vec())
 }
 
-fn resolve_tls_public_keys(
-    cert_paths: Option<&str>,
-    explicit_spkis: Option<&str>,
-    domain_cert_paths: Option<&str>,
-    domain_spkis: Option<&str>,
-) -> Result<Option<Vec<TlsSpki>>, String> {
-    let configured = [
-        cert_paths.is_some(),
-        explicit_spkis.is_some(),
-        domain_cert_paths.is_some(),
-        domain_spkis.is_some(),
-    ]
-    .into_iter()
-    .filter(|configured| *configured)
-    .count();
-    if configured > 1 {
-        return Err(
-            "set only one TLS binding source: PRIVATE_AI_GATEWAY_TLS_CERT_PATHS, \
-             PRIVATE_AI_GATEWAY_TLS_SPKI_SHA256, PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS, \
-             or PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256"
-                .to_string(),
-        );
-    }
-    if let Some(paths) = cert_paths {
-        return parse_tls_cert_paths(paths).map(Some);
-    }
-    if let Some(spkis) = explicit_spkis {
-        return parse_tls_spki_list(spkis).map(Some);
-    }
-    if let Some(paths) = domain_cert_paths {
-        return parse_domain_cert_paths(paths).map(Some);
-    }
-    if let Some(spkis) = domain_spkis {
-        return parse_domain_spki_map(spkis).map(Some);
+fn resolve_tls_public_keys(config: &GatewayTlsConfig) -> Result<Option<Vec<TlsSpki>>, String> {
+    if !config.domain_certificates.is_empty() {
+        return parse_domain_cert_entries(&config.domain_certificates).map(Some);
     }
     Ok(None)
 }
@@ -327,157 +308,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let bind = env_pref("PRIVATE_AI_GATEWAY_BIND", "DSTACK_LLM_ROUTER_BIND")
+    let gateway_config_path = env_non_empty("PRIVATE_AI_GATEWAY_CONFIG_PATH").ok_or_else(|| {
+        invalid_input("PRIVATE_AI_GATEWAY_CONFIG_PATH must point to the static gateway config file")
+    })?;
+    let gateway_config = load_gateway_config(&gateway_config_path)?;
+
+    let bind = gateway_config
+        .bind
+        .clone()
         .unwrap_or_else(|| "127.0.0.1:8086".to_string());
-    let upstream_config_path = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH",
-        "DSTACK_LLM_ROUTER_UPSTREAM_CONFIG_PATH",
-    )
-    .unwrap_or_else(|| "/var/lib/private-ai-gateway/upstreams.json".to_string());
-    let upstream_config_seed_path = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_SEED_PATH",
-        "DSTACK_LLM_ROUTER_UPSTREAM_CONFIG_SEED_PATH",
-    );
-    let admin_token = env_pref(
-        "PRIVATE_AI_GATEWAY_ADMIN_TOKEN",
-        "DSTACK_LLM_ROUTER_ADMIN_TOKEN",
-    );
-    let repo_url = env_pref("PRIVATE_AI_GATEWAY_REPO_URL", "DSTACK_LLM_ROUTER_REPO_URL");
-    let repo_commit = env_pref(
-        "PRIVATE_AI_GATEWAY_REPO_COMMIT",
-        "DSTACK_LLM_ROUTER_REPO_COMMIT",
-    );
-    // Must be > 0: it is also the session retention window, and a 0 TTL would
-    // make every session born-expired (evicted on write) so receipts resolve to
-    // not-found.
-    let receipt_ttl_seconds = env_pref(
-        "PRIVATE_AI_GATEWAY_RECEIPT_TTL_SECONDS",
-        "DSTACK_LLM_ROUTER_RECEIPT_TTL_SECONDS",
-    )
-    .as_deref()
-    .map(|value| parse_positive_seconds("receipt TTL", value))
-    .transpose()?
-    .unwrap_or(3600);
-    let tls_cert_paths = env_pref(
-        "PRIVATE_AI_GATEWAY_TLS_CERT_PATHS",
-        "DSTACK_LLM_ROUTER_TLS_CERT_PATHS",
-    );
-    let tls_spkis = env_pref(
-        "PRIVATE_AI_GATEWAY_TLS_SPKI_SHA256",
-        "DSTACK_LLM_ROUTER_TLS_SPKI_SHA256",
-    );
-    let tls_domain_cert_paths = env_pref(
-        "PRIVATE_AI_GATEWAY_TLS_DOMAIN_CERT_PATHS",
-        "DSTACK_LLM_ROUTER_TLS_DOMAIN_CERT_PATHS",
-    );
-    let tls_domain_spkis = env_pref(
-        "PRIVATE_AI_GATEWAY_TLS_DOMAIN_SPKI_SHA256",
-        "DSTACK_LLM_ROUTER_TLS_DOMAIN_SPKI_SHA256",
-    );
-    let tls_public_keys = resolve_tls_public_keys(
-        tls_cert_paths.as_deref(),
-        tls_spkis.as_deref(),
-        tls_domain_cert_paths.as_deref(),
-        tls_domain_spkis.as_deref(),
-    )?;
-    let upstream_verifier_mode = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER",
-        "DSTACK_LLM_ROUTER_UPSTREAM_VERIFIER",
-    )
-    .unwrap_or_else(|| "none".to_string());
-    let upstream_verifier_mode = UpstreamVerifierMode::parse(&upstream_verifier_mode)
-        .map_err(|e| invalid_input(e.to_string()))?;
-    let upstream_verifier_cache_seconds = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_CACHE_SECONDS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_VERIFIER_CACHE_SECONDS",
-    )
-    .as_deref()
-    .map(|value| parse_positive_seconds("upstream verifier cache", value))
-    .transpose()?
-    .unwrap_or(300);
-    let upstream_connect_timeout_seconds = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECONDS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_CONNECT_TIMEOUT_SECONDS",
-    )
-    .as_deref()
-    .map(|value| parse_positive_seconds("upstream connect timeout", value))
-    .transpose()?
-    .unwrap_or(DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS);
-    let upstream_read_timeout_seconds = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_READ_TIMEOUT_SECONDS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_READ_TIMEOUT_SECONDS",
-    )
-    .as_deref()
-    .map(|value| parse_positive_seconds("upstream read timeout", value))
-    .transpose()?
-    .unwrap_or(DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS);
-    let upstream_verifier_request_timeout_seconds = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_VERIFIER_REQUEST_TIMEOUT_SECONDS",
-    )
-    .as_deref()
-    .map(|value| parse_positive_seconds("upstream verifier request timeout", value))
-    .transpose()?
-    .unwrap_or(DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS);
-    let upstream_accepted_workload_ids = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_WORKLOAD_IDS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_ACCEPTED_WORKLOAD_IDS",
-    );
-    let upstream_accepted_image_digests = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_ACCEPTED_IMAGE_DIGESTS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_ACCEPTED_IMAGE_DIGESTS",
-    );
-    let upstream_dstack_kms_root_public_keys = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS",
-        "DSTACK_LLM_ROUTER_UPSTREAM_DSTACK_KMS_ROOT_PUBLIC_KEYS",
-    );
-    let upstream_pccs_url = env_pref(
-        "PRIVATE_AI_GATEWAY_UPSTREAM_PCCS_URL",
-        "DSTACK_LLM_ROUTER_UPSTREAM_PCCS_URL",
-    );
-    let dstack_endpoint = env_pref(
-        "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT",
-        "DSTACK_LLM_ROUTER_DSTACK_ENDPOINT",
-    )
-    .or_else(|| {
-        env_pref(
-            "PRIVATE_AI_GATEWAY_DSTACK_QUOTER_URL",
-            "DSTACK_LLM_ROUTER_DSTACK_QUOTER_URL",
-        )
-    });
-    let executor_uds_path = std::env::var("PRIVATE_AI_GATEWAY_EXECUTOR_UDS_PATH")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-    let backend_uds_path = std::env::var("PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "/run/private-ai-gateway/backend.sock".to_string());
+    let state_dir = resolve_state_dir(gateway_config.state_dir.as_deref())?;
+    std::fs::create_dir_all(&state_dir).map_err(|err| {
+        invalid_input(format!(
+            "failed to create gateway state directory {}: {err}",
+            state_dir.display()
+        ))
+    })?;
+    let upstream_config_path = upstream_config_path(&state_dir);
+    let session_log_path = session_log_path(&state_dir);
+    let upstream_config_seed_path = gateway_config.upstream_config_seed_path.clone();
+    let admin_token = gateway_config.admin_token.clone();
+    let source_provenance = resolve_source_provenance()?;
+    let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
+    let dstack_endpoint = gateway_config.dstack_endpoint.clone();
 
     let provider = Arc::new(
         DstackAciProvider::new(dstack_endpoint, DstackAciProviderConfig::default()).await?,
     );
     let keys: Arc<dyn KeyProvider> = provider.clone();
     let quoter: Arc<dyn Quoter> = provider;
-    seed_upstream_config_if_empty(
-        Path::new(&upstream_config_path),
-        upstream_config_seed_path.as_deref(),
-    )?;
+    seed_upstream_config_if_empty(&upstream_config_path, upstream_config_seed_path.as_deref())?;
     let upstream_config = Arc::new(UpstreamConfigManager::load(
-        upstream_config_path,
+        upstream_config_path.clone(),
         UpstreamRuntimeOptions {
-            verifier_mode: upstream_verifier_mode.clone(),
-            accepted_workload_ids: parse_comma_list(upstream_accepted_workload_ids.as_deref()),
-            accepted_image_digests: parse_comma_list(upstream_accepted_image_digests.as_deref()),
-            accepted_dstack_kms_root_public_keys: parse_comma_list(
-                upstream_dstack_kms_root_public_keys.as_deref(),
-            ),
-            pccs_url: upstream_pccs_url,
-            verifier_cache_seconds: upstream_verifier_cache_seconds,
-            connect_timeout_seconds: upstream_connect_timeout_seconds,
-            read_timeout_seconds: upstream_read_timeout_seconds,
-            verifier_request_timeout_seconds: upstream_verifier_request_timeout_seconds,
+            verifier_mode: UpstreamVerifierMode::None,
+            accepted_workload_ids: Vec::new(),
+            accepted_image_digests: Vec::new(),
+            accepted_dstack_kms_root_public_keys: Vec::new(),
+            pccs_url: None,
+            verifier_cache_seconds: 300,
+            connect_timeout_seconds: DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+            read_timeout_seconds: DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
+            verifier_request_timeout_seconds: DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS,
         },
     )?);
     let upstream = upstream_config.backend();
@@ -487,12 +359,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = AciServiceConfig {
         vendor: "private-ai-gateway-dev".to_string(),
         tee_type: "tdx".to_string(),
-        source_provenance: SourceProvenance {
-            repo_url,
-            repo_commit,
-            image_digest: None,
-            image_provenance: None,
-        },
+        source_provenance,
         keyset_epoch: KeysetEpoch {
             version: 1,
             not_after: u64::MAX,
@@ -502,13 +369,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             supported_e2ee_versions: vec!["2".to_string()],
         },
         freshness_seconds: 3600,
-        receipt_ttl_seconds,
+        receipt_ttl_seconds: 3600,
         upstream_required_default: true,
         allow_test_keys: false,
         tls_public_keys,
     };
 
-    let mut service_inner = AciService::new_with_upstream_verifier(
+    let service_inner = AciService::new_with_upstream_verifier(
         keys,
         quoter,
         upstream,
@@ -517,22 +384,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config,
         Arc::new(SystemClock),
     )?;
-    // Opt into a durable append-only session log when a path is configured;
-    // otherwise sessions stay in memory (prior behavior).
-    if let Ok(path) = std::env::var("PRIVATE_AI_GATEWAY_SESSION_LOG_PATH") {
-        let path = path.trim();
-        if !path.is_empty() {
-            match JsonlSessionStore::open(path) {
-                Ok(store) => {
-                    tracing::info!(session_log = %path, "persisting attested sessions to JSONL log");
-                    service_inner = service_inner.with_session_store(Arc::new(store));
-                }
-                Err(err) => {
-                    tracing::error!(error = %err, session_log = %path, "failed to open session log; using in-memory session store");
-                }
-            }
-        }
-    }
+    let session_store = JsonlSessionStore::open(&session_log_path).map_err(|err| {
+        invalid_input(format!(
+            "failed to open gateway session log {}: {err}",
+            session_log_path.display()
+        ))
+    })?;
+    tracing::info!(session_log = %session_log_path.display(), "persisting attested sessions to JSONL log");
+    let service_inner = service_inner.with_session_store(Arc::new(session_store));
     let service = Arc::new(service_inner);
     // The background upstream verification keeps the attested-session store fresh
     // on the same cadence it re-attests for serving, so `/v1/aci/sessions`
@@ -543,30 +402,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     upstream_config.set_session_sink(service.clone());
     spawn_upstream_lifecycle(upstream_config.clone());
 
-    let app = if let Some(executor_uds_path) = executor_uds_path {
-        let request_store = GatewayRequestStore::default();
-        let backend_app = build_internal_backend_router(service.clone(), request_store.clone());
-        let backend_listener = bind_unix_listener(&backend_uds_path)?;
-        tracing::info!(
-            backend_uds_path = %backend_uds_path,
-            executor_uds_path = %executor_uds_path,
-            "private-ai-gateway internal backend listening on Unix socket"
-        );
-        tokio::spawn(async move {
-            if let Err(err) = serve_unix_listener(backend_listener, backend_app).await {
-                tracing::error!(error = %err, "private-ai-gateway internal backend stopped");
-            }
-        });
-        build_router_with_admin_and_uds_middleware(
-            service,
-            upstream_config,
-            admin_token,
-            request_store,
-            executor_uds_path,
-        )
-    } else {
-        build_router_with_admin(service, upstream_config, admin_token)
-    };
+    let app = build_router_with_admin(service, upstream_config, admin_token);
 
     tracing::info!(%bind, "private-ai-gateway listening");
     let listener = tokio::net::TcpListener::bind(&bind).await?;
@@ -657,8 +493,9 @@ mod tests {
     use private_ai_gateway::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
 
     use super::{
-        parse_domain_spki_map, parse_positive_seconds, parse_tls_cert_paths, parse_tls_spki_list,
-        resolve_tls_public_keys, seed_upstream_config_if_empty,
+        load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
+        seed_upstream_config_if_empty, session_log_path,
+        source_provenance_from_git_launcher_config, upstream_config_path,
     };
 
     const TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -707,58 +544,153 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
     }
 
     #[test]
-    fn positive_timeout_seconds_rejects_zero() {
-        assert_eq!(
-            parse_positive_seconds("upstream connect timeout", "1").unwrap(),
-            1
-        );
-        assert!(parse_positive_seconds("upstream connect timeout", "0").is_err());
-    }
-
-    #[test]
-    fn parses_tls_spki_list_as_lowercase_hex_digests() {
-        let first = "AA".repeat(32);
-        let second = "bb".repeat(32);
-        let parsed = parse_tls_spki_list(&format!("{first},{second}")).unwrap();
-        assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed[0].domain, None);
-        assert_eq!(parsed[0].spki_sha256_hex, "aa".repeat(32));
-        assert_eq!(parsed[1].spki_sha256_hex, "bb".repeat(32));
-    }
-
-    #[test]
-    fn parses_domain_tls_spki_map_as_lowercase_domains_and_digests() {
-        let parsed = parse_domain_spki_map(&format!(
-            "Api.Example.COM={first},chat.example.com={second}",
-            first = "AA".repeat(32),
-            second = "bb".repeat(32),
-        ))
+    fn gateway_config_parses_state_dir() {
+        let config_path = temp_path("gateway-config-state-dir");
+        std::fs::write(
+            &config_path,
+            r#"{
+                "state_dir": "/gateway/state"
+            }"#,
+        )
         .unwrap();
-        assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed[0].domain.as_deref(), Some("api.example.com"));
-        assert_eq!(parsed[0].spki_sha256_hex, "aa".repeat(32));
-        assert_eq!(parsed[1].domain.as_deref(), Some("chat.example.com"));
-        assert_eq!(parsed[1].spki_sha256_hex, "bb".repeat(32));
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(config.state_dir.as_deref(), Some("/gateway/state"));
+        let _ = std::fs::remove_file(config_path);
     }
 
     #[test]
-    fn rejects_invalid_domain_tls_spki_map() {
-        assert!(parse_domain_spki_map("api.example.com").is_err());
-        assert!(parse_domain_spki_map(&format!("api.example.com={}", "aa")).is_err());
-        assert!(parse_domain_spki_map(&format!("api:443={}", "aa".repeat(32))).is_err());
-        assert!(parse_domain_spki_map(&format!(
-            "api.example.com={},API.example.com={}",
-            "aa".repeat(32),
-            "bb".repeat(32)
-        ))
-        .is_err());
+    fn gateway_config_rejects_removed_fields() {
+        for (name, body) in [
+            ("receipt-ttl", r#"{"receipt_ttl_seconds": 3600}"#),
+            (
+                "upstream-verifier",
+                r#"{"upstream_verifier": {"mode": "none"}}"#,
+            ),
+            (
+                "source-provenance",
+                r#"{"source_provenance": {"repo_url": "https://example.com/repo", "repo_commit": "deadbeef"}}"#,
+            ),
+            (
+                "tls-certificate-paths",
+                r#"{"tls": {"certificate_paths": ["/cert.pem"]}}"#,
+            ),
+            (
+                "executor-uds",
+                r#"{"executor_uds_path": "/tmp/executor.sock"}"#,
+            ),
+            (
+                "backend-uds",
+                r#"{"backend_uds_path": "/tmp/backend.sock"}"#,
+            ),
+        ] {
+            let config_path = temp_path(name);
+            std::fs::write(&config_path, body).unwrap();
+
+            let err = load_gateway_config(config_path.to_str().unwrap())
+                .expect_err("removed gateway config field must be rejected");
+
+            assert!(
+                err.contains("unknown field"),
+                "unexpected parse error for {name}: {err}"
+            );
+            let _ = std::fs::remove_file(config_path);
+        }
     }
 
     #[test]
-    fn rejects_invalid_tls_spki_list() {
-        assert!(parse_tls_spki_list("").is_err());
-        assert!(parse_tls_spki_list("aa").is_err());
-        assert!(parse_tls_spki_list(&format!("{},zz", "aa".repeat(32))).is_err());
+    fn source_provenance_parses_git_launcher_pin() {
+        let config_path = temp_path("git-launcher-config");
+        std::fs::write(
+            &config_path,
+            r#"
+                # fetched by git-launcher before entrypoint.sh runs
+                REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+                COMMIT_SHA=0123456789abcdef0123456789abcdef01234567
+                WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+            "#,
+        )
+        .unwrap();
+
+        let provenance = source_provenance_from_git_launcher_config(&config_path)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            provenance.repo_url.as_deref(),
+            Some("https://github.com/Dstack-TEE/private-ai-gateway.git")
+        );
+        assert_eq!(
+            provenance.repo_commit.as_deref(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+        assert!(provenance.image_digest.is_none());
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn source_provenance_rejects_incomplete_git_launcher_pin() {
+        let config_path = temp_path("git-launcher-config-missing-commit");
+        std::fs::write(
+            &config_path,
+            "REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git\n",
+        )
+        .unwrap();
+
+        let err = source_provenance_from_git_launcher_config(&config_path)
+            .expect_err("incomplete git-launcher config must fail startup");
+
+        assert!(err.contains("COMMIT_SHA"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn source_provenance_rejects_non_full_git_launcher_commit_pin() {
+        let config_path = temp_path("git-launcher-config-short-commit");
+        std::fs::write(
+            &config_path,
+            r#"
+                REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+                COMMIT_SHA=main
+            "#,
+        )
+        .unwrap();
+
+        let err = source_provenance_from_git_launcher_config(&config_path)
+            .expect_err("git-launcher config must pin a full commit hash");
+
+        assert!(err.contains("full 40- or 64-character hexadecimal commit hash"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn source_provenance_is_unknown_when_git_launcher_pin_is_absent() {
+        let config_path = temp_path("git-launcher-config-missing");
+        let _ = std::fs::remove_file(&config_path);
+
+        let provenance = source_provenance_from_git_launcher_config(&config_path).unwrap();
+
+        assert!(provenance.is_none());
+    }
+
+    #[test]
+    fn gateway_state_paths_are_derived_from_state_dir() {
+        let state_dir = std::path::PathBuf::from("/var/lib/private-ai-gateway");
+
+        assert_eq!(
+            resolve_state_dir(Some("/var/lib/private-ai-gateway")).unwrap(),
+            state_dir
+        );
+        assert_eq!(
+            upstream_config_path(&state_dir),
+            state_dir.join("upstreams.json")
+        );
+        assert_eq!(
+            session_log_path(&state_dir),
+            state_dir.join("sessions.jsonl")
+        );
+        assert!(resolve_state_dir(Some("  ")).is_err());
     }
 
     #[test]
@@ -947,27 +879,68 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
     }
 
     #[test]
-    fn parses_tls_cert_paths_as_spki_digests() {
-        let path = write_temp_cert();
-        let parsed = parse_tls_cert_paths(path.to_str().unwrap()).unwrap();
-        let _ = std::fs::remove_file(path);
-        assert_eq!(parsed.len(), 1);
+    fn gateway_config_domain_certificates_parse_as_spki_digests() {
+        let api_cert = write_temp_cert();
+        let chat_cert = write_temp_cert();
+        let config_path = temp_path("gateway-config-domain-certificates");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"{{
+                    "tls": {{
+                        "domain_certificates": [
+                            {{"domain":"Api.Example.COM", "certificate_path":"{}"}},
+                            {{"domain":"chat.example.com.", "certificate_path":"{}"}}
+                        ]
+                    }}
+                }}"#,
+                api_cert.display(),
+                chat_cert.display()
+            ),
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+        let parsed = resolve_tls_public_keys(&config.tls).unwrap().unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].domain.as_deref(), Some("api.example.com"));
+        assert_eq!(parsed[1].domain.as_deref(), Some("chat.example.com"));
         assert_eq!(
             parsed[0].spki_sha256_hex,
             "c6686007081874ef8a5e8f95b7620e16c0ff0c65235ff8efcf9350cd9c5cf9dd"
         );
+        let _ = std::fs::remove_file(api_cert);
+        let _ = std::fs::remove_file(chat_cert);
+        let _ = std::fs::remove_file(config_path);
     }
 
     #[test]
-    fn tls_cert_paths_and_explicit_spkis_are_mutually_exclusive() {
-        let explicit = "aa".repeat(32);
-        assert!(resolve_tls_public_keys(Some("/cert.pem"), Some(&explicit), None, None).is_err());
-        assert!(resolve_tls_public_keys(
-            None,
-            Some(&explicit),
-            None,
-            Some(&format!("api.example.com={}", "bb".repeat(32)))
+    fn rejects_duplicate_domain_tls_config_entries() {
+        let cert = write_temp_cert();
+        let config_path = temp_path("gateway-config-domain-certificates-duplicate");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"{{
+                    "tls": {{
+                        "domain_certificates": [
+                            {{"domain":"api.example.com", "certificate_path":"{}"}},
+                            {{"domain":"API.example.com", "certificate_path":"{}"}}
+                        ]
+                    }}
+                }}"#,
+                cert.display(),
+                cert.display()
+            ),
         )
-        .is_err());
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+        let err = resolve_tls_public_keys(&config.tls).unwrap_err();
+
+        assert!(err.contains("duplicated"));
+        let _ = std::fs::remove_file(cert);
+        let _ = std::fs::remove_file(config_path);
     }
 }

--- a/tests/entrypoint.rs
+++ b/tests/entrypoint.rs
@@ -84,16 +84,11 @@ fn entrypoint_sh_does_not_export_runtime_policy() {
     // Runtime policy lives in audited deployment config, not inside the
     // workload bytes. entrypoint.sh must never bake it in.
     let body = script_text();
-    for needle in &[
-        "PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT=",
-        "export PRIVATE_AI_GATEWAY_DSTACK_ENDPOINT",
-    ] {
-        assert!(
-            !body.contains(needle),
-            "entrypoint.sh must not set runtime deployment policy itself \
-             (found {needle:?}); it belongs in compose environment so a verifier audits it"
-        );
-    }
+    assert!(
+        !body.contains("dstack_endpoint"),
+        "entrypoint.sh must not set runtime deployment policy itself; \
+         dstack_endpoint belongs in the static gateway config"
+    );
 }
 
 #[test]
@@ -105,11 +100,9 @@ fn entrypoint_sh_does_not_bake_upstream_config_policy() {
     for needle in &[
         "PRIVATE_AI_GATEWAY_UPSTREAM_URL=",
         "PRIVATE_AI_GATEWAY_UPSTREAMS_JSON=",
-        "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH=",
         "PRIVATE_AI_GATEWAY_ADMIN_TOKEN=",
         "export PRIVATE_AI_GATEWAY_UPSTREAM_URL",
         "export PRIVATE_AI_GATEWAY_UPSTREAMS_JSON",
-        "export PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH",
         "export PRIVATE_AI_GATEWAY_ADMIN_TOKEN",
     ] {
         assert!(
@@ -250,6 +243,11 @@ fn deploy_text(name: &str) -> String {
     std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()))
 }
 
+fn repo_text(path: &str) -> String {
+    let p = repo_root().join(path);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()))
+}
+
 #[test]
 fn launcher_config_uses_only_default_mode_keys() {
     // aggregator.conf is the launcher config. The launcher contract is
@@ -352,12 +350,38 @@ fn deploy_readme_documents_one_command_deploy_and_seed_config() {
         "deploy/README.md must document the one-command compose path"
     );
     assert!(
-        body.contains("UPSTREAM_CONFIG_SEED_PATH"),
+        body.contains("upstream_config_seed_path"),
         "deploy/README.md must document the compose-mounted upstream seed"
     );
     assert!(
         body.contains("does not set `REPO_SUBDIR`"),
         "deploy/README.md must state that the public gateway repo runs from repo root"
+    );
+}
+
+#[test]
+fn docs_include_config_and_env_reference() {
+    let reference = repo_text("docs/configuration-reference.md");
+    for needle in [
+        "Configuration Reference",
+        "Config Fields",
+        "Environment Variables",
+        "`state_dir`",
+        "`PRIVATE_AI_GATEWAY_CONFIG_PATH`",
+    ] {
+        assert!(
+            reference.contains(needle),
+            "configuration reference must document {needle:?}"
+        );
+    }
+
+    assert!(
+        repo_text("README.md").contains("docs/configuration-reference.md"),
+        "README.md must link the configuration reference"
+    );
+    assert!(
+        deploy_text("README.md").contains("../docs/configuration-reference.md"),
+        "deploy/README.md must link the configuration reference"
     );
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -212,6 +212,30 @@ async fn attestation_report_selects_domain_tls_binding_from_host_header() {
 }
 
 #[tokio::test]
+async fn attestation_report_rejects_unconfigured_domain_tls_binding_host() {
+    let h = make_harness_with_tls_public_keys(Some(vec![TlsSpki {
+        domain: Some("api.example.com".to_string()),
+        spki_sha256_hex: "aa".repeat(32),
+    }]));
+    let app = build_router(h.service.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/attestation/report?nonce=abcd")
+                .header("host", "other.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body: serde_json::Value =
+        serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    assert_eq!(body["error"]["type"], "not_found");
+}
+
+#[tokio::test]
 async fn attestation_report_nonce_null_when_absent() {
     let h = make_harness();
     let app = build_router(h.service.clone());

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 mod common;
 
 use async_trait::async_trait;
-use private_ai_gateway::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent};
+use private_ai_gateway::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use private_ai_gateway::aci::types::{ServiceCapabilities, SourceProvenance};
 use private_ai_gateway::aci::upstream::{
     PreparedUpstreamRequest, UpstreamBackend, UpstreamError, UpstreamRequest, UpstreamResponse,
@@ -15,7 +15,8 @@ use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore, ServiceError,
     UpstreamVerificationError,
 };
-use private_ai_gateway::aggregator::session::ClaimStatus;
+use private_ai_gateway::aggregator::session::{AttestedSession, ClaimStatus};
+use private_ai_gateway::aggregator::session_store::SessionStore;
 use private_ai_gateway::aggregator::upstream_config::UpstreamSessionSink;
 
 use common::{failed_event, verified_event, StaticKeyProvider, StubQuoter};
@@ -25,6 +26,22 @@ type ReceivedBody = Arc<Mutex<Option<Vec<u8>>>>;
 struct StubUpstream {
     body: Vec<u8>,
     received: ReceivedBody,
+}
+
+struct FailingSessionStore;
+
+impl SessionStore for FailingSessionStore {
+    fn put_session(&self, _session: AttestedSession, _ts: u64) -> std::io::Result<u64> {
+        Err(std::io::Error::other("session store unavailable"))
+    }
+
+    fn get_session(&self, _session_id: &str, _now: u64) -> Option<AttestedSession> {
+        None
+    }
+
+    fn list_sessions(&self, _provider: Option<&str>, _now: u64) -> Vec<AttestedSession> {
+        Vec::new()
+    }
 }
 
 impl StubUpstream {
@@ -66,7 +83,7 @@ impl UpstreamBackend for StubUpstream {
     }
 }
 
-fn make_service(body: &[u8], upstream_required_default: bool) -> (Arc<AciService>, ReceivedBody) {
+fn make_service_raw(body: &[u8], upstream_required_default: bool) -> (AciService, ReceivedBody) {
     let keys = Arc::new(StaticKeyProvider::default());
     let quoter = Arc::new(StubQuoter::default());
     let (upstream, received) = StubUpstream::new(body);
@@ -87,6 +104,11 @@ fn make_service(body: &[u8], upstream_required_default: bool) -> (Arc<AciService
         Arc::new(FixedClock(1_700_000_000)),
     )
     .unwrap();
+    (svc, received)
+}
+
+fn make_service(body: &[u8], upstream_required_default: bool) -> (Arc<AciService>, ReceivedBody) {
+    let (svc, received) = make_service_raw(body, upstream_required_default);
     (Arc::new(svc), received)
 }
 
@@ -272,6 +294,36 @@ async fn verified_upstream_binding_creates_attested_session() {
 }
 
 #[tokio::test]
+async fn verified_upstream_binding_fails_without_persisted_session() {
+    let (svc, received) = make_service_raw(br#"{"id":"chat-xyz","model":"x"}"#, true);
+    let svc = svc.with_session_store(Arc::new(FailingSessionStore));
+    let event = UpstreamVerifiedEvent {
+        upstream_name: "stub-upstream".to_string(),
+        provider: None,
+        model_id: "x".to_string(),
+        url_origin: Some("https://stub-upstream".to_string()),
+        verifier_id: "stub-verifier-1".to_string(),
+        result: VerificationResult::Verified,
+        required: true,
+        reason: None,
+        evidence: None,
+        channel_bindings: vec![ChannelBinding::TlsSpkiSha256 {
+            origin: "https://stub-upstream".to_string(),
+            spki_sha256: "aa".repeat(32),
+        }],
+        provider_claims: None,
+    };
+
+    let err = svc
+        .forward_chat_completion(br#"{"model":"x","messages":[]}"#, None, None, Some(event))
+        .await
+        .expect_err("receipt must not cite a session that was not persisted");
+
+    assert!(matches!(err, ServiceError::SessionStore(_)));
+    assert!(received.lock().unwrap().is_some());
+}
+
+#[tokio::test]
 async fn session_is_per_tee_channel_not_per_model() {
     // Two requests to the SAME TEE channel (same upstream / endpoint / binding /
     // evidence) routed to different models must collapse to ONE session: a
@@ -429,7 +481,7 @@ async fn verifier_event_failed_with_required_fails_before_forwarding() {
 }
 
 #[test]
-fn service_init_rejects_empty_source_provenance() {
+fn service_init_accepts_unknown_source_provenance() {
     let keys = Arc::new(StaticKeyProvider::default());
     let quoter = Arc::new(StubQuoter::default());
     let (upstream, _) = StubUpstream::new(b"{}");
@@ -437,10 +489,7 @@ fn service_init_rejects_empty_source_provenance() {
     let store = Arc::new(InMemoryReceiptStore::default());
     let mut cfg = AciServiceConfig::for_test("x");
     cfg.source_provenance = SourceProvenance::default();
-    let err = AciService::new(keys, quoter, upstream, store, cfg, Arc::new(FixedClock(0)))
-        .err()
-        .expect("must fail");
-    assert!(matches!(err, ServiceError::InvalidSourceProvenance));
+    AciService::new(keys, quoter, upstream, store, cfg, Arc::new(FixedClock(0))).unwrap();
 }
 
 #[test]

--- a/tests/smoke_scripts.rs
+++ b/tests/smoke_scripts.rs
@@ -46,9 +46,11 @@ fn phala_multi_upstream_smoke_script_keeps_core_assertions() {
     let body = smoke_script_text("phala_multi_upstream_smoke.sh");
     for needle in [
         "set -euo pipefail",
-        "PRIVATE_AI_GATEWAY_UPSTREAM_CONFIG_PATH",
+        "PRIVATE_AI_GATEWAY_CONFIG_PATH",
         "configs:",
-        "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: aci-dcap",
+        "--build-arg SOURCE_REPO_URL=local-build://private-ai-gateway",
+        "--build-arg SOURCE_COMMIT=\"$COMMIT_SHA\"",
+        "provider: \"aci-dcap\"",
         "routed-upstream-a-model",
         "routed-upstream-b-model",
         "request.forwarded",
@@ -62,6 +64,10 @@ fn phala_multi_upstream_smoke_script_keeps_core_assertions() {
             "smoke script must retain assertion surface {needle:?}"
         );
     }
+    assert!(
+        !body.contains("\"provider\": \"preverified\""),
+        "preverified must not be exposed as an upstream provider"
+    );
 }
 
 #[test]
@@ -71,8 +77,10 @@ fn local_multi_upstream_smoke_script_keeps_core_assertions() {
         "set -euo pipefail",
         "DSTACK_SOCK",
         "docker compose",
-        "PRIVATE_AI_GATEWAY_ADMIN_TOKEN",
-        "PRIVATE_AI_GATEWAY_UPSTREAM_VERIFIER: aci-dcap",
+        "\"admin_token\": \"${ADMIN_TOKEN}\"",
+        "--build-arg SOURCE_REPO_URL=local-build://private-ai-gateway",
+        "--build-arg SOURCE_COMMIT=\"$COMMIT_SHA\"",
+        "provider: \"aci-dcap\"",
         "routed-upstream-a-model",
         "routed-upstream-b-model",
         "routed-upstream-a-embed-model",
@@ -89,6 +97,10 @@ fn local_multi_upstream_smoke_script_keeps_core_assertions() {
             "local smoke script must retain assertion surface {needle:?}"
         );
     }
+    assert!(
+        !body.contains("\"provider\": \"preverified\""),
+        "preverified must not be exposed as an upstream provider"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move gateway runtime policy into a required static JSON config selected by `PRIVATE_AI_GATEWAY_CONFIG_PATH`.
- Derive gateway-owned writable state from `state_dir`, with read-only upstream seed input and mutable active upstream state under the gateway state directory.
- Add multi-domain downstream TLS binding from mounted certificate material, with host-based binding selection and fail-closed unknown-host behavior.
- Remove raw SPKI config inputs, legacy runtime env surfaces, self-reported source provenance, and separate upstream attestation report base URL support.
- Keep ACI/DCAP report fetch and model traffic on the same provider TLS endpoint, using the attested SPKI for pinned upstream requests.
- Update docs, deploy examples, live E2E helpers, and local/Phala smoke scripts for the new config model and canonical receipt/session routes.

## Why

The frontend needs the gateway attestation report to bind the correct downstream TLS SPKI for the public host the user is actually targeting, without exposing internal routing details to users. The old env-heavy configuration also made multi-domain deployments awkward and left trust-bearing fields in places that should not exist prelaunch.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked`
- `python3 -m py_compile scripts/live_e2e/router_session_smoke.py scripts/live_e2e/router_refresh_smoke.py`
- `bash -n scripts/phala_multi_upstream_smoke.sh scripts/local_multi_upstream_smoke.sh`
- `shellcheck scripts/phala_multi_upstream_smoke.sh scripts/local_multi_upstream_smoke.sh`
- `cargo test --locked --test smoke_scripts --quiet`
- Real local dstack smoke with `scripts/local_multi_upstream_smoke.sh` using a forwarded dstack socket
- Native subagent PR review via `multi_agent_v1` after rebase

## Notes

The PR is opened as draft for final maintainer review. The remaining design assumption is intentional: upstream TLS pinning treats the attested SPKI as the endpoint identity for the pinned provider request path.