### PR TITLE
Trim thick docstrings on the attestation-scope path

### DIFF
--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -31,9 +31,7 @@ pub enum ProviderVerifierConfigError {
 #[derive(Debug, Clone)]
 pub(super) struct ExternalProviderVerifier {
     provider: &'static str,
-    /// The channel boundary this provider attests, resolved once from
-    /// `UpstreamProvider::attestation_scope`. Drives channel-keying and the
-    /// fail-closed scope seam.
+    /// The channel boundary this provider attests (channel-keying + scope seam).
     scope: AttestationScope,
     command: Vec<String>,
     current_dir: Option<PathBuf>,
@@ -135,19 +133,8 @@ impl ExternalProviderVerifier {
         self
     }
 
-    /// Cache / channel-identity key for a verification, derived from the
-    /// provider's [`AttestationScope`]. A per-router provider (e.g. NEAR AI)
-    /// verifies one gateway TEE channel shared by every model behind it, so the
-    /// model is omitted from the key: a request for any model resolves to that
-    /// one verified channel, and the channel-addressed session dedups to one per
-    /// router. Per-model (Phala-direct) and per-instance (Chutes) providers keep
-    /// the model in the key, so each really is its own channel.
-    ///
-    /// A router-cached event is still tagged with the requesting model by
-    /// `CachedExternalProviderEvent::event_for`, so the receipt reports the right
-    /// per-request model. The model itself is never attested by a router channel;
-    /// a request-bound, per-instance model attestation is a roadmap item
-    /// (docs/roadmap.md) and would live on the receipt, not the channel session.
+    /// Cache / channel-identity key. A per-router provider shares one verified
+    /// channel across all its models, so the model is dropped from the key.
     fn cache_key(&self, request: &UpstreamVerificationRequest) -> ExternalProviderVerifierCacheKey {
         let mut key = ExternalProviderVerifierCacheKey::from_request(request);
         if self.scope.is_per_router() {
@@ -381,13 +368,9 @@ impl ExternalProviderVerifier {
         })
     }
 
-    /// Fail-closed scope seam: a provider must attest the channel boundary it is
-    /// declared to use ([`AttestationScope`]). A per-router provider that returns
-    /// anything but router-scoped evidence — or declares no scope at all — is
-    /// rejected, so a router's attested session can never be sealed from
-    /// model-scoped evidence (which would split one channel into a session per
-    /// model). The served model is the gateway's request/receipt fact, never a
-    /// channel claim.
+    /// Fail-closed scope seam: a verified result must declare the scope its
+    /// provider attests; a per-router provider that returns model-scoped evidence,
+    /// or none, is rejected.
     fn enforce_attested_scope(&self, declared: Option<&str>) -> Result<(), String> {
         let expected = self.scope;
         match declared {

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -158,22 +158,18 @@ pub enum UpstreamProvider {
 }
 
 impl UpstreamProvider {
-    /// The channel boundary this provider attests — the single source of truth
-    /// for [`AttestationScope`]. Exhaustive by design: adding a provider is a
-    /// compile error here until it declares a scope, so a new variant can never
-    /// silently inherit a default.
+    /// The channel boundary this provider attests. Exhaustive so a new provider
+    /// must choose its scope rather than inherit a default.
     pub(crate) fn attestation_scope(self) -> AttestationScope {
         match self {
             UpstreamProvider::NearAi | UpstreamProvider::Tinfoil => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
             UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
-            // OpenAI-compatible has no verifier (no attestation), and ACI/DCAP
-            // uses its own verifier rather than the channel-keying here — so for
-            // both this scope only affects prewarm probe granularity, never the
-            // cache key or the seam. Per-model is the conservative default: it
-            // verifies every model and never collapses distinct channels. ACI can
-            // be router- or model-based depending on the ACI service; resolving
-            // that dynamically is deferred until ACI is a first-party router.
+            // OpenAI-compatible has no verifier and ACI/DCAP uses its own, so for
+            // both this only tunes prewarm probe granularity. Per-model is the safe
+            // default — it never collapses channels. ACI's real scope is
+            // service-dependent (router or model), resolved when ACI becomes a
+            // first-party router.
             UpstreamProvider::OpenAiCompatible | UpstreamProvider::AciDcap => {
                 AttestationScope::PerModel
             }
@@ -181,20 +177,9 @@ impl UpstreamProvider {
     }
 }
 
-/// The channel boundary a provider's attestation proves — and therefore what
-/// identifies its attested session.
-///
-/// A *per-router* provider verifies one TEE channel (a gateway TD or a
-/// confidential model router) that fronts many models, so the model is not part
-/// of the channel identity and one session is shared across models. *Per-model*
-/// and *per-instance* providers verify a distinct channel for each model or
-/// serving instance, so the model participates in the channel identity.
-///
-/// This is the single axis that decides channel-keyed verification (the model
-/// is dropped from the verifier cache key for routers) and is enforced
-/// fail-closed at the verifier seam: a verifier must attest the scope its
-/// provider is declared to use. It is resolved once via
-/// [`UpstreamProvider::attestation_scope`] and carried on the verifier.
+/// The channel boundary a provider's attestation proves, and thus what identifies
+/// its attested session: one shared channel for a router (model dropped from the
+/// verifier cache key) or a distinct channel per model / per serving instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttestationScope {
     PerRouter,


### PR DESCRIPTION
Docstrings should be helpful, not a place to document the details. These four (from #22) had grown into multi-line specs:

- `external.rs` `cache_key` — 13 lines on channel-keying + `event_for` + a roadmap note → 2.
- `mod.rs` `AttestationScope` enum — the full per-router/per-model/per-instance + seam writeup → 3.
- `external.rs` `enforce_attested_scope` — 7 → 3.
- `mod.rs` `UpstreamProvider::attestation_scope` and the `scope` field — trimmed.

The mechanics and rationale already live where they belong — inline at the relevant lines, or in `docs/attested-session-system.md` / `docs/roadmap.md`. No behavior change; 231 tests, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)