### PR TITLE
Legacy /v1/attestation/report compatibility (report_data binding + upstream GPU evidence)

### DIFF
--- a/src/aci/keys.rs
+++ b/src/aci/keys.rs
@@ -68,13 +68,19 @@ pub struct Quote {
     pub vm_config: serde_json::Value,
 }
 
-/// Produces a TEE quote whose report-data slot binds 32 bytes.
+/// Produces a TEE quote binding caller-supplied report-data.
 #[async_trait]
 pub trait Quoter: Send + Sync {
-    /// Return a fresh quote whose report-data slot equals
-    /// `report_data` verbatim. The implementation MUST NOT mutate or
-    /// pad the supplied bytes.
+    /// Return a fresh quote whose report-data slot binds the supplied 32
+    /// bytes (the vendor profile decides any padding to the native slot
+    /// width). Used by the canonical ACI report.
     async fn get_quote(&self, report_data: [u8; 32]) -> Result<Quote, KeyError>;
+
+    /// Return a fresh quote whose report-data slot equals the supplied 64
+    /// bytes verbatim. The legacy dstack-vllm-proxy compatibility report
+    /// uses this to bind `signing_address ‖ zeros ‖ nonce` exactly, so the
+    /// implementation MUST NOT mutate or pad the supplied bytes.
+    async fn get_quote_raw(&self, report_data: [u8; 64]) -> Result<Quote, KeyError>;
 }
 
 /// The set of ACI private-key operations the aggregator needs.

--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use ml_kem::ml_kem_768::DecapsulationKey as MlKemDecapsulationKey768;
+use rand::RngCore;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -316,6 +317,40 @@ impl ChutesProviderBackend {
         let discovery = self.fetch_instances(&chute_id, &api_key).await?;
         self.cache_verified_chutes_nonces(&chute_id, discovery, &accepted)
     }
+
+    /// `GET {api_base}/chutes/{chute_id}/evidence?nonce={nonce}` → per-instance
+    /// TDX quote + GPU evidence.
+    async fn fetch_evidence(
+        &self,
+        chute_id: &str,
+        nonce: &str,
+        api_key: &str,
+    ) -> Result<Vec<ChutesInstanceEvidence>, UpstreamError> {
+        let url = format!("{}/chutes/{chute_id}/evidence", self.e2ee_api_base);
+        let resp = self
+            .client
+            .get(url)
+            .query(&[("nonce", nonce)])
+            .header("authorization", format!("Bearer {api_key}"))
+            .header("accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| UpstreamError::Transport(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| UpstreamError::Transport(e.to_string()))?;
+        if !(200..300).contains(&status) {
+            return Err(UpstreamError::Upstream {
+                status,
+                body: String::from_utf8_lossy(&body).into_owned(),
+            });
+        }
+        let parsed: ChutesEvidenceResponse =
+            serde_json::from_slice(&body).map_err(|e| UpstreamError::Transport(e.to_string()))?;
+        Ok(parsed.evidence)
+    }
 }
 
 #[async_trait]
@@ -403,6 +438,46 @@ impl UpstreamBackend for ChutesProviderBackend {
     async fn models(&self) -> Result<UpstreamResponse, UpstreamError> {
         self.inner.models().await
     }
+
+    /// Legacy dstack/chutes-compatible attestation report. The gateway cannot
+    /// produce the per-instance TDX quote + GPU evidence itself, so it generates
+    /// a fresh nonce, fetches the live per-instance evidence and E2EE public keys
+    /// from Chutes, and assembles the old multi-instance shape:
+    /// `{ attestation_type, nonce, all_attestations: [{instance_id, nonce,
+    /// e2e_pubkey, intel_quote, gpu_evidence}] }`. The nonce is server-generated
+    /// (clients verify the GPU evidence against the returned nonce).
+    async fn chutes_attestation_report(&self, model: &str) -> Result<Value, UpstreamError> {
+        let api_key = self.api_key()?;
+        let chute_id = self.resolve_chute_id(model, &api_key).await?;
+        let nonce = random_nonce_hex();
+        let pubkeys: HashMap<String, String> = self
+            .fetch_instances(&chute_id, &api_key)
+            .await?
+            .instances
+            .into_iter()
+            .map(|i| (i.instance_id, i.e2e_pubkey))
+            .collect();
+        let evidence = self.fetch_evidence(&chute_id, &nonce, &api_key).await?;
+
+        let all_attestations: Vec<Value> = evidence
+            .into_iter()
+            .map(|item| {
+                serde_json::json!({
+                    "instance_id": item.instance_id,
+                    "nonce": nonce,
+                    "e2e_pubkey": pubkeys.get(&item.instance_id).cloned(),
+                    "intel_quote": item.quote,
+                    "gpu_evidence": item.gpu_evidence,
+                })
+            })
+            .collect();
+
+        Ok(serde_json::json!({
+            "attestation_type": "chutes",
+            "nonce": nonce,
+            "all_attestations": all_attestations,
+        }))
+    }
 }
 
 struct ChutesInvokeResponse {
@@ -435,6 +510,28 @@ struct ChutesInstanceInfo {
     instance_id: String,
     e2e_pubkey: String,
     nonces: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChutesEvidenceResponse {
+    #[serde(default)]
+    evidence: Vec<ChutesInstanceEvidence>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChutesInstanceEvidence {
+    instance_id: String,
+    /// Base64-encoded TDX quote (surfaced as `intel_quote`, verbatim).
+    #[serde(default)]
+    quote: Option<Value>,
+    #[serde(default)]
+    gpu_evidence: Value,
+}
+
+fn random_nonce_hex() -> String {
+    let mut nonce = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+    hex::encode(nonce)
 }
 
 #[derive(Debug)]

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -196,4 +196,17 @@ pub trait UpstreamBackend: Send + Sync {
         }
         self.forward_stream_prepared(req).await
     }
+
+    /// Legacy multi-instance attestation report for `model`, in the old
+    /// dstack/chutes shape. Only the Chutes provider supports it; other
+    /// backends fail so callers can fall back to the gateway's own report.
+    async fn chutes_attestation_report(
+        &self,
+        _model: &str,
+    ) -> Result<serde_json::Value, UpstreamError> {
+        Err(UpstreamError::Routing(format!(
+            "backend {} does not produce a chutes attestation report",
+            self.name()
+        )))
+    }
 }

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -281,6 +281,19 @@ impl UpstreamBackend for ModelRouterBackend {
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
         })
     }
+
+    async fn chutes_attestation_report(
+        &self,
+        model: &str,
+    ) -> Result<serde_json::Value, UpstreamError> {
+        let route = self.route_for(model)?;
+        // The backend resolves the chute by its own upstream model id, the same
+        // value the inference path forwards after rewriting the request model.
+        route
+            .upstream
+            .chutes_attestation_report(&route.upstream_model_id)
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -11,11 +11,16 @@ use super::{
     AciService, E2eeError, E2eePreparedRequest, E2eeReplayKey, E2eeRequestContext,
     E2eeRequestParts, ServiceError,
 };
+use sha2::{Digest, Sha256};
+
 use crate::aci::e2ee::{
     normalize_secp256k1_public_key_hex, E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519,
     E2EE_ALGO_SECP256K1_AESGCM, E2EE_VERSION_V1, E2EE_VERSION_V2,
 };
 use crate::aci::identity::{self, attestation_statement, report_data};
+use crate::aci::keys::{
+    ethereum_address_from_uncompressed_public_key, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
+};
 use crate::aci::types::{AttestationEnvelope, AttestationReport, Freshness, KeysetEndorsement};
 
 impl AciService {
@@ -37,7 +42,136 @@ impl AciService {
         let statement = attestation_statement(&self.keyset, nonce)?;
         let rd = report_data(&statement)?;
         let quote = self.quoter.get_quote(rd).await?;
+        self.assemble_report(&rd, quote, domain).await
+    }
 
+    /// Legacy dstack-vllm-proxy compatibility report. The quote binds
+    /// `report_data = identity(32) ‖ nonce(32)` exactly as the proxy does, so
+    /// old clients verify against this gateway:
+    ///
+    /// * `signing_algo`: `ecdsa` → identity starts with the 20-byte secp256k1
+    ///   Ethereum address; `ed25519` → the 32-byte ed25519 public key. (Same
+    ///   key the shim surfaces as `signing_address`.)
+    /// * `version`: 1 → identity is the signing key right-padded to 32 bytes;
+    ///   2 → identity is `SHA256(signing_key ‖ tls_spki_fingerprint)`.
+    pub async fn legacy_attestation_report_for_domain(
+        &self,
+        signing_algo: Option<&str>,
+        version: u32,
+        nonce: Option<&str>,
+        domain: Option<&str>,
+    ) -> Result<AttestationReport, ServiceError> {
+        let rd = self.legacy_report_data(signing_algo, version, nonce, domain)?;
+        let quote = self.quoter.get_quote_raw(rd).await?;
+        self.assemble_report(&rd, quote, domain).await
+    }
+
+    /// Build `identity(32) ‖ nonce(32)`. The nonce is the raw 32 bytes when it
+    /// decodes as 32-byte hex, otherwise `sha256(nonce)` — both forms the
+    /// legacy verifier accepts. An absent nonce leaves the trailing 32 bytes
+    /// zeroed.
+    fn legacy_report_data(
+        &self,
+        signing_algo: Option<&str>,
+        version: u32,
+        nonce: Option<&str>,
+        domain: Option<&str>,
+    ) -> Result<[u8; 64], ServiceError> {
+        let signing_key = self.legacy_signing_key_bytes(signing_algo)?;
+        let mut rd = [0u8; 64];
+        if version >= 2 {
+            // v2 identity = SHA256(signing_key ‖ TLS SPKI fingerprint).
+            let cert_fingerprint = self.legacy_tls_spki_fingerprint(domain)?;
+            let mut hasher = Sha256::new();
+            hasher.update(&signing_key);
+            hasher.update(cert_fingerprint);
+            rd[..32].copy_from_slice(&hasher.finalize());
+        } else {
+            // v1 identity = signing key right-padded to 32 bytes.
+            rd[..signing_key.len()].copy_from_slice(&signing_key);
+        }
+        if let Some(nonce) = nonce {
+            let nonce_bytes = match hex::decode(nonce) {
+                Ok(bytes) if bytes.len() == 32 => bytes,
+                _ => Sha256::digest(nonce.as_bytes()).to_vec(),
+            };
+            rd[32..].copy_from_slice(&nonce_bytes);
+        }
+        Ok(rd)
+    }
+
+    /// The signing-key identity bytes the legacy report_data binds, matching the
+    /// `signing_address` the shim reports: the 20-byte secp256k1 Ethereum
+    /// address for `ecdsa`, or the 32-byte ed25519 public key for `ed25519`.
+    fn legacy_signing_key_bytes(
+        &self,
+        signing_algo: Option<&str>,
+    ) -> Result<Vec<u8>, ServiceError> {
+        let signing_algo = signing_algo
+            .unwrap_or(LEGACY_ALGO_ECDSA)
+            .to_ascii_lowercase();
+        let e2ee_keys = self.keys.e2ee_keys();
+        let key_err =
+            |msg: &str| ServiceError::Key(crate::aci::keys::KeyError::Crypto(msg.to_string()));
+        match signing_algo.as_str() {
+            LEGACY_ALGO_ECDSA => {
+                let key = e2ee_keys
+                    .iter()
+                    .find(|key| key.algo == E2EE_ALGO_SECP256K1_AESGCM)
+                    .ok_or_else(|| {
+                        key_err("no secp256k1 E2EE key for legacy report_data binding")
+                    })?;
+                let address = ethereum_address_from_uncompressed_public_key(&key.public_key_hex)?;
+                hex::decode(address.trim_start_matches("0x"))
+                    .map_err(|e| key_err(&format!("invalid signing address hex: {e}")))
+            }
+            LEGACY_ALGO_ED25519 => {
+                let key = e2ee_keys
+                    .iter()
+                    .find(|key| key.algo == E2EE_ALGO_LEGACY_ED25519)
+                    .ok_or_else(|| key_err("no ed25519 E2EE key for legacy report_data binding"))?;
+                hex::decode(&key.public_key_hex)
+                    .map_err(|e| key_err(&format!("invalid ed25519 public key hex: {e}")))
+            }
+            other => Err(ServiceError::Key(
+                crate::aci::keys::KeyError::UnsupportedAlgo(other.to_string()),
+            )),
+        }
+    }
+
+    /// The 32-byte TLS SPKI fingerprint bound by an attestation-v2 report, for
+    /// the request's `domain`. Errors when no matching TLS key is published
+    /// (v2 cannot be produced without one — matching the proxy).
+    fn legacy_tls_spki_fingerprint(&self, domain: Option<&str>) -> Result<[u8; 32], ServiceError> {
+        let key_err = |msg: String| ServiceError::Key(crate::aci::keys::KeyError::Crypto(msg));
+        let spki_hex = domain
+            .and_then(normalize_downstream_domain)
+            .and_then(|domain| {
+                self.keyset
+                    .tls_public_keys
+                    .iter()
+                    .find(|key| key.domain.as_deref() == Some(domain.as_str()))
+            })
+            .map(|key| key.spki_sha256_hex.clone())
+            .ok_or_else(|| {
+                key_err(
+                    "attestation version 2 requires a published TLS SPKI for the request host"
+                        .to_string(),
+                )
+            })?;
+        let bytes =
+            hex::decode(&spki_hex).map_err(|e| key_err(format!("invalid TLS SPKI hex: {e}")))?;
+        bytes
+            .try_into()
+            .map_err(|_| key_err("TLS SPKI fingerprint is not 32 bytes".to_string()))
+    }
+
+    async fn assemble_report(
+        &self,
+        report_data_bytes: &[u8],
+        quote: crate::aci::keys::Quote,
+        domain: Option<&str>,
+    ) -> Result<AttestationReport, ServiceError> {
         let endorsement_payload = identity::keyset_endorsement_payload(&self.keyset)?;
         let endorsement_sig = self.keys.sign_keyset_endorsement(&endorsement_payload)?;
         let endorsement = KeysetEndorsement {
@@ -79,7 +213,7 @@ impl AciService {
             vendor: self.config.vendor.clone(),
             tee_type: self.config.tee_type.clone(),
             workload_keyset: self.keyset.clone(),
-            report_data_hex: hex::encode(rd),
+            report_data_hex: hex::encode(report_data_bytes),
             keyset_endorsement: endorsement,
             source_provenance: self.config.source_provenance.clone(),
             freshness,

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -131,6 +131,13 @@ impl UpstreamBackend for DynamicUpstreamBackend {
             .forward_stream_verified_prepared(req, event)
             .await
     }
+
+    async fn chutes_attestation_report(
+        &self,
+        model: &str,
+    ) -> Result<serde_json::Value, UpstreamError> {
+        self.backend().chutes_attestation_report(model).await
+    }
 }
 
 pub(super) struct DynamicUpstreamVerifier {

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -249,6 +249,21 @@ pub struct UpstreamRuntimeOptions {
     pub verifier_request_timeout_seconds: u64,
 }
 
+/// Connection details for fetching a model's attestation report from its
+/// upstream node. Produced by [`UpstreamConfigManager::attestation_upstream_target`].
+#[derive(Debug, Clone)]
+pub struct AttestationUpstreamTarget {
+    pub upstream_name: String,
+    pub provider: UpstreamProvider,
+    /// Base URL with any trailing slash trimmed.
+    pub base_url: String,
+    /// The upstream's own model id (some providers need it as a query param).
+    pub upstream_model_id: String,
+    pub bearer_token: Option<String>,
+    pub connect_timeout_seconds: u64,
+    pub read_timeout_seconds: u64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct UpstreamConfigSnapshot {
     pub config_path: String,
@@ -364,6 +379,37 @@ impl UpstreamConfigManager {
             .filter(|cfg| cfg.models.contains_key(model) || cfg.models.values().any(|v| v == model))
             .map(|cfg| cfg.name.clone())
             .collect()
+    }
+
+    /// Resolve `model` to the first configured upstream that serves it, with the
+    /// connection details needed to fetch its attestation report. Carries the
+    /// bearer token (so it is not derived from the redacted [`snapshot`]).
+    /// Returns `None` when no configured upstream serves `model`.
+    pub fn attestation_upstream_target(&self, model: &str) -> Option<AttestationUpstreamTarget> {
+        let state = self.state.read().unwrap_or_else(|p| p.into_inner()).clone();
+        let cfg = state.config.iter().find(|cfg| {
+            cfg.models.contains_key(model) || cfg.models.values().any(|v| v == model)
+        })?;
+        // `model` is either a public alias (mapped to an upstream id) or already
+        // an upstream model id.
+        let upstream_model_id = cfg
+            .models
+            .get(model)
+            .cloned()
+            .unwrap_or_else(|| model.to_string());
+        Some(AttestationUpstreamTarget {
+            upstream_name: cfg.name.clone(),
+            provider: cfg.provider,
+            base_url: cfg.base_url.trim_end_matches('/').to_string(),
+            upstream_model_id,
+            bearer_token: cfg.bearer_token.clone(),
+            connect_timeout_seconds: cfg
+                .connect_timeout_seconds
+                .unwrap_or(self.options.connect_timeout_seconds),
+            read_timeout_seconds: cfg
+                .read_timeout_seconds
+                .unwrap_or(self.options.read_timeout_seconds),
+        })
     }
 
     pub fn snapshot(&self) -> UpstreamConfigSnapshot {

--- a/src/dstack.rs
+++ b/src/dstack.rs
@@ -241,23 +241,24 @@ fn decode_hex_field(field: &str, value: &str) -> Result<Vec<u8>, KeyError> {
     hex::decode(hex_value).map_err(|e| KeyError::Quote(format!("invalid hex in {field}: {e}")))
 }
 
-#[async_trait]
-impl Quoter for DstackAciProvider {
-    async fn get_quote(&self, report_data: [u8; 32]) -> Result<Quote, KeyError> {
-        let dstack_report_data = Self::dstack_report_data(report_data);
+impl DstackAciProvider {
+    /// Request a dstack TDX quote binding exactly the supplied 64-byte
+    /// report-data, returning the verified quote plus its event log and VM
+    /// config evidence.
+    async fn quote_with_report_data(&self, report_data: [u8; 64]) -> Result<Quote, KeyError> {
         let response = self
             .client
-            .get_quote(dstack_report_data.to_vec())
+            .get_quote(report_data.to_vec())
             .await
             .map_err(|e| KeyError::Quote(format!("dstack get_quote: {e}")))?;
         let raw_quote = response
             .decode_quote()
             .map_err(|e| KeyError::Quote(format!("invalid dstack quote hex: {e}")))?;
         let returned_report_data = decode_hex_field("dstack report_data", &response.report_data)?;
-        if returned_report_data != dstack_report_data {
+        if returned_report_data != report_data {
             return Err(KeyError::Quote(format!(
                 "dstack quote report_data mismatch: expected {}, got {}",
-                hex::encode(dstack_report_data),
+                hex::encode(report_data),
                 hex::encode(returned_report_data)
             )));
         }
@@ -275,6 +276,18 @@ impl Quoter for DstackAciProvider {
             event_log: serde_json::Value::String(event_log),
             vm_config: serde_json::Value::String(response.vm_config),
         })
+    }
+}
+
+#[async_trait]
+impl Quoter for DstackAciProvider {
+    async fn get_quote(&self, report_data: [u8; 32]) -> Result<Quote, KeyError> {
+        self.quote_with_report_data(Self::dstack_report_data(report_data))
+            .await
+    }
+
+    async fn get_quote_raw(&self, report_data: [u8; 64]) -> Result<Quote, KeyError> {
+        self.quote_with_report_data(report_data).await
     }
 }
 

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -18,6 +18,7 @@ use crate::aggregator::service::{
     AciService, ChatCompletionRequest, E2eeRequestContext, E2eeResponseInfo, GatewayRequestContext,
     MiddlewareForwardResult, ReceiptOwner, ServiceError, StreamingForwardResult,
 };
+use crate::aggregator::upstream_config::{AttestationUpstreamTarget, UpstreamProvider};
 
 use super::error_responses::{
     e2ee_error_response, error_response, insert_str_header, internal_error_response,
@@ -351,6 +352,62 @@ pub(super) fn upstream_direct_response_headers(
         resp_headers.insert(header_name, header_value);
     }
     resp_headers
+}
+
+/// Fetch the upstream model node's real `nvidia_payload` GPU evidence, bound to
+/// the client's `nonce`, so a model-scoped attestation report can carry GPU
+/// evidence the gateway (CPU-only) cannot produce itself. Dispatches per
+/// provider; returns `None` on any failure or for providers that do not expose
+/// `nvidia_payload` via `/v1/attestation/report` (caller falls back to an empty
+/// placeholder).
+pub(super) async fn fetch_upstream_nvidia_payload(
+    target: &AttestationUpstreamTarget,
+    nonce: &str,
+) -> Option<Value> {
+    let query = match target.provider {
+        UpstreamProvider::PhalaDirect => format!("signing_algo=ecdsa&nonce={nonce}&version=2"),
+        UpstreamProvider::NearAi => format!(
+            "signing_algo=ecdsa&nonce={nonce}&include_tls_fingerprint=true&model={}",
+            target.upstream_model_id
+        ),
+        // Chutes / Tinfoil expose GPU evidence through other mechanisms.
+        _ => return None,
+    };
+    fetch_report_nvidia_payload(target, &query).await
+}
+
+/// GET `{base_url}/v1/attestation/report?{query}` and return its top-level
+/// `nvidia_payload` field verbatim. `None` on any error.
+async fn fetch_report_nvidia_payload(
+    target: &AttestationUpstreamTarget,
+    query: &str,
+) -> Option<Value> {
+    let url = format!("{}/v1/attestation/report?{query}", target.base_url);
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(target.connect_timeout_seconds))
+        .read_timeout(std::time::Duration::from_secs(target.read_timeout_seconds))
+        .build()
+        .map_err(|e| tracing::warn!(upstream = %target.upstream_name, error = %e, "build attestation client"))
+        .ok()?;
+    let mut req = client.get(&url).header("accept", "application/json");
+    if let Some(token) = &target.bearer_token {
+        req = req.header("authorization", format!("Bearer {token}"));
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| tracing::warn!(upstream = %target.upstream_name, error = %e, "fetch upstream nvidia_payload"))
+        .ok()?;
+    if !resp.status().is_success() {
+        tracing::warn!(upstream = %target.upstream_name, status = %resp.status(), "upstream attestation report non-2xx");
+        return None;
+    }
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| tracing::warn!(upstream = %target.upstream_name, error = %e, "parse upstream attestation report"))
+        .ok()?;
+    body.get("nvidia_payload").cloned()
 }
 
 pub(super) fn reqwest_response_headers(upstream_headers: &reqwest::header::HeaderMap) -> HeaderMap {

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -255,7 +255,6 @@ pub(super) async fn attestation_report(
             match report_with_legacy_attestation_fields(
                 report,
                 q.signing_algo.as_deref(),
-                Some(&nonce),
                 nvidia_payload,
             ) {
                 Ok(value) => Json(value).into_response(),
@@ -327,7 +326,6 @@ pub(super) async fn aci_attestation_report(
 pub(super) fn report_with_legacy_attestation_fields(
     report: AttestationReport,
     signing_algo: Option<&str>,
-    request_nonce: Option<&str>,
     nvidia_payload: Value,
 ) -> Result<Value, ServiceError> {
     let mut value = serde_json::to_value(report)
@@ -415,12 +413,6 @@ pub(super) fn report_with_legacy_attestation_fields(
         .map(str::to_string)
     {
         obj.insert("intel_quote".to_string(), Value::String(intel_quote));
-    }
-    if let Some(nonce) = request_nonce {
-        obj.insert(
-            "request_nonce".to_string(),
-            Value::String(nonce.to_string()),
-        );
     }
     obj.insert("nvidia_payload".to_string(), nvidia_payload);
 

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use rand::RngCore;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -22,11 +23,11 @@ use crate::aggregator::service::{
     CHAT_COMPLETIONS_PATH, COMPLETIONS_PATH, EMBEDDINGS_PATH, MESSAGES_PATH, RESPONSES_PATH,
 };
 use crate::aggregator::session_store::sort_sessions_newest_first;
-use crate::aggregator::upstream_config::parse_config_text;
+use crate::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
 
 use super::backend::{
-    forward_to_backend, generate_request_id, strip_empty_tool_calls, upstream_direct_response,
-    upstream_proxy_error_response, BackendForwardInput,
+    fetch_upstream_nvidia_payload, forward_to_backend, generate_request_id, strip_empty_tool_calls,
+    upstream_direct_response, upstream_proxy_error_response, BackendForwardInput,
 };
 use super::error_responses::{
     admin_not_found_response, e2ee_error_response, error_response, insert_str_header,
@@ -46,6 +47,8 @@ use super::{AppState, StoredGatewayRequest};
 pub(super) struct AttestationQuery {
     nonce: Option<String>,
     signing_algo: Option<String>,
+    model: Option<String>,
+    version: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -196,13 +199,65 @@ pub(super) async fn attestation_report(
     Query(q): Query<AttestationQuery>,
 ) -> Response {
     let domain = request_host_domain(&headers);
+    let model = q.model.as_deref().filter(|m| !m.is_empty());
+
+    // Resolve the upstream serving `model` (direct-upstream mode only).
+    let target = model.and_then(|m| {
+        state
+            .upstream_config
+            .as_ref()
+            .and_then(|mgr| mgr.attestation_upstream_target(m))
+    });
+
+    // Chutes serves a self-contained multi-instance report from the upstream,
+    // independent of the gateway's own keyset.
+    if let (Some(model), Some(target)) = (model, target.as_ref()) {
+        if target.provider == UpstreamProvider::Chutes {
+            return match state
+                .service
+                .upstream()
+                .chutes_attestation_report(model)
+                .await
+            {
+                Ok(value) => Json(value).into_response(),
+                Err(e) => upstream_proxy_error_response(e),
+            };
+        }
+    }
+
+    // Otherwise (no model, or a non-Chutes provider): the gateway's own report,
+    // enriched with the upstream model node's real GPU evidence when the provider
+    // exposes it (PhalaDirect / NearAi).
+    //
+    // Effective nonce: the client's, or a freshly generated one when omitted —
+    // matching dstack-vllm-proxy, which binds a fresh nonce rather than leaving
+    // the slot empty. The same nonce is bound into report_data, echoed as
+    // request_nonce, and used to fetch the upstream GPU evidence so all three
+    // agree.
+    let nonce = resolve_report_nonce(q.nonce.as_deref());
     match state
         .service
-        .attestation_report_for_domain(q.nonce, domain.as_deref())
+        .legacy_attestation_report_for_domain(
+            q.signing_algo.as_deref(),
+            q.version.unwrap_or(1),
+            Some(&nonce),
+            domain.as_deref(),
+        )
         .await
     {
         Ok(report) => {
-            match report_with_legacy_attestation_fields(report, q.signing_algo.as_deref()) {
+            let nvidia_payload = match target.as_ref() {
+                Some(target) => fetch_upstream_nvidia_payload(target, &nonce)
+                    .await
+                    .unwrap_or_else(|| empty_nvidia_payload(Some(&nonce))),
+                None => empty_nvidia_payload(Some(&nonce)),
+            };
+            match report_with_legacy_attestation_fields(
+                report,
+                q.signing_algo.as_deref(),
+                Some(&nonce),
+                nvidia_payload,
+            ) {
                 Ok(value) => Json(value).into_response(),
                 Err(e) => internal_error_response(e),
             }
@@ -213,6 +268,34 @@ pub(super) async fn attestation_report(
         ) => unknown_downstream_host_response(e),
         Err(e) => internal_error_response(e),
     }
+}
+
+/// The nonce a legacy report binds: the client's when supplied (and non-empty),
+/// otherwise a freshly generated 32-byte hex nonce — matching dstack-vllm-proxy,
+/// which never leaves the report-data nonce slot empty.
+fn resolve_report_nonce(client_nonce: Option<&str>) -> String {
+    match client_nonce.filter(|n| !n.is_empty()) {
+        Some(nonce) => nonce.to_string(),
+        None => {
+            let mut bytes = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut bytes);
+            hex::encode(bytes)
+        }
+    }
+}
+
+/// Empty legacy `nvidia_payload` (a JSON string), used when no real upstream GPU
+/// evidence is available. Field shape stays stable for old clients; the empty
+/// `evidence_list` honestly signals "no GPU evidence".
+fn empty_nvidia_payload(nonce: Option<&str>) -> Value {
+    Value::String(
+        json!({
+            "nonce": nonce.unwrap_or_default(),
+            "evidence_list": [],
+            "arch": "HOPPER",
+        })
+        .to_string(),
+    )
 }
 
 /// Canonical ACI attestation report — the bare report, no legacy
@@ -237,9 +320,15 @@ pub(super) async fn aci_attestation_report(
     }
 }
 
+/// Place the legacy dstack-vllm-proxy compatibility fields on a gateway
+/// attestation report. `nvidia_payload` is supplied by the caller — the
+/// handler decides whether it carries real upstream GPU evidence or an empty
+/// placeholder — so this function only shapes/positions the fields.
 pub(super) fn report_with_legacy_attestation_fields(
     report: AttestationReport,
     signing_algo: Option<&str>,
+    request_nonce: Option<&str>,
+    nvidia_payload: Value,
 ) -> Result<Value, ServiceError> {
     let mut value = serde_json::to_value(report)
         .map_err(|e| ServiceError::Key(KeyError::Crypto(format!("serialize report: {e}"))))?;
@@ -314,6 +403,26 @@ pub(super) fn report_with_legacy_attestation_fields(
             );
         }
     }
+
+    // Legacy dstack-vllm-proxy compatibility fields. Old clients read these from
+    // the top level (and from each `all_attestations` entry), so inject them
+    // before the clone below.
+    if let Some(intel_quote) = obj
+        .get("attestation")
+        .and_then(|v| v.get("evidence"))
+        .and_then(|v| v.get("quote"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    {
+        obj.insert("intel_quote".to_string(), Value::String(intel_quote));
+    }
+    if let Some(nonce) = request_nonce {
+        obj.insert(
+            "request_nonce".to_string(),
+            Value::String(nonce.to_string()),
+        );
+    }
+    obj.insert("nvidia_payload".to_string(), nvidia_payload);
 
     let mut legacy_attestation = obj.clone();
     legacy_attestation.remove("all_attestations");

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -47,7 +47,12 @@
 //!
 //! Legacy aliases for dstack-vllm-proxy compatibility:
 //! * `GET  /v1/attestation/report` - report plus legacy e2ee/`signing_address`
-//!   compatibility fields.
+//!   compatibility fields. With `?model=X` it also surfaces the upstream model
+//!   node's GPU evidence: PhalaDirect/NearAi upstreams have their real
+//!   `nvidia_payload` (bound to the request nonce) merged into the gateway's own
+//!   report; Chutes returns the self-contained `attestation_type:"chutes"`
+//!   multi-instance report. Without a model (or on upstream failure) the
+//!   gateway's own report is returned with an empty `nvidia_payload` placeholder.
 //! * `GET  /v1/signature/{id}` - the legacy signature wrapper
 //!   (`text`/`signature`/`signing_address`) with the signed ACI receipt
 //!   carried in `receipt`.

--- a/tests/aggregator_scenarios.rs
+++ b/tests/aggregator_scenarios.rs
@@ -508,16 +508,15 @@ async fn report_establishes_identity_keyset_endorsement_and_nonce_binding() {
     let (verifier, _verifier_calls) = ScriptedVerifier::verified();
     let h = make_harness(verifier);
 
+    // The legacy endpoint binds the old dstack-vllm-proxy report_data layout:
+    // signing_address(20) ‖ zeros(12) ‖ nonce(32), with a 32-byte hex nonce
+    // placed verbatim.
+    let nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
     let response = h
         .requester
-        .get("/v1/attestation/report?nonce=client%20nonce")
+        .get(&format!("/v1/attestation/report?nonce={nonce}"))
         .await;
     assert_eq!(response.status, StatusCode::OK);
-    let report = h
-        .service
-        .attestation_report(Some("client nonce".to_string()))
-        .await
-        .unwrap();
     let body = json_body(&response);
 
     assert_eq!(body["api_version"], "aci/1");
@@ -526,13 +525,24 @@ async fn report_establishes_identity_keyset_endorsement_and_nonce_binding() {
         body["workload_keyset_digest"],
         h.service.workload_keyset_digest()
     );
-    assert_eq!(
-        body["attestation"]["report_data"],
-        report.attestation.report_data_hex
-    );
+
+    let signing_address = body["signing_address"]
+        .as_str()
+        .unwrap()
+        .trim_start_matches("0x")
+        .to_string();
+    let report_data_hex = body["attestation"]["report_data"].as_str().unwrap();
+    assert_eq!(&report_data_hex[0..40], signing_address);
+    assert_eq!(&report_data_hex[40..64], &"00".repeat(12));
+    assert_eq!(&report_data_hex[64..128], nonce);
 
     let endorsement_payload = identity::keyset_endorsement_payload(h.service.keyset()).unwrap();
-    let endorsement_sig = hex::decode(&report.attestation.keyset_endorsement.value_hex).unwrap();
+    let endorsement_sig = hex::decode(
+        body["attestation"]["keyset_endorsement"]["value"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
     assert!(verify_keyset_endorsement(
         &h.service.keyset().workload_identity.public_key,
         &endorsement_payload,
@@ -540,7 +550,7 @@ async fn report_establishes_identity_keyset_endorsement_and_nonce_binding() {
     ));
 
     let quote = hex::decode(body["attestation"]["evidence"]["quote"].as_str().unwrap()).unwrap();
-    let report_data = hex::decode(body["attestation"]["report_data"].as_str().unwrap()).unwrap();
+    let report_data = hex::decode(report_data_hex).unwrap();
     assert!(
         quote.ends_with(&report_data),
         "stub quote should carry the exact report_data bytes"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -247,18 +247,28 @@ impl Default for StubQuoter {
     }
 }
 
-#[async_trait]
-impl Quoter for StubQuoter {
-    async fn get_quote(&self, report_data: [u8; 32]) -> Result<Quote, KeyError> {
-        let mut raw = Vec::with_capacity(self.vendor_label.len() + 1 + 32);
+impl StubQuoter {
+    fn quote_for(&self, report_data: Vec<u8>) -> Quote {
+        let mut raw = Vec::with_capacity(self.vendor_label.len() + 1 + report_data.len());
         raw.extend_from_slice(&self.vendor_label);
         raw.push(b'|');
         raw.extend_from_slice(&report_data);
-        Ok(Quote {
+        Quote {
             raw_quote: raw,
-            report_data: report_data.to_vec(),
+            report_data,
             event_log: serde_json::Value::Null,
             vm_config: serde_json::json!({ "stub": true }),
-        })
+        }
+    }
+}
+
+#[async_trait]
+impl Quoter for StubQuoter {
+    async fn get_quote(&self, report_data: [u8; 32]) -> Result<Quote, KeyError> {
+        Ok(self.quote_for(report_data.to_vec()))
+    }
+
+    async fn get_quote_raw(&self, report_data: [u8; 64]) -> Result<Quote, KeyError> {
+        Ok(self.quote_for(report_data.to_vec()))
     }
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -181,7 +181,6 @@ async fn attestation_report_endpoint_shape() {
     // level (and mirrored into each all_attestations entry).
     let quote = body["attestation"]["evidence"]["quote"].as_str().unwrap();
     assert_eq!(body["intel_quote"].as_str().unwrap(), quote);
-    assert_eq!(body["request_nonce"].as_str().unwrap(), nonce);
     let nvidia_payload: serde_json::Value =
         serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
     assert_eq!(nvidia_payload["nonce"], nonce);
@@ -190,7 +189,6 @@ async fn attestation_report_endpoint_shape() {
     assert_eq!(nvidia_payload["evidence_list"], serde_json::json!([]));
     let first = &body["all_attestations"][0];
     assert_eq!(first["intel_quote"].as_str().unwrap(), quote);
-    assert_eq!(first["request_nonce"].as_str().unwrap(), nonce);
 
     // The quote binds the legacy report_data layout the old verifier parses:
     // signing_address(20) ‖ zeros(12) ‖ nonce(32). With a 32-byte hex nonce the
@@ -921,16 +919,14 @@ async fn attestation_report_generates_nonce_and_merges_when_client_omits_nonce()
 
     // Real evidence merged (not the empty placeholder).
     assert_eq!(body["nvidia_payload"].as_str().unwrap(), nvidia_payload);
-    // A 32-byte hex nonce was generated and echoed.
-    let request_nonce = body["request_nonce"].as_str().unwrap();
-    assert_eq!(request_nonce.len(), 64);
-    assert!(request_nonce.chars().all(|c| c.is_ascii_hexdigit()));
-    // The upstream was queried with that generated nonce.
+    // The gateway generated a 32-byte hex nonce and queried the upstream with it.
     let (query, _auth) = captured.lock().unwrap().clone().unwrap();
-    assert!(
-        query.contains(&format!("nonce={request_nonce}")),
-        "query: {query}"
-    );
+    let generated = query
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("nonce="))
+        .expect("upstream query carries a nonce");
+    assert_eq!(generated.len(), 64);
+    assert!(generated.chars().all(|c| c.is_ascii_hexdigit()));
 }
 
 #[tokio::test]

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -10,7 +10,11 @@ mod common;
 use async_trait::async_trait;
 use axum::{
     body::{to_bytes, Body},
-    http::{Request, StatusCode},
+    extract::{RawQuery, State},
+    http::{HeaderMap, Request, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
 };
 use private_ai_gateway::aci::keys::{verify_receipt_signature, KeyProvider};
 use private_ai_gateway::aci::receipt::{
@@ -23,7 +27,11 @@ use private_ai_gateway::aci::upstream::{
 use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
 };
-use private_ai_gateway::http::build_router;
+use private_ai_gateway::aggregator::upstream_config::{
+    UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
+};
+use private_ai_gateway::http::{build_router, build_router_with_admin};
+use serde_json::Value;
 use tower::ServiceExt;
 
 use common::{verified_event, StaticKeyProvider, StubQuoter};
@@ -120,10 +128,11 @@ async fn body_bytes(b: Body) -> Vec<u8> {
 async fn attestation_report_endpoint_shape() {
     let h = make_harness();
     let app = build_router(h.service.clone());
+    let nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
     let resp = app
         .oneshot(
             Request::builder()
-                .uri("/v1/attestation/report?nonce=abcd")
+                .uri(format!("/v1/attestation/report?nonce={nonce}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -167,6 +176,105 @@ async fn attestation_report_endpoint_shape() {
             .unwrap(),
         &serde_json::Value::Array(vec![])
     );
+
+    // Legacy dstack-vllm-proxy compatibility fields are injected at the top
+    // level (and mirrored into each all_attestations entry).
+    let quote = body["attestation"]["evidence"]["quote"].as_str().unwrap();
+    assert_eq!(body["intel_quote"].as_str().unwrap(), quote);
+    assert_eq!(body["request_nonce"].as_str().unwrap(), nonce);
+    let nvidia_payload: serde_json::Value =
+        serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
+    assert_eq!(nvidia_payload["nonce"], nonce);
+    assert_eq!(nvidia_payload["arch"], "HOPPER");
+    // No model / no upstream configured → empty GPU evidence placeholder.
+    assert_eq!(nvidia_payload["evidence_list"], serde_json::json!([]));
+    let first = &body["all_attestations"][0];
+    assert_eq!(first["intel_quote"].as_str().unwrap(), quote);
+    assert_eq!(first["request_nonce"].as_str().unwrap(), nonce);
+
+    // The quote binds the legacy report_data layout the old verifier parses:
+    // signing_address(20) ‖ zeros(12) ‖ nonce(32). With a 32-byte hex nonce the
+    // trailing field is the raw nonce bytes.
+    let signing_address = body["signing_address"]
+        .as_str()
+        .unwrap()
+        .trim_start_matches("0x");
+    let report_data = body["attestation"]["evidence"]["quote_report_data"]
+        .as_str()
+        .unwrap();
+    assert_eq!(&report_data[0..40], signing_address);
+    assert_eq!(&report_data[40..64], &"00".repeat(12));
+    assert_eq!(&report_data[64..128], nonce);
+}
+
+#[tokio::test]
+async fn attestation_report_ed25519_binds_pubkey_identity() {
+    // v1 + ed25519: report_data identity is the 32-byte ed25519 public key
+    // (not a 20-byte address), then the raw nonce.
+    let h = make_harness();
+    let app = build_router(h.service.clone());
+    let nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/attestation/report?nonce={nonce}&signing_algo=ed25519"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    assert_eq!(body["signing_algo"], "ed25519");
+    let signing_address = body["signing_address"].as_str().unwrap();
+    let report_data = body["attestation"]["evidence"]["quote_report_data"]
+        .as_str()
+        .unwrap();
+    assert_eq!(&report_data[0..64], signing_address);
+    assert_eq!(&report_data[64..128], nonce);
+}
+
+#[tokio::test]
+async fn attestation_report_v2_binds_sha256_of_address_and_tls_spki() {
+    // v2: report_data identity is SHA256(signing_key ‖ TLS SPKI fingerprint).
+    let spki = "aa".repeat(32);
+    let h = make_harness_with_tls_public_keys(Some(vec![TlsSpki {
+        domain: Some("api.example.com".to_string()),
+        spki_sha256_hex: spki.clone(),
+    }]));
+    let app = build_router(h.service.clone());
+    let nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/attestation/report?nonce={nonce}&signing_algo=ecdsa&version=2"
+                ))
+                .header("host", "api.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    let signing_address = body["signing_address"]
+        .as_str()
+        .unwrap()
+        .trim_start_matches("0x");
+    let report_data = body["attestation"]["evidence"]["quote_report_data"]
+        .as_str()
+        .unwrap();
+    let mut preimage = hex::decode(signing_address).unwrap();
+    preimage.extend(hex::decode(&spki).unwrap());
+    let expected = private_ai_gateway::aci::canonical::sha256_hex(&preimage);
+    let expected = expected.trim_start_matches("sha256:");
+    assert_eq!(&report_data[0..64], expected);
+    assert_eq!(&report_data[64..128], nonce);
 }
 
 #[tokio::test]
@@ -239,10 +347,12 @@ async fn attestation_report_rejects_unconfigured_domain_tls_binding_host() {
 async fn attestation_report_nonce_null_when_absent() {
     let h = make_harness();
     let app = build_router(h.service.clone());
+    // The canonical ACI endpoint binds the statement digest as report_data; the
+    // legacy endpoint instead binds the old signing_address ‖ nonce layout.
     let resp = app
         .oneshot(
             Request::builder()
-                .uri("/v1/attestation/report")
+                .uri("/v1/aci/attestation")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -646,4 +756,265 @@ async fn receipt_lookup_unknown_chat_id_returns_404() {
             .unwrap(),
         "not_found"
     );
+}
+
+// ---- Model-scoped attestation report (upstream GPU evidence) ----
+
+fn upstream_runtime_options() -> UpstreamRuntimeOptions {
+    UpstreamRuntimeOptions {
+        verifier_mode: UpstreamVerifierMode::Preverified,
+        accepted_workload_ids: vec![],
+        accepted_image_digests: vec![],
+        accepted_dstack_kms_root_public_keys: vec![],
+        pccs_url: None,
+        verifier_cache_seconds: 300,
+        connect_timeout_seconds: 10,
+        read_timeout_seconds: 30,
+        verifier_request_timeout_seconds: 30,
+    }
+}
+
+fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
+    // Unique per call: a coarse system clock can hand concurrent tests the same
+    // nanos, so an atomic counter guarantees distinct temp paths.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "pag-http-upstreams-{}-{}.json",
+        std::process::id(),
+        SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    ));
+    std::fs::write(&path, config_json).unwrap();
+    let manager = Arc::new(UpstreamConfigManager::load(&path, upstream_runtime_options()).unwrap());
+    let keys = Arc::new(StaticKeyProvider::default());
+    let service = Arc::new(
+        AciService::new_with_upstream_verifier(
+            keys,
+            Arc::new(StubQuoter::default()),
+            manager.backend(),
+            manager.verifier(),
+            Arc::new(InMemoryReceiptStore::default()),
+            AciServiceConfig::for_test("private-ai-gateway"),
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap(),
+    );
+    let app = build_router_with_admin(service.clone(), manager, None);
+    (service, app)
+}
+
+/// Records the query string and `Authorization` header the stub received.
+type CapturedRequest = Arc<Mutex<Option<(String, Option<String>)>>>;
+
+#[derive(Clone)]
+struct PhalaStubState {
+    captured: CapturedRequest,
+    nvidia_payload: Option<String>,
+}
+
+async fn phala_attest_handler(
+    State(s): State<PhalaStubState>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Response {
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    *s.captured.lock().unwrap() = Some((query.unwrap_or_default(), auth));
+    match s.nvidia_payload {
+        Some(payload) => Json(serde_json::json!({ "nvidia_payload": payload })).into_response(),
+        None => (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response(),
+    }
+}
+
+async fn serve_phala_stub(nvidia_payload: Option<String>) -> (String, CapturedRequest) {
+    let captured = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/v1/attestation/report", get(phala_attest_handler))
+        .with_state(PhalaStubState {
+            captured: captured.clone(),
+            nvidia_payload,
+        });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), captured)
+}
+
+const TEST_NONCE: &str = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
+
+#[tokio::test]
+async fn attestation_report_merges_upstream_nvidia_payload() {
+    let nvidia_payload =
+        r#"{"nonce":"x","evidence_list":[{"certificate":"c","evidence":"e"}],"arch":"HOPPER"}"#
+            .to_string();
+    let (base, captured) = serve_phala_stub(Some(nvidia_payload.clone())).await;
+    let config = format!(
+        r#"[{{"name":"phala-a","provider":"phala-direct","base_url":"{base}","models":{{"phala/gemma":"gemma-up"}},"bearer_token":"tok"}}]"#
+    );
+    let (_svc, app) = setup_with_config(&config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/attestation/report?model=phala/gemma&nonce={TEST_NONCE}&signing_algo=ecdsa"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+
+    // The upstream's real nvidia_payload is merged at the top level and mirrored.
+    assert_eq!(body["nvidia_payload"].as_str().unwrap(), nvidia_payload);
+    assert_eq!(
+        body["all_attestations"][0]["nvidia_payload"]
+            .as_str()
+            .unwrap(),
+        nvidia_payload
+    );
+    // The gateway's own report fields are untouched.
+    let quote = body["attestation"]["evidence"]["quote"].as_str().unwrap();
+    assert_eq!(body["intel_quote"].as_str().unwrap(), quote);
+    assert!(body["signing_address"].is_string());
+
+    // The upstream was queried with the client nonce, version=2, and the bearer.
+    let (query, auth) = captured.lock().unwrap().clone().unwrap();
+    assert!(
+        query.contains(&format!("nonce={TEST_NONCE}")),
+        "query: {query}"
+    );
+    assert!(query.contains("version=2"), "query: {query}");
+    assert_eq!(auth.as_deref(), Some("Bearer tok"));
+}
+
+#[tokio::test]
+async fn attestation_report_generates_nonce_and_merges_when_client_omits_nonce() {
+    // No client nonce: the gateway generates one (like dstack-vllm-proxy) and
+    // still fetches/merges the upstream GPU evidence, rather than returning an
+    // empty placeholder.
+    let nvidia_payload =
+        r#"{"nonce":"x","evidence_list":[{"certificate":"c","evidence":"e"}],"arch":"HOPPER"}"#
+            .to_string();
+    let (base, captured) = serve_phala_stub(Some(nvidia_payload.clone())).await;
+    let config = format!(
+        r#"[{{"name":"phala-a","provider":"phala-direct","base_url":"{base}","models":{{"phala/gemma":"gemma-up"}},"bearer_token":"tok"}}]"#
+    );
+    let (_svc, app) = setup_with_config(&config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/attestation/report?model=phala/gemma")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+
+    // Real evidence merged (not the empty placeholder).
+    assert_eq!(body["nvidia_payload"].as_str().unwrap(), nvidia_payload);
+    // A 32-byte hex nonce was generated and echoed.
+    let request_nonce = body["request_nonce"].as_str().unwrap();
+    assert_eq!(request_nonce.len(), 64);
+    assert!(request_nonce.chars().all(|c| c.is_ascii_hexdigit()));
+    // The upstream was queried with that generated nonce.
+    let (query, _auth) = captured.lock().unwrap().clone().unwrap();
+    assert!(
+        query.contains(&format!("nonce={request_nonce}")),
+        "query: {query}"
+    );
+}
+
+#[tokio::test]
+async fn attestation_report_degrades_to_empty_nvidia_on_upstream_error() {
+    let (base, _captured) = serve_phala_stub(None).await; // upstream returns 500
+    let config = format!(
+        r#"[{{"name":"phala-a","provider":"phala-direct","base_url":"{base}","models":{{"phala/gemma":"gemma-up"}},"bearer_token":"tok"}}]"#
+    );
+    let (_svc, app) = setup_with_config(&config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/attestation/report?model=phala/gemma&nonce={TEST_NONCE}&signing_algo=ecdsa"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    let nvidia: Value = serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
+    assert_eq!(nvidia["evidence_list"], serde_json::json!([]));
+    assert_eq!(nvidia["nonce"], TEST_NONCE);
+}
+
+async fn chutes_instances_handler() -> Json<Value> {
+    Json(serde_json::json!({
+        "instances": [{"instance_id": "inst-1", "e2e_pubkey": "pk-1", "nonces": ["n1"]}],
+        "nonce_expires_in": 60,
+    }))
+}
+
+async fn chutes_evidence_handler() -> Json<Value> {
+    Json(serde_json::json!({
+        "evidence": [{
+            "instance_id": "inst-1",
+            "quote": "cXVvdGUtYjY0",
+            "gpu_evidence": [{"arch": "HOPPER"}],
+        }]
+    }))
+}
+
+async fn serve_chutes_stub() -> String {
+    let app = Router::new()
+        .route("/e2e/instances/:chute_id", get(chutes_instances_handler))
+        .route("/chutes/:chute_id/evidence", get(chutes_evidence_handler));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn attestation_report_chutes_multi_instance_shape() {
+    let base = serve_chutes_stub().await;
+    let config = format!(
+        r#"[{{"name":"chutes-a","provider":"chutes","base_url":"{base}","models":{{"chutes/m":"m-up"}},"bearer_token":"tok","chutes_e2ee_api_base":"{base}","chutes_chute_ids":{{"m-up":"00000000-0000-0000-0000-0000000c1234"}}}}]"#
+    );
+    let (_svc, app) = setup_with_config(&config);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/attestation/report?model=chutes/m")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+
+    assert_eq!(body["attestation_type"], "chutes");
+    let nonce = body["nonce"].as_str().unwrap();
+    let entries = body["all_attestations"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["instance_id"], "inst-1");
+    assert_eq!(entries[0]["e2e_pubkey"], "pk-1");
+    assert_eq!(entries[0]["nonce"].as_str().unwrap(), nonce);
+    assert_eq!(entries[0]["intel_quote"], "cXVvdGUtYjY0");
+    assert!(entries[0]["gpu_evidence"].is_array());
 }


### PR DESCRIPTION
## What

Make `GET /v1/attestation/report` verifiable by existing redpill-gateway clients again (the old dstack-vllm-proxy contract), including `nvidia.valid`. The canonical `/v1/aci/attestation` (aci/1) endpoint is untouched.

After migrating to this gateway, old clients failed verification:
- `signingAddressBinding` / `nonceBinding` failed — the aci/1 quote binds `report_data = SHA256(statement) ‖ zeros`, not the layout old clients parse.
- `nvidia.valid` failed — the gateway runs in a CPU-only TDX VM and has no GPU evidence.

## How

**report_data binding** — `/v1/attestation/report` now binds the dstack-vllm-proxy layout `identity(32) ‖ nonce(32)`:
- `signing_algo` ecdsa → 20-byte secp256k1 address; ed25519 → 32-byte key.
- `version` 1 → identity = signing key right-padded to 32 bytes; 2 → identity = `SHA256(signing key ‖ TLS SPKI fingerprint)`.
- Effective nonce = the client's, or a generated 32-byte hex when omitted (matching the proxy), bound into report_data, echoed as `request_nonce`, and used to fetch upstream evidence.

**GPU evidence (`nvidia_payload`), by provider** — the gateway has no local GPU, so it sources real evidence from the upstream model node bound to the same nonce:
- **PhalaDirect / NearAi**: fetch the upstream's `/v1/attestation/report` and merge its real `nvidia_payload`. Upstream failure / no model / other providers fall back to an empty placeholder.
- **Chutes**: a self-contained `attestation_type:"chutes"` multi-instance report (own nonce, per-instance quote + gpu_evidence).

The gateway's own TDX quote, signing/e2ee keys and report_data binding are always its own (E2EE terminates at the gateway); only the GPU evidence is borrowed from upstream.

**New top-level fields vs main** (default / PhalaDirect / NearAi): `intel_quote`, `request_nonce`, `nvidia_payload` (also mirrored into `all_attestations[]`). `report_data`'s value changes from the aci digest to the legacy layout.

## Tests

`tests/http.rs`: report_data layout (ecdsa/ed25519 × v1/v2), upstream merge, generated-nonce merge, degrade-on-upstream-error, Chutes multi-instance. Full suite + clippy green.

## Note

Compatibility layer only — once clients move to aci/1 it can be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)