### PR TITLE
fix: use jemalloc to bound resident memory under allocation churn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,6 +3244,7 @@ dependencies = [
  "sha2",
  "sha3 0.10.9",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tracing",
@@ -4386,6 +4387,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,14 @@ async-trait = "0.1"
 # Upstream ACI/DCAP verification.
 dcap-qvl = { version = "0.3.12", default-features = false, features = ["std", "report", "rustcrypto"] }
 
+# Global allocator. The gateway churns large attestation-evidence allocations
+# across every worker thread; glibc malloc grows per-arena 64 MiB sub-heaps and
+# holds them resident instead of returning freed pages, so RSS climbs without
+# bound. jemalloc returns memory to the OS and resists that fragmentation.
+# Skipped only on MSVC (no jemalloc); the binary's targets are unix.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,43 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+// Run on jemalloc instead of glibc malloc: the gateway churns large
+// attestation-evidence buffers across every worker thread, and glibc grows
+// per-arena 64 MiB sub-heaps and holds them resident, so RSS climbs without
+// bound while the live set stays small. jemalloc returns freed pages to the OS
+// and fragments far less. Every unix target has it; only MSVC lacks it.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Run a background purge thread so even idle arenas return freed pages to the
+// OS on jemalloc's default decay schedule. Decay windows are left at the
+// defaults: the goal is to return memory, not to churn it — short windows would
+// purge then re-fault the gateway's repeated large allocations. Production
+// glibc-Linux only; the background thread is unavailable on musl, and other
+// targets keep jemalloc's defaults (which return memory, just without a
+// dedicated purge thread).
+//
+// The symbol is jemalloc's `const char *_rjem_malloc_conf`, so it must be a thin
+// pointer to a NUL-terminated string: `&b"…\0"[0]` is that `&'static u8`, and the
+// union reinterprets it as `&c_char`. A plain `&[u8]` is a fat pointer — wrong ABI.
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+union MallocConfPtr {
+    bytes: &'static u8,
+    c_char: &'static core::ffi::c_char,
+}
+
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[used]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
+pub static malloc_conf: Option<&'static core::ffi::c_char> = Some(unsafe {
+    MallocConfPtr {
+        bytes: &b"background_thread:true\0"[0],
+    }
+    .c_char
+});
+
 use private_ai_gateway::aci::keys::{KeyProvider, Quoter};
 use private_ai_gateway::aci::types::{KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki};
 use private_ai_gateway::aci::upstream::{


### PR DESCRIPTION
## Problem

The gateway allocates and frees large attestation-evidence buffers (multi-megabyte base64 blobs and their parsed JSON trees) across all worker threads. Under that pattern **glibc malloc grows per-arena 64 MiB sub-heaps and keeps them resident** once any live chunk pins one, so resident memory grows over time even though the live working set stays small — the usual glibc arena-fragmentation profile for a long-running multithreaded server. The retained memory is not live data and not a reference leak; it is freed-but-unreturned arena space.

## Fix

Switch the global allocator to **jemalloc** (`tikv-jemallocator`), which returns freed pages to the OS and fragments far less. On glibc Linux, run a background purge thread via `_rjem_malloc_conf` so even idle arenas are reclaimed.

Decay windows are deliberately left at jemalloc's defaults (not shortened): the goal is to return memory, and very short windows would purge then re-fault the gateway's repeated large allocations. `background_thread:true` alone is what guarantees idle arenas get purged.

Two non-obvious details (both caught in review):

- **ABI**: jemalloc declares the config symbol as `const char *_rjem_malloc_conf` (a *thin* pointer). The override is built via a `union` reinterpreting `&b"…\0"[0]` (`&'static u8`) as `&c_char`, exactly as the crate's own tests do (`tikv-jemalloc-sys/tests/malloc_conf_set.rs`). A plain `&[u8]` is a 16-byte fat pointer — wrong ABI.
- **Platform gate**: `background_thread` is restricted to glibc Linux. The jemalloc background thread is unavailable on musl, and there is no runtime guard resetting `opt_background_thread`, so enabling it on an unsupported build is undefined. Other targets keep jemalloc defaults (still return memory, just without a dedicated purge thread).

## Verification

- `cargo build` / `cargo clippy --all-targets` clean; lib tests pass.
- jemalloc linked as the global allocator and `_rjem_malloc_conf` present in the binary (verified via `nm`).
- Runtime effect (resident memory plateauing instead of climbing) is validated on the glibc-Linux deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)