### PR TITLE
Add /health liveness endpoint

### DIFF
--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -62,6 +62,12 @@ pub(super) struct SessionListQuery {
     model: Option<String>,
 }
 
+// Liveness probe for load balancers and orchestrators. Unauthenticated and
+// version-independent: it reports only that the process is serving requests.
+pub(super) async fn health() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}
+
 pub(super) async fn root(State(state): State<AppState>) -> Json<Value> {
     Json(json!({
         "api_version": "aci/1",

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -27,6 +27,8 @@
 //!   middleware only.
 //! * `GET  /v1/embeddings/models` - embedding model catalog (control-plane
 //!   middleware only).
+//! * `GET  /health` - unauthenticated liveness probe for load balancers and
+//!   orchestrators; reports only that the process is serving requests.
 //! * `GET  /v1/metrics` - expose aggregator-owned Prometheus metrics.
 //! * `GET  /v1/admin/upstreams` - authenticated admin view of the
 //!   current upstream config, with secrets redacted.
@@ -98,8 +100,8 @@ use backend::internal_forward;
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
     admin_put_upstreams, attestation_report, attested_session, chat_completions, completions,
-    embeddings, embeddings_models, messages, metrics, models, models_subpath, receipt_by_chat_id,
-    responses, root,
+    embeddings, embeddings_models, health, messages, metrics, models, models_subpath,
+    receipt_by_chat_id, responses, root,
 };
 
 #[derive(Clone)]
@@ -261,6 +263,7 @@ fn build_router_inner(
     };
     Router::new()
         .route("/", get(root))
+        .route("/health", get(health))
         // OpenAI- and Anthropic-compatible inference surface.
         .route("/v1/models", get(models))
         .route("/v1/models/*rest", get(models_subpath))

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -125,6 +125,25 @@ async fn body_bytes(b: Body) -> Vec<u8> {
 }
 
 #[tokio::test]
+async fn health_endpoint_reports_ok() {
+    let h = make_harness();
+    let app = build_router(h.service.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    assert_eq!(body, serde_json::json!({ "status": "ok" }));
+}
+
+#[tokio::test]
 async fn attestation_report_endpoint_shape() {
     let h = make_harness();
     let app = build_router(h.service.clone());


### PR DESCRIPTION
Adds an unauthenticated `GET /health` endpoint that returns `{ "status": "ok" }`, so load balancers and orchestrators can probe the gateway without touching the authenticated or attestation surfaces.

- Handler in `src/http/app/handlers.rs`, route registered in `build_router_inner`.
- Version-independent path (`/health`, not under `/v1/`) since it's infrastructure, not part of the API surface.
- Test in `tests/http.rs` driving the router via `oneshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)