### PR TITLE
fix(failover): fail over on provider auth/account errors (401/402/403)

### DIFF
--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -24,8 +24,13 @@ use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
 use crate::aggregator::session::SessionClaims;
 use std::collections::HashMap;
 
+// Provider statuses that make this candidate worth abandoning for the next one.
+// Beyond the transient 429/5xx signals, an auth/account failure specific to this
+// provider — 401 (invalid key), 402 (out of credit), 403 (key lacks access) — can
+// still be served by a sibling candidate on a different account. Request-level 4xx
+// (400/404/422) are excluded: they would fail identically on every candidate.
 fn is_retryable_provider_status(status: u16) -> bool {
-    matches!(status, 429 | 500 | 502 | 503 | 504)
+    matches!(status, 401 | 402 | 403 | 429 | 500 | 502 | 503 | 504)
 }
 
 /// Track the highest-priority failover error so that, when every candidate
@@ -552,5 +557,29 @@ impl AciService {
             body: Box::pin(body),
             e2ee: e2ee_response,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_retryable_provider_status;
+
+    #[test]
+    fn retryable_covers_transient_and_account_specific_statuses() {
+        // Transient provider trouble (429/5xx) plus auth/account failures
+        // (401 invalid key, 402 out of credit, 403 no access) fail over.
+        for status in [401, 402, 403, 429, 500, 502, 503, 504] {
+            assert!(
+                is_retryable_provider_status(status),
+                "{status} should retry"
+            );
+        }
+        // Request-level errors would fail identically on every candidate.
+        for status in [400, 404, 422] {
+            assert!(
+                !is_retryable_provider_status(status),
+                "{status} should not retry"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

`is_retryable_provider_status` (the failover gate in the middleware forwarding
loop) only failed over on transient `429`/`5xx`. An upstream **401** (invalid key),
**402** (out of credit), or **403** (key lacks access) was treated as terminal — so
one provider's billing lapse or key problem failed the user's request even when a
sibling candidate on a different account could have served it.

The failover decision keys on the **raw upstream status**, so this was masked: a
402 maps to a client-facing 502, but the loop saw the raw 402 and stopped instead
of trying the next candidate.

## Change

Add `401 | 402 | 403` to the retryable set. These are auth/account failures
specific to a provider's own account/key, so another candidate can still serve the
request. Request-level `4xx` (`400`/`404`/`422`) stay terminal — they fail
identically on every candidate.

| Category | Statuses | Failover |
|---|---|---|
| Transport / unreachable | — | yes |
| Rate-limit / server errors | 429, 500, 502, 503, 504 | yes |
| **Auth / account (provider-specific)** | **401, 402, 403** | **yes (new)** |
| Request-level | 400, 404, 422 | no |

Single-candidate requests are unchanged (nothing to fail over to → the mapped
client status is returned as before). Only multi-candidate routing benefits.

Adds a focused unit test pinning the retryable set.

Gate: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 305 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)