### PR TITLE
Echo the GPU-attested nonce in the Chutes nvidia_payload

### DIFF
--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use futures_util::StreamExt;
 use ml_kem::ml_kem_768::DecapsulationKey as MlKemDecapsulationKey768;
 use serde::Deserialize;
@@ -471,8 +472,16 @@ impl UpstreamBackend for ChutesProviderBackend {
             .ok_or_else(|| {
                 UpstreamError::Routing("chutes returned no usable GPU evidence".to_string())
             })?;
+        // Chutes does not sign the raw request nonce into the GPU report: it binds
+        // the report to a value derived from the request nonce and the instance
+        // E2EE key. NRAS checks the nonce the client submits against the one
+        // actually inside the report, so echo the attested nonce read from the
+        // evidence (not the raw request nonce); otherwise the client's standard
+        // NRAS check fails with "nonce missing in JWT". Report freshness is still
+        // anchored by the gateway quote, which binds the raw request nonce.
+        let report_nonce = gpu_report_nonce(&evidence_list).unwrap_or_else(|| nonce.to_string());
         let payload = serde_json::json!({
-            "nonce": nonce,
+            "nonce": report_nonce,
             "evidence_list": evidence_list,
             "arch": arch,
         });
@@ -522,6 +531,22 @@ struct ChutesEvidenceResponse {
 struct ChutesInstanceEvidence {
     #[serde(default)]
     gpu_evidence: Value,
+}
+
+/// The 32-byte nonce the GPU actually signed into its attestation report, read
+/// straight from the report. NVIDIA's GPU evidence begins with a 4-byte header
+/// followed by the 32-byte nonce (verified against both Hopper and Blackwell
+/// reports); the gateway echoes this exact value so the client's NRAS check
+/// matches, without needing to know how Chutes derived it. Returns `None` if the
+/// evidence is missing or too short to hold the field.
+fn gpu_report_nonce(evidence_list: &Value) -> Option<String> {
+    let evidence = evidence_list
+        .as_array()?
+        .first()?
+        .get("evidence")?
+        .as_str()?;
+    let raw = BASE64.decode(evidence).ok()?;
+    raw.get(4..36).map(hex::encode)
 }
 
 #[derive(Debug)]

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -974,13 +974,23 @@ async fn attestation_report_degrades_to_empty_nvidia_on_upstream_error() {
     assert_eq!(nvidia["nonce"], TEST_NONCE);
 }
 
+// `evidence` = base64 of [4-byte NVIDIA header][32-byte attested nonce = 0xAB*32]
+// [trailing]. The nonce the GPU signed lives at byte offset 4; Chutes derives it
+// from the request nonce, so it differs from what the client sent. nvidia_payload
+// must echo this attested nonce (not the request nonce) for the client's NRAS.
+const CHUTES_GPU_EVIDENCE_B64: &str = "EeAB/6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urABE=";
+const CHUTES_GPU_REPORT_NONCE: &str =
+    "abababababababababababababababababababababababababababababababab";
+
 async fn chutes_evidence_handler() -> Json<Value> {
     // First instance has empty GPU evidence; the report must skip it and use the
     // first instance with a usable evidence list + arch.
     Json(serde_json::json!({
         "evidence": [
             {"instance_id": "inst-0", "gpu_evidence": []},
-            {"instance_id": "inst-1", "gpu_evidence": [{"arch": "HOPPER", "certificate": "c", "evidence": "e"}]},
+            {"instance_id": "inst-1", "gpu_evidence": [
+                {"arch": "HOPPER", "certificate": "c", "evidence": CHUTES_GPU_EVIDENCE_B64}
+            ]},
         ]
     }))
 }
@@ -1025,17 +1035,23 @@ async fn attestation_report_chutes_returns_gateway_report_with_gpu_evidence() {
     assert!(body["signing_address"].is_string());
 
     // nvidia_payload carries the first usable instance's GPU evidence (the empty
-    // inst-0 is skipped), bound to the report nonce.
+    // inst-0 is skipped).
     let nv: Value = serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
     assert_eq!(
         nv["evidence_list"],
-        serde_json::json!([{"arch": "HOPPER", "certificate": "c", "evidence": "e"}])
+        serde_json::json!([
+            {"arch": "HOPPER", "certificate": "c", "evidence": CHUTES_GPU_EVIDENCE_B64}
+        ])
     );
     assert_eq!(nv["arch"], "HOPPER");
+    // nonce echoes the value the GPU actually signed (read from the evidence), not
+    // the raw request nonce — that is what the client's NRAS check matches.
+    assert_eq!(nv["nonce"].as_str().unwrap(), CHUTES_GPU_REPORT_NONCE);
     let report_data = body["attestation"]["evidence"]["quote_report_data"]
         .as_str()
         .unwrap();
-    assert_eq!(nv["nonce"].as_str().unwrap(), &report_data[64..128]);
+    // The gateway quote still binds the raw request nonce (anchors freshness).
+    assert_ne!(nv["nonce"].as_str().unwrap(), &report_data[64..128]);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A client verifying a Chutes model's `/v1/attestation/report` got:

```
nvidia: { valid: false, error: "8 of 9 attestation token(s) failed verification:
          Nonce missing in JWT when expected; ..." (x8) }
```

## Root cause

NVIDIA GPU attestation is verified by submitting the GPU report **plus a nonce** to NRAS (NVIDIA's remote attestation service), which returns a JWT whose `eat_nonce` must match. The nonce has to be **signed inside the GPU report**.

- **PhalaDirect/NearAi**: sign the **raw request nonce** into the report → `nvidia_payload.nonce` (the raw nonce) matches → NRAS passes.
- **Chutes**: signs a value **derived from the request nonce + the instance E2EE key** into the report (binding GPU↔E2EE channel), *not* the raw nonce. We were still putting the raw request nonce in `nvidia_payload.nonce`, so NRAS found no matching nonce in the report → "nonce missing in JWT".

Verified empirically against live reports: the 32 bytes at offset 4 of the GPU evidence are the raw request nonce for Phala, but a derived value for Chutes (identical across the instance's 8 GPUs, deterministic per request nonce).

## Fix

Read the nonce the GPU actually signed straight from the evidence (the 32 bytes after the 4-byte NVIDIA header) and echo **that** as `nvidia_payload.nonce`, so the client's standard NRAS check matches — without the gateway needing to know Chutes' derivation. Falls back to the request nonce if the evidence is missing/too short.

Only the Chutes path changes; Phala/NearAi sign the raw nonce, so reading offset 4 returns the same value.

Report freshness is still anchored by the gateway's own TDX quote, whose `report_data` binds the raw request nonce (the client verifies that). The GPU evidence rides on that attested report.

## Caveat — needs a live re-test

This makes the client's NRAS step pass. **If** the client also hard-asserts `nvidia_payload.nonce == the request nonce it sent`, echoing the derived value would fail that check (it's invisible for Phala, where the two are equal). Confirm against the customer's verifier after deploy; if such a check exists, fall back to a Chutes-specific shape carrying the per-instance `e2e_pubkey`.

## Tests

Stub evidence now uses a realistic `[4-byte header][32-byte nonce][trailing]` blob; the test asserts `nvidia_payload.nonce` is the nonce read from the evidence (not the raw request nonce) and differs from the quote's `report_data` nonce. Full suite + clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)