### PR TITLE
Wire the executor middleware through the static gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,11 +383,8 @@ Deployment files:
 
 ## Middleware
 
-The current binary deployment runs in no-middleware mode. Middleware router
-helpers exist for future executor integration, but the static gateway config
-does not expose middleware socket fields.
-
-In middleware mode:
+The gateway runs in no-middleware mode unless middleware is configured. In
+middleware mode:
 
 - Public `/v1/models` is forwarded to middleware.
 - Public inference requests are decrypted and normalized by the frontend, then

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,9 +11,8 @@ generic; install, build, run, and ACI policy live in this repo.
 
 The checked-in compose runs in no-middleware mode: the public ACI frontend and
 verified-provider backend are the same process, and traffic is forwarded
-directly from frontend to backend. Middleware router helpers exist for future
-executor integration, but this deploy path does not expose middleware socket
-fields in the static gateway config. See
+directly from frontend to backend. To enable middleware, configure it in the
+static gateway config (this compose leaves it disabled). See
 [`../docs/frontend-middleware-backend.md`](../docs/frontend-middleware-backend.md)
 and
 [`../docs/middleware-integration.md`](../docs/middleware-integration.md).

--- a/deploy/gateway.config.example.json
+++ b/deploy/gateway.config.example.json
@@ -3,5 +3,9 @@
   "state_dir": "/var/lib/private-ai-gateway",
   "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
   "admin_token": "<long-random-admin-token>",
-  "dstack_endpoint": "unix:/var/run/dstack.sock"
+  "dstack_endpoint": "unix:/var/run/dstack.sock",
+  "executor": {
+    "uds_path": "/run/private-ai-gateway/executor.sock",
+    "backend_uds_path": "/run/private-ai-gateway/backend.sock"
+  }
 }

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -43,20 +43,19 @@ This is the smallest practical container config.
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
-| `executor` | unset | Optional executor (middleware) section. When present, the gateway forwards public requests to the out-of-process executor; when unset it serves directly. See [Executor Middleware](#executor-middleware). |
+| `executor` | unset | Optional middleware section. When present, the gateway forwards public requests through the middleware; when unset it serves directly. See [Middleware](#middleware). |
 
-## Executor Middleware
+## Middleware
 
-The optional `executor` section connects an out-of-process executor (middleware)
-into the request path. When it is present the gateway dials the executor at
-`uds_path` to forward public requests, and serves an internal backend on
-`backend_uds_path` for the executor to call back. When the section is omitted the
-gateway serves requests directly with no middleware.
+The optional `executor` section wires the out-of-process middleware into the
+request path. When present the gateway forwards public requests to the middleware
+over `uds_path`, and serves an internal backend on `backend_uds_path` for the
+middleware to call back. When the section is omitted the gateway serves directly.
 
 | Field | Use |
 | --- | --- |
-| `executor.uds_path` | Unix socket the executor listens on; the gateway forwards public requests here. |
-| `executor.backend_uds_path` | Unix socket the gateway's internal backend serves for the executor to call back. |
+| `executor.uds_path` | Unix socket the middleware listens on; the gateway forwards public requests here. |
+| `executor.backend_uds_path` | Unix socket the gateway's internal backend serves for the middleware to call back. |
 
 ```json
 {

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -43,6 +43,31 @@ This is the smallest practical container config.
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
+| `executor` | unset | Optional executor (middleware) section. When present, the gateway forwards public requests to the out-of-process executor; when unset it serves directly. See [Executor Middleware](#executor-middleware). |
+
+## Executor Middleware
+
+The optional `executor` section connects an out-of-process executor (middleware)
+into the request path. When it is present the gateway dials the executor at
+`uds_path` to forward public requests, and serves an internal backend on
+`backend_uds_path` for the executor to call back. When the section is omitted the
+gateway serves requests directly with no middleware.
+
+| Field | Use |
+| --- | --- |
+| `executor.uds_path` | Unix socket the executor listens on; the gateway forwards public requests here. |
+| `executor.backend_uds_path` | Unix socket the gateway's internal backend serves for the executor to call back. |
+
+```json
+{
+  "executor": {
+    "uds_path": "/run/private-ai-gateway/executor.sock",
+    "backend_uds_path": "/run/private-ai-gateway/backend.sock"
+  }
+}
+```
+
+Both fields are required together.
 
 ## Source Provenance
 

--- a/docs/frontend-middleware-backend.md
+++ b/docs/frontend-middleware-backend.md
@@ -124,15 +124,15 @@ headers or claims.
 
 ## Config Sketch
 
-Disabled mode is the current binary behavior. The static gateway config has no
-middleware socket fields, so the frontend calls the backend directly in-process.
+Disabled mode is the default: the frontend calls the backend directly
+in-process.
 
 ```text
-# no middleware variables required
+# middleware disabled (default)
 ```
 
-Middleware mode is a router-helper contract for custom embedding and tests. It
-is not exposed by the checked-in static config.
+Middleware mode is enabled in the static gateway config; see the configuration
+reference.
 
 The pending request-context TTL is 300 seconds. A middleware must call
 `POST /internal/forward` before the context expires.

--- a/docs/middleware-integration.md
+++ b/docs/middleware-integration.md
@@ -25,10 +25,11 @@ The gateway frontend owns downstream ACI.
 
 ## Runtime Wiring
 
-The middleware router is available through the Rust HTTP router helpers. The
-checked-in gateway binary and static config do not expose middleware socket
-fields. Current deployments run no-middleware mode unless they embed the
-middleware router wiring in a custom binary.
+Enable middleware with the `executor` section in the static gateway config: set
+`executor.uds_path` (the socket the gateway forwards public requests to) and
+`executor.backend_uds_path` (the internal backend the gateway serves for the
+executor to call back). When the section is omitted the gateway runs in
+no-middleware mode and serves directly.
 
 In this mode the gateway has three HTTP surfaces:
 
@@ -303,8 +304,9 @@ Run it locally:
 uvicorn middleware:app --uds /run/private-ai-gateway/executor.sock
 ```
 
-The current static gateway config has no middleware fields. Use the integration
-tests as the executable reference for middleware router wiring.
+Point the gateway at this socket with the `executor` section in the static
+config (`executor.uds_path`). The integration tests are the executable
+reference for the middleware router wiring.
 
 Then call the public gateway as usual:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,8 +112,8 @@ Source design: [frontend-middleware-backend.md](frontend-middleware-backend.md).
   request context lookup. Implemented as a separate internal router builder and
   runtime listener when middleware is enabled.
 - Add optional UDS middleware mode with a fixture middleware for tests.
-  Implemented through router helpers and tests; not exposed by the static
-  gateway config.
+  Implemented through router helpers and tests; enabled in the static gateway
+  config.
 - Ensure external `X-Private-AI-Gateway-*` headers cannot steer the public
   frontend. Implemented by generating internal context server-side; covered by
   tests.

--- a/middleware/executor/src/cost.ts
+++ b/middleware/executor/src/cost.ts
@@ -9,9 +9,9 @@ type OnComplete = (usage: Usage | null) => void;
  * Meter the user-visible response: inject `usage.cost` (when pricing is known)
  * and surface the raw upstream usage to `onComplete` for post-request billing.
  * `computeCost` is a pure formula (not commercial IP), so the executor injects
- * locally. Ported from the prior gateway's spend-log pass, which likewise
- * injected cost and reported usage in one traversal: buffered JSON gets
- * `usage = {...usage, cost}`; for SSE, each `data:` chunk carrying usage is
+ * locally. Cost injection and usage reporting happen in one traversal:
+ * buffered JSON gets `usage = {...usage, cost}`; for SSE, each `data:` chunk
+ * carrying usage is
  * re-emitted with cost spliced in and every other chunk passes through
  * byte-for-byte. The usage handed to `onComplete` is always the raw upstream
  * usage (cost is spliced into a copy), so billing records pre-injection counts.

--- a/middleware/executor/src/stream.ts
+++ b/middleware/executor/src/stream.ts
@@ -16,7 +16,7 @@ function isNetworkConnectionError(error: any): boolean {
  * Iterate an upstream SSE byte stream, split it into events by `splitPattern`,
  * and yield each event — transformed by `transformFunction` when present
  * (which carries mutable `streamState` across chunks), otherwise re-emitted
- * with its delimiter. Ported from the prior gateway's reader.
+ * with its delimiter.
  */
 export async function* readStream(
   reader: ReadableStreamDefaultReader,
@@ -89,8 +89,7 @@ export async function* readStream(
 
 /**
  * Buffered response: run the provider's response transform over the parsed
- * upstream JSON and rebuild the response. Ported/trimmed from the prior
- * gateway's `handleNonStreamingMode` (hooks/cache/RequestContext removed).
+ * upstream JSON and rebuild the response.
  */
 export async function handleNonStreamingMode(
   response: Response,
@@ -116,8 +115,7 @@ export async function handleNonStreamingMode(
 /**
  * Streaming response: transform each upstream SSE event through the provider's
  * stream transform and re-emit it, cancelling the upstream read if the
- * downstream client goes away. Ported/trimmed from the prior gateway's
- * `handleStreamingMode` (Bedrock/JSON-stream/content-type special cases removed).
+ * downstream client goes away.
  */
 export function handleStreamingMode(
   response: Response,

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -19,7 +19,10 @@ pub struct ModelRoute {
     pub upstream: Arc<dyn UpstreamBackend>,
     pub route_id: String,
     /// Per-upstream POST path (e.g. `/v1/messages` for native Anthropic
-    /// upstreams). `None` keeps the caller-supplied request path unchanged.
+    /// upstreams). `None` resolves chat-shaped surfaces to
+    /// `/v1/chat/completions` and leaves other surfaces on the
+    /// caller-supplied path. See [`ModelRouterBackend::prepare`] for the
+    /// resolution.
     pub path: Option<String>,
     /// Whether this route's provider is an attested (TEE) provider.
     /// `None` means unclassified (routes built directly via

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -169,19 +169,23 @@ impl UpstreamBackend for ModelRouterBackend {
         };
         let mut request = req;
         request.body = rewrite_request_model(&request.body, &route.upstream_model_id)?;
-        // A configured per-upstream path overrides the chat-completions
-        // surface only (e.g. native Anthropic `/v1/messages`). Other
-        // surfaces (`/v1/completions`, `/v1/embeddings`) keep the
-        // caller-supplied path so they route to the matching upstream path.
-        if let Some(route_path) = &route.path {
-            let on_chat_surface = request
-                .path
-                .as_deref()
-                .map(|path| path == "/v1/chat/completions")
-                .unwrap_or(true);
-            if on_chat_surface {
-                request.path = Some(route_path.clone());
-            }
+        // The chat-shaped downstream surfaces (`/v1/chat/completions` and the
+        // Anthropic `/v1/messages`) are converted to the upstream's chat
+        // request format before they reach here, so both must target the
+        // upstream's chat path rather than the downstream surface path: a
+        // configured per-upstream path when set (e.g. native Anthropic
+        // upstreams use `/v1/messages`), otherwise defer to the backend's own
+        // default (`/v1/chat/completions` for OpenAI-compatible upstreams).
+        // Other surfaces (`/v1/completions`, `/v1/embeddings`, `/v1/responses`)
+        // keep the caller-supplied path so they route to the matching upstream
+        // path.
+        let on_chat_surface = request
+            .path
+            .as_deref()
+            .map(|path| path == "/v1/chat/completions" || path == "/v1/messages")
+            .unwrap_or(true);
+        if on_chat_surface {
+            request.path = route.path.clone();
         }
         Ok(PreparedUpstreamRequest {
             request,
@@ -345,6 +349,77 @@ mod tests {
         assert_eq!(
             request_model_id(&targeted_prepared.request.body).as_deref(),
             Some("secret-model")
+        );
+    }
+
+    fn single_route_router(path: Option<String>) -> ModelRouterBackend {
+        let mut router = ModelRouterBackend::new("model-router");
+        router
+            .add_route(
+                ModelRoute::new(
+                    "openai/gpt-4o",
+                    "gpt-4o",
+                    Arc::new(StubBackend { name: "openai" }),
+                    "openai:gpt-4o",
+                )
+                .unwrap()
+                .with_path(path),
+            )
+            .unwrap();
+        router
+    }
+
+    fn prepared_path(router: &ModelRouterBackend, surface: &str) -> Option<String> {
+        let body = br#"{"model":"openai/gpt-4o","messages":[]}"#.to_vec();
+        router
+            .prepare(UpstreamRequest {
+                body,
+                path: Some(surface.to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .request
+            .path
+    }
+
+    #[test]
+    fn chat_surfaces_clear_path_for_openai_upstreams() {
+        // OpenAI-compatible upstreams configure no per-route path; both chat
+        // surfaces must defer to the backend's own /v1/chat/completions
+        // default rather than forwarding the downstream /v1/messages path
+        // (which the upstream does not serve, causing an empty-body 500).
+        let router = single_route_router(None);
+        assert_eq!(prepared_path(&router, "/v1/chat/completions"), None);
+        assert_eq!(prepared_path(&router, "/v1/messages"), None);
+    }
+
+    #[test]
+    fn chat_surfaces_use_configured_path_for_native_anthropic() {
+        // Native Anthropic upstreams pin /v1/messages; both chat surfaces map
+        // onto it.
+        let router = single_route_router(Some("/v1/messages".to_string()));
+        assert_eq!(
+            prepared_path(&router, "/v1/chat/completions").as_deref(),
+            Some("/v1/messages")
+        );
+        assert_eq!(
+            prepared_path(&router, "/v1/messages").as_deref(),
+            Some("/v1/messages")
+        );
+    }
+
+    #[test]
+    fn non_chat_surfaces_keep_caller_path() {
+        // Passthrough surfaces are not converted to the chat format, so they
+        // must reach the matching upstream path verbatim.
+        let router = single_route_router(None);
+        assert_eq!(
+            prepared_path(&router, "/v1/embeddings").as_deref(),
+            Some("/v1/embeddings")
+        );
+        assert_eq!(
+            prepared_path(&router, "/v1/responses").as_deref(),
+            Some("/v1/responses")
         );
     }
 }

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -174,18 +174,24 @@ impl UpstreamBackend for ModelRouterBackend {
         // request format before they reach here, so both must target the
         // upstream's chat path rather than the downstream surface path: a
         // configured per-upstream path when set (e.g. native Anthropic
-        // upstreams use `/v1/messages`), otherwise defer to the backend's own
-        // default (`/v1/chat/completions` for OpenAI-compatible upstreams).
-        // Other surfaces (`/v1/completions`, `/v1/embeddings`, `/v1/responses`)
-        // keep the caller-supplied path so they route to the matching upstream
-        // path.
+        // upstreams use `/v1/messages`), otherwise the OpenAI-compatible
+        // `/v1/chat/completions`. The path is resolved explicitly (rather than
+        // deferred to the backend default) so the forwarded request is
+        // deterministic. Other surfaces (`/v1/completions`, `/v1/embeddings`,
+        // `/v1/responses`) keep the caller-supplied path so they route to the
+        // matching upstream path.
         let on_chat_surface = request
             .path
             .as_deref()
             .map(|path| path == "/v1/chat/completions" || path == "/v1/messages")
             .unwrap_or(true);
         if on_chat_surface {
-            request.path = route.path.clone();
+            request.path = Some(
+                route
+                    .path
+                    .clone()
+                    .unwrap_or_else(|| "/v1/chat/completions".to_string()),
+            );
         }
         Ok(PreparedUpstreamRequest {
             request,
@@ -383,14 +389,20 @@ mod tests {
     }
 
     #[test]
-    fn chat_surfaces_clear_path_for_openai_upstreams() {
+    fn chat_surfaces_resolve_to_chat_completions_for_openai_upstreams() {
         // OpenAI-compatible upstreams configure no per-route path; both chat
-        // surfaces must defer to the backend's own /v1/chat/completions
-        // default rather than forwarding the downstream /v1/messages path
-        // (which the upstream does not serve, causing an empty-body 500).
+        // surfaces must resolve to /v1/chat/completions rather than forwarding
+        // the downstream /v1/messages path (which the upstream does not serve,
+        // causing an empty-body 500).
         let router = single_route_router(None);
-        assert_eq!(prepared_path(&router, "/v1/chat/completions"), None);
-        assert_eq!(prepared_path(&router, "/v1/messages"), None);
+        assert_eq!(
+            prepared_path(&router, "/v1/chat/completions").as_deref(),
+            Some("/v1/chat/completions")
+        );
+        assert_eq!(
+            prepared_path(&router, "/v1/messages").as_deref(),
+            Some("/v1/chat/completions")
+        );
     }
 
     #[test]

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -41,8 +41,10 @@ pub struct UpstreamConfig {
     pub base_url: String,
     /// Per-upstream POST path the generic forwarder targets (e.g.
     /// `/v1/messages` for native Anthropic upstreams), appended to
-    /// `base_url`. When omitted the downstream surface path is used
-    /// verbatim, matching today's OpenAI-compatible behaviour.
+    /// `base_url`. When omitted, chat-shaped surfaces
+    /// (`/v1/chat/completions` and `/v1/messages`) target
+    /// `/v1/chat/completions` (the OpenAI-compatible default) and other
+    /// surfaces use the downstream path verbatim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     pub models: BTreeMap<String, String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,11 @@
 //! Gateway-owned writable files are derived from `state_dir` in the static
 //! config. The active upstream database is `upstreams.json` and the
 //! attested-session log is `sessions.jsonl` inside that directory.
+//!
+//! When the static config includes an `executor` section, the gateway forwards
+//! public requests to the out-of-process executor over `executor.uds_path` and
+//! serves its internal backend on `executor.backend_uds_path` for the executor
+//! to call back. Without the section the gateway serves directly.
 
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -36,7 +41,10 @@ use private_ai_gateway::aggregator::upstream_config::{
     parse_config_text, UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::dstack::{DstackAciProvider, DstackAciProviderConfig};
-use private_ai_gateway::http::build_router_with_admin;
+use private_ai_gateway::http::{
+    bind_unix_listener, build_internal_backend_router, build_router_with_admin,
+    build_router_with_admin_and_uds_middleware, serve_unix_listener, GatewayRequestStore,
+};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use x509_parser::prelude::parse_x509_certificate;
@@ -63,6 +71,14 @@ struct GatewayConfigFile {
     admin_token: Option<String>,
     tls: GatewayTlsConfig,
     dstack_endpoint: Option<String>,
+    executor: Option<GatewayExecutorConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GatewayExecutorConfig {
+    uds_path: String,
+    backend_uds_path: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -331,6 +347,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source_provenance = resolve_source_provenance()?;
     let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
     let dstack_endpoint = gateway_config.dstack_endpoint.clone();
+    let executor = gateway_config.executor.clone();
 
     let provider = Arc::new(
         DstackAciProvider::new(dstack_endpoint, DstackAciProviderConfig::default()).await?,
@@ -402,7 +419,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     upstream_config.set_session_sink(service.clone());
     spawn_upstream_lifecycle(upstream_config.clone());
 
-    let app = build_router_with_admin(service, upstream_config, admin_token);
+    let app = if let Some(executor) = executor {
+        let request_store = GatewayRequestStore::default();
+        let backend_app = build_internal_backend_router(service.clone(), request_store.clone());
+        let backend_listener = bind_unix_listener(&executor.backend_uds_path)?;
+        tracing::info!(
+            backend_uds_path = %executor.backend_uds_path,
+            executor_uds_path = %executor.uds_path,
+            "private-ai-gateway internal backend listening on Unix socket"
+        );
+        tokio::spawn(async move {
+            if let Err(err) = serve_unix_listener(backend_listener, backend_app).await {
+                tracing::error!(error = %err, "private-ai-gateway internal backend stopped");
+            }
+        });
+        build_router_with_admin_and_uds_middleware(
+            service,
+            upstream_config,
+            admin_token,
+            request_store,
+            executor.uds_path,
+        )
+    } else {
+        build_router_with_admin(service, upstream_config, admin_token)
+    };
 
     tracing::info!(%bind, "private-ai-gateway listening");
     let listener = tokio::net::TcpListener::bind(&bind).await?;
@@ -561,6 +601,30 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
     }
 
     #[test]
+    fn gateway_config_parses_executor_section() {
+        let config_path = temp_path("gateway-config-executor");
+        std::fs::write(
+            &config_path,
+            r#"{
+                "executor": {
+                    "uds_path": "/run/pag/executor.sock",
+                    "backend_uds_path": "/run/pag/backend.sock"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+
+        // The executor section drives the middleware wiring in `main()`; the
+        // forwarding behavior itself is covered by tests/aggregator_scenarios.rs.
+        let executor = config.executor.expect("executor section must parse");
+        assert_eq!(executor.uds_path, "/run/pag/executor.sock");
+        assert_eq!(executor.backend_uds_path, "/run/pag/backend.sock");
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
     fn gateway_config_rejects_removed_fields() {
         for (name, body) in [
             ("receipt-ttl", r#"{"receipt_ttl_seconds": 3600}"#),
@@ -575,14 +639,6 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
             (
                 "tls-certificate-paths",
                 r#"{"tls": {"certificate_paths": ["/cert.pem"]}}"#,
-            ),
-            (
-                "executor-uds",
-                r#"{"executor_uds_path": "/tmp/executor.sock"}"#,
-            ),
-            (
-                "backend-uds",
-                r#"{"backend_uds_path": "/tmp/backend.sock"}"#,
             ),
         ] {
             let config_path = temp_path(name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,9 @@
 //! attested-session log is `sessions.jsonl` inside that directory.
 //!
 //! When the static config includes an `executor` section, the gateway forwards
-//! public requests to the out-of-process executor over `executor.uds_path` and
-//! serves its internal backend on `executor.backend_uds_path` for the executor
-//! to call back. Without the section the gateway serves directly.
+//! public requests through the out-of-process middleware over `executor.uds_path`
+//! and serves its internal backend on `executor.backend_uds_path` for the
+//! middleware to call back. Without the section the gateway serves directly.
 
 use std::io::Cursor;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
The static-config migration in bcc3a48 un-wired the executor/middleware forwarding path from the gateway binary: `main.rs` now unconditionally builds the no-middleware router, so `state.middleware` is always `None` and the (still-tested) forwarding code is dead in the running binary.

This reconnects it via the static config rather than the old env vars:

- Add an optional `executor: { uds_path, backend_uds_path }` section to `GatewayConfigFile`.
- When present, build the internal backend router, bind+spawn its UDS listener, and build the middleware router (`build_router_with_admin_and_uds_middleware`); otherwise keep the plain router.
- Drop the stale `executor_uds_path`/`backend_uds_path` cases from `gateway_config_rejects_removed_fields` and add a positive parse test. Document the `executor` section in the config reference and sample.

Forwarding logic itself is unchanged and stays covered by `tests/aggregator_scenarios.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)