### PR TITLE
Relay namespace and embedding model catalogs

### DIFF
--- a/middleware/executor/src/app.ts
+++ b/middleware/executor/src/app.ts
@@ -3,9 +3,11 @@ import { Hono } from 'hono';
 import {
   chatCompletions,
   completions,
+  embeddingModels,
   embeddings,
   messages,
   models,
+  namespaceModels,
   responses,
 } from './handlers';
 
@@ -21,6 +23,8 @@ export const app = new Hono();
 app.get('/', (c) => c.text('private-ai-gateway middleware executor\n'));
 
 app.get('/v1/models', models);
+app.get('/v1/models/:namespace', namespaceModels);
+app.get('/v1/embeddings/models', embeddingModels);
 app.post('/v1/chat/completions', chatCompletions);
 app.post('/v1/completions', completions);
 app.post('/v1/embeddings', embeddings);

--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -266,3 +266,22 @@ export const models = async (): Promise<Response> => {
     headers: { "content-type": "application/json" },
   });
 };
+
+/** GET /v1/models/:namespace — relay a namespace-scoped catalog from control. */
+export const namespaceModels = async (c: Context): Promise<Response> => {
+  const ns = c.req.param("namespace") ?? "";
+  const r = await fetchCatalog(`/models/${encodeURIComponent(ns)}`);
+  return new Response(r.body, {
+    status: r.status,
+    headers: { "content-type": "application/json" },
+  });
+};
+
+/** GET /v1/embeddings/models — relay the embedding catalog from control. */
+export const embeddingModels = async (): Promise<Response> => {
+  const r = await fetchCatalog("/embeddings/models");
+  return new Response(r.body, {
+    status: r.status,
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/middleware/executor/src/integrations/control.ts
+++ b/middleware/executor/src/integrations/control.ts
@@ -165,7 +165,9 @@ export function consultPost(report: PostReport): void {
   });
 }
 
-/** Fetch the model catalog (relayed by the executor's GET /v1/models). */
-export function fetchCatalog(): Promise<{ status: number; body: string }> {
-  return controlRequest("GET", "/models");
+/** Fetch a model catalog (relayed by the executor's GET /v1/models* routes). */
+export function fetchCatalog(
+  path: string = "/models"
+): Promise<{ status: number; body: string }> {
+  return controlRequest("GET", path);
 }


### PR DESCRIPTION
## What

Adds executor relay routes for the control plane's two new model-catalog endpoints, completing the `/v1/models` reorganization on the public gateway side.

- `GET /v1/models/:namespace` → control `GET /models/:namespace` — lists models exposed under a `{namespace}/` alias prefix (e.g. `phala/*`, `openai/*`), each entry re-id'd to its alias.
- `GET /v1/embeddings/models` → control `GET /embeddings/models` — embedding-only catalog.

`fetchCatalog` now takes a path argument so one helper serves every catalog relay. Handlers stay control-agnostic — no hardcoded namespace names.

## Endpoint shape (after this + the control change)

- `/v1/models` → canonical catalog; no `xxx/` alias entries, no embedding-only models.
- `/v1/models/:namespace` → `{namespace}/*` alias entries.
- `/v1/embeddings/models` → embedding-only models.

## Notes

- Pairs with the control-plane change (committed separately) that adds `getModelsByNamespace` / the `/models/:namespace` + `/embeddings/models` routes and removes the dead catalog code.
- `/v1/models/providers/phala` (the old provider-aggregation endpoint) is intentionally not relayed yet.

## Test

- `npm run typecheck` passes in `middleware/executor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)