### PR TITLE
fix(executor): add a control-plane request timeout (wired to consultPre)

### DIFF
--- a/middleware/executor/src/integrations/__tests__/control.test.ts
+++ b/middleware/executor/src/integrations/__tests__/control.test.ts
@@ -9,6 +9,7 @@ describe("control — remote dial", () => {
   let serverClosed = false;
   let received: { auth?: string; path?: string; body?: string }[] = [];
   let nextResponse = { status: 200, body: "{}" };
+  let hang = false;
   let consultPre: typeof import("../control").consultPre;
 
   beforeAll(async () => {
@@ -21,6 +22,7 @@ describe("control — remote dial", () => {
           path: req.url,
           body: b,
         });
+        if (hang) return; // never respond — exercises the consultPre timeout
         res.writeHead(nextResponse.status, {
           "content-type": "application/json",
         });
@@ -31,6 +33,8 @@ describe("control — remote dial", () => {
     const port = (server.address() as AddressInfo).port;
     process.env.PRIVATE_AI_GATEWAY_CONTROL_URL = `http://127.0.0.1:${port}`;
     process.env.PRIVATE_AI_GATEWAY_CONTROL_TOKEN = "test-token";
+    // Short timeout so the hang test is fast; read at module load below.
+    process.env.PRIVATE_AI_GATEWAY_CONTROL_TIMEOUT_MS = "300";
     ({ consultPre } = await import("../control"));
   });
 
@@ -41,6 +45,7 @@ describe("control — remote dial", () => {
   beforeEach(() => {
     received = [];
     nextResponse = { status: 200, body: "{}" };
+    hang = false;
   });
 
   it("sends the Bearer token + {apiKeyHash, model} body to /consult/pre and parses the result", async () => {
@@ -61,6 +66,18 @@ describe("control — remote dial", () => {
 
   it("fails closed (503) on a non-200 control response", async () => {
     nextResponse = { status: 500, body: "boom" };
+    const res = await consultPre("gpt-4o", "abc");
+    expect(res).toEqual({
+      allow: false,
+      status: 503,
+      message: "control plane unavailable",
+    });
+  });
+
+  it("fails closed (503) when the control plane hangs (request timeout)", async () => {
+    // Server accepts but never responds; only the request timeout can resolve
+    // this — if the timeout regressed, consultPre would hang and the test fail.
+    hang = true;
     const res = await consultPre("gpt-4o", "abc");
     expect(res).toEqual({
       allow: false,

--- a/middleware/executor/src/integrations/control.ts
+++ b/middleware/executor/src/integrations/control.ts
@@ -22,6 +22,7 @@ function controlRequest(
   method: string,
   path: string,
   body?: string,
+  signal?: AbortSignal,
 ): Promise<{ status: number; body: string }> {
   if (!CONTROL_URL) {
     return Promise.reject(
@@ -38,6 +39,7 @@ function controlRequest(
       {
         method,
         agent,
+        signal,
         headers: {
           "content-type": "application/json",
           ...(CONTROL_TOKEN
@@ -108,6 +110,16 @@ export interface ProviderRouting {
   allow_fallbacks?: boolean;
 }
 
+// Timeout for control-plane HTTP requests — never make an unbounded control call.
+// Wired to `consultPre` here (it is on the request's critical path and fails
+// closed, so a degraded control plane fails the request fast instead of leaving
+// requests hanging and piling up). `consultPost` will adopt the same timeout per
+// attempt once its retry queue lands. Generous by default — it only guards
+// against an indefinite hang, not normal latency; tune via the env var.
+const CONTROL_TIMEOUT_MS = Number(
+  process.env.PRIVATE_AI_GATEWAY_CONTROL_TIMEOUT_MS?.trim() || 60_000,
+);
+
 /**
  * Pre-request consult: {apiKeyHash?, model, provider?} -> {allow, ...}.
  * Because this gates authorization, it fails CLOSED — an unreachable control
@@ -123,6 +135,7 @@ export async function consultPre(
       "POST",
       "/consult/pre",
       JSON.stringify({ apiKeyHash, model, provider }),
+      AbortSignal.timeout(CONTROL_TIMEOUT_MS),
     );
     if (res.status !== 200) {
       return {


### PR DESCRIPTION
## Problem

`controlRequest` (`src/integrations/control.ts`) made **unbounded** HTTP calls to the control plane — no timeout. `consultPre` (the per-request authorization check) is `await`ed on the request critical path, so when the control plane is slow or degraded, requests hang on it and accumulate (pending requests hold handler state + an open socket). Never making an unbounded outbound call is the baseline reliability expectation; this restores it.

## Fix

Add a **general** control-plane request timeout — `CONTROL_TIMEOUT_MS` (default **60s**, overridable via `PRIVATE_AI_GATEWAY_CONTROL_TIMEOUT_MS`) — and wire it into `consultPre` via a new optional `signal` param on `controlRequest`. `consultPre` already **fails closed (503)**, so a degraded control plane now fails fast instead of hanging. The timeout only bounds an indefinite hang — it's generous on purpose; tune from production p99 via the env var.

The variable is named generally (not `*_PRE_*`) because a single per-dependency request timeout is the conventional shape: `consultPost` will adopt the **same** timeout per attempt once its retry queue lands (separate follow-up). It is **not** wired into `consultPost` yet — today that call is fire-and-forget with no retry, so a timeout would simply *drop* the usage report. **No billing behavior changes in this PR.**

## Verification

- `npm run typecheck` clean; `npm test` 44/44 pass; `npm run build` (esbuild) clean.
- Added a focused test: with the control server accepting but never responding, `consultPre` returns its fail-closed 503 after the timeout (and does not hang indefinitely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)