### PR TITLE
fix: add permissive CORS so browser clients can call the gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "webpki-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ webpki-roots = "1"
 axum = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net", "process", "io-util", "time"] }
 tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }
 futures-util = "0.3"
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio", "service"] }

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -80,6 +80,7 @@ use hyper::server::conn::http1::Builder as HyperHttp1Builder;
 use hyper_util::{rt::TokioIo, service::TowerToHyperService};
 use tokio::net::UnixListener;
 use tower::ServiceExt as _;
+use tower_http::cors::CorsLayer;
 
 use crate::aggregator::service::{
     AciService, E2eeRequestContext, MiddlewareReceiptJournal, ReceiptOwner,
@@ -287,6 +288,10 @@ fn build_router_inner(
             state.clone(),
             aci_headers_middleware,
         ))
+        // Permissive CORS so browser clients can call the gateway directly.
+        // Outermost layer: it answers preflight OPTIONS before routing, which
+        // otherwise 405s since the routes only declare GET/POST/PUT.
+        .layer(CorsLayer::permissive())
         .with_state(state)
 }
 


### PR DESCRIPTION
## Problem

Browser clients calling the new gateway hit:

> Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.

The axum router only declares `GET`/`POST`/`PUT` handlers, so preflight `OPTIONS` requests returned `405` with no CORS headers. The old gateway (`redpill-gateway`) avoided this with Hono's global `app.use('*', cors())`.

## Fix

Add an outermost `tower_http::cors::CorsLayer::permissive()` to the public router:

- Answers preflight `OPTIONS` before routing (otherwise 405, since no OPTIONS handlers exist).
- Stamps `Access-Control-Allow-Origin: *` on every response.
- Mirrors the old gateway's permissive `cors()` semantics (`*` origin, no credentials).

Layer ordering puts CORS outside `aci_headers_middleware`, so the `X-ACI-*` headers are still emitted and the two don't conflict.

## Verification

- `cargo build` and `cargo clippy` clean.
- No existing tests depend on the old OPTIONS/405 behavior.
- Confirmed at runtime via a throwaway oneshot test (removed to keep the diff minimal):
  - `OPTIONS /v1/chat/completions` → `200` with `Access-Control-Allow-Origin: *`, `Allow-Methods`, `Allow-Headers`.
  - `GET /` → response carries `Access-Control-Allow-Origin: *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)