### PR TITLE
fix: close pinned upstream connections instead of leaking them to CLOSE_WAIT

### DIFF
--- a/src/aci/upstream/tls.rs
+++ b/src/aci/upstream/tls.rs
@@ -47,6 +47,13 @@ pub(super) fn pinned_spki_client(
         .connect_timeout(Duration::from_secs(connect_timeout_seconds))
         .read_timeout(Duration::from_secs(read_timeout_seconds))
         .use_preconfigured_tls(tls)
+        // This client is rebuilt per verified request (the SPKI pin comes from
+        // the request's channel binding) and used once. Disable idle keep-alive:
+        // otherwise the single-use connection is parked in this short-lived
+        // client's pool and then orphaned when the client drops at end of
+        // request, lingering in CLOSE_WAIT once the upstream closes it. With no
+        // idle pool the connection is closed as soon as the response completes.
+        .pool_max_idle_per_host(0)
         .build()
         .map_err(|e| UpstreamError::Transport(e.to_string()))
 }


### PR DESCRIPTION
## Problem

The gateway accumulates half-closed upstream sockets in **CLOSE_WAIT** (peer sent FIN, we never close), to provider `:443` endpoints. They are owned by the gateway process and grow over time, holding kernel socket memory (TCP buffers + slab) and file descriptors — the latter previously caused EMFILE crashes.

Root cause: the pinned-TLS upstream client is **rebuilt per verified request**. The SPKI pin comes from the request's channel binding, so `client_for_event()` (`openai.rs`) calls `pinned_spki_client()` (`tls.rs`) for every verified forward (`forward_verified_prepared` / `forward_stream_verified_prepared`). That fresh `reqwest::Client` has reqwest's default keep-alive pool, so the single-use connection is parked in the client's idle pool and then **orphaned when the client is dropped at the end of the request**. When the upstream later closes its side, the orphaned connection sits in CLOSE_WAIT and never gets closed.

## Fix

Disable the idle pool on the pinned client (`pool_max_idle_per_host(0)`) so the connection is closed as soon as the response completes, instead of being parked idle and orphaned. The pinned client was already single-use (a fresh one per request), so this removes **no** connection reuse — it only stops the leak.

## Verification

- `cargo build` / `cargo clippy --lib` / `cargo fmt --check` clean; upstream tests pass.
- The pinned client is the per-request one whose connections were attributed (via fd→inode) to the gateway process and the CLOSE_WAIT-to-:443 sockets.

## Follow-up (not in this PR)

The deeper inefficiency is that a fresh pinned client + TLS handshake is built **per request** (also a CPU cost). A follow-up could cache pinned clients keyed by their SPKI pin-set (stable per channel) with bounded pool config, enabling connection reuse and cutting per-request handshakes. This PR is the minimal, no-regression leak stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)