### PR TITLE
feat: surface failed-over attempts and TTFT to the caller

### DIFF
--- a/middleware/executor/src/__tests__/responses.test.ts
+++ b/middleware/executor/src/__tests__/responses.test.ts
@@ -23,6 +23,7 @@ describe('/v1/responses — meterResponse usage/cost', () => {
         headers: { 'content-type': 'application/json' },
       }),
       PRICING,
+      0,
       (u) => (reported = u)
     );
     const out = (await res.json()) as { usage: { cost: number } };
@@ -38,10 +39,15 @@ describe('/v1/responses — meterResponse usage/cost', () => {
       'event: response.completed\n' +
       'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":40,"output_tokens":24,"total_tokens":64}}}\n\n';
     let reported: unknown = undefined;
+    let reportedTtft: number | undefined = undefined;
     const res = await meterResponse(
       new Response(sse, { headers: { 'content-type': 'text/event-stream' } }),
       PRICING,
-      (u) => (reported = u)
+      0,
+      (u, t) => {
+        reported = u;
+        reportedTtft = t;
+      }
     );
     const text = await res.text();
     // cost spliced into the nested response.usage of the completed event
@@ -51,6 +57,9 @@ describe('/v1/responses — meterResponse usage/cost', () => {
     const parsed = JSON.parse(completed.slice(6));
     expect(parsed.response.usage.cost).toBeCloseTo(EXPECTED_COST, 10);
     expect(reported).toMatchObject({ input_tokens: 40, output_tokens: 24 });
+    // streaming reports time-to-first-token (measured from the passed start)
+    expect(typeof reportedTtft).toBe('number');
+    expect(reportedTtft as unknown as number).toBeGreaterThanOrEqual(0);
     // non-usage events pass through untouched
     expect(text).toContain('"type":"response.created"');
   });
@@ -63,6 +72,7 @@ describe('/v1/responses — meterResponse usage/cost', () => {
         headers: { 'content-type': 'application/json' },
       }),
       null,
+      0,
       (u) => (reported = u)
     );
     const out = (await res.json()) as { usage: Record<string, unknown> };

--- a/middleware/executor/src/cost.ts
+++ b/middleware/executor/src/cost.ts
@@ -2,8 +2,12 @@ import { computeCost, PricingConfig } from './services/pricing';
 
 type Usage = Record<string, unknown>;
 
-/** Called once with the raw upstream usage (before cost injection), or null. */
-type OnComplete = (usage: Usage | null) => void;
+/**
+ * Called once with the raw upstream usage (before cost injection), or null.
+ * `ttftMs` is the time-to-first-token for streaming responses (undefined for
+ * buffered responses, which have no meaningful TTFT).
+ */
+type OnComplete = (usage: Usage | null, ttftMs?: number) => void;
 
 /**
  * Meter the user-visible response: inject `usage.cost` (when pricing is known)
@@ -19,6 +23,7 @@ type OnComplete = (usage: Usage | null) => void;
 export function meterResponse(
   response: Response,
   pricing: PricingConfig | null,
+  start: number,
   onComplete: OnComplete
 ): Response | Promise<Response> {
   const inject = pricing !== null;
@@ -32,8 +37,11 @@ export function meterResponse(
     const textDecoder = new TextDecoder();
     const textEncoder = new TextEncoder();
     let lastUsage: Usage | null = null;
+    // First chunk out of the upstream stream marks time-to-first-token.
+    let ttftMs: number | undefined;
     const transform = new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
+        if (ttftMs === undefined) ttftMs = Date.now() - start;
         const lines = textDecoder.decode(chunk).split('\n');
         let rewritten = false;
         const outLines = lines.map((line) => {
@@ -79,7 +87,7 @@ export function meterResponse(
         );
       },
       flush() {
-        onComplete(lastUsage);
+        onComplete(lastUsage, ttftMs);
       },
     });
     return new Response(response.body.pipeThrough(transform), response);

--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -236,12 +236,47 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
   const isStreaming =
     backendResp.headers.get("content-type")?.includes("text/event-stream") ??
     false;
-  return meterResponse(response, pricing, (usage) => {
+
+  // Report each failed-over attempt (header value is `route_id=status`,
+  // comma-separated in the order tried) to the control plane as its own usage
+  // report, carrying no usage since the attempt produced no response body.
+  const failedAttempts = backendResp.headers.get(
+    "x-private-ai-gateway-failed-attempts",
+  );
+  if (failedAttempts) {
+    const endpoint = new URL(c.req.url).pathname;
+    failedAttempts.split(",").forEach((entry, i) => {
+      const eq = entry.lastIndexOf("=");
+      if (eq <= 0) return;
+      const failedStatus = Number(entry.slice(eq + 1));
+      // `Number("")` is 0, not NaN — reject non-positive so a malformed
+      // `route=` entry can't post a bogus status-0 row.
+      if (!Number.isInteger(failedStatus) || failedStatus <= 0) return;
+      consultPost({
+        requestId,
+        endpoint,
+        status: failedStatus,
+        durationMs: 0,
+        isStreaming,
+        attemptIndex: i,
+        selectedRouteId: entry.slice(0, eq),
+        requestModel: params.model ?? "",
+        usage: null,
+        pricing,
+        spendMode: consult.spendMode,
+        userId: consult.userId,
+        virtualKeyId: consult.virtualKeyId,
+      });
+    });
+  }
+
+  return meterResponse(response, pricing, start, (usage, ttftMs) => {
     consultPost({
       requestId,
       endpoint: new URL(c.req.url).pathname,
       status: backendResp.status,
       durationMs: Date.now() - start,
+      ttftMs,
       isStreaming,
       attemptIndex,
       selectedRouteId,

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -143,6 +143,13 @@ impl AciService {
         // + upstream.verified + hashes).
         let mut aggregated_err: Option<(u8, ServiceError)> = None;
 
+        // Candidates that failed and were failed over, as (route_id, status),
+        // in the order tried. The committed route is carried separately via
+        // `selected_route`; these are surfaced to the caller so every attempt
+        // is observable, not just the one that served the response. Non-HTTP
+        // failures (prepare/verification/transport) record 502.
+        let mut failed_attempts: Vec<(String, u16)> = Vec::new();
+
         for (index, candidate) in candidates.iter().enumerate() {
             let route_id = candidate.route_id.clone();
             let is_last = index == last_index;
@@ -155,6 +162,7 @@ impl AciService {
             }) {
                 Ok(prepared) => prepared,
                 Err(UpstreamError::Routing(message)) => {
+                    failed_attempts.push((route_id.clone(), 502));
                     upgrade_err(
                         &mut aggregated_err,
                         1,
@@ -163,6 +171,7 @@ impl AciService {
                     continue;
                 }
                 Err(err) => {
+                    failed_attempts.push((route_id.clone(), 502));
                     upgrade_err(&mut aggregated_err, 2, err.into());
                     continue;
                 }
@@ -184,6 +193,7 @@ impl AciService {
             {
                 Ok(event) => event,
                 Err(ServiceError::UpstreamVerification(uv)) => {
+                    failed_attempts.push((route_id.clone(), 502));
                     upgrade_err(
                         &mut aggregated_err,
                         3,
@@ -233,6 +243,7 @@ impl AciService {
                     }
                 };
                 let Some(upstream_response) = upstream_response else {
+                    failed_attempts.push((route_id.clone(), 502));
                     continue;
                 };
 
@@ -245,6 +256,7 @@ impl AciService {
                         None,
                     );
                     if is_retryable_provider_status(status) && !is_last {
+                        failed_attempts.push((route_id.clone(), status));
                         continue;
                     }
                     self.metrics
@@ -297,7 +309,7 @@ impl AciService {
                         upstream_headers,
                         body: Box::pin(body),
                         selected_route: route_id.clone(),
-                        attempts: index + 1,
+                        failed_attempts: std::mem::take(&mut failed_attempts),
                         session_id,
                     },
                 )));
@@ -340,6 +352,7 @@ impl AciService {
                 }
             };
             let Some(upstream_response) = upstream_response else {
+                failed_attempts.push((route_id.clone(), 502));
                 continue;
             };
 
@@ -351,6 +364,7 @@ impl AciService {
                     status,
                     None,
                 );
+                failed_attempts.push((route_id.clone(), status));
                 continue;
             }
 
@@ -400,7 +414,7 @@ impl AciService {
                     upstream_body: upstream_response.body,
                     upstream_headers: upstream_response.headers,
                     selected_route: route_id.clone(),
-                    attempts: index + 1,
+                    failed_attempts: std::mem::take(&mut failed_attempts),
                     session_id,
                 },
             )));

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -73,10 +73,13 @@ pub struct MiddlewareForwarded {
     pub upstream_status: u16,
     pub upstream_body: Vec<u8>,
     pub upstream_headers: std::collections::HashMap<String, String>,
-    /// Which route served the request, how many routes were tried, and the
-    /// attested session id (if any) — returned to the caller as headers.
+    /// Which route served the request and the attested session id (if any) —
+    /// returned to the caller as headers.
     pub selected_route: String,
-    pub attempts: usize,
+    /// Failed-over candidates as (route_id, status), in the order tried. The
+    /// committed route is `selected_route`; these are surfaced so the caller can
+    /// observe every attempt, not just the one that served the response.
+    pub failed_attempts: Vec<(String, u16)>,
     pub session_id: Option<String>,
 }
 
@@ -85,10 +88,13 @@ pub struct MiddlewareStreamingForwarded {
     pub upstream_status: u16,
     pub upstream_headers: std::collections::HashMap<String, String>,
     pub body: ServiceResponseStream,
-    /// Which route served the request, how many routes were tried, and the
-    /// attested session id (if any) — returned to the caller as headers.
+    /// Which route served the request and the attested session id (if any) —
+    /// returned to the caller as headers.
     pub selected_route: String,
-    pub attempts: usize,
+    /// Failed-over candidates as (route_id, status), in the order tried. The
+    /// committed route is `selected_route`; these are surfaced so the caller can
+    /// observe every attempt, not just the one that served the response.
+    pub failed_attempts: Vec<(String, u16)>,
     pub session_id: Option<String>,
 }
 

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -217,7 +217,7 @@ pub(super) async fn internal_forward(
             insert_attribution_headers(
                 &mut resp_headers,
                 &forward.selected_route,
-                forward.attempts,
+                &forward.failed_attempts,
                 forward.session_id.as_deref(),
             );
             let status = StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
@@ -242,7 +242,7 @@ pub(super) async fn internal_forward(
             insert_attribution_headers(
                 &mut resp_headers,
                 &forward.selected_route,
-                forward.attempts,
+                &forward.failed_attempts,
                 forward.session_id.as_deref(),
             );
             let status = StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -157,7 +157,7 @@ pub(super) fn build_forward_candidates(
 pub(super) fn insert_attribution_headers(
     headers: &mut HeaderMap,
     selected_route: &str,
-    attempts: usize,
+    failed_attempts: &[(String, u16)],
     session_id: Option<&str>,
 ) {
     if let Ok(value) = HeaderValue::from_str(selected_route) {
@@ -166,11 +166,20 @@ pub(super) fn insert_attribution_headers(
             value,
         );
     }
-    if let Ok(value) = HeaderValue::from_str(&attempts.to_string()) {
-        headers.insert(
-            HeaderName::from_static("x-private-ai-gateway-attempts"),
-            value,
-        );
+    // Failed-over candidates as `route_id=status`, comma-separated in the order
+    // tried. Route ids and statuses are ASCII; `,`/`=` are valid header bytes.
+    if !failed_attempts.is_empty() {
+        let encoded = failed_attempts
+            .iter()
+            .map(|(route, status)| format!("{route}={status}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        if let Ok(value) = HeaderValue::from_str(&encoded) {
+            headers.insert(
+                HeaderName::from_static("x-private-ai-gateway-failed-attempts"),
+                value,
+            );
+        }
     }
     if let Some(session_id) = session_id {
         if let Ok(value) = HeaderValue::from_str(session_id) {

--- a/tests/aggregator_scenarios.rs
+++ b/tests/aggregator_scenarios.rs
@@ -1811,9 +1811,12 @@ async fn failover_advances_to_next_candidate_on_provider_error() {
         header_str(&response.headers, "x-private-ai-gateway-selected-route"),
         "upstream-b:public-b"
     );
+    // The failed-over candidate is surfaced (route=status) so the caller can
+    // record a per-attempt request_log for deployment health metrics. Its
+    // presence (one entry) also conveys that two routes were tried.
     assert_eq!(
-        header_str(&response.headers, "x-private-ai-gateway-attempts"),
-        "2"
+        header_str(&response.headers, "x-private-ai-gateway-failed-attempts"),
+        "upstream-a:public-a=503"
     );
 
     let draft = journal.take().expect("receipt draft");


### PR DESCRIPTION
## What

Two gaps in what the forwarder reports to the caller:

1. **Failed-over attempts were invisible.** The forwarder tries candidates in order but only reported the committed route, so any candidate that failed and was failed-over-from produced no usage report at all — the caller (and anything built on its usage reports) only ever saw the route that succeeded.

2. **TTFT was never populated.** Streaming responses carried no time-to-first-token.

## Changes

- **Backend (`middleware.rs`/`wire.rs`/`util.rs`/`backend.rs`)**: accumulate each failed-over candidate as `(route_id, status)` during the failover loop (HTTP failures use the real status; prepare/verification/transport failures use 502) and surface them via a new `x-private-ai-gateway-failed-attempts` response header (`route_id=status`, comma-separated, in order tried). This **replaces** the `x-private-ai-gateway-attempts` count header, which nothing consumed and which is derivable from this list.
- **Executor (`handlers.ts`)**: parse the header and emit one usage report per failed attempt (no usage payload, since a failed attempt produced no response body).
- **Executor (`cost.ts`/`handlers.ts`)**: measure time-to-first-token on streaming responses (first chunk out of the upstream stream, relative to request start) and pass it through in the usage report.

## Test plan

- `cargo check` / `cargo check --tests` clean
- Rust integration tests pass (`aggregator_scenarios`, `forward_binding_reverify`); extended `failover_advances_to_next_candidate_on_provider_error` to assert the new header
- Executor `tsc --noEmit` clean; `npm test` 43/43 passing (added a TTFT assertion to the streaming meter test)