### PR TITLE
Unify Chutes /v1/attestation/report to the standard report shape

### DIFF
--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use ml_kem::ml_kem_768::DecapsulationKey as MlKemDecapsulationKey768;
-use rand::RngCore;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -439,44 +438,45 @@ impl UpstreamBackend for ChutesProviderBackend {
         self.inner.models().await
     }
 
-    /// Legacy dstack/chutes-compatible attestation report. The gateway cannot
-    /// produce the per-instance TDX quote + GPU evidence itself, so it generates
-    /// a fresh nonce, fetches the live per-instance evidence and E2EE public keys
-    /// from Chutes, and assembles the old multi-instance shape:
-    /// `{ attestation_type, nonce, all_attestations: [{instance_id, nonce,
-    /// e2e_pubkey, intel_quote, gpu_evidence}] }`. The nonce is server-generated
-    /// (clients verify the GPU evidence against the returned nonce).
-    async fn chutes_attestation_report(&self, model: &str) -> Result<Value, UpstreamError> {
+    /// Fetch the Chutes GPU evidence bound to `nonce` and shape it as the legacy
+    /// `nvidia_payload` so the gateway can merge it into its own attestation
+    /// report (same shape as every other provider).
+    async fn chutes_nvidia_payload(
+        &self,
+        model: &str,
+        nonce: &str,
+    ) -> Result<Value, UpstreamError> {
         let api_key = self.api_key()?;
         let chute_id = self.resolve_chute_id(model, &api_key).await?;
-        let nonce = random_nonce_hex();
-        let pubkeys: HashMap<String, String> = self
-            .fetch_instances(&chute_id, &api_key)
-            .await?
-            .instances
+        let evidence = self.fetch_evidence(&chute_id, nonce, &api_key).await?;
+        // Chutes returns per-instance GPU evidence; the nvidia_payload carries a
+        // single instance's evidence_list (one NRAS verification), matching the
+        // {nonce, evidence_list, arch} shape used by the other providers. Pick the
+        // first instance whose evidence is a non-empty list with a usable arch —
+        // an instance can report empty/malformed evidence, so don't blindly take
+        // the first, and never fabricate a default arch.
+        let (evidence_list, arch) = evidence
             .into_iter()
-            .map(|i| (i.instance_id, i.e2e_pubkey))
-            .collect();
-        let evidence = self.fetch_evidence(&chute_id, &nonce, &api_key).await?;
-
-        let all_attestations: Vec<Value> = evidence
-            .into_iter()
-            .map(|item| {
-                serde_json::json!({
-                    "instance_id": item.instance_id,
-                    "nonce": nonce,
-                    "e2e_pubkey": pubkeys.get(&item.instance_id).cloned(),
-                    "intel_quote": item.quote,
-                    "gpu_evidence": item.gpu_evidence,
-                })
+            .find_map(|item| {
+                let arch = item
+                    .gpu_evidence
+                    .as_array()
+                    .and_then(|list| list.first())
+                    .and_then(|e| e.get("arch"))
+                    .and_then(Value::as_str)
+                    .filter(|arch| !arch.is_empty())?
+                    .to_string();
+                Some((item.gpu_evidence, arch))
             })
-            .collect();
-
-        Ok(serde_json::json!({
-            "attestation_type": "chutes",
+            .ok_or_else(|| {
+                UpstreamError::Routing("chutes returned no usable GPU evidence".to_string())
+            })?;
+        let payload = serde_json::json!({
             "nonce": nonce,
-            "all_attestations": all_attestations,
-        }))
+            "evidence_list": evidence_list,
+            "arch": arch,
+        });
+        Ok(Value::String(payload.to_string()))
     }
 }
 
@@ -520,18 +520,8 @@ struct ChutesEvidenceResponse {
 
 #[derive(Debug, Deserialize)]
 struct ChutesInstanceEvidence {
-    instance_id: String,
-    /// Base64-encoded TDX quote (surfaced as `intel_quote`, verbatim).
-    #[serde(default)]
-    quote: Option<Value>,
     #[serde(default)]
     gpu_evidence: Value,
-}
-
-fn random_nonce_hex() -> String {
-    let mut nonce = [0u8; 32];
-    rand::rngs::OsRng.fill_bytes(&mut nonce);
-    hex::encode(nonce)
 }
 
 #[derive(Debug)]

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -200,12 +200,17 @@ pub trait UpstreamBackend: Send + Sync {
     /// Legacy multi-instance attestation report for `model`, in the old
     /// dstack/chutes shape. Only the Chutes provider supports it; other
     /// backends fail so callers can fall back to the gateway's own report.
-    async fn chutes_attestation_report(
+    /// The legacy `nvidia_payload` (a JSON string) for `model`, sourced from the
+    /// Chutes GPU evidence bound to `nonce`. Only the Chutes provider implements
+    /// it; the gateway merges the result into its own attestation report so
+    /// Chutes returns the same shape as the other providers.
+    async fn chutes_nvidia_payload(
         &self,
         _model: &str,
+        _nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
         Err(UpstreamError::Routing(format!(
-            "backend {} does not produce a chutes attestation report",
+            "backend {} does not produce chutes GPU evidence",
             self.name()
         )))
     }

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -282,16 +282,17 @@ impl UpstreamBackend for ModelRouterBackend {
         })
     }
 
-    async fn chutes_attestation_report(
+    async fn chutes_nvidia_payload(
         &self,
         model: &str,
+        nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
         let route = self.route_for(model)?;
         // The backend resolves the chute by its own upstream model id, the same
         // value the inference path forwards after rewriting the request model.
         route
             .upstream
-            .chutes_attestation_report(&route.upstream_model_id)
+            .chutes_nvidia_payload(&route.upstream_model_id, nonce)
             .await
     }
 }

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -132,11 +132,12 @@ impl UpstreamBackend for DynamicUpstreamBackend {
             .await
     }
 
-    async fn chutes_attestation_report(
+    async fn chutes_nvidia_payload(
         &self,
         model: &str,
+        nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
-        self.backend().chutes_attestation_report(model).await
+        self.backend().chutes_nvidia_payload(model, nonce).await
     }
 }
 

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -215,25 +215,10 @@ pub(super) async fn attestation_report(
             .and_then(|mgr| mgr.attestation_upstream_target(m))
     });
 
-    // Chutes serves a self-contained multi-instance report from the upstream,
-    // independent of the gateway's own keyset.
-    if let (Some(model), Some(target)) = (model, target.as_ref()) {
-        if target.provider == UpstreamProvider::Chutes {
-            return match state
-                .service
-                .upstream()
-                .chutes_attestation_report(model)
-                .await
-            {
-                Ok(value) => Json(value).into_response(),
-                Err(e) => upstream_proxy_error_response(e),
-            };
-        }
-    }
-
-    // Otherwise (no model, or a non-Chutes provider): the gateway's own report,
-    // enriched with the upstream model node's real GPU evidence when the provider
-    // exposes it (PhalaDirect / NearAi).
+    // Every provider returns the gateway's own report (the gateway terminates
+    // E2EE with its own keys for all of them), enriched with the upstream's real
+    // GPU evidence as nvidia_payload when available — PhalaDirect/NearAi expose it
+    // via their attestation report, Chutes via its per-instance GPU evidence.
     //
     // Effective nonce: the client's, or a freshly generated one when omitted —
     // matching dstack-vllm-proxy, which binds a fresh nonce rather than leaving
@@ -252,12 +237,28 @@ pub(super) async fn attestation_report(
         .await
     {
         Ok(report) => {
-            let nvidia_payload = match target.as_ref() {
-                Some(target) => fetch_upstream_nvidia_payload(target, &nonce)
+            let fetched = match (model, target.as_ref()) {
+                (Some(model), Some(t)) if t.provider == UpstreamProvider::Chutes => match state
+                    .service
+                    .upstream()
+                    .chutes_nvidia_payload(model, &nonce)
                     .await
-                    .unwrap_or_else(|| empty_nvidia_payload(Some(&nonce))),
-                None => empty_nvidia_payload(Some(&nonce)),
+                {
+                    Ok(value) => Some(value),
+                    Err(e) => {
+                        tracing::warn!(
+                            model = %model,
+                            upstream = %t.upstream_name,
+                            error = %e,
+                            "chutes GPU evidence fetch failed; returning report without it"
+                        );
+                        None
+                    }
+                },
+                (_, Some(t)) => fetch_upstream_nvidia_payload(t, &nonce).await,
+                _ => None,
             };
+            let nvidia_payload = fetched.unwrap_or_else(|| empty_nvidia_payload(Some(&nonce)));
             match report_with_legacy_attestation_fields(
                 report,
                 q.signing_algo.as_deref(),

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -974,27 +974,19 @@ async fn attestation_report_degrades_to_empty_nvidia_on_upstream_error() {
     assert_eq!(nvidia["nonce"], TEST_NONCE);
 }
 
-async fn chutes_instances_handler() -> Json<Value> {
-    Json(serde_json::json!({
-        "instances": [{"instance_id": "inst-1", "e2e_pubkey": "pk-1", "nonces": ["n1"]}],
-        "nonce_expires_in": 60,
-    }))
-}
-
 async fn chutes_evidence_handler() -> Json<Value> {
+    // First instance has empty GPU evidence; the report must skip it and use the
+    // first instance with a usable evidence list + arch.
     Json(serde_json::json!({
-        "evidence": [{
-            "instance_id": "inst-1",
-            "quote": "cXVvdGUtYjY0",
-            "gpu_evidence": [{"arch": "HOPPER"}],
-        }]
+        "evidence": [
+            {"instance_id": "inst-0", "gpu_evidence": []},
+            {"instance_id": "inst-1", "gpu_evidence": [{"arch": "HOPPER", "certificate": "c", "evidence": "e"}]},
+        ]
     }))
 }
 
 async fn serve_chutes_stub() -> String {
-    let app = Router::new()
-        .route("/e2e/instances/:chute_id", get(chutes_instances_handler))
-        .route("/chutes/:chute_id/evidence", get(chutes_evidence_handler));
+    let app = Router::new().route("/chutes/:chute_id/evidence", get(chutes_evidence_handler));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -1004,7 +996,10 @@ async fn serve_chutes_stub() -> String {
 }
 
 #[tokio::test]
-async fn attestation_report_chutes_multi_instance_shape() {
+async fn attestation_report_chutes_returns_gateway_report_with_gpu_evidence() {
+    // Chutes returns the same shape as every other provider — the gateway's own
+    // report with the Chutes GPU evidence merged into nvidia_payload — not a
+    // bespoke attestation_type:"chutes" envelope.
     let base = serve_chutes_stub().await;
     let config = format!(
         r#"[{{"name":"chutes-a","provider":"chutes","base_url":"{base}","models":{{"chutes/m":"m-up"}},"bearer_token":"tok","chutes_e2ee_api_base":"{base}","chutes_chute_ids":{{"m-up":"00000000-0000-0000-0000-0000000c1234"}}}}]"#
@@ -1014,7 +1009,7 @@ async fn attestation_report_chutes_multi_instance_shape() {
     let resp = app
         .oneshot(
             Request::builder()
-                .uri("/v1/attestation/report?model=chutes/m")
+                .uri("/v1/attestation/report?model=chutes/m&signing_algo=ecdsa")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1023,15 +1018,24 @@ async fn attestation_report_chutes_multi_instance_shape() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
 
-    assert_eq!(body["attestation_type"], "chutes");
-    let nonce = body["nonce"].as_str().unwrap();
-    let entries = body["all_attestations"].as_array().unwrap();
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0]["instance_id"], "inst-1");
-    assert_eq!(entries[0]["e2e_pubkey"], "pk-1");
-    assert_eq!(entries[0]["nonce"].as_str().unwrap(), nonce);
-    assert_eq!(entries[0]["intel_quote"], "cXVvdGUtYjY0");
-    assert!(entries[0]["gpu_evidence"].is_array());
+    // Standard gateway report shape (consistent with PhalaDirect/NearAi).
+    assert_eq!(body["api_version"], "aci/1");
+    assert!(body.get("attestation_type").is_none());
+    assert!(body["intel_quote"].is_string());
+    assert!(body["signing_address"].is_string());
+
+    // nvidia_payload carries the first usable instance's GPU evidence (the empty
+    // inst-0 is skipped), bound to the report nonce.
+    let nv: Value = serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        nv["evidence_list"],
+        serde_json::json!([{"arch": "HOPPER", "certificate": "c", "evidence": "e"}])
+    );
+    assert_eq!(nv["arch"], "HOPPER");
+    let report_data = body["attestation"]["evidence"]["quote_report_data"]
+        .as_str()
+        .unwrap();
+    assert_eq!(nv["nonce"].as_str().unwrap(), &report_data[64..128]);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

For a Chutes-backed model, `GET /v1/attestation/report?model=<chutes>` returned a bespoke `attestation_type:"chutes"` multi-instance envelope that was **missing the fields every other provider returns** — `intel_quote`, `nvidia_payload`, `signing_address`, and the `aci/1` envelope. Customers saw an inconsistent shape with many fields absent.

## Why it was wrong

The bespoke shape exposed the per-instance `e2e_pubkey`s, on the assumption the client talks E2EE directly to the instances. It doesn't: for Chutes the client encrypts to the **gateway's own E2EE key** (`prepare_e2ee_v2_request` validates against the gateway keyset), the gateway decrypts, then re-encrypts to the instance internally (`build_chutes_e2ee_request`). So the client needs the **gateway's own** attestation report — same as PhalaDirect/NearAi — not the instances'.

## Fix

Route Chutes through the same path as the other providers: the gateway's own report (`intel_quote`, `signing_address`, `aci/1` envelope, `all_attestations`), with the Chutes GPU evidence merged into `nvidia_payload` (bound to the report nonce).

- `UpstreamBackend::chutes_attestation_report(model)` → `chutes_nvidia_payload(model, nonce)`: fetches `/chutes/{id}/evidence?nonce=` and shapes one instance's evidence as `{nonce, evidence_list, arch}`.
- Handler drops the bespoke Chutes branch; Chutes now flows through the standard gateway-report + GPU-merge path.

Result: Chutes returns the **same shape** as PhalaDirect/NearAi.

## Tests

Rewrote the Chutes test to assert the unified shape (`api_version:"aci/1"`, `intel_quote`, `signing_address`, and `nvidia_payload` carrying the Chutes GPU evidence bound to the report nonce). Full suite + clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)