### PR TITLE
fix(executor): bound the backend UDS hop with a no-progress idle timeout

### DIFF
--- a/middleware/executor/src/errors/__tests__/response.test.ts
+++ b/middleware/executor/src/errors/__tests__/response.test.ts
@@ -15,11 +15,12 @@ describe("normalizeUpstreamError — OpenAI surface", () => {
   const surface: Surface = "openai";
 
   it("maps upstream 402 to 502 (no leak of provider 402)", async () => {
-    const res = await normalizeUpstreamError(
-      jsonResponse(402, { error: { message: "provider out of credits" } }),
-      surface,
-    );
+    const upstream = jsonResponse(402, {
+      error: { message: "provider out of credits" },
+    });
+    const res = await normalizeUpstreamError(upstream, surface);
     expect(res.status).toBe(502);
+    expect(upstream.bodyUsed).toBe(true);
     const body = (await res.json()) as {
       error: { message: string; type: string };
     };
@@ -70,6 +71,7 @@ describe("normalizeUpstreamError — OpenAI surface", () => {
       );
       const res = await normalizeUpstreamError(upstream, surface);
       expect(res.status).toBe(status);
+      expect(upstream.bodyUsed).toBe(true);
       // upstream message is surfaced, but the type is ours and the upstream
       // header never reaches the client.
       expect(await res.json()).toEqual({

--- a/middleware/executor/src/errors/response.ts
+++ b/middleware/executor/src/errors/response.ts
@@ -114,9 +114,19 @@ async function tryParseJsonBody(
   response: Response,
 ): Promise<Record<string, any> | null> {
   try {
-    return await response.clone().json();
+    return await response.json();
   } catch {
     return null;
+  }
+}
+
+async function discardBody(response: Response): Promise<void> {
+  try {
+    // Cancel rather than drain: we don't read this body, and cancelling closes
+    // the backend hop immediately instead of waiting out a stalled body.
+    await response.body?.cancel();
+  } catch {
+    // Best effort: closing the hop is what matters.
   }
 }
 
@@ -221,6 +231,8 @@ export async function normalizeUpstreamError(
         requestId,
       );
     }
+  } else {
+    await discardBody(response);
   }
 
   const status = mapUpstreamStatus(upstreamStatus);

--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -55,7 +55,8 @@ function buildForwardPayload(
   // A shared body is only valid when every candidate shapes the request
   // identically — same format AND same engine (engine alters the openai shaping).
   const sameShape = candidates.every(
-    (c) => c.format === candidates[0].format && c.engine === candidates[0].engine
+    (c) =>
+      c.format === candidates[0].format && c.engine === candidates[0].engine,
   );
   return sameShape
     ? { targets, body: JSON.stringify(shaped[0].body) }
@@ -204,6 +205,7 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
       targets,
       body,
       userTier: consult.userTier,
+      signal: c.req.raw.signal,
     });
   } catch (err) {
     return errorResponse(
@@ -320,7 +322,9 @@ export const namespaceModels = async (c: Context): Promise<Response> => {
 /** GET /v1/models/providers/:provider — relay a provider-scoped catalog. */
 export const providerModels = async (c: Context): Promise<Response> => {
   const provider = c.req.param("provider") ?? "";
-  const r = await fetchCatalog(`/models/providers/${encodeURIComponent(provider)}`);
+  const r = await fetchCatalog(
+    `/models/providers/${encodeURIComponent(provider)}`,
+  );
   return new Response(r.body, {
     status: r.status,
     headers: { "content-type": "application/json" },

--- a/middleware/executor/src/integrations/__tests__/backend.test.ts
+++ b/middleware/executor/src/integrations/__tests__/backend.test.ts
@@ -1,0 +1,188 @@
+import { existsSync, mkdtempSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import http from "node:http";
+
+function waitFor<T>(promise: Promise<T>, timeoutMs = 1_000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+      timer.unref?.();
+    }),
+  ]);
+}
+
+async function listen(server: http.Server, socketPath: string): Promise<void> {
+  if (existsSync(socketPath)) unlinkSync(socketPath);
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+}
+
+describe("backend — UDS response lifecycle", () => {
+  let forwardToBackend: typeof import("../backend").forwardToBackend;
+
+  beforeAll(async () => {
+    process.env.PRIVATE_AI_GATEWAY_BACKEND_IDLE_TIMEOUT_MS = "100";
+    ({ forwardToBackend } = await import("../backend"));
+  });
+
+  it("closes the backend socket when the returned body is cancelled", async () => {
+    const socketPath = path.join(
+      mkdtempSync(path.join(tmpdir(), "pag-backend-")),
+      "backend.sock",
+    );
+    let socketClosed!: Promise<void>;
+    const server = http.createServer((req, res) => {
+      req.resume();
+      socketClosed = new Promise((resolve) =>
+        req.socket.once("close", resolve),
+      );
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: hello\n\n");
+    });
+
+    try {
+      await listen(server, socketPath);
+      process.env.PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH = socketPath;
+
+      const response = await forwardToBackend({
+        requestId: "req_cancel",
+        targets: ["route-a"],
+        body: "{}",
+      });
+
+      expect(response.status).toBe(200);
+      await response.body?.cancel("client stopped reading");
+      await waitFor(socketClosed);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
+  it("idle-times out a backend response body that is never consumed", async () => {
+    const socketPath = path.join(
+      mkdtempSync(path.join(tmpdir(), "pag-backend-")),
+      "backend.sock",
+    );
+    let socketClosed!: Promise<void>;
+    const server = http.createServer((req, res) => {
+      req.resume();
+      socketClosed = new Promise((resolve) =>
+        req.socket.once("close", resolve),
+      );
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: first\n\n");
+    });
+
+    try {
+      await listen(server, socketPath);
+      process.env.PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH = socketPath;
+
+      const response = await forwardToBackend({
+        requestId: "req_unread",
+        targets: ["route-a"],
+        body: "{}",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.bodyUsed).toBe(false);
+      await waitFor(socketClosed, 1_500);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
+  it("closes the backend socket when a consumed stream goes idle mid-read", async () => {
+    const socketPath = path.join(
+      mkdtempSync(path.join(tmpdir(), "pag-backend-")),
+      "backend.sock",
+    );
+    let socketClosed!: Promise<void>;
+    const server = http.createServer((req, res) => {
+      req.resume();
+      socketClosed = new Promise((resolve) =>
+        req.socket.once("close", resolve),
+      );
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: first\n\n");
+    });
+
+    try {
+      await listen(server, socketPath);
+      process.env.PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH = socketPath;
+
+      const response = await forwardToBackend({
+        requestId: "req_mid_read_idle",
+        targets: ["route-a"],
+        body: "{}",
+      });
+      const reader = response.body!.getReader();
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+      expect(new TextDecoder().decode(first.value)).toContain("data: first");
+
+      void reader.read().catch(() => {
+        // The important assertion is that the stalled backend socket closes.
+      });
+      await waitFor(socketClosed, 1_500);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
+  it("rejects without dialing when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      forwardToBackend({
+        requestId: "req_pre_abort",
+        targets: ["route-a"],
+        body: "{}",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("closes the backend socket when the signal aborts after response headers", async () => {
+    const socketPath = path.join(
+      mkdtempSync(path.join(tmpdir(), "pag-backend-")),
+      "backend.sock",
+    );
+    let socketClosed!: Promise<void>;
+    const server = http.createServer((req, res) => {
+      req.resume();
+      socketClosed = new Promise((resolve) =>
+        req.socket.once("close", resolve),
+      );
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: first\n\n");
+      // never end — only the abort can release this connection
+    });
+
+    try {
+      await listen(server, socketPath);
+      process.env.PRIVATE_AI_GATEWAY_BACKEND_UDS_PATH = socketPath;
+
+      const controller = new AbortController();
+      const response = await forwardToBackend({
+        requestId: "req_abort_after",
+        targets: ["route-a"],
+        body: "{}",
+        signal: controller.signal,
+      });
+      expect(response.status).toBe(200);
+
+      controller.abort();
+      await waitFor(socketClosed);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+});

--- a/middleware/executor/src/integrations/backend.ts
+++ b/middleware/executor/src/integrations/backend.ts
@@ -25,6 +25,10 @@ function backendSocketPath(): string {
   );
 }
 
+const BACKEND_IDLE_TIMEOUT_MS = Number(
+  process.env.PRIVATE_AI_GATEWAY_BACKEND_IDLE_TIMEOUT_MS?.trim() || 600_000,
+);
+
 export interface ForwardArgs {
   /** Request id minted by the frontend; the backend looks up the stored request by it. */
   requestId: string;
@@ -38,6 +42,8 @@ export interface ForwardArgs {
   body: Uint8Array | string;
   /** Tier value to relay to the gateway as the x-user-tier header. */
   userTier?: string;
+  /** Aborts the backend hop when the caller's request/response is abandoned. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -50,6 +56,17 @@ export interface ForwardArgs {
 export function forwardToBackend(args: ForwardArgs): Promise<Response> {
   const payload = Buffer.from(args.body);
   return new Promise((resolve, reject) => {
+    if (args.signal?.aborted) {
+      reject(new Error("gateway backend request aborted"));
+      return;
+    }
+
+    let settled = false;
+    let completed = false;
+    let destroyed = false;
+    let idleTimer: NodeJS.Timeout | undefined;
+    let backendResponse: http.IncomingMessage | undefined;
+
     const req = http.request(
       {
         socketPath: backendSocketPath(),
@@ -64,6 +81,7 @@ export function forwardToBackend(args: ForwardArgs): Promise<Response> {
         },
       },
       (res) => {
+        backendResponse = res;
         // Relay semantic headers (content-type, x-receipt-id, the
         // x-private-ai-gateway-* attribution headers, cache-control,
         // x-accel-buffering, ...); drop per-hop framing headers and let the
@@ -77,11 +95,96 @@ export function forwardToBackend(args: ForwardArgs): Promise<Response> {
             Array.isArray(value) ? value.join(", ") : String(value),
           );
         }
-        const body = Readable.toWeb(res) as ReadableStream<Uint8Array>;
+        const upstream = Readable.toWeb(res) as ReadableStream<Uint8Array>;
+        const reader = upstream.getReader();
+        const finish = () => {
+          completed = true;
+          cleanup();
+        };
+        const body = new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            resetIdleTimer();
+            try {
+              const { done, value } = await reader.read();
+              if (done) {
+                finish();
+                controller.close();
+                return;
+              }
+              resetIdleTimer();
+              controller.enqueue(value);
+            } catch (error) {
+              cleanup();
+              controller.error(error);
+            }
+          },
+          async cancel(reason) {
+            destroyBackend(reason);
+            try {
+              await reader.cancel(reason);
+            } catch {
+              // The destroy above may already have torn down the node stream.
+            }
+          },
+        });
+        resetIdleTimer();
+        settled = true;
         resolve(new Response(body, { status: res.statusCode ?? 502, headers }));
       },
     );
-    req.on("error", reject);
+
+    const cleanup = () => {
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+      args.signal?.removeEventListener("abort", onAbort);
+    };
+
+    const fail = (error: Error) => {
+      cleanup();
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+
+    const destroyBackend = (reason?: unknown) => {
+      if (completed || destroyed) return;
+      destroyed = true;
+      cleanup();
+      const error =
+        reason instanceof Error
+          ? reason
+          : new Error(
+              typeof reason === "string"
+                ? reason
+                : "gateway backend response was abandoned",
+            );
+      backendResponse?.destroy(error);
+      req.destroy(error);
+      fail(error);
+    };
+
+    const resetIdleTimer = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        destroyBackend(
+          new Error(
+            `gateway backend idle timeout after ${BACKEND_IDLE_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, BACKEND_IDLE_TIMEOUT_MS);
+      idleTimer.unref?.();
+    };
+
+    const onAbort = () => {
+      destroyBackend(new Error("gateway backend request aborted"));
+    };
+
+    args.signal?.addEventListener("abort", onAbort, { once: true });
+    req.on("socket", resetIdleTimer);
+    req.on("error", fail);
     req.write(payload);
     req.end();
   });


### PR DESCRIPTION
## Problem

`forwardToBackend` (`middleware/executor/src/integrations/backend.ts`) dials the gateway's internal backend at `/internal/forward` over its Unix domain socket with **no timeout and no teardown**. The connection is released only when the response body is fully read or cancelled — so any path that stalls (the backend goes quiet mid-stream) or never consumes the body leaves the `http.IncomingMessage` and its socket open. Under sustained traffic these accumulate without bound, exhausting file descriptors and growing off-heap socket buffers on both ends. The executor's V8 heap cap can't bound this (the growth is off-heap), and the `consultPre` timeout is a different subsystem.

## Fix

Add a **no-progress (idle) timeout** to the hop, mirroring the gateway's `WriteIdleTimeout`: the timer arms when the socket is assigned and resets on every read of the response body, so a long but actively-flowing stream is never cut — only one that makes no progress for the timeout is torn down (request + response destroyed, socket closed). Default **600s** (aligned with the gateway's 600s write-idle budget), overridable via `PRIVATE_AI_GATEWAY_BACKEND_IDLE_TIMEOUT_MS`.

Also:
- Thread the inbound request's `AbortSignal` (`c.req.raw.signal`) into the hop so a client disconnect tears it down promptly.
- Cancelling the returned body destroys the backend socket.
- `normalizeUpstreamError` cancels the discarded upstream error body instead of leaving it open.

## Tests

`backend.test.ts` covers: body-cancel closes the socket; idle timeout on an unconsumed body and on a mid-read-stalled stream; abort before and after response headers. `response.test.ts` asserts the upstream error body is consumed (no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)