### PR TITLE
Sign legacy ECDSA responses with the E2EE key (fix E2EE signature mismatch)

### DIFF
--- a/src/dstack.rs
+++ b/src/dstack.rs
@@ -388,9 +388,12 @@ impl KeyProvider for DstackAciProvider {
     ) -> Result<LegacySignature, KeyError> {
         match signing_algo {
             LEGACY_ALGO_ECDSA => {
+                // Legacy clients use one secp256k1 key (the E2EE key) for both
+                // encryption and response signing, and verify against the
+                // attestation `signing_address` (also the E2EE key) — sign with it.
+                let signing_key = K256SigningKey::from(&self.e2ee);
                 let prehash = ethereum_personal_message_hash(text);
-                let (sig, recid): (K256Signature, RecoveryId) = self
-                    .receipt
+                let (sig, recid): (K256Signature, RecoveryId) = signing_key
                     .sign_prehash_recoverable(&prehash)
                     .map_err(|e| KeyError::Crypto(format!("k256 legacy sign_prehash: {e}")))?;
                 let mut out = Vec::with_capacity(65);
@@ -399,7 +402,7 @@ impl KeyProvider for DstackAciProvider {
                 Ok(LegacySignature {
                     signing_algo: LEGACY_ALGO_ECDSA.to_string(),
                     signing_address: ethereum_address_from_uncompressed_public_key(
-                        &public_key_hex(&self.receipt),
+                        &public_key_from_secret(&self.e2ee),
                     )?,
                     signature: format!("0x{}", hex::encode(out)),
                 })

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -193,9 +193,10 @@ impl KeyProvider for StaticKeyProvider {
     ) -> Result<LegacySignature, KeyError> {
         match signing_algo {
             LEGACY_ALGO_ECDSA => {
+                // Mirror production: legacy ECDSA signs with the E2EE key.
+                let signing_key = K256SigningKey::from(&self.e2ee);
                 let prehash = ethereum_personal_message_hash(text);
-                let (sig, recid): (K256Signature, RecoveryId) = self
-                    .receipt
+                let (sig, recid): (K256Signature, RecoveryId) = signing_key
                     .sign_prehash_recoverable(&prehash)
                     .map_err(|e| KeyError::Crypto(format!("k256 legacy sign_prehash: {e}")))?;
                 let mut out = Vec::with_capacity(65);
@@ -204,7 +205,7 @@ impl KeyProvider for StaticKeyProvider {
                 Ok(LegacySignature {
                     signing_algo: LEGACY_ALGO_ECDSA.to_string(),
                     signing_address: ethereum_address_from_uncompressed_public_key(
-                        &public_key_hex(&self.receipt),
+                        &public_key_from_secret(&self.e2ee),
                     )?,
                     signature: format!("0x{}", hex::encode(out)),
                 })

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -1014,3 +1014,49 @@ async fn attestation_report_chutes_multi_instance_shape() {
     assert_eq!(entries[0]["intel_quote"], "cXVvdGUtYjY0");
     assert!(entries[0]["gpu_evidence"].is_array());
 }
+
+#[test]
+fn legacy_ecdsa_signature_uses_the_e2ee_signing_address() {
+    // Regression: the legacy ECDSA signature must actually be produced by the
+    // E2EE key (the attestation signing_address), not the receipt key. We
+    // recover the signer from the signature itself — asserting only the
+    // returned signing_address field would still pass if the code signed with
+    // the wrong key and merely relabeled the field.
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use private_ai_gateway::aci::e2ee::E2EE_ALGO_SECP256K1_AESGCM;
+    use private_ai_gateway::aci::keys::{
+        ethereum_address_from_uncompressed_public_key, LEGACY_ALGO_ECDSA,
+    };
+    use sha3::{Digest, Keccak256};
+
+    let keys = StaticKeyProvider::default();
+    let e2ee = keys
+        .e2ee_keys()
+        .into_iter()
+        .find(|k| k.algo == E2EE_ALGO_SECP256K1_AESGCM)
+        .expect("secp256k1 e2ee key");
+    let expected = ethereum_address_from_uncompressed_public_key(&e2ee.public_key_hex).unwrap();
+
+    let text = "hello";
+    let sig = keys.sign_legacy_message(LEGACY_ALGO_ECDSA, text).unwrap();
+    assert_eq!(sig.signing_address.to_lowercase(), expected.to_lowercase());
+
+    // Recover the actual signer from `signature` over the Ethereum
+    // personal-message hash and confirm it is the E2EE key.
+    let sig_bytes = hex::decode(sig.signature.trim_start_matches("0x")).unwrap();
+    assert_eq!(sig_bytes.len(), 65, "r || s || v");
+    let recid = RecoveryId::from_byte(sig_bytes[64] - 27).expect("recovery id");
+    let signature = Signature::from_slice(&sig_bytes[..64]).unwrap();
+    let prehash =
+        Keccak256::digest(format!("\x19Ethereum Signed Message:\n{}{text}", text.len()).as_bytes());
+    let recovered = VerifyingKey::recover_from_prehash(&prehash, &signature, recid).unwrap();
+    let recovered_addr = ethereum_address_from_uncompressed_public_key(&hex::encode(
+        recovered.to_encoded_point(false).as_bytes(),
+    ))
+    .unwrap();
+    assert_eq!(
+        recovered_addr.to_lowercase(),
+        expected.to_lowercase(),
+        "legacy ecdsa signature must recover to the E2EE signing_address"
+    );
+}


### PR DESCRIPTION
## Problem

E2EE chat against `phala/gemma-4-26b-a4b-uncensored` failed with:

```
Recovered signer address ffb22d95… does not match expected signing address 79a5061e…
```

- `0x79a5061e` = the gateway's **E2EE secp256k1 key** (`dstack-kms-e2ee-v1`) — what the attestation report advertises as `signing_address` and what the client encrypts to.
- `0xffb22d95` = the gateway's **receipt key** (`dstack-kms-receipt-v1`).

`sign_legacy_message` (the dstack-vllm-proxy compatibility signature, used by `/v1/signature/{id}` and verified after E2EE chat) signed the ECDSA message with the **receipt key**, while the attestation advertises the **E2EE key**. The legacy dstack-vllm-proxy contract uses a single secp256k1 key for both encryption and response signing, so clients recover the signer and compare it to the attestation `signing_address` → mismatch.

## Fix

Sign the legacy ECDSA message with the **E2EE key**, so the recovered signer equals the advertised `signing_address` (and the key the client encrypts to). `ed25519` already signed with its own key and is unchanged. The ACI receipt signing (`sign_receipt`) is unrelated and untouched.

Adds a regression test asserting the legacy ECDSA signer equals the E2EE `signing_address` — the cross-check that was missing.

Not introduced by the attestation-compat PR (#36); this is a pre-existing key conflation in the legacy signing path that surfaced once clients verified against the gateway's attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)