### PR TITLE
Relay model sub-catalogs (namespace, providers, embeddings) through the frontend

### DIFF
--- a/middleware/executor/src/app.ts
+++ b/middleware/executor/src/app.ts
@@ -8,6 +8,7 @@ import {
   messages,
   models,
   namespaceModels,
+  providerModels,
   responses,
 } from './handlers';
 
@@ -23,6 +24,7 @@ export const app = new Hono();
 app.get('/', (c) => c.text('private-ai-gateway middleware executor\n'));
 
 app.get('/v1/models', models);
+app.get('/v1/models/providers/:provider', providerModels);
 app.get('/v1/models/:namespace', namespaceModels);
 app.get('/v1/embeddings/models', embeddingModels);
 app.post('/v1/chat/completions', chatCompletions);

--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -277,6 +277,16 @@ export const namespaceModels = async (c: Context): Promise<Response> => {
   });
 };
 
+/** GET /v1/models/providers/:provider — relay a provider-scoped catalog. */
+export const providerModels = async (c: Context): Promise<Response> => {
+  const provider = c.req.param("provider") ?? "";
+  const r = await fetchCatalog(`/models/providers/${encodeURIComponent(provider)}`);
+  return new Response(r.body, {
+    status: r.status,
+    headers: { "content-type": "application/json" },
+  });
+};
+
 /** GET /v1/embeddings/models — relay the embedding catalog from control. */
 export const embeddingModels = async (): Promise<Response> => {
   const r = await fetchCatalog("/embeddings/models");

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -77,6 +77,35 @@ pub(super) async fn models(State(state): State<AppState>) -> Response {
     }
 }
 
+// Models exposed under a `{namespace}/` alias prefix (e.g. phala/*, openai/*).
+// Only meaningful in the control-plane middleware topology.
+pub(super) async fn models_namespace(
+    State(state): State<AppState>,
+    Path(namespace): Path<String>,
+) -> Response {
+    let Some(middleware) = state.middleware.clone() else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "namespace model catalog is not available in direct-upstream mode",
+        );
+    };
+    get_from_middleware(middleware, &format!("/v1/models/{namespace}")).await
+}
+
+// Embedding model catalog. Only meaningful in the control-plane middleware
+// topology.
+pub(super) async fn embeddings_models(State(state): State<AppState>) -> Response {
+    let Some(middleware) = state.middleware.clone() else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "embedding model catalog is not available in direct-upstream mode",
+        );
+    };
+    get_from_middleware(middleware, "/v1/embeddings/models").await
+}
+
 pub(super) async fn metrics(State(state): State<AppState>) -> Response {
     match state.service.metrics() {
         Ok(snapshot) => {

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -77,20 +77,22 @@ pub(super) async fn models(State(state): State<AppState>) -> Response {
     }
 }
 
-// Models exposed under a `{namespace}/` alias prefix (e.g. phala/*, openai/*).
-// Only meaningful in the control-plane middleware topology.
-pub(super) async fn models_namespace(
+// Relay every /v1/models/<sub> sub-catalog to the middleware, which owns the
+// real routing (namespace, providers, ...). matchit 0.7.3 forbids a param and
+// a static sibling at the same position, so we relay the whole subtree rather
+// than enumerate routes here. Only meaningful in the middleware topology.
+pub(super) async fn models_subpath(
     State(state): State<AppState>,
-    Path(namespace): Path<String>,
+    Path(rest): Path<String>,
 ) -> Response {
     let Some(middleware) = state.middleware.clone() else {
         return error_response(
             StatusCode::NOT_FOUND,
             "not_found",
-            "namespace model catalog is not available in direct-upstream mode",
+            "model sub-catalogs are not available in direct-upstream mode",
         );
     };
-    get_from_middleware(middleware, &format!("/v1/models/{namespace}")).await
+    get_from_middleware(middleware, &format!("/v1/models/{rest}")).await
 }
 
 // Embedding model catalog. Only meaningful in the control-plane middleware

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -91,8 +91,8 @@ use backend::internal_forward;
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
     admin_put_upstreams, attestation_report, attested_session, chat_completions, completions,
-    embeddings, embeddings_models, messages, metrics, models, models_subpath,
-    receipt_by_chat_id, responses, root,
+    embeddings, embeddings_models, messages, metrics, models, models_subpath, receipt_by_chat_id,
+    responses, root,
 };
 
 #[derive(Clone)]

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -21,6 +21,10 @@
 //!   E2EE is supported and operates on the `input` request field and
 //!   each `data[].embedding` response field.
 //! * `GET  /v1/models` - proxy the upstream OpenAI-compatible model list.
+//! * `GET  /v1/models/:namespace` - models exposed under a `{namespace}/`
+//!   alias prefix (control-plane middleware only).
+//! * `GET  /v1/embeddings/models` - embedding model catalog (control-plane
+//!   middleware only).
 //! * `GET  /v1/metrics` - expose aggregator-owned Prometheus metrics.
 //! * `GET  /v1/admin/upstreams` - authenticated admin view of the
 //!   current upstream config, with secrets redacted.
@@ -85,7 +89,8 @@ use backend::internal_forward;
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
     admin_put_upstreams, attestation_report, attested_session, chat_completions, completions,
-    embeddings, messages, metrics, models, receipt_by_chat_id, responses, root,
+    embeddings, embeddings_models, messages, metrics, models, models_namespace,
+    receipt_by_chat_id, responses, root,
 };
 
 #[derive(Clone)]
@@ -249,6 +254,8 @@ fn build_router_inner(
         .route("/", get(root))
         // OpenAI- and Anthropic-compatible inference surface.
         .route("/v1/models", get(models))
+        .route("/v1/models/:namespace", get(models_namespace))
+        .route("/v1/embeddings/models", get(embeddings_models))
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/completions", post(completions))
         .route("/v1/embeddings", post(embeddings))

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -21,8 +21,10 @@
 //!   E2EE is supported and operates on the `input` request field and
 //!   each `data[].embedding` response field.
 //! * `GET  /v1/models` - proxy the upstream OpenAI-compatible model list.
-//! * `GET  /v1/models/:namespace` - models exposed under a `{namespace}/`
-//!   alias prefix (control-plane middleware only).
+//! * `GET  /v1/models/*` - relay model sub-catalogs to the middleware, which
+//!   owns the routing: `/v1/models/:namespace` (alias-prefix catalog) and
+//!   `/v1/models/providers/:provider` (provider catalog). Control-plane
+//!   middleware only.
 //! * `GET  /v1/embeddings/models` - embedding model catalog (control-plane
 //!   middleware only).
 //! * `GET  /v1/metrics` - expose aggregator-owned Prometheus metrics.
@@ -89,7 +91,7 @@ use backend::internal_forward;
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
     admin_put_upstreams, attestation_report, attested_session, chat_completions, completions,
-    embeddings, embeddings_models, messages, metrics, models, models_namespace,
+    embeddings, embeddings_models, messages, metrics, models, models_subpath,
     receipt_by_chat_id, responses, root,
 };
 
@@ -254,7 +256,7 @@ fn build_router_inner(
         .route("/", get(root))
         // OpenAI- and Anthropic-compatible inference surface.
         .route("/v1/models", get(models))
-        .route("/v1/models/:namespace", get(models_namespace))
+        .route("/v1/models/*rest", get(models_subpath))
         .route("/v1/embeddings/models", get(embeddings_models))
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/completions", post(completions))

--- a/src/http/app/proxy.rs
+++ b/src/http/app/proxy.rs
@@ -44,7 +44,7 @@ pub(super) async fn forward_to_middleware(
     middleware_completion_response(builder.body(body).send().await, stream).await
 }
 
-pub(super) async fn get_from_middleware(middleware: UdsMiddleware, path: &'static str) -> Response {
+pub(super) async fn get_from_middleware(middleware: UdsMiddleware, path: &str) -> Response {
     let url = format!("{}{}", middleware.base_url, path);
     match buffered_middleware_response(middleware.client.get(url).send().await).await {
         Ok(response) => response.into_response(),


### PR DESCRIPTION
## What

Makes the public gateway frontend relay the control plane's model sub-catalog endpoints, and adds the new provider catalog. Completes the `/v1/models` reorganization.

Endpoints now reachable end-to-end (frontend → executor → control):

- `GET /v1/models/:namespace` — models under a `{namespace}/` alias prefix (`phala/*`, `openai/*`), re-id'd to the alias.
- `GET /v1/models/providers/:provider` — models with an active deployment for the provider, **real** provider names, canonical ids, embeddings excluded. The `phala` provider additionally surfaces every TEE-backed model (`specs.is_tee`), even those without a phala deployment.
- `GET /v1/embeddings/models` — embedding-only catalog.

## Frontend routing: catch-all relay

The frontend (axum 0.7.9 + **matchit 0.7.3**) cannot register `/v1/models/:namespace` and `/v1/models/providers/:provider` together — matchit 0.7 forbids a param and a static sibling at the same position (overlap support landed in matchit 0.8). So the frontend relays the whole subtree via a single catch-all `GET /v1/models/*rest` → middleware `/v1/models/{rest}`, and the middleware's Hono router (which supports static-over-param precedence) does the real routing.

Without this, `/v1/models/phala` and `/v1/models/providers/phala` returned 404 at the frontend before ever reaching the executor.

## Behavior change vs old gateway

`/v1/models/providers/phala` no longer aggregates `phala + near-ai` or masks the provider name as `phala`. It now returns phala-deployed models ∪ TEE models, with real provider names and canonical ids.

## Pairs with

Control-plane changes committed to `private-ai-control` `main` (namespace/embedding catalogs + `getModelsByProvider`/`getTeeModels` + `/models/providers/:provider`).

## Test

- `npm run typecheck` passes in `middleware/executor`.
- `cargo build` clean; `cargo test --test http` (12 tests) passes — confirms the router builds with the catch-all and `/v1/models` coexisting (no matchit conflict panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)