### PR TITLE
Forward request provider block to the control plane

### DIFF
--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -154,6 +154,7 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
   const consult = await consultPre(
     params.model,
     bearer ? hashApiKey(bearer) : undefined,
+    params.provider,
   );
   if (!consult.allow) {
     const status = consult.status ?? 403;

--- a/middleware/executor/src/integrations/control.ts
+++ b/middleware/executor/src/integrations/control.ts
@@ -6,7 +6,8 @@ import { PricingConfig } from "../services/pricing";
 
 // The executor reaches the control plane over HTTP(S) at
 // PRIVATE_AI_GATEWAY_CONTROL_URL, authenticated with a bearer token; use TLS in
-// production. The consult payloads carry only {apiKeyHash, model} and usage counts.
+// production. The consult payloads carry only {apiKeyHash, model, provider} and
+// usage counts — `provider` is a routing hint, not content.
 const CONTROL_URL = process.env.PRIVATE_AI_GATEWAY_CONTROL_URL?.trim();
 const CONTROL_TOKEN = process.env.PRIVATE_AI_GATEWAY_CONTROL_TOKEN?.trim();
 
@@ -92,20 +93,28 @@ export function hashApiKey(apiKey: string): string {
   return createHash("sha256").update(apiKey).digest("hex");
 }
 
+/** Provider routing block, forwarded verbatim to control. */
+export interface ProviderRouting {
+  only?: string[];
+  order?: string[];
+  allow_fallbacks?: boolean;
+}
+
 /**
- * Pre-request consult: {apiKeyHash?, model} -> {allow, ...}.
+ * Pre-request consult: {apiKeyHash?, model, provider?} -> {allow, ...}.
  * Because this gates authorization, it fails CLOSED — an unreachable control
  * plane blocks the request (503) rather than letting it through unauthorized.
  */
 export async function consultPre(
   model: string | undefined,
   apiKeyHash: string | undefined,
+  provider?: ProviderRouting,
 ): Promise<PreConsult> {
   try {
     const res = await controlRequest(
       "POST",
       "/consult/pre",
-      JSON.stringify({ apiKeyHash, model }),
+      JSON.stringify({ apiKeyHash, model, provider }),
     );
     if (res.status !== 200) {
       return {

--- a/middleware/executor/src/types/requestBody.ts
+++ b/middleware/executor/src/types/requestBody.ts
@@ -171,6 +171,14 @@ export interface Tool extends PromptCache {
  */
 export interface Params {
   model?: string;
+  // Provider routing block. Only `only`/`order` are honored by the control
+  // plane (which restricts selection to supported providers); dropped before
+  // forwarding upstream by the whitelist request transform.
+  provider?: {
+    only?: string[];
+    order?: string[];
+    allow_fallbacks?: boolean;
+  };
   prompt?: string | string[];
   messages?: Message[];
   functions?: Function[];


### PR DESCRIPTION
## What

The executor now reads an optional `provider` routing block from the request body and forwards it to the control plane's pre-request consult (`/consult/pre`), which uses it to restrict candidate selection to the requested provider(s).

```jsonc
POST /v1/chat/completions
{ "model": "gpt-4", "messages": [...], "provider": { "only": ["phala"] } }
```

## Details

- `Params.provider` accepts the `{ only?, order? }` block (extra fields ignored).
- `consultPre(model, apiKeyHash, provider?)` includes `provider` in the consult payload; when absent it is omitted by `JSON.stringify`, so the existing `{apiKeyHash, model}` contract is unchanged.
- The `provider` field is a routing hint only — the whitelist request transform drops it before forwarding upstream, so it never reaches OpenAI/Anthropic backends.

## Coupling

The control plane consumes this field (validation, provider restriction, 400/404 semantics) — that side lands separately. The executor change here is pass-through and inert until the control plane reads it.

## Test

`npm run typecheck` and `npm test` (40/40) pass; the existing `control.test.ts` body assertion is unaffected (undefined `provider` is omitted from the serialized payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)