### PR TITLE
Restore the self-contained Chutes attestation report

### DIFF
--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use ml_kem::ml_kem_768::DecapsulationKey as MlKemDecapsulationKey768;
+use rand::RngCore;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -438,45 +439,44 @@ impl UpstreamBackend for ChutesProviderBackend {
         self.inner.models().await
     }
 
-    /// Fetch the Chutes GPU evidence bound to `nonce` and shape it as the legacy
-    /// `nvidia_payload` so the gateway can merge it into its own attestation
-    /// report (same shape as every other provider).
-    async fn chutes_nvidia_payload(
-        &self,
-        model: &str,
-        nonce: &str,
-    ) -> Result<Value, UpstreamError> {
+    /// Legacy dstack/chutes-compatible attestation report. The gateway cannot
+    /// produce the per-instance TDX quote + GPU evidence itself, so it generates
+    /// a fresh nonce, fetches the live per-instance evidence and E2EE public keys
+    /// from Chutes, and assembles the old multi-instance shape:
+    /// `{ attestation_type, nonce, all_attestations: [{instance_id, nonce,
+    /// e2e_pubkey, intel_quote, gpu_evidence}] }`. The nonce is server-generated
+    /// (clients verify the GPU evidence against the returned nonce).
+    async fn chutes_attestation_report(&self, model: &str) -> Result<Value, UpstreamError> {
         let api_key = self.api_key()?;
         let chute_id = self.resolve_chute_id(model, &api_key).await?;
-        let evidence = self.fetch_evidence(&chute_id, nonce, &api_key).await?;
-        // Chutes returns per-instance GPU evidence; the nvidia_payload carries a
-        // single instance's evidence_list (one NRAS verification), matching the
-        // {nonce, evidence_list, arch} shape used by the other providers. Pick the
-        // first instance whose evidence is a non-empty list with a usable arch —
-        // an instance can report empty/malformed evidence, so don't blindly take
-        // the first, and never fabricate a default arch.
-        let (evidence_list, arch) = evidence
+        let nonce = random_nonce_hex();
+        let pubkeys: HashMap<String, String> = self
+            .fetch_instances(&chute_id, &api_key)
+            .await?
+            .instances
             .into_iter()
-            .find_map(|item| {
-                let arch = item
-                    .gpu_evidence
-                    .as_array()
-                    .and_then(|list| list.first())
-                    .and_then(|e| e.get("arch"))
-                    .and_then(Value::as_str)
-                    .filter(|arch| !arch.is_empty())?
-                    .to_string();
-                Some((item.gpu_evidence, arch))
+            .map(|i| (i.instance_id, i.e2e_pubkey))
+            .collect();
+        let evidence = self.fetch_evidence(&chute_id, &nonce, &api_key).await?;
+
+        let all_attestations: Vec<Value> = evidence
+            .into_iter()
+            .map(|item| {
+                serde_json::json!({
+                    "instance_id": item.instance_id,
+                    "nonce": nonce,
+                    "e2e_pubkey": pubkeys.get(&item.instance_id).cloned(),
+                    "intel_quote": item.quote,
+                    "gpu_evidence": item.gpu_evidence,
+                })
             })
-            .ok_or_else(|| {
-                UpstreamError::Routing("chutes returned no usable GPU evidence".to_string())
-            })?;
-        let payload = serde_json::json!({
+            .collect();
+
+        Ok(serde_json::json!({
+            "attestation_type": "chutes",
             "nonce": nonce,
-            "evidence_list": evidence_list,
-            "arch": arch,
-        });
-        Ok(Value::String(payload.to_string()))
+            "all_attestations": all_attestations,
+        }))
     }
 }
 
@@ -520,8 +520,18 @@ struct ChutesEvidenceResponse {
 
 #[derive(Debug, Deserialize)]
 struct ChutesInstanceEvidence {
+    instance_id: String,
+    /// Base64-encoded TDX quote (surfaced as `intel_quote`, verbatim).
+    #[serde(default)]
+    quote: Option<Value>,
     #[serde(default)]
     gpu_evidence: Value,
+}
+
+fn random_nonce_hex() -> String {
+    let mut nonce = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
+    hex::encode(nonce)
 }
 
 #[derive(Debug)]

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -200,17 +200,12 @@ pub trait UpstreamBackend: Send + Sync {
     /// Legacy multi-instance attestation report for `model`, in the old
     /// dstack/chutes shape. Only the Chutes provider supports it; other
     /// backends fail so callers can fall back to the gateway's own report.
-    /// The legacy `nvidia_payload` (a JSON string) for `model`, sourced from the
-    /// Chutes GPU evidence bound to `nonce`. Only the Chutes provider implements
-    /// it; the gateway merges the result into its own attestation report so
-    /// Chutes returns the same shape as the other providers.
-    async fn chutes_nvidia_payload(
+    async fn chutes_attestation_report(
         &self,
         _model: &str,
-        _nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
         Err(UpstreamError::Routing(format!(
-            "backend {} does not produce chutes GPU evidence",
+            "backend {} does not produce a chutes attestation report",
             self.name()
         )))
     }

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -282,17 +282,16 @@ impl UpstreamBackend for ModelRouterBackend {
         })
     }
 
-    async fn chutes_nvidia_payload(
+    async fn chutes_attestation_report(
         &self,
         model: &str,
-        nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
         let route = self.route_for(model)?;
         // The backend resolves the chute by its own upstream model id, the same
         // value the inference path forwards after rewriting the request model.
         route
             .upstream
-            .chutes_nvidia_payload(&route.upstream_model_id, nonce)
+            .chutes_attestation_report(&route.upstream_model_id)
             .await
     }
 }

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -132,12 +132,11 @@ impl UpstreamBackend for DynamicUpstreamBackend {
             .await
     }
 
-    async fn chutes_nvidia_payload(
+    async fn chutes_attestation_report(
         &self,
         model: &str,
-        nonce: &str,
     ) -> Result<serde_json::Value, UpstreamError> {
-        self.backend().chutes_nvidia_payload(model, nonce).await
+        self.backend().chutes_attestation_report(model).await
     }
 }
 

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -215,10 +215,25 @@ pub(super) async fn attestation_report(
             .and_then(|mgr| mgr.attestation_upstream_target(m))
     });
 
-    // Every provider returns the gateway's own report (the gateway terminates
-    // E2EE with its own keys for all of them), enriched with the upstream's real
-    // GPU evidence as nvidia_payload when available — PhalaDirect/NearAi expose it
-    // via their attestation report, Chutes via its per-instance GPU evidence.
+    // Chutes serves a self-contained multi-instance report from the upstream,
+    // independent of the gateway's own keyset.
+    if let (Some(model), Some(target)) = (model, target.as_ref()) {
+        if target.provider == UpstreamProvider::Chutes {
+            return match state
+                .service
+                .upstream()
+                .chutes_attestation_report(model)
+                .await
+            {
+                Ok(value) => Json(value).into_response(),
+                Err(e) => upstream_proxy_error_response(e),
+            };
+        }
+    }
+
+    // Otherwise (no model, or a non-Chutes provider): the gateway's own report,
+    // enriched with the upstream model node's real GPU evidence when the provider
+    // exposes it (PhalaDirect / NearAi).
     //
     // Effective nonce: the client's, or a freshly generated one when omitted —
     // matching dstack-vllm-proxy, which binds a fresh nonce rather than leaving
@@ -237,28 +252,12 @@ pub(super) async fn attestation_report(
         .await
     {
         Ok(report) => {
-            let fetched = match (model, target.as_ref()) {
-                (Some(model), Some(t)) if t.provider == UpstreamProvider::Chutes => match state
-                    .service
-                    .upstream()
-                    .chutes_nvidia_payload(model, &nonce)
+            let nvidia_payload = match target.as_ref() {
+                Some(target) => fetch_upstream_nvidia_payload(target, &nonce)
                     .await
-                {
-                    Ok(value) => Some(value),
-                    Err(e) => {
-                        tracing::warn!(
-                            model = %model,
-                            upstream = %t.upstream_name,
-                            error = %e,
-                            "chutes GPU evidence fetch failed; returning report without it"
-                        );
-                        None
-                    }
-                },
-                (_, Some(t)) => fetch_upstream_nvidia_payload(t, &nonce).await,
-                _ => None,
+                    .unwrap_or_else(|| empty_nvidia_payload(Some(&nonce))),
+                None => empty_nvidia_payload(Some(&nonce)),
             };
-            let nvidia_payload = fetched.unwrap_or_else(|| empty_nvidia_payload(Some(&nonce)));
             match report_with_legacy_attestation_fields(
                 report,
                 q.signing_algo.as_deref(),

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -974,19 +974,27 @@ async fn attestation_report_degrades_to_empty_nvidia_on_upstream_error() {
     assert_eq!(nvidia["nonce"], TEST_NONCE);
 }
 
-async fn chutes_evidence_handler() -> Json<Value> {
-    // First instance has empty GPU evidence; the report must skip it and use the
-    // first instance with a usable evidence list + arch.
+async fn chutes_instances_handler() -> Json<Value> {
     Json(serde_json::json!({
-        "evidence": [
-            {"instance_id": "inst-0", "gpu_evidence": []},
-            {"instance_id": "inst-1", "gpu_evidence": [{"arch": "HOPPER", "certificate": "c", "evidence": "e"}]},
-        ]
+        "instances": [{"instance_id": "inst-1", "e2e_pubkey": "pk-1", "nonces": ["n1"]}],
+        "nonce_expires_in": 60,
+    }))
+}
+
+async fn chutes_evidence_handler() -> Json<Value> {
+    Json(serde_json::json!({
+        "evidence": [{
+            "instance_id": "inst-1",
+            "quote": "cXVvdGUtYjY0",
+            "gpu_evidence": [{"arch": "HOPPER"}],
+        }]
     }))
 }
 
 async fn serve_chutes_stub() -> String {
-    let app = Router::new().route("/chutes/:chute_id/evidence", get(chutes_evidence_handler));
+    let app = Router::new()
+        .route("/e2e/instances/:chute_id", get(chutes_instances_handler))
+        .route("/chutes/:chute_id/evidence", get(chutes_evidence_handler));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -996,10 +1004,7 @@ async fn serve_chutes_stub() -> String {
 }
 
 #[tokio::test]
-async fn attestation_report_chutes_returns_gateway_report_with_gpu_evidence() {
-    // Chutes returns the same shape as every other provider — the gateway's own
-    // report with the Chutes GPU evidence merged into nvidia_payload — not a
-    // bespoke attestation_type:"chutes" envelope.
+async fn attestation_report_chutes_multi_instance_shape() {
     let base = serve_chutes_stub().await;
     let config = format!(
         r#"[{{"name":"chutes-a","provider":"chutes","base_url":"{base}","models":{{"chutes/m":"m-up"}},"bearer_token":"tok","chutes_e2ee_api_base":"{base}","chutes_chute_ids":{{"m-up":"00000000-0000-0000-0000-0000000c1234"}}}}]"#
@@ -1009,7 +1014,7 @@ async fn attestation_report_chutes_returns_gateway_report_with_gpu_evidence() {
     let resp = app
         .oneshot(
             Request::builder()
-                .uri("/v1/attestation/report?model=chutes/m&signing_algo=ecdsa")
+                .uri("/v1/attestation/report?model=chutes/m")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1018,24 +1023,15 @@ async fn attestation_report_chutes_returns_gateway_report_with_gpu_evidence() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
 
-    // Standard gateway report shape (consistent with PhalaDirect/NearAi).
-    assert_eq!(body["api_version"], "aci/1");
-    assert!(body.get("attestation_type").is_none());
-    assert!(body["intel_quote"].is_string());
-    assert!(body["signing_address"].is_string());
-
-    // nvidia_payload carries the first usable instance's GPU evidence (the empty
-    // inst-0 is skipped), bound to the report nonce.
-    let nv: Value = serde_json::from_str(body["nvidia_payload"].as_str().unwrap()).unwrap();
-    assert_eq!(
-        nv["evidence_list"],
-        serde_json::json!([{"arch": "HOPPER", "certificate": "c", "evidence": "e"}])
-    );
-    assert_eq!(nv["arch"], "HOPPER");
-    let report_data = body["attestation"]["evidence"]["quote_report_data"]
-        .as_str()
-        .unwrap();
-    assert_eq!(nv["nonce"].as_str().unwrap(), &report_data[64..128]);
+    assert_eq!(body["attestation_type"], "chutes");
+    let nonce = body["nonce"].as_str().unwrap();
+    let entries = body["all_attestations"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["instance_id"], "inst-1");
+    assert_eq!(entries[0]["e2e_pubkey"], "pk-1");
+    assert_eq!(entries[0]["nonce"].as_str().unwrap(), nonce);
+    assert_eq!(entries[0]["intel_quote"], "cXVvdGUtYjY0");
+    assert!(entries[0]["gpu_evidence"].is_array());
 }
 
 #[test]


### PR DESCRIPTION
## Why

A client verifying a Chutes model got `8 of 9 attestation token(s) failed: Nonce missing in JWT when expected`.

Root cause (confirmed against `scripts/confidential_verifier/providers/chutes.py`): Chutes binds its GPU **and** TDX attestation to

```
expected = sha256(request_nonce ‖ instance_e2e_pubkey)
```

per instance, and submits `expected` to NRAS — **not** the raw request nonce. A verifier therefore needs the instance **`e2e_pubkey`** to recompute `expected`, confirm the evidence is fresh for its request, and call NRAS.

The unified phala-style `nvidia_payload` (`{nonce, evidence_list, arch}`) introduced in #47 has nowhere to put `e2e_pubkey`, so Chutes GPU evidence simply cannot be verified through it. #48 tried to paper over this by echoing the nonce read out of the GPU report, but that lets **any historical evidence** pass NRAS (nothing ties it to the request nonce) — a replay hole, so #48 is dropped.

## What

Restore the self-contained per-instance Chutes report — `{instance_id, nonce, e2e_pubkey, intel_quote, gpu_evidence}` under `attestation_type: "chutes"` — which `scripts/confidential_verifier` and downstream clients already verify, and which the previous gateway served. This is the only shape that carries what a verifier needs, and it makes the failing verification pass the same way it did before.

PhalaDirect/NearAi `nvidia_payload` enrichment is **unaffected** (it was added in #36, not #47).

Mechanically this reverts the Chutes unification from #47; the diff is the exact inverse, restoring the prior code and tests.

## Tradeoff

Chutes' attestation shape differs from the other providers again — but Chutes' GPU attestation is irreducibly `e2e_pubkey`-bound, so a uniform phala-style payload cannot represent it securely. Verifiability wins over shape uniformity.

## Tests

Full suite + clippy + fmt green; the restored `attestation_report_chutes_multi_instance_shape` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)