### PR TITLE
fix: stop embedding upstream evidence in receipts

### DIFF
--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -138,6 +138,13 @@ impl TransparencyEventKind {
 
 impl UpstreamVerifiedEvent {
     fn to_fields(&self) -> Value {
+        // `evidence` is never inlined in a receipt. It can be large, and the
+        // receipt store keeps every receipt for the receipt TTL, so inlining it
+        // would let that store grow with traffic. Its system of record is the
+        // attested session: a verified receipt commits to the evidence through
+        // the content-addressed `session_id` (a deep audit re-fetches it from the
+        // session store). A failed or unbound verification has no session, so its
+        // evidence is not retained here either — `reason` records why it failed.
         serde_json::json!({
             "upstream_name": self.upstream_name,
             "provider": self.provider,
@@ -147,7 +154,6 @@ impl UpstreamVerifiedEvent {
             "result": self.result.as_str(),
             "required": self.required,
             "reason": self.reason,
-            "evidence": self.evidence.clone(),
             "channel_bindings": self.channel_bindings,
             "provider_claims": self.provider_claims.clone(),
         })

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -284,6 +284,15 @@ async fn verified_upstream_binding_creates_attested_session() {
     assert_eq!(receipt_claims["tee_attested"]["source"], "verifier_derived");
     assert_eq!(receipt_claims["tcb_up_to_date"]["status"], "unknown");
 
+    // The receipt must NOT inline the (potentially large) evidence: the
+    // content-addressed session_id commits to it, and the session store is its
+    // system of record. Inlining it in every retained receipt is what grew the
+    // in-memory receipt store under load.
+    assert!(
+        uv.fields.get("evidence").is_none(),
+        "verified receipt must reference evidence via session_id, not inline it"
+    );
+
     // Deep audit: the persisted session carries the same verdicts plus evidence.
     let session_claims = serde_json::to_value(&session.claims).unwrap();
     assert_eq!(session_claims["tee_attested"]["status"], "asserted");


### PR DESCRIPTION
## Problem

`UpstreamVerifiedEvent::to_fields()` inlined the full attestation `evidence` into the receipt's `upstream.verified` event. The `InMemoryReceiptStore` keeps every receipt for the receipt TTL, so each retained receipt held a copy of the (potentially multi-megabyte) evidence — a duplicate of what the attested session already stores. The receipt store therefore grew with request volume. This memory is genuinely live (receipts are queryable for their TTL), so it cannot be reclaimed by the allocator — the evidence must not be stored there in the first place.

## Fix

Stop inlining `evidence` in receipts entirely (both the verified and the no-session/failed paths). The evidence's system of record is the attested **session**:

- A **verified** receipt commits to the evidence through the content-addressed `session_id` (already present); a deep audit re-fetches it from the session store.
- A **failed/unbound** verification has no session, so its evidence is not retained in the receipt either — the `reason` field records why it failed.

Receipts now carry ids, hashes, channel bindings, and typed claim verdicts. The store stays bounded regardless of the success/failure mix.

### Receipt format note (behavioral change)

The `upstream.verified` event no longer contains an `evidence` field on **any** receipt. Consumers that need the evidence follow `session_id` → `GET /v1/aci/sessions/:session_id`, which returns the full session including `evidence` (`{digest, data}`); `session_id` is a content hash committing to the evidence digest, so it stays verifiable. The chat-completion responses themselves are unchanged — this only affects the receipt audit artifact (`/v1/aci/receipts/:id`, `/v1/signature/:chat_id`).

## Verification

- `cargo build` / `cargo clippy --all-targets` clean; lib + integration suites pass.
- Added an assertion to `verified_upstream_binding_creates_attested_session` that a verified receipt does not inline `evidence` (existing assertions confirm the session still carries it, reachable by `session_id`). The existing non-TEE test already asserts the no-session path carries no evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)