### PR TITLE
fix: reap downstream-stalled streaming forwards to release upstream connections

### DIFF
--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -92,6 +92,7 @@ mod error_responses;
 mod handlers;
 mod proxy;
 mod util;
+mod write_idle_timeout;
 
 use backend::internal_forward;
 use handlers::{
@@ -359,8 +360,15 @@ pub async fn serve_unix_listener(
             .map_request(|request: hyper::Request<Incoming>| request.map(Body::new));
         tokio::spawn(async move {
             let hyper_service = TowerToHyperService::new(service);
+            // Wrap the connection so a downstream that stalls without closing
+            // (and would otherwise pin a streaming forward's upstream connection
+            // open forever) is reaped after a long no-write-progress window.
+            let io = TokioIo::new(write_idle_timeout::WriteIdleTimeout::new(
+                stream,
+                write_idle_timeout::DOWNSTREAM_WRITE_IDLE_TIMEOUT,
+            ));
             if let Err(err) = HyperHttp1Builder::new()
-                .serve_connection(TokioIo::new(stream), hyper_service)
+                .serve_connection(io, hyper_service)
                 .await
             {
                 tracing::debug!(error = %err, "Unix-socket HTTP connection closed");

--- a/src/http/app/write_idle_timeout.rs
+++ b/src/http/app/write_idle_timeout.rs
@@ -1,0 +1,162 @@
+//! Downstream write-idle timeout for served connections.
+//!
+//! A streaming forward holds the upstream connection open while it pumps the
+//! response to the downstream. If the downstream stops reading (its TCP/UDS
+//! receive side is not drained — e.g. a client or middleware that stalls without
+//! closing), the serving connection's write blocks, the response body stops
+//! being polled, and the upstream connection is held indefinitely (eventually
+//! `CLOSE_WAIT`, leaking sockets and kernel memory). Hyper only learns of a
+//! *closed* downstream; a stalled-open one has no signal.
+//!
+//! [`WriteIdleTimeout`] wraps the downstream IO and fails a write that stays
+//! pending past `idle`. The error tears the connection down, which drops the
+//! response body and with it the upstream stream — closing the upstream
+//! connection. The timeout lives in the IO layer (which hyper always polls),
+//! not in the body's poll chain (which a stalled downstream never polls).
+//!
+//! It is a no-progress timeout, not a total one: any accepted write resets it,
+//! so a long but flowing stream (a slow LLM that keeps emitting) is never cut —
+//! only a downstream that accepts nothing for `idle` is.
+
+use std::future::Future;
+use std::io::{self, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::{sleep, Sleep};
+
+/// How long a downstream write may make no progress before the connection is
+/// torn down. Generous on purpose: legitimate streams keep flowing well under
+/// this, so it only reaps genuinely stalled downstreams. Matches the upstream
+/// read timeout order of magnitude.
+pub(super) const DOWNSTREAM_WRITE_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+pub(super) struct WriteIdleTimeout<IO> {
+    inner: IO,
+    idle: Duration,
+    timer: Option<Pin<Box<Sleep>>>,
+}
+
+impl<IO> WriteIdleTimeout<IO> {
+    pub(super) fn new(inner: IO, idle: Duration) -> Self {
+        Self {
+            inner,
+            idle,
+            timer: None,
+        }
+    }
+
+    /// Called while the inner write is pending. Arms (once) and polls the idle
+    /// timer; fires a `TimedOut` error if it elapses. Generic in the success
+    /// type so both `poll_write` (`usize`) and the vectored variant can reuse it.
+    fn poll_idle<T>(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<T>> {
+        let idle = self.idle;
+        let timer = self.timer.get_or_insert_with(|| Box::pin(sleep(idle)));
+        match timer.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                self.timer = None;
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "downstream write idle timeout",
+                )))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<IO: AsyncRead + Unpin> AsyncRead for WriteIdleTimeout<IO> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<IO: AsyncWrite + Unpin> AsyncWrite for WriteIdleTimeout<IO> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write(cx, buf) {
+            Poll::Ready(r) => {
+                self.timer = None;
+                Poll::Ready(r)
+            }
+            Poll::Pending => self.poll_idle(cx),
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write_vectored(cx, bufs) {
+            Poll::Ready(r) => {
+                self.timer = None;
+                Poll::Ready(r)
+            }
+            Poll::Pending => self.poll_idle(cx),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use tokio::io::AsyncWriteExt;
+
+    /// An IO whose writes never make progress — models a downstream that has
+    /// stopped reading.
+    struct StalledIo;
+    impl AsyncRead for StalledIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+    impl AsyncWrite for StalledIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_write_times_out_after_idle() {
+        let mut io = WriteIdleTimeout::new(StalledIo, Duration::from_secs(600));
+        let err = io.write(b"hello").await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+}


### PR DESCRIPTION
## Problem

The gateway accumulates half-closed upstream sockets in **CLOSE_WAIT** to provider `:443` endpoints — owned by the gateway process, growing, never reaped. They hold kernel socket memory (TCP receive buffers + slab) and file descriptors (which previously caused EMFILE crashes).

Read-only inspection of the live sockets showed **every** CLOSE_WAIT had a **non-empty receive queue** (mostly >16 KB of unread upstream data). So these are not idle pooled connections — they are **abandoned/stalled in-flight responses**: the gateway received upstream data and stopped reading it.

Root cause: a streaming forward (`/internal/forward`, served over a Unix socket and consumed by the executor) holds its upstream connection open while pumping the response downstream. The serving path is poll-driven by hyper. If the downstream stops reading **without closing** (a client or the middleware stalling under backpressure), hyper's response write blocks, the body stops being polled, the gateway stops reading the upstream, its data backs up in the socket, the upstream eventually FINs → CLOSE_WAIT, and with **no timeout anywhere**, the stalled forward and its upstream connection live forever.

Hyper detects a *closed* downstream (and tears the request down), but not a *stalled-open* one. A timeout in the body's poll chain can't help either: while the write is blocked, the body chain is never polled.

## Fix

Wrap each served connection's IO with `WriteIdleTimeout` (in `serve_unix_listener`, which serves the internal backend). A write that makes no progress for `DOWNSTREAM_WRITE_IDLE_TIMEOUT` (600 s) returns an error → hyper tears the connection down → the response body and the upstream stream are dropped → the upstream connection closes.

The timeout sits in the **IO layer**, which hyper always polls (even when the body chain isn't), and it **resets on any accepted write**, so it is a no-progress timeout, not a total one:
- A long but flowing stream (a slow model that keeps emitting tokens, with the client reading) never stalls a write → never cut.
- Only a downstream that accepts **nothing** for the full window is reaped.

### Why 600 s

Matches the LLM-appropriate scale used by the prior gateway (its request timeout default was 600 s) and the existing upstream read-timeout order of magnitude. Reaping a stalled connection after 600 s turns an unbounded leak into a bounded one (stalled connections live at most ~600 s) with no risk to legitimate slow streams.

## Verification

- Reproduced the leak and validated the fix in a standalone program using the **exact gateway serving model** (`hyper http1::serve_connection(TokioIo::new(io), svc)` + a `reqwest` `bytes_stream` body): with a client that reads a little then stalls, the upstream connection is held open forever on baseline, and dropped right after the idle window with the `WriteIdleTimeout` IO wrapper.
- Unit test (`stalled_write_times_out_after_idle`, paused-time) asserts a write that never makes progress returns `TimedOut` after the idle window.
- `cargo build` / `cargo clippy --lib` / `cargo fmt --check` clean; full lib + http/service integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)