### PR TITLE
Relay x-user-tier from the executor to upstreams

### DIFF
--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -199,7 +199,12 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
   const { targets, body } = buildForwardPayload(params, fn, candidates);
   let backendResp: Response;
   try {
-    backendResp = await forwardToBackend({ requestId, targets, body });
+    backendResp = await forwardToBackend({
+      requestId,
+      targets,
+      body,
+      userTier: consult.userTier,
+    });
   } catch (err) {
     return errorResponse(
       surface,

--- a/middleware/executor/src/integrations/backend.ts
+++ b/middleware/executor/src/integrations/backend.ts
@@ -36,6 +36,8 @@ export interface ForwardArgs {
    * target order matches `targets`.
    */
   body: Uint8Array | string;
+  /** Tier value to relay to the gateway as the x-user-tier header. */
+  userTier?: string;
 }
 
 /**
@@ -58,6 +60,7 @@ export function forwardToBackend(args: ForwardArgs): Promise<Response> {
           "content-length": payload.byteLength,
           "x-private-ai-gateway-request-id": args.requestId,
           "x-private-ai-gateway-targets": args.targets.join(","),
+          ...(args.userTier ? { "x-user-tier": args.userTier } : {}),
         },
       },
       (res) => {

--- a/middleware/executor/src/integrations/control.ts
+++ b/middleware/executor/src/integrations/control.ts
@@ -90,6 +90,8 @@ export interface PreConsult {
   userId?: number;
   virtualKeyId?: number;
   spendMode?: SpendMode;
+  // Tier to forward to the upstream as the x-user-tier header.
+  userTier?: string;
   // Set on a 429 denial: drives the X-RateLimit-* / Retry-After headers.
   rateLimit?: { limit: number; resetAt: number };
 }

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -22,6 +22,7 @@ use crate::aci::receipt::{ReceiptBuilder, TransparencyEventKind, UpstreamVerifie
 use crate::aci::upstream::{UpstreamError, UpstreamRequest};
 use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
 use crate::aggregator::session::SessionClaims;
+use std::collections::HashMap;
 
 fn is_retryable_provider_status(status: u16) -> bool {
     matches!(status, 429 | 500 | 502 | 503 | 504)
@@ -126,6 +127,12 @@ impl AciService {
             candidates.iter().map(|c| c.route_id.clone()).collect();
         let last_index = candidates.len() - 1;
 
+        // Optional x-user-tier passed through to every upstream attempt.
+        let mut upstream_headers: HashMap<String, String> = HashMap::new();
+        if let Some(tier) = req.context.user_tier.as_deref() {
+            upstream_headers.insert("x-user-tier".to_string(), tier.to_string());
+        }
+
         // Highest-priority error across exhausted candidates, returned if
         // no candidate succeeds.
         //
@@ -142,9 +149,9 @@ impl AciService {
 
             let prepared = match self.upstream.prepare(UpstreamRequest {
                 body: candidate.body.clone(),
+                headers: upstream_headers.clone(),
                 path: Some(endpoint_path.to_string()),
                 target_route_id: Some(route_id.clone()),
-                ..Default::default()
             }) {
                 Ok(prepared) => prepared,
                 Err(UpstreamError::Routing(message)) => {

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -235,6 +235,9 @@ pub struct GatewayRequestContext {
     pub request_id: String,
     pub user_model: Option<String>,
     pub target_route_id: Option<String>,
+    /// Optional x-user-tier value to relay to the upstream. None when the
+    /// caller supplied no x-user-tier header.
+    pub user_tier: Option<String>,
 }
 
 /// One ordered failover candidate: a route id to try plus the request

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -173,6 +173,7 @@ pub(super) async fn internal_forward(
                     request_id,
                     user_model: stored.user_model,
                     target_route_id: None,
+                    user_tier: header_str(&headers, "x-user-tier").map(str::to_string),
                 },
                 endpoint_path: stored.endpoint_path,
                 received_body: &received_body,

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -458,6 +458,8 @@ pub(super) async fn openai_completion_endpoint(
             .and_then(Value::as_str)
             .map(str::to_string),
         target_route_id: None,
+        // Populated from the x-user-tier header on the internal-forward path.
+        user_tier: None,
     };
 
     let stream = !force_buffered


### PR DESCRIPTION
## What

The control consult returns a per-key `userTier`. This carries it through the executor and the gateway so it reaches the upstream as an `x-user-tier` request header.

## Changes
- **executor**: thread the consult's `userTier` into `forwardToBackend`, which sets the `x-user-tier` header on the `/internal/forward` request.
- **gateway**: read `x-user-tier` on the internal-forward path into `GatewayRequestContext`, and add it to every upstream attempt's headers. OpenAI-compatible upstreams forward `UpstreamRequest.headers`; the value is treated as an opaque pass-through (no business semantics in the gateway).

## Notes
- chutes upstreams build their own request headers and do not forward `UpstreamRequest.headers`, so they do not carry `x-user-tier` (by design).
- The no-middleware direct path does not supply the header, so `user_tier` is `None` there.

## Verification
- `cargo check` ✅
- executor `tsc` ✅ and `npm test` (43/43) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)