### PR TITLE
feat(executor): report gateway-generated 5xx failures to the control plane

### DIFF
--- a/middleware/executor/src/__tests__/handlers.gateway-failure.test.ts
+++ b/middleware/executor/src/__tests__/handlers.gateway-failure.test.ts
@@ -1,0 +1,122 @@
+import { jest } from "@jest/globals";
+
+const consultPre = jest.fn<() => Promise<any>>();
+const consultPost = jest.fn();
+const fetchCatalog = jest.fn();
+const forwardToBackend = jest.fn<() => Promise<Response>>();
+
+jest.unstable_mockModule("../integrations/control", () => ({
+  consultPre,
+  consultPost,
+  fetchCatalog,
+  hashApiKey: jest.fn(() => "hashed-key"),
+}));
+
+jest.unstable_mockModule("../integrations/backend", () => ({
+  forwardToBackend,
+}));
+
+const { app } = await import("../app");
+
+const request = () =>
+  app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer sk-test",
+      "content-type": "application/json",
+      "x-private-ai-gateway-request-id": "req_gateway_failure",
+    },
+    body: JSON.stringify({ model: "model-a", messages: [] }),
+  });
+
+describe("executor gateway-failure request logs", () => {
+  beforeEach(() => {
+    consultPre.mockReset();
+    consultPost.mockReset();
+    fetchCatalog.mockReset();
+    forwardToBackend.mockReset();
+  });
+
+  it("reports consultPre 5xx denials as control-source gateway failures", async () => {
+    consultPre.mockResolvedValue({
+      allow: false,
+      status: 503,
+      message: "control plane unavailable",
+    });
+
+    const res = await request();
+
+    expect(res.status).toBe(503);
+    expect(forwardToBackend).not.toHaveBeenCalled();
+    expect(consultPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req_gateway_failure",
+        status: 503,
+        selectedRouteId: null,
+        requestModel: "model-a",
+        usage: null,
+        errorSource: "control",
+      }),
+    );
+  });
+
+  it("reports backend connection failures as backend-source gateway failures", async () => {
+    consultPre.mockResolvedValue({
+      allow: true,
+      pricing: null,
+      candidates: [{ routeId: "provider:model-a", format: "openai" }],
+      userId: 123,
+      virtualKeyId: 456,
+      spendMode: "regular",
+    });
+    forwardToBackend.mockRejectedValue(new Error("backend socket missing"));
+
+    const res = await request();
+
+    expect(res.status).toBe(502);
+    expect(consultPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req_gateway_failure",
+        status: 502,
+        selectedRouteId: null,
+        requestModel: "model-a",
+        usage: null,
+        userId: 123,
+        virtualKeyId: 456,
+        errorSource: "backend",
+      }),
+    );
+  });
+
+  it("does not record a gateway failure when the client aborts before the backend responds", async () => {
+    consultPre.mockResolvedValue({
+      allow: true,
+      pricing: null,
+      candidates: [{ routeId: "provider:model-a", format: "openai" }],
+      userId: 123,
+      virtualKeyId: 456,
+      spendMode: "regular",
+    });
+    // forwardToBackend rejects because the client's signal aborted, not a real
+    // backend fault.
+    forwardToBackend.mockRejectedValue(
+      new Error("gateway backend request aborted"),
+    );
+    const controller = new AbortController();
+    controller.abort();
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer sk-test",
+        "content-type": "application/json",
+        "x-private-ai-gateway-request-id": "req_aborted",
+      },
+      body: JSON.stringify({ model: "model-a", messages: [] }),
+      signal: controller.signal,
+    });
+
+    expect(res.status).toBe(499);
+    expect(consultPost).not.toHaveBeenCalled();
+  });
+});

--- a/middleware/executor/src/handlers.ts
+++ b/middleware/executor/src/handlers.ts
@@ -14,6 +14,8 @@ import {
   fetchCatalog,
   Format,
   hashApiKey,
+  PostReport,
+  PreConsult,
   RouteCandidate,
 } from "./integrations/control";
 import { meterResponse, StreamOutcome } from "./cost";
@@ -88,6 +90,46 @@ function meteredStatus(
     default:
       return upstreamStatus;
   }
+}
+
+function safeErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.slice(0, 500);
+}
+
+function reportGatewayFailure(args: {
+  c: Context;
+  requestId: string;
+  params: Params;
+  status: number;
+  start: number;
+  source: PostReport["errorSource"];
+  message: string;
+  consult?: PreConsult;
+  pricing?: PostReport["pricing"];
+  // Defaults to 0. Paths that fail after the backend already reported failed
+  // failover attempts must pass a value above those attempts' indices, so this
+  // gateway-generated row wins `argMax(status_code, attempt_index)` as the final
+  // status instead of being shadowed by an earlier failed attempt.
+  attemptIndex?: number;
+}): void {
+  consultPost({
+    requestId: args.requestId,
+    endpoint: new URL(args.c.req.url).pathname,
+    status: args.status,
+    durationMs: Date.now() - args.start,
+    isStreaming: Boolean(args.params.stream),
+    attemptIndex: args.attemptIndex ?? 0,
+    selectedRouteId: null,
+    requestModel: args.params.model ?? "",
+    usage: null,
+    pricing: args.pricing ?? args.consult?.pricing ?? null,
+    spendMode: args.consult?.spendMode,
+    userId: args.consult?.userId,
+    virtualKeyId: args.consult?.virtualKeyId,
+    errorSource: args.source,
+    errorMessage: args.message.slice(0, 500),
+  });
 }
 
 function responseTransformerFor(
@@ -192,6 +234,30 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
   if (!consult.allow) {
     const status = consult.status ?? 403;
     const message = consult.message ?? "forbidden";
+    // Record a gateway failure only when OUR infrastructure failed (5xx). The
+    // other denial statuses are attributable to the user's request, not our
+    // availability, so — like 400/403/413/429 — they are not recorded:
+    //   401  invalid user API key
+    //   402  user out of budget/credits
+    //   404  user pinned a provider that has no node for the model
+    // Real upstream 401/402/etc. (the provider's key/billing failed) are a
+    // different thing and still count — recorded from the metered/failed-attempt
+    // paths below. (Caveat: the Rust backend does not set attribution headers on
+    // a FINAL upstream error, so such rows currently land with selectedRouteId
+    // null and no provider/deployment attribution — a separate, pre-existing
+    // backend gap.)
+    if (status >= 500) {
+      reportGatewayFailure({
+        c,
+        requestId,
+        params,
+        status,
+        start,
+        source: "control",
+        message,
+        consult,
+      });
+    }
     if (status === 429 && consult.rateLimit) {
       return rateLimitResponse(
         surface,
@@ -224,7 +290,31 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
     );
   }
 
-  const { targets, body } = buildForwardPayload(params, fn, candidates);
+  let targets: string[];
+  let body: string;
+  try {
+    ({ targets, body } = buildForwardPayload(params, fn, candidates));
+  } catch (err) {
+    const message = `failed to shape provider request: ${safeErrorMessage(err)}`;
+    reportGatewayFailure({
+      c,
+      requestId,
+      params,
+      status: 500,
+      start,
+      source: "executor",
+      message,
+      consult,
+      pricing,
+    });
+    return errorResponse(
+      surface,
+      500,
+      errorType(surface, 500),
+      message,
+      requestId,
+    );
+  }
   let backendResp: Response;
   try {
     backendResp = await forwardToBackend({
@@ -235,22 +325,76 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
       signal: c.req.raw.signal,
     });
   } catch (err) {
+    // The client's request signal is wired into forwardToBackend, so a client
+    // disconnect before the backend responds also rejects here. That's a client
+    // abort (499), not our failure — don't record it as a gateway/backend 502.
+    if (c.req.raw.signal?.aborted) {
+      return errorResponse(
+        surface,
+        499,
+        errorType(surface, 499),
+        "client closed request before the backend responded",
+        requestId,
+      );
+    }
+    const message = `failed to reach gateway backend: ${(err as Error).message}`;
+    reportGatewayFailure({
+      c,
+      requestId,
+      params,
+      status: 502,
+      start,
+      source: "backend",
+      message,
+      consult,
+      pricing,
+    });
     return errorResponse(
       surface,
       502,
       "backend_unreachable",
-      `failed to reach gateway backend: ${(err as Error).message}`,
+      message,
       requestId,
     );
   }
-  const response = await driveResponse(
-    backendResp,
-    params,
-    fn,
-    candidates,
-    surface,
-    requestId,
-  );
+  let response: Response;
+  try {
+    response = await driveResponse(
+      backendResp,
+      params,
+      fn,
+      candidates,
+      surface,
+      requestId,
+    );
+  } catch (err) {
+    // This catches the whole response pipeline, not just executor code bugs: a
+    // selected upstream returning a malformed/non-JSON 200 (or transform-
+    // incompatible data) also throws here. We attribute ALL of it to the executor
+    // (selectedRouteId null → deployment 0), i.e. a provider that emits malformed
+    // 200s is NOT penalized in deployment/routing health. Accepted tradeoff — at
+    // this point we can't cleanly separate a provider-data fault from an executor
+    // bug; the request is still correctly counted as a 502 failure either way.
+    const message = `failed to transform upstream response: ${safeErrorMessage(err)}`;
+    reportGatewayFailure({
+      c,
+      requestId,
+      params,
+      status: 502,
+      start,
+      source: "executor",
+      message,
+      consult,
+      pricing,
+    });
+    return errorResponse(
+      surface,
+      502,
+      errorType(surface, 502),
+      message,
+      requestId,
+    );
+  }
 
   // Post-request consult (billing + request log). Fired once the
   // raw upstream usage is known — immediately for buffered responses, at stream
@@ -299,28 +443,59 @@ async function handle(c: Context, fn: endpointStrings): Promise<Response> {
     });
   }
 
-  return meterResponse(response, pricing, start, (usage, ttftMs, outcome) => {
-    consultPost({
-      requestId,
-      endpoint: new URL(c.req.url).pathname,
-      // Record the raw upstream status (`backendResp.status`) so upstream errors
-      // like 402/401/500 are observable as themselves. The client still receives
-      // the mapped status from `normalizeUpstreamError` (e.g. 402 -> generic 502);
-      // we deliberately do not record that mapped value.
-      status: meteredStatus(outcome, backendResp.status),
-      durationMs: Date.now() - start,
-      ttftMs,
-      isStreaming,
-      attemptIndex,
-      selectedRouteId,
-      requestModel: params.model ?? "",
-      usage,
+  try {
+    return await meterResponse(
+      response,
       pricing,
-      spendMode: consult.spendMode,
-      userId: consult.userId,
-      virtualKeyId: consult.virtualKeyId,
+      start,
+      (usage, ttftMs, outcome) => {
+        consultPost({
+          requestId,
+          endpoint: new URL(c.req.url).pathname,
+          // Record the raw upstream status (`backendResp.status`) so upstream errors
+          // like 402/401/500 are observable as themselves. The client still receives
+          // the mapped status from `normalizeUpstreamError` (e.g. 402 -> generic 502);
+          // we deliberately do not record that mapped value.
+          status: meteredStatus(outcome, backendResp.status),
+          durationMs: Date.now() - start,
+          ttftMs,
+          isStreaming,
+          attemptIndex,
+          selectedRouteId,
+          requestModel: params.model ?? "",
+          usage,
+          pricing,
+          spendMode: consult.spendMode,
+          userId: consult.userId,
+          virtualKeyId: consult.virtualKeyId,
+        });
+      },
+    );
+  } catch (err) {
+    const message = `failed to meter upstream response: ${safeErrorMessage(err)}`;
+    reportGatewayFailure({
+      c,
+      requestId,
+      params,
+      status: 502,
+      start,
+      source: "executor",
+      message,
+      consult,
+      pricing,
+      // This failure happens after any failed failover attempts were reported
+      // (each at its own attempt_index); sit one past the committed attempt so
+      // this 502 is the final status, not an earlier attempt's code.
+      attemptIndex: attemptIndex + 1,
     });
-  });
+    return errorResponse(
+      surface,
+      502,
+      errorType(surface, 502),
+      message,
+      requestId,
+    );
+  }
 }
 
 export const chatCompletions = (c: Context) => handle(c, "chatComplete");

--- a/middleware/executor/src/integrations/control.ts
+++ b/middleware/executor/src/integrations/control.ts
@@ -113,11 +113,18 @@ export interface ProviderRouting {
 // Timeout for control-plane HTTP requests — never make an unbounded control call.
 // Wired to `consultPre` here (it is on the request's critical path and fails
 // closed, so a degraded control plane fails the request fast instead of leaving
-// requests hanging and piling up). `consultPost` will adopt the same timeout per
-// attempt once its retry queue lands. Generous by default — it only guards
-// against an indefinite hang, not normal latency; tune via the env var.
+// requests hanging and piling up). Generous by default — it only guards against
+// an indefinite hang, not normal latency; tune via the env var.
 const CONTROL_TIMEOUT_MS = Number(
   process.env.PRIVATE_AI_GATEWAY_CONTROL_TIMEOUT_MS?.trim() || 60_000,
+);
+// `consultPost` is fire-and-forget (off the critical path), so it gets a much
+// shorter timeout: it only bounds a hung control plane so abandoned posts don't
+// pile up sockets/promises under load. Still NO retry — a stalled post is dropped
+// (best-effort), never resent (re-sending a report the control plane may have
+// already processed would record it twice; the report is not idempotent).
+const CONTROL_POST_TIMEOUT_MS = Number(
+  process.env.PRIVATE_AI_GATEWAY_CONTROL_POST_TIMEOUT_MS?.trim() || 10_000,
 );
 
 /**
@@ -168,14 +175,27 @@ export interface PostReport {
   spendMode?: SpendMode;
   userId?: number;
   virtualKeyId?: number;
+  // Set only on a gateway-synthesized failure (no real upstream attempt): which
+  // component produced it. Empty/absent for real upstream attempts. Drives the
+  // control plane's `error_source` column.
+  errorSource?: "control" | "backend" | "executor";
+  errorMessage?: string;
 }
 
 /**
- * Post-request consult: fire-and-forget usage report. Billing is best-effort —
- * a control-plane hiccup must never fail the user's already-served response.
+ * Post-request consult: fire-and-forget usage report. Delivery is best-effort — a
+ * control-plane hiccup must never fail the user's already-served response, and we
+ * never retry: re-sending a report the control plane already processed would
+ * record it twice (the report is not idempotent). Bounded by a short timeout so a
+ * hung control plane can't accumulate sockets/promises.
  */
 export function consultPost(report: PostReport): void {
-  controlRequest("POST", "/consult/post", JSON.stringify(report)).catch(() => {
+  controlRequest(
+    "POST",
+    "/consult/post",
+    JSON.stringify(report),
+    AbortSignal.timeout(CONTROL_POST_TIMEOUT_MS),
+  ).catch(() => {
     /* best-effort */
   });
 }


### PR DESCRIPTION
## What

The executor now reports its own 5xx failures to the control plane so they land in request logs (previously they vanished). Each report is tagged with the component that produced the failure via a new `errorSource` field (`control` / `backend` / `executor`).

## Details

- **Reported (gateway 5xx):** pre-consult control-unavailable (503), backend-unreachable (502), and request/response transform & metering exceptions (502/500).
- **Not reported:** user-attributable denials 401/402/404/429 (they reflect the user's request, not gateway availability). A client disconnect before the backend responds becomes a 499, not a gateway failure.
- **`consultPost`:** stays fire-and-forget / at-most-once (no retry, so a report is never sent twice), now bounded by a short timeout (`PRIVATE_AI_GATEWAY_CONTROL_POST_TIMEOUT_MS`, default 10s) so a hung control plane can't accumulate sockets/promises.

Normal (successful) requests are unaffected — every addition is in a failure/catch path or denial-gated; `consultPost` is background fire-and-forget and never blocks the response.

## Known limitations

- A control-plane outage can't be reported this way — the "control unavailable" report is delivered to the same down control (best-effort).
- A final upstream error currently lands without provider/deployment attribution (the backend doesn't set attribution headers on the final error response) — a separate, pre-existing backend gap.
- A malformed upstream 200 that fails the transform is attributed to the executor, not the specific deployment (accepted tradeoff).

## Tests

`handlers.gateway-failure.test.ts` covers the pre-consult, backend, and client-abort paths. Full executor suite passes (62 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)