### PR TITLE
Per-instance attested sessions for Chutes (#6)

### DIFF
--- a/scripts/live_e2e/chutes_session_smoke.py
+++ b/scripts/live_e2e/chutes_session_smoke.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Live check for Chutes per-instance attested sessions (#6).
+
+Boots the gateway with ONE Chutes upstream (which fronts several TEE instances,
+each with its own E2EE key), sends a request, and asserts:
+
+  1. the attested-session list has one session per *verified instance*, each
+     bound to that instance's E2EE key (`e2ee_public_key_sha256` with a `key_id`),
+     not one bundled session, and
+  2. the request's receipt cites one of those per-instance sessions — i.e. the
+     session of the instance that actually served — so the chain receipt ->
+     instance session -> that instance's claims holds.
+
+`chutes_e2ee_discovery_rounds` is set so discovery samples more than one instance
+when the chute is served by several; with a single live instance the smoke still
+passes (one per-instance session) and reports the count.
+
+Usage (from scripts/, with CHUTES_API_KEY in the environment):
+    uv run python live_e2e/chutes_session_smoke.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import requests  # noqa: E402
+
+from live_e2e.common import (  # noqa: E402
+    DEFAULT_DSTACK_ENDPOINT,
+    DEFAULT_DSTACK_VERIFIER_URL,
+    ROOT,
+)
+
+PORT = 18087
+BASE = f"http://127.0.0.1:{PORT}"
+NAME = "chutes-tee"
+PUBLIC_MODEL = "chutes-model"
+UPSTREAM_MODEL = "zai-org/GLM-5.1-TEE"
+
+
+def list_sessions() -> list[dict]:
+    r = requests.get(f"{BASE}/v1/aci/sessions", params={"provider": NAME}, timeout=10)
+    if r.status_code != 200:
+        return []
+    return (r.json() or {}).get("sessions", [])
+
+
+def instance_binding(session: dict) -> dict | None:
+    """The session's single per-instance E2EE binding, if it is one."""
+    for binding in session.get("channel_binding", []):
+        if binding.get("type") == "e2ee_public_key_sha256" and binding.get("key_id"):
+            return binding
+    return None
+
+
+def send_request() -> tuple[int, str | None]:
+    body = {
+        "model": PUBLIC_MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+    }
+    resp = requests.post(f"{BASE}/v1/chat/completions", json=body, timeout=180)
+    rid = resp.headers.get("x-receipt-id")
+    if resp.status_code != 200 or not rid:
+        print(f"    request: status={resp.status_code} body={resp.text[:300]}")
+        return resp.status_code, None
+    rc = requests.get(f"{BASE}/v1/aci/receipts/{rid}", timeout=30).json()
+    receipt = rc.get("receipt") if "event_log" not in rc else rc
+    uv = next(
+        (e for e in (receipt or {}).get("event_log", []) if e.get("type") == "upstream.verified"),
+        {},
+    )
+    return resp.status_code, uv.get("session_id")
+
+
+def main() -> int:
+    token = os.environ.get("CHUTES_API_KEY")
+    if not token:
+        print("missing CHUTES_API_KEY")
+        return 2
+
+    config = [
+        {
+            "name": NAME,
+            "provider": "chutes",
+            "base_url": "https://api.chutes.ai",
+            "models": {PUBLIC_MODEL: UPSTREAM_MODEL},
+            "bearer_token": token,
+            "chutes_e2ee_discovery_rounds": 4,
+            "connect_timeout_seconds": 10,
+            "read_timeout_seconds": 600,
+            "verifier_request_timeout_seconds": 120,
+        }
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="chutes-session-smoke-") as tmp:
+        upstream_seed_path = Path(tmp) / "upstreams.seed.json"
+        gateway_config_path = Path(tmp) / "gateway.config.json"
+        state_dir = Path(tmp) / "state"
+        upstream_seed_path.write_text(json.dumps(config))
+        gateway_config_path.write_text(
+            json.dumps(
+                {
+                    "bind": f"127.0.0.1:{PORT}",
+                    "state_dir": str(state_dir),
+                    "upstream_config_seed_path": str(upstream_seed_path),
+                    "dstack_endpoint": DEFAULT_DSTACK_ENDPOINT,
+                }
+            )
+        )
+        log_path = Path(tmp) / "aggregator.log"
+        env = {
+            **os.environ,
+            "PRIVATE_AI_GATEWAY_CONFIG_PATH": str(gateway_config_path),
+            "DSTACK_VERIFIER_URL": os.environ.get("DSTACK_VERIFIER_URL", DEFAULT_DSTACK_VERIFIER_URL),
+            "RUST_LOG": "warn",
+        }
+        env.pop("CHUTES_API_KEY", None)  # lives in the config file, not the env
+        log = log_path.open("wb")
+        proc = subprocess.Popen(
+            ["cargo", "run", "--bin", "private-ai-gateway"],
+            cwd=ROOT,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            deadline = time.time() + 240
+            ready = False
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    print("gateway exited early; log tail:\n", log_path.read_text()[-1200:])
+                    return 1
+                try:
+                    r = requests.get(f"{BASE}/v1/models", timeout=2)
+                    if r.status_code == 200 and PUBLIC_MODEL in {
+                        m.get("id") for m in r.json().get("data", [])
+                    }:
+                        ready = True
+                        break
+                except Exception:
+                    pass
+                time.sleep(0.75)
+            if not ready:
+                print("gateway not ready; log tail:\n", log_path.read_text()[-1200:])
+                return 1
+
+            status, cited = send_request()
+            if status != 200 or not cited:
+                return 1
+
+            sessions = list_sessions()
+            if not sessions:
+                print("FAIL: no attested sessions recorded for Chutes")
+                return 1
+
+            # 1. Every Chutes session is a single per-instance E2EE channel.
+            key_ids: list[str] = []
+            for s in sessions:
+                binding = instance_binding(s)
+                if binding is None:
+                    print(f"FAIL: session {s.get('session_id')} is not a per-instance E2EE channel: "
+                          f"{s.get('channel_binding')}")
+                    return 1
+                key_ids.append(binding["key_id"])
+            if len(set(key_ids)) != len(key_ids):
+                print(f"FAIL: duplicate instance bindings across sessions: {key_ids}")
+                return 1
+
+            ids = {s.get("session_id") for s in sessions}
+            print(f"  sessions: {len(sessions)} (one per instance), instances={sorted(key_ids)}")
+            print(f"  receipt cites: {cited}")
+
+            # 2. The receipt cites one of the per-instance sessions.
+            if cited not in ids:
+                print(f"FAIL: receipt session id {cited} is not among the per-instance sessions {sorted(ids)}")
+                return 1
+
+            # 3. That session binds the serving instance's own evidence: its CPU
+            #    measurement profile, and its GPU verification outcome.
+            cited_session = next((s for s in sessions if s.get("session_id") == cited), {})
+            claims = cited_session.get("claims", {})
+            measurement = claims.get("extra", {}).get("measurement")
+            gpu_attested = (claims.get("gpu_attested") or {}).get("status")
+            print(f"  cited session binds: measurement={measurement} gpu_attested={gpu_attested}")
+            if not measurement:
+                print("FAIL: cited session does not bind the instance's CPU measurement")
+                return 1
+
+            print(
+                f"\nPASS: {len(sessions)} per-instance Chutes session(s); the receipt resolves to the "
+                f"serving instance's session ({cited}), which binds its CPU measurement and GPU outcome."
+            )
+            return 0
+        finally:
+            if proc.poll() is None:
+                os.killpg(proc.pid, signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    os.killpg(proc.pid, signal.SIGKILL)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/provider_verifier/chutes.py
+++ b/scripts/provider_verifier/chutes.py
@@ -445,6 +445,9 @@ async def verify_chutes(request: dict[str, Any]) -> None:
     # deep audit sees the outcome; the typed gpu_attested claim stays Unknown.
     instance_gpu = {item["instance_id"]: item.get("gpu") for item in verified}
     gpus = [g for g in instance_gpu.values() if isinstance(g, dict)]
+    # Per-instance measurement profile (stable hardware identity, no nonce) so a
+    # single instance's session can bind its own CPU evidence.
+    instance_measurements = {item["instance_id"]: item["measurement"] for item in verified}
     provider_claims = {
         "trust_boundary": "model_instance",
         "evidence_scope": "model_instance",
@@ -455,6 +458,7 @@ async def verify_chutes(request: dict[str, Any]) -> None:
         "verified_public_key_sha256": [item["public_key_sha256"] for item in verified],
         "tcb_status": fleet_tcb_status,
         "instance_tcb_statuses": instance_tcb_statuses,
+        "instance_measurements": instance_measurements,
         "gpu_verified": bool(gpus) and all(g.get("gpu_verified") for g in gpus),
         "gpu_evidence_present": any(g.get("gpu_evidence_present") for g in gpus),
         "instance_gpu": instance_gpu,

--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -183,6 +183,7 @@ impl ChutesProviderBackend {
             headers,
             response_sk: encrypted.response_sk,
             response: resp,
+            instance_id: selected.instance_id,
         })
     }
 
@@ -379,6 +380,7 @@ impl UpstreamBackend for ChutesProviderBackend {
         let invoke = self.invoke_verified(req, event, false).await?;
         let status_code = invoke.status_code;
         let headers = invoke.headers;
+        let served_instance_id = Some(invoke.instance_id);
         let body = invoke
             .response
             .bytes()
@@ -390,6 +392,7 @@ impl UpstreamBackend for ChutesProviderBackend {
                 status_code,
                 body,
                 headers,
+                served_instance_id,
             });
         }
         let body = decrypt_chutes_response(&body, &invoke.response_sk)?;
@@ -397,6 +400,7 @@ impl UpstreamBackend for ChutesProviderBackend {
             status_code,
             body,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            served_instance_id,
         })
     }
 
@@ -415,6 +419,7 @@ impl UpstreamBackend for ChutesProviderBackend {
         let invoke = self.invoke_verified(req, event, true).await?;
         let status_code = invoke.status_code;
         let mut headers = invoke.headers;
+        let served_instance_id = Some(invoke.instance_id);
         let raw_body = invoke
             .response
             .bytes_stream()
@@ -432,6 +437,7 @@ impl UpstreamBackend for ChutesProviderBackend {
             status_code,
             headers,
             body,
+            served_instance_id,
         })
     }
 
@@ -485,6 +491,9 @@ struct ChutesInvokeResponse {
     headers: HashMap<String, String>,
     response_sk: MlKemDecapsulationKey768,
     response: reqwest::Response,
+    /// The instance that served this request — cited by the receipt as the
+    /// attested session it used.
+    instance_id: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -68,11 +68,15 @@ pub struct PreparedUpstreamRequest {
     pub is_tee: Option<bool>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct UpstreamResponse {
     pub status_code: u16,
     pub body: Vec<u8>,
     pub headers: HashMap<String, String>,
+    /// The instance that actually served this request, when the backend fronts
+    /// several (Chutes: the serving instance id). Lets the receipt cite that
+    /// instance's attested session; `None` for single-channel backends.
+    pub served_instance_id: Option<String>,
 }
 
 pub type UpstreamBodyStream = Pin<Box<dyn Stream<Item = Result<Bytes, UpstreamError>> + Send>>;
@@ -81,6 +85,8 @@ pub struct UpstreamStreamResponse {
     pub status_code: u16,
     pub headers: HashMap<String, String>,
     pub body: UpstreamBodyStream,
+    /// See [`UpstreamResponse::served_instance_id`].
+    pub served_instance_id: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -170,6 +176,7 @@ pub trait UpstreamBackend: Send + Sync {
             status_code: response.status_code,
             headers: response.headers,
             body: Box::pin(stream::once(async move { Ok(body) })),
+            served_instance_id: response.served_instance_id,
         })
     }
 

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -147,6 +147,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             status_code: status,
             body,
             headers,
+            served_instance_id: None,
         })
     }
 
@@ -169,6 +170,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             status_code: status,
             headers,
             body: Box::pin(body),
+            served_instance_id: None,
         })
     }
 
@@ -199,6 +201,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             status_code: status,
             body,
             headers,
+            served_instance_id: None,
         })
     }
 
@@ -223,6 +226,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             status_code: status,
             headers,
             body: Box::pin(body),
+            served_instance_id: None,
         })
     }
 }
@@ -307,6 +311,7 @@ impl OpenAICompatibleBackend {
             status_code: status,
             body,
             headers,
+            served_instance_id: None,
         })
     }
 

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -279,6 +279,7 @@ impl UpstreamBackend for ModelRouterBackend {
             status_code: 200,
             body,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            served_instance_id: None,
         })
     }
 

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use super::AciService;
-use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use crate::aggregator::session::{Claim, ClaimSource, SessionClaims};
 use crate::aggregator::upstream_config::UpstreamSessionSink;
 
@@ -49,6 +49,98 @@ pub(super) fn session_claims_for_event(event: &UpstreamVerifiedEvent) -> Session
         }
     }
     claims
+}
+
+/// The Chutes instance id a binding attests, if this is a per-instance Chutes
+/// channel. Chutes seals one session per instance; every other provider has a
+/// single channel (None), so its claims/evidence apply to the event as a whole.
+pub(super) fn chutes_instance_id<'a>(
+    event: &UpstreamVerifiedEvent,
+    binding: &'a ChannelBinding,
+) -> Option<&'a str> {
+    if event.provider.as_deref() != Some("chutes") {
+        return None;
+    }
+    match binding {
+        ChannelBinding::E2eePublicKeySha256 {
+            key_id: Some(id), ..
+        } => Some(id.as_str()),
+        _ => None,
+    }
+}
+
+/// Typed claims for one Chutes instance: the verifier's facts for that instance
+/// only, so its session is content-addressed on its own data and survives fleet
+/// churn (a sibling instance joining or failing does not change it).
+pub(super) fn per_instance_session_claims(
+    event: &UpstreamVerifiedEvent,
+    instance_id: &str,
+) -> SessionClaims {
+    let instance_event = UpstreamVerifiedEvent {
+        provider: event.provider.clone(),
+        verifier_id: event.verifier_id.clone(),
+        result: event.result,
+        provider_claims: Some(per_instance_provider_claims(
+            event.provider_claims.as_ref(),
+            instance_id,
+        )),
+        ..Default::default()
+    };
+    session_claims_for_event(&instance_event)
+}
+
+/// One instance's slice of the Chutes `provider_claims` — that instance's own
+/// attestation facts, so its session binds its CPU and GPU evidence while staying
+/// stable under fleet churn. Everything fleet-shaped is dropped (the lists, the
+/// per-instance maps, and the *fleet-aggregate* GPU scalars — `all`/`any` over
+/// instances). What is kept is per-instance and nonce-free: the matched CPU
+/// measurement profile, this instance's TCB status, and this instance's GPU
+/// verification outcome (verified / arch). The raw nonce-bound quotes stay out.
+fn per_instance_provider_claims(full: Option<&Value>, instance_id: &str) -> Value {
+    let mut pc = serde_json::Map::new();
+    let Some(Value::Object(map)) = full else {
+        return Value::Object(pc);
+    };
+    for key in [
+        "trust_boundary",
+        "evidence_scope",
+        "chute_id",
+        "canonical_model_id",
+    ] {
+        if let Some(value) = map.get(key) {
+            pc.insert(key.to_string(), value.clone());
+        }
+    }
+    pc.insert(
+        "instance_id".to_string(),
+        Value::String(instance_id.to_string()),
+    );
+    if let Some(status) = map
+        .get("instance_tcb_statuses")
+        .and_then(|statuses| statuses.get(instance_id))
+    {
+        pc.insert("tcb_status".to_string(), status.clone());
+    }
+    if let Some(measurement) = map
+        .get("instance_measurements")
+        .and_then(|measurements| measurements.get(instance_id))
+    {
+        pc.insert("measurement".to_string(), measurement.clone());
+    }
+    // This instance's own GPU outcome (NOT the fleet aggregate), lifted to the
+    // top of the slice so `gpu_attested` reflects this instance and the slice
+    // stays stable when a sibling instance's GPU does not.
+    if let Some(Value::Object(gpu)) = map
+        .get("instance_gpu")
+        .and_then(|instances| instances.get(instance_id))
+    {
+        for key in ["gpu_verified", "gpu_arch", "gpu_evidence_present"] {
+            if let Some(value) = gpu.get(key) {
+                pc.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    Value::Object(pc)
 }
 
 /// `tee_attested` rooted in a verified hardware quote with the request channel
@@ -490,5 +582,82 @@ mod claim_mapping_tests {
         );
         // Raw claims are still recorded for the audit trail.
         assert!(claims.extra.contains_key("config_repo"));
+    }
+
+    #[test]
+    fn chutes_instance_id_only_for_chutes_e2ee_bindings() {
+        use super::chutes_instance_id;
+        let e2ee = ChannelBinding::E2eePublicKeySha256 {
+            provider: "chutes".to_string(),
+            key_id: Some("inst-1".to_string()),
+            algorithm: "chutes-ml-kem-768".to_string(),
+            public_key_sha256: "aa".repeat(32),
+        };
+        let tls = ChannelBinding::TlsSpkiSha256 {
+            origin: "https://up".to_string(),
+            spki_sha256: "aa".repeat(32),
+        };
+        let chutes = event(Some("chutes"), VerificationResult::Verified, None);
+        let near = event(Some("near-ai"), VerificationResult::Verified, None);
+        assert_eq!(chutes_instance_id(&chutes, &e2ee), Some("inst-1"));
+        assert_eq!(chutes_instance_id(&chutes, &tls), None); // not an e2ee instance
+        assert_eq!(chutes_instance_id(&near, &e2ee), None); // not Chutes
+    }
+
+    #[test]
+    fn per_instance_claims_pick_the_instance_and_drop_fleet_data() {
+        use super::per_instance_session_claims;
+        // Fleet TCB + GPU are aggregates (inst-2 is bad on both); per-instance
+        // maps carry each instance's own facts. A slice must bind the instance's
+        // own facts and ignore the fleet, so it survives sibling churn.
+        let pc = json!({
+            "trust_boundary": "model_instance",
+            "chute_id": "chute-x",
+            "tcb_status": "OutOfDate",
+            "gpu_verified": false,
+            "verified_instance_ids": ["inst-1", "inst-2"],
+            "instance_tcb_statuses": { "inst-1": "UpToDate", "inst-2": "OutOfDate" },
+            "instance_measurements": { "inst-1": "profile-x", "inst-2": "profile-y" },
+            "instance_gpu": {
+                "inst-1": { "gpu_verified": true, "gpu_arch": "hopper", "gpu_evidence_present": true },
+                "inst-2": { "gpu_verified": false }
+            },
+        });
+        let ev = event(Some("chutes"), VerificationResult::Verified, Some(pc));
+
+        // inst-1's session binds inst-1's own TCB, measurement, and GPU — even
+        // though the fleet TCB is OutOfDate and the fleet gpu_verified is false.
+        let c1 = per_instance_session_claims(&ev, "inst-1");
+        assert_eq!(c1.tcb_up_to_date.status, ClaimStatus::Asserted);
+        assert_eq!(c1.tcb_up_to_date.source, Some(ClaimSource::HardwareProven));
+        assert_eq!(c1.gpu_attested.status, ClaimStatus::Asserted);
+        assert_eq!(
+            c1.extra.get("instance_id").and_then(Value::as_str),
+            Some("inst-1")
+        );
+        assert_eq!(
+            c1.extra.get("tcb_status").and_then(Value::as_str),
+            Some("UpToDate")
+        );
+        assert_eq!(
+            c1.extra.get("measurement").and_then(Value::as_str),
+            Some("profile-x")
+        );
+        assert_eq!(
+            c1.extra.get("gpu_verified").and_then(Value::as_bool),
+            Some(true)
+        );
+        // Fleet-wide fields are dropped, so the slice (and the session content id)
+        // does not change when a sibling instance does (per-instance idempotency).
+        assert!(!c1.extra.contains_key("verified_instance_ids"));
+        assert!(!c1.extra.contains_key("instance_tcb_statuses"));
+        assert!(!c1.extra.contains_key("instance_measurements"));
+        assert!(!c1.extra.contains_key("instance_gpu"));
+
+        // inst-2 differs (its own TCB refuted, its own GPU not asserted), so its
+        // session id will too.
+        let c2 = per_instance_session_claims(&ev, "inst-2");
+        assert_eq!(c2.tcb_up_to_date.status, ClaimStatus::Refuted);
+        assert_eq!(c2.gpu_attested.status, ClaimStatus::Unknown);
     }
 }

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 
 use crate::aci::receipt::{
-    ReceiptBuilder, ReceiptError, TransparencyEventKind, UpstreamVerifiedEvent, VerificationResult,
+    ChannelBinding, ReceiptBuilder, ReceiptError, TransparencyEventKind, UpstreamVerifiedEvent,
+    VerificationResult,
 };
 use crate::aci::types::Receipt;
 use crate::aci::upstream::{PreparedUpstreamRequest, UpstreamError, UpstreamRequest};
@@ -10,7 +11,7 @@ use crate::aggregator::session::{
     AttestedSession, EvidenceRef, SessionClaims, WorkloadIdentityRef,
 };
 
-use super::claims::session_claims_for_event;
+use super::claims::{chutes_instance_id, per_instance_session_claims, session_claims_for_event};
 use super::e2ee_crypto::encrypt_e2ee_response_body;
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
@@ -36,6 +37,33 @@ pub(super) enum ReverifyOutcome<R> {
     /// error. Both map to the caller's failure path; the helper has already
     /// applied any mismatch invalidation.
     Failed(UpstreamError),
+}
+
+/// A session sealed for one verified channel binding (one per Chutes instance).
+pub(super) struct SealedSession {
+    /// The per-instance key (Chutes instance id) for a multi-instance backend;
+    /// `None` for a single-channel backend.
+    instance_key: Option<String>,
+    session_id: String,
+    claims: SessionClaims,
+}
+
+/// Pick which sealed session the receipt cites. For a backend that fronts
+/// several instances (Chutes), cite the one that actually served; a
+/// single-channel backend reports no served instance, so its one session is
+/// used. A served instance with no matching sealed session (e.g. it dropped out
+/// of this verification) cites nothing — never the wrong instance.
+pub(super) fn cite_served_session(
+    sealed: &[SealedSession],
+    served_instance_id: Option<&str>,
+) -> Option<(String, SessionClaims)> {
+    let chosen = match served_instance_id {
+        Some(id) => sealed
+            .iter()
+            .find(|s| s.instance_key.as_deref() == Some(id)),
+        None => sealed.first(),
+    };
+    chosen.map(|s| (s.session_id.clone(), s.claims.clone()))
 }
 
 impl AciService {
@@ -161,7 +189,11 @@ impl AciService {
         if received_body != forwarded_body.as_slice() {
             builder.add_transparency_event(TransparencyEventKind::RequestModified)?;
         }
-        let recorded = self.record_attested_upstream_session(&recorded_event)?;
+        let sealed = self.record_attested_upstream_session(&recorded_event)?;
+        // When the backend fronts several instances (Chutes), cite the session of
+        // the instance that actually served this request.
+        let recorded =
+            cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
         Self::append_upstream_verified(&mut builder, recorded_event, recorded)?;
         // The session is keyed on the requested (routed) model; record the exact
         // upstream-served model in the receipt's upstream.verified event.
@@ -302,7 +334,11 @@ impl AciService {
         if received_body != forwarded_body.as_slice() {
             builder.add_transparency_event(TransparencyEventKind::RequestModified)?;
         }
-        let recorded = self.record_attested_upstream_session(&recorded_event)?;
+        let sealed = self.record_attested_upstream_session(&recorded_event)?;
+        // When the backend fronts several instances (Chutes), cite the session of
+        // the instance that actually served this request.
+        let recorded =
+            cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
         Self::append_upstream_verified(&mut builder, recorded_event, recorded)?;
 
         let e2ee_response = req.e2ee.as_ref().map(|ctx| E2eeResponseInfo {
@@ -506,16 +542,16 @@ impl AciService {
         }
     }
 
-    /// Seal + persist the attested session for a verified event, and return its
-    /// `(session_id, claim-verdicts)`. The verdicts are surfaced inline in the
-    /// receipt's `upstream.verified` (shallow audit), while the persisted session
-    /// also carries the evidence + reasons (deep audit).
+    /// Seal + persist one attested session per verified channel binding, and
+    /// return them. A single-TEE provider yields one; Chutes yields one per
+    /// instance. The receipt cites one of these (see [`cite_served_session`]);
+    /// each persisted session also carries the evidence + reasons (deep audit).
     pub(super) fn record_attested_upstream_session(
         &self,
         event: &UpstreamVerifiedEvent,
-    ) -> Result<Option<(String, SessionClaims)>, ServiceError> {
-        if event.result != VerificationResult::Verified || event.channel_bindings.is_empty() {
-            return Ok(None);
+    ) -> Result<Vec<SealedSession>, ServiceError> {
+        if event.result != VerificationResult::Verified {
+            return Ok(Vec::new());
         }
 
         let now = self.clock.now_secs();
@@ -527,35 +563,75 @@ impl AciService {
         // validity one (the forwarding path only ever uses a fresh lease).
         let expires_at = now.saturating_add(self.config.receipt_ttl_seconds);
 
-        let claims = session_claims_for_event(event);
-
-        // Lift the response-signing address into the verified identity when present.
-        let mut identity = WorkloadIdentityRef::default();
-        if let Some(Value::Object(map)) = event.provider_claims.as_ref() {
-            if let Some(addr) = map.get("signing_address").and_then(Value::as_str) {
-                identity.signing_address = Some(addr.to_string());
-            }
+        // One content-addressed session per channel binding: a single-TEE
+        // provider has one binding (its channel); Chutes has one per instance, so
+        // each instance becomes its own session. This relies on every
+        // non-instance provider verifying a single channel with exactly one
+        // binding; a channel that emitted several bindings would be split into
+        // separate sessions here, which would be wrong for one logical channel.
+        let identity = Self::identity_from_provider_claims(event.provider_claims.as_ref());
+        let mut sealed = Vec::with_capacity(event.channel_bindings.len());
+        for binding in &event.channel_bindings {
+            let instance = chutes_instance_id(event, binding);
+            let claims = match instance {
+                Some(instance_id) => per_instance_session_claims(event, instance_id),
+                None => session_claims_for_event(event),
+            };
+            // A per-instance (Chutes) binding excludes the shared, nonce-bound raw
+            // evidence so re-verifying the same instance is a no-op; a single
+            // channel keeps the event's evidence.
+            let evidence = if instance.is_some() {
+                EvidenceRef::default()
+            } else {
+                event
+                    .evidence
+                    .as_ref()
+                    .map(EvidenceRef::from_value)
+                    .unwrap_or_default()
+            };
+            let session_id = self.seal_attested_session(
+                event,
+                identity.clone(),
+                vec![binding.clone()],
+                claims.clone(),
+                evidence,
+                now,
+                expires_at,
+            )?;
+            sealed.push(SealedSession {
+                instance_key: instance.map(str::to_string),
+                session_id,
+                claims,
+            });
         }
-        let identity = (!identity.is_empty()).then_some(identity);
+        Ok(sealed)
+    }
 
-        // The content-addressed id commits to the evidence *digest*, not its
-        // bytes, so it can be derived from a digest-only seal. When the same
-        // channel is already recorded and live, renew its deadline in the index
-        // rather than re-sealing and re-appending the full evidence per request.
-        let evidence_digest = event
-            .evidence
-            .as_ref()
-            .and_then(|value| value.get("digest").and_then(Value::as_str))
-            .map(str::to_string);
+    /// Seal (or renew) one session for a verified channel binding and return its
+    /// content-addressed id. The id commits to the evidence *digest*, not its
+    /// bytes, so a digest-only seal derives the same id: if the session is
+    /// already recorded and live, renew its deadline rather than re-sealing and
+    /// re-appending its evidence each request.
+    #[allow(clippy::too_many_arguments)]
+    fn seal_attested_session(
+        &self,
+        event: &UpstreamVerifiedEvent,
+        identity: Option<WorkloadIdentityRef>,
+        channel_bindings: Vec<ChannelBinding>,
+        claims: SessionClaims,
+        evidence: EvidenceRef,
+        now: u64,
+        expires_at: u64,
+    ) -> Result<String, ServiceError> {
         let session_id = AttestedSession::seal(
             event.upstream_name.clone(),
             event.url_origin.clone(),
             event.verifier_id.clone(),
             identity.clone(),
-            event.channel_bindings.clone(),
+            channel_bindings.clone(),
             claims.clone(),
             EvidenceRef {
-                digest: evidence_digest,
+                digest: evidence.digest.clone(),
                 data_uri: None,
             },
             now,
@@ -566,24 +642,18 @@ impl AciService {
             .session_store
             .renew_session(&session_id, expires_at, now)
         {
-            return Ok(Some((session_id, claims)));
+            return Ok(session_id);
         }
 
         // First sighting (or the prior record lapsed): seal the full evidence
         // and persist it once.
-        let evidence = event
-            .evidence
-            .as_ref()
-            .map(EvidenceRef::from_value)
-            .unwrap_or_default();
-
         let session = AttestedSession::seal(
             event.upstream_name.clone(),
             event.url_origin.clone(),
             event.verifier_id.clone(),
             identity,
-            event.channel_bindings.clone(),
-            claims.clone(),
+            channel_bindings,
+            claims,
             evidence,
             now,
             expires_at,
@@ -592,7 +662,6 @@ impl AciService {
             session.session_id, session_id,
             "digest-only probe must derive the same id as the full seal"
         );
-
         self.session_store
             .put_session(session, now)
             .map_err(|err| {
@@ -600,7 +669,21 @@ impl AciService {
                     "failed to persist attested session {session_id}: {err}"
                 ))
             })?;
-        Ok(Some((session_id, claims)))
+        Ok(session_id)
+    }
+
+    /// Lift the response-signing address out of provider claims into a verified
+    /// identity, when present.
+    fn identity_from_provider_claims(
+        provider_claims: Option<&Value>,
+    ) -> Option<WorkloadIdentityRef> {
+        let mut identity = WorkloadIdentityRef::default();
+        if let Some(Value::Object(map)) = provider_claims {
+            if let Some(addr) = map.get("signing_address").and_then(Value::as_str) {
+                identity.signing_address = Some(addr.to_string());
+            }
+        }
+        (!identity.is_empty()).then_some(identity)
     }
 
     /// Append the `upstream.verified` receipt event, attaching the session id and
@@ -624,5 +707,45 @@ impl AciService {
         let now = self.clock.now_secs();
         let expires_at = now.saturating_add(self.config.receipt_ttl_seconds);
         self.receipt_store.put(receipt, requester, now, expires_at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cite_served_session, SealedSession};
+    use crate::aggregator::session::SessionClaims;
+
+    fn sealed(instance_key: Option<&str>, session_id: &str) -> SealedSession {
+        SealedSession {
+            instance_key: instance_key.map(str::to_string),
+            session_id: session_id.to_string(),
+            claims: SessionClaims::default(),
+        }
+    }
+
+    #[test]
+    fn cite_picks_the_serving_instances_session() {
+        let sessions = vec![
+            sealed(Some("inst-a"), "as_a"),
+            sealed(Some("inst-b"), "as_b"),
+        ];
+        assert_eq!(
+            cite_served_session(&sessions, Some("inst-b")).map(|(id, _)| id),
+            Some("as_b".to_string()),
+        );
+        // A served instance with no sealed session cites nothing, not the wrong one.
+        assert!(cite_served_session(&sessions, Some("inst-z")).is_none());
+    }
+
+    #[test]
+    fn cite_uses_the_single_session_for_a_single_channel() {
+        let sessions = vec![sealed(None, "as_one")];
+        // No served instance (single-channel backend) -> the one sealed session.
+        assert_eq!(
+            cite_served_session(&sessions, None).map(|(id, _)| id),
+            Some("as_one".to_string()),
+        );
+        // Nothing sealed -> nothing cited.
+        assert!(cite_served_session(&[], None).is_none());
     }
 }

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -3,7 +3,7 @@
 //!
 
 use super::e2ee_crypto::{encrypt_e2ee_final_response, is_sse_content_type};
-use super::forward::ReverifyOutcome;
+use super::forward::{cite_served_session, ReverifyOutcome};
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
 };
@@ -276,7 +276,9 @@ impl AciService {
                 let upstream_headers = upstream_response.headers;
                 let receipt_id = generate_receipt_id();
                 let served_at = self.clock.now_secs();
-                let recorded = self.record_attested_upstream_session(&recorded_event)?;
+                let sealed = self.record_attested_upstream_session(&recorded_event)?;
+                let recorded =
+                    cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
                 let session_id = recorded.as_ref().map(|(id, _)| id.clone());
                 let builder = self.build_middleware_receipt_prefix(MiddlewareReceiptInputs {
                     receipt_id: &receipt_id,
@@ -380,7 +382,9 @@ impl AciService {
             let receipt_id = generate_receipt_id();
             let served_at = self.clock.now_secs();
             let chat_id = extract_chat_id(&upstream_response.body);
-            let recorded = self.record_attested_upstream_session(&recorded_event)?;
+            let sealed = self.record_attested_upstream_session(&recorded_event)?;
+            let recorded =
+                cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
             let session_id = recorded.as_ref().map(|(id, _)| id.clone());
             let mut builder = self.build_middleware_receipt_prefix(MiddlewareReceiptInputs {
                 receipt_id: &receipt_id,

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -53,6 +53,7 @@ impl UpstreamBackend for EmptyUpstreamBackend {
             body: serde_json::to_vec(&json!({"object": "list", "data": []}))
                 .map_err(|e| UpstreamError::Routing(e.to_string()))?,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            served_instance_id: None,
         })
     }
 }

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -179,6 +179,7 @@ impl UpstreamBackend for RecordingUpstream {
             status_code: 200,
             body: self.response_body.clone(),
             headers,
+            served_instance_id: None,
         })
     }
 
@@ -191,6 +192,7 @@ impl UpstreamBackend for RecordingUpstream {
             status_code: self.stream_status,
             headers: self.stream_headers.clone(),
             body: Box::pin(stream::iter(self.stream_chunks.clone().into_iter().map(Ok))),
+            served_instance_id: None,
         })
     }
 }

--- a/tests/aggregator_scenarios.rs
+++ b/tests/aggregator_scenarios.rs
@@ -104,6 +104,7 @@ impl MockUpstream {
                     status_code,
                     body: body.to_vec(),
                     headers,
+                    served_instance_id: None,
                 }),
                 models_response: Mutex::new(UpstreamResponse {
                     status_code: 200,
@@ -112,6 +113,7 @@ impl MockUpstream {
                         "content-type".to_string(),
                         "application/json".to_string(),
                     )]),
+                    served_instance_id: None,
                 }),
                 calls: calls.clone(),
             },

--- a/tests/auth_and_retention.rs
+++ b/tests/auth_and_retention.rs
@@ -44,6 +44,7 @@ impl UpstreamBackend for StubUpstream {
             status_code: 200,
             body: CHAT_RESPONSE.to_vec(),
             headers,
+            served_instance_id: None,
         })
     }
 }

--- a/tests/dstack_live.rs
+++ b/tests/dstack_live.rs
@@ -79,6 +79,7 @@ impl UpstreamBackend for LiveStubUpstream {
             status_code: 200,
             body: CHAT_RESPONSE.to_vec(),
             headers,
+            served_instance_id: None,
         })
     }
 }

--- a/tests/forward_binding_reverify.rs
+++ b/tests/forward_binding_reverify.rs
@@ -120,6 +120,7 @@ impl MismatchingBackend {
             status_code: 200,
             body: br#"{"id":"chat-ok","object":"chat.completion","model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}"#.to_vec(),
             headers: std::collections::HashMap::new(),
+            served_instance_id: None,
         }
     }
 }
@@ -171,6 +172,7 @@ impl UpstreamBackend for MismatchingBackend {
             status_code: response.status_code,
             headers: response.headers,
             body: Box::pin(futures_util::stream::once(async move { Ok(body) })),
+            served_instance_id: None,
         })
     }
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -72,6 +72,7 @@ impl UpstreamBackend for StubUpstream {
             status_code: 200,
             body: self.body.clone(),
             headers,
+            served_instance_id: None,
         })
     }
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -76,6 +76,7 @@ impl UpstreamBackend for StubUpstream {
             status_code: 200,
             body: self.body.clone(),
             headers: Default::default(),
+            served_instance_id: None,
         })
     }
 

--- a/tests/upstream_verifier.rs
+++ b/tests/upstream_verifier.rs
@@ -32,6 +32,7 @@ impl UpstreamBackend for NoopUpstream {
             status_code: 200,
             body: b"{}".to_vec(),
             headers: HashMap::new(),
+            served_instance_id: None,
         })
     }
 }


### PR DESCRIPTION
Chutes fronts many TEE instances behind one model, each its own worker with its own ML-KEM key. Previously the gateway bundled them into a single attested session. This seals **one session per verified instance** and links a request's receipt to the instance that served it.

Closes #6.

## What changed
- **Seal per channel binding.** `record_attested_upstream_session` seals one `AttestedSession` per channel binding instead of bundling. A single-TEE provider has one binding → one session (unchanged); Chutes has one binding per instance → one session each. The per-instance unit is the existing binding — no new type, no `AttestedWorkload`. Each binding renews its session if it is already recorded and live, otherwise seals fresh.
- **Each instance's session binds its own evidence.** Its E2EE key (the binding), its CPU measurement profile, its TCB status, and its GPU verification outcome (`gpu_attested`) — all from that instance's own facts, never the fleet aggregate; the raw nonce-bound quotes are excluded. Everything bound is per-instance and nonce-free, so re-verifying the same instance is a content-addressed no-op even when a sibling instance's TCB or GPU changes.
- **Receipt linkage.** The serving instance id rides back on `UpstreamResponse`/`UpstreamStreamResponse` (set by the Chutes backend, `None` elsewhere). At receipt time the receipt cites that instance's freshly-sealed session id; if no sealed session matches, nothing is cited rather than the wrong instance. Applies on the buffered, streaming, and middleware paths.

Reuses `AttestedSession`, the session store, and the existing Chutes channel management as-is; no new persisted concept.

## Validation
- 274 unit/integration tests, clippy + fmt clean.
- Live Chutes smoke (`scripts/live_e2e/chutes_session_smoke.py`): the chute was served by ~13–16 instances → one per-instance session each, and the request's receipt resolved to the serving instance's session, binding its CPU measurement and `gpu_attested=asserted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)