### PR TITLE
fix(errors): return 400 for client image-URL fetch failures, not 5xx

### DIFF
--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -152,10 +152,34 @@ impl AciService {
             response_model.as_deref(),
         );
 
+        // A client image-URL fetch failure the upstream reports as a 5xx is the
+        // caller's bad input: remap it to a surface-correct 400. This is decided on
+        // the cleartext body here — before E2EE encryption and before the receipt is
+        // built — so the receipt attests exactly the body/status the client receives.
+        let mut upstream_headers = upstream_response.headers;
+        let (client_status, client_body) = match crate::middleware::errors::image_input_error_parts(
+            crate::middleware::errors::surface_for_path(endpoint_path),
+            received_body,
+            upstream_response.status_code,
+            &upstream_response.body,
+            None,
+        ) {
+            Some((status, body)) => {
+                // The remapped body is a JSON envelope; don't let the client inherit
+                // a non-JSON upstream content-type (some backends 5xx with text/*).
+                upstream_headers.insert("content-type".to_string(), "application/json".to_string());
+                (status, body)
+            }
+            None => (
+                upstream_response.status_code,
+                upstream_response.body.clone(),
+            ),
+        };
+
         let e2ee = req.e2ee.as_ref();
         let wire_response_body = match e2ee {
-            Some(ctx) => encrypt_e2ee_response_body(&upstream_response.body, ctx, endpoint_path)?,
-            None => upstream_response.body.clone(),
+            Some(ctx) => encrypt_e2ee_response_body(&client_body, ctx, endpoint_path)?,
+            None => client_body.clone(),
         };
         let e2ee_response = e2ee.map(|ctx| E2eeResponseInfo {
             version: ctx.version.clone(),
@@ -167,7 +191,7 @@ impl AciService {
         // do not even consult it; the byte source is the body the
         // service received from axum.
         let receipt_id = generate_receipt_id();
-        let chat_id = extract_chat_id(&upstream_response.body);
+        let chat_id = extract_chat_id(&client_body);
         let served_at = self.clock.now_secs();
         let mut builder = ReceiptBuilder::new(
             receipt_id,
@@ -198,10 +222,12 @@ impl AciService {
         // The session is keyed on the requested (routed) model; record the exact
         // upstream-served model in the receipt's upstream.verified event.
         builder.set_upstream_verified_model_id(response_model.clone());
+        // Modified when the returned bytes differ from what the upstream sent —
+        // whether from E2EE encryption or an image-input 400 remap.
         if upstream_response.body != wire_response_body {
             builder.add_transparency_event(TransparencyEventKind::ResponseModified)?;
         }
-        builder.add_response_returned(&upstream_response.body, &wire_response_body)?;
+        builder.add_response_returned(&client_body, &wire_response_body)?;
 
         let receipt = builder.finalize(self.keys.as_ref(), &self.default_receipt_key_id)?;
         self.store_receipt(receipt.clone(), req.requester.clone());
@@ -213,9 +239,9 @@ impl AciService {
 
         Ok(ForwardResult {
             receipt,
-            upstream_status: upstream_response.status_code,
+            upstream_status: client_status,
             upstream_body: wire_response_body,
-            upstream_headers: upstream_response.headers,
+            upstream_headers,
             e2ee: e2ee_response,
         })
     }

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -33,6 +33,20 @@ fn is_retryable_provider_status(status: u16) -> bool {
     matches!(status, 401 | 402 | 403 | 429 | 500 | 502 | 503 | 504)
 }
 
+// Whether to abandon this candidate and try the next. The status must be a
+// provider-specific/transient failure AND the error must not be the client's own
+// fault: a fetch failure on a client-supplied image URL fails identically on every
+// candidate, so it is terminal (committed and surfaced as a 400) rather than retried.
+fn should_fail_over(status: u16, received_body: &[u8], upstream_body: &[u8]) -> bool {
+    is_retryable_provider_status(status)
+        && crate::middleware::errors::classify_image_input_error(
+            received_body,
+            status,
+            upstream_body,
+        )
+        .is_none()
+}
+
 /// Track the highest-priority failover error so that, when every candidate
 /// fails, the returned error reflects the most informative failure.
 /// Priority order: verification (3), then transport (2), then routing (1).
@@ -260,14 +274,20 @@ impl AciService {
                         status,
                         None,
                     );
-                    if is_retryable_provider_status(status) && !is_last {
+                    // Collect the (small) error body up front so the failover
+                    // decision can inspect it. A truncated/unreadable error body
+                    // must not abort the remaining candidates, so it degrades to
+                    // empty — the caller's normalizer emits its generic message.
+                    let upstream_headers = upstream_response.headers;
+                    let upstream_body = collect_upstream_body(upstream_response.body)
+                        .await
+                        .unwrap_or_default();
+                    if !is_last && should_fail_over(status, received_body, &upstream_body) {
                         failed_attempts.push((route_id.clone(), status));
                         continue;
                     }
                     self.metrics
                         .record_stream_error(endpoint_path, StreamErrorKind::UpstreamNon2xx);
-                    let upstream_headers = upstream_response.headers;
-                    let upstream_body = collect_upstream_body(upstream_response.body).await?;
                     return Ok(MiddlewareForwardResult::UpstreamError(
                         StreamingUpstreamError {
                             upstream_status: status,
@@ -364,7 +384,7 @@ impl AciService {
             };
 
             let status = upstream_response.status_code;
-            if is_retryable_provider_status(status) && !is_last {
+            if !is_last && should_fail_over(status, received_body, &upstream_response.body) {
                 self.metrics.record_upstream_response(
                     endpoint_path,
                     RequestMode::Buffered,

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -55,6 +55,8 @@ pub(super) enum E2eeDecryptor<'a> {
 #[derive(Debug, Clone)]
 pub struct ForwardResult {
     pub receipt: Receipt,
+    /// Client-facing status: the upstream's, or 400 when the service remapped a
+    /// client image-URL fetch failure. The receipt attests the matching body.
     pub upstream_status: u16,
     pub upstream_body: Vec<u8>,
     pub upstream_headers: std::collections::HashMap<String, String>,

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -77,10 +77,23 @@ pub(super) async fn forward_to_backend(
                 (status, resp_headers, body).into_response()
             }
             Ok(StreamingForwardResult::UpstreamError(forward)) => {
-                let status =
-                    StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
-                let resp_headers = upstream_direct_response_headers(&forward.upstream_headers);
-                (status, resp_headers, forward.upstream_body).into_response()
+                // The streaming error body is cleartext (E2EE applies to the stream,
+                // not this pre-stream error), so classify and remap it here directly.
+                match image_input_error_response(
+                    input.endpoint_path,
+                    &input.received_body,
+                    forward.upstream_status,
+                    &forward.upstream_body,
+                ) {
+                    Some(resp) => resp,
+                    None => {
+                        let status =
+                            StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
+                        let resp_headers =
+                            upstream_direct_response_headers(&forward.upstream_headers);
+                        (status, resp_headers, forward.upstream_body).into_response()
+                    }
+                }
             }
             Err(ServiceError::UpstreamVerification(uv)) => upstream_verification_error_response(uv),
             Err(ServiceError::E2ee(err)) => e2ee_error_response(err),
@@ -105,6 +118,9 @@ pub(super) async fn forward_to_backend(
         .await;
     match result {
         Ok(forward) => {
+            // The service already remapped a client image-URL fetch failure to a
+            // surface-correct 400 (with a matching receipt + E2EE wire body), so the
+            // buffered response is returned uniformly here.
             let resp_headers = chat_response_headers(
                 &forward.receipt.receipt_id,
                 &forward.upstream_headers,
@@ -305,6 +321,25 @@ pub(super) fn upstream_direct_response(
     }
     let status = StatusCode::from_u16(upstream.status_code).unwrap_or(StatusCode::BAD_GATEWAY);
     (status, headers, upstream.body).into_response()
+}
+
+/// The surface-appropriate 400 when the upstream error is a client image-URL
+/// fetch failure; `None` for any other error (caller keeps verbatim passthrough).
+fn image_input_error_response(
+    endpoint_path: &str,
+    received_body: &[u8],
+    upstream_status: u16,
+    upstream_body: &[u8],
+) -> Option<Response> {
+    use crate::middleware::errors::{image_input_error_parts, parts_response, surface_for_path};
+    let (status, body) = image_input_error_parts(
+        surface_for_path(endpoint_path),
+        received_body,
+        upstream_status,
+        upstream_body,
+        None,
+    )?;
+    Some(parts_response(status, body))
 }
 
 pub(super) fn upstream_proxy_error_response(err: crate::aci::upstream::UpstreamError) -> Response {

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -266,10 +266,11 @@ pub async fn run(
                     surface,
                     upstream_status,
                     &forward.upstream_body,
+                    &received_body,
                     Some(&request_id),
                 );
                 meter.success(
-                    upstream_status,
+                    reported_status(mapped, upstream_status),
                     attempt_index,
                     Some(&forward.selected_route),
                     None,
@@ -395,14 +396,15 @@ pub async fn run(
         }
         Ok(MiddlewareForwardResult::UpstreamError(forward)) => {
             // Streaming non-2xx: attribution is not carried on this variant, so the
-            // report records the raw status with no selected route (parity).
-            meter.upstream_error(forward.upstream_status);
+            // report records the status with no selected route (parity).
             let (status, body) = errors::normalize_upstream_error_parts(
                 surface,
                 forward.upstream_status,
                 &forward.upstream_body,
+                &received_body,
                 Some(&request_id),
             );
+            meter.upstream_error(reported_status(status, forward.upstream_status));
             finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
         }
         // All candidates failed. Record an upstream-attributed failure so the
@@ -516,6 +518,18 @@ impl Meter<'_> {
 
 fn truncate(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
+}
+
+// The status reported to the control plane for a normalized upstream error: the
+// client-facing status when it is client-attributable (4xx) — a remapped
+// image-fetch failure must not count against the provider's health — otherwise
+// the raw upstream status, preserving the provider's real code in the logs.
+fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
+    if (400..500).contains(&mapped) {
+        mapped
+    } else {
+        upstream_status
+    }
 }
 
 // Map a forward/finalize `ServiceError` to a client-facing generated response.

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -203,6 +203,143 @@ fn extract_error_message(body: &[u8]) -> Option<String> {
     }
 }
 
+/// The host component of an `http(s)://` URL (`https://a.example/x?y` -> `a.example`).
+/// Used to correlate an upstream error message with a request image URL when the
+/// message names only the host (e.g. a DNS failure) rather than the full URL.
+fn url_host(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let end = rest.find(['/', ':', '?', '#']).unwrap_or(rest.len());
+    let host = &rest[..end];
+    (!host.is_empty()).then_some(host)
+}
+
+/// Whether `message` names `host` as a standalone host token. Two guards keep this
+/// from misfiring on an unrelated provider error: the host must be domain-like (have
+/// a dot), so a bare single-label host such as `internal` can't match the word
+/// "internal" in a generic message; and the token must match whole (splitting the
+/// message on non-host characters), so `a.co` doesn't match inside `banana.com`.
+fn message_references_host(message: &str, host: &str) -> bool {
+    host.contains('.')
+        && message
+            .split(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '-'))
+            .any(|token| token == host)
+}
+
+/// The fetchable remote URL of a single content part, across the request shapes this
+/// gateway serves on one code path: OpenAI chat `{"type":"image_url","image_url":{"url"}}`,
+/// Responses `{"type":"input_image","image_url":"<url>"}` (image_url may be a bare
+/// string or an object), and Anthropic `{"type":"image","source":{"type":"url","url"}}`.
+/// Data-URI (`data:`) sources carry no fetchable URL and yield `None`.
+fn image_part_url(part: &Value) -> Option<&str> {
+    match part.get("type").and_then(Value::as_str) {
+        Some("image_url") | Some("input_image") => {
+            let image_url = part.get("image_url")?;
+            image_url
+                .as_str()
+                .or_else(|| image_url.get("url").and_then(Value::as_str))
+        }
+        Some("image") => part
+            .get("source")
+            .filter(|source| source.get("type").and_then(Value::as_str) == Some("url"))
+            .and_then(|source| source.get("url"))
+            .and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+/// Collect the remote (`http`/`https`) image URLs a request asks the upstream to
+/// fetch. Covers every surface served by the completion path — OpenAI chat and
+/// Anthropic messages (`messages[].content[]`) and Responses (`input[]`, whose image
+/// parts may sit directly in the array or nested under `content`). A cheap substring
+/// guard skips the JSON parse entirely when the body has no image content at all.
+fn remote_image_urls(request_body: &[u8]) -> Vec<String> {
+    let Ok(text) = std::str::from_utf8(request_body) else {
+        return Vec::new();
+    };
+    if !text.contains("image") {
+        return Vec::new();
+    }
+    let Ok(value) = serde_json::from_str::<Value>(text) else {
+        return Vec::new();
+    };
+    let mut urls = Vec::new();
+    for key in ["messages", "input"] {
+        let Some(items) = value.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        for item in items {
+            // Chat/messages nest image parts under `content`; Responses may also
+            // place a part directly in the `input` array, so check the item itself.
+            let nested = item.get("content").and_then(Value::as_array);
+            for part in std::iter::once(item).chain(nested.into_iter().flatten()) {
+                if let Some(url) = image_part_url(part) {
+                    if url.starts_with("https://") || url.starts_with("http://") {
+                        urls.push(url.to_string());
+                    }
+                }
+            }
+        }
+    }
+    urls
+}
+
+/// When a non-2xx upstream error was caused by a remote image URL in the client's
+/// request that the upstream could not fetch, return a normalized, client-facing
+/// message and let the caller treat it as a 400. Detection is URL-correlation
+/// based: the request carried a remote image URL AND the upstream error message
+/// names that URL (or its host). This keeps false positives out — an unrelated 5xx
+/// never matches. Returns `None` when it is not an image-input error (caller keeps
+/// the existing mapping). The status check runs first, so success responses never
+/// touch the request body.
+pub fn classify_image_input_error(
+    received_body: &[u8],
+    upstream_status: u16,
+    upstream_body: &[u8],
+) -> Option<String> {
+    if (200..300).contains(&upstream_status) {
+        return None;
+    }
+    let message = extract_error_message(upstream_body)?;
+    let matched = remote_image_urls(received_body).into_iter().find(|url| {
+        message.contains(url.as_str())
+            || url_host(url).is_some_and(|host| message_references_host(&message, host))
+    })?;
+    Some(format!(
+        "Failed to fetch the image at the provided URL: {matched}. \
+         Ensure the URL is correct and publicly accessible."
+    ))
+}
+
+/// The error-envelope surface for an endpoint path: `/v1/messages` is
+/// Anthropic-shaped, everything else OpenAI-shaped.
+pub fn surface_for_path(endpoint_path: &str) -> Surface {
+    if endpoint_path == crate::aggregator::service::MESSAGES_PATH {
+        Surface::Anthropic
+    } else {
+        Surface::Openai
+    }
+}
+
+/// The client-facing `(status, envelope bytes)` for an image-input error, or
+/// `None` when the upstream error is not one (see
+/// [`classify_image_input_error`]). The single place the 400 response for this
+/// error is assembled — every serving path applies these parts as-is.
+pub fn image_input_error_parts(
+    surface: Surface,
+    received_body: &[u8],
+    upstream_status: u16,
+    upstream_body: &[u8],
+    request_id: Option<&str>,
+) -> Option<(u16, Vec<u8>)> {
+    let message = classify_image_input_error(received_body, upstream_status, upstream_body)?;
+    Some((
+        400,
+        envelope_bytes(surface, error_type(surface, 400), &message, request_id),
+    ))
+}
+
 /// Normalize a non-2xx upstream response into the client-facing status and the
 /// surface-shaped error body bytes. For actionable client errors the provider's
 /// own message is re-wrapped at the original status; everything else gets a
@@ -211,8 +348,16 @@ pub fn normalize_upstream_error_parts(
     surface: Surface,
     upstream_status: u16,
     body: &[u8],
+    received_body: &[u8],
     request_id: Option<&str>,
 ) -> (u16, Vec<u8>) {
+    // A failed fetch of a client-supplied image URL is the caller's problem, not a
+    // provider fault: surface it as a 400 with a message naming the URL.
+    if let Some(parts) =
+        image_input_error_parts(surface, received_body, upstream_status, body, request_id)
+    {
+        return parts;
+    }
     if is_actionable_client_error(upstream_status) {
         if let Some(message) = extract_error_message(body) {
             return (
@@ -238,32 +383,25 @@ pub fn normalize_upstream_error_parts(
     )
 }
 
+/// Wrap `(status, envelope bytes)` parts into a JSON error response.
+pub fn parts_response(status: u16, body: Vec<u8>) -> Response {
+    let status = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    (status, headers, body).into_response()
+}
+
 /// Normalize a non-2xx upstream response into a surface-shaped error response.
 pub fn normalize_upstream_error(
     surface: Surface,
     upstream_status: u16,
     body: &[u8],
+    received_body: &[u8],
     request_id: Option<&str>,
 ) -> Response {
-    if is_actionable_client_error(upstream_status) {
-        if let Some(message) = extract_error_message(body) {
-            return error_response(
-                surface,
-                upstream_status,
-                error_type(surface, upstream_status),
-                &message,
-                request_id,
-            );
-        }
-    }
-    let status = map_upstream_status(upstream_status);
-    error_response(
-        surface,
-        status,
-        error_type(surface, status),
-        upstream_message(upstream_status),
-        request_id,
-    )
+    let (status, bytes) =
+        normalize_upstream_error_parts(surface, upstream_status, body, received_body, request_id);
+    parts_response(status, bytes)
 }
 
 #[cfg(test)]
@@ -348,6 +486,7 @@ mod tests {
             Surface::Openai,
             400,
             br#"{"error":{"message":"missing field foo"}}"#,
+            b"",
             None,
         ))
         .await;
@@ -358,6 +497,7 @@ mod tests {
             Surface::Openai,
             500,
             br#"{"error":{"message":"upstream secret"}}"#,
+            b"",
             None,
         ))
         .await;
@@ -366,5 +506,101 @@ mod tests {
             body["error"]["message"],
             json!("The upstream provider returned an error")
         );
+    }
+
+    #[test]
+    fn remote_image_urls_covers_all_shapes_and_skips_data_uris() {
+        // OpenAI chat (object form) + data URI skipped.
+        let openai = br#"{"messages":[{"role":"user","content":[
+            {"type":"text","text":"hi"},
+            {"type":"image_url","image_url":{"url":"https://a.example/x.jpg"}},
+            {"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}
+        ]}]}"#;
+        assert_eq!(
+            remote_image_urls(openai),
+            vec!["https://a.example/x.jpg".to_string()]
+        );
+        // Anthropic native: image `source` of type url; base64 source skipped.
+        let anthropic = br#"{"messages":[{"role":"user","content":[
+            {"type":"image","source":{"type":"url","url":"https://a.example/anthropic.jpg"}},
+            {"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}
+        ]}]}"#;
+        assert_eq!(
+            remote_image_urls(anthropic),
+            vec!["https://a.example/anthropic.jpg".to_string()]
+        );
+        // Responses: input[] parts nested under content and directly, image_url as a
+        // bare string.
+        let responses = br#"{"input":[
+            {"role":"user","content":[{"type":"input_image","image_url":"https://a.example/nested.jpg"}]},
+            {"type":"input_image","image_url":"https://a.example/direct.jpg"}
+        ]}"#;
+        assert_eq!(
+            remote_image_urls(responses),
+            vec![
+                "https://a.example/nested.jpg".to_string(),
+                "https://a.example/direct.jpg".to_string()
+            ]
+        );
+        // No image content at all -> empty (and the cheap guard skips the parse).
+        assert!(remote_image_urls(br#"{"messages":[{"role":"user","content":"hi"}]}"#).is_empty());
+    }
+
+    #[test]
+    fn classify_image_input_error_matches_url_and_host() {
+        // A request carrying one remote image URL.
+        fn request(url: &str) -> Vec<u8> {
+            serde_json::to_vec(&json!({
+                "messages": [{ "role": "user", "content": [
+                    { "type": "image_url", "image_url": { "url": url } }
+                ]}]
+            }))
+            .unwrap()
+        }
+        let req = request("https://halleonard.example/wl/02116757-wl.jpg");
+        // Full-URL match (the 403-fetch probe).
+        assert!(classify_image_input_error(
+            &req,
+            500,
+            br#"{"error":{"message":"403, message='Forbidden', url='https://halleonard.example/wl/02116757-wl.jpg'"}}"#,
+        )
+        .is_some());
+        // Host-only match (the DNS-failure probe).
+        assert!(classify_image_input_error(
+            &request("https://files.teleclaw.io/workspace/x.jpg"),
+            500,
+            br#"{"error":{"message":"Cannot connect to host files.teleclaw.io:443 ssl:default [Name or service not known]"}}"#,
+        )
+        .is_some());
+        // No remote URL in the request (invalid base64 probe) -> not an image-input error.
+        assert!(classify_image_input_error(
+            &request("data:image/png;base64,bm90YW5pbWFnZQ=="),
+            400,
+            br#"{"error":{"message":"Failed to load image: cannot identify image file"}}"#,
+        )
+        .is_none());
+        // A 5xx that names an unrelated URL must not be misclassified.
+        assert!(classify_image_input_error(
+            &req,
+            500,
+            br#"{"error":{"message":"internal error talking to https://other.example/foo"}}"#,
+        )
+        .is_none());
+        // A bare single-label host must NOT match an unrelated word in a generic
+        // provider error (the `contains(host)` false positive).
+        assert!(classify_image_input_error(
+            &request("https://internal/x.jpg"),
+            500,
+            br#"{"error":{"message":"internal error"}}"#,
+        )
+        .is_none());
+        // A domain-like host must only match as a whole token, not as a substring of
+        // a larger hostname.
+        assert!(classify_image_input_error(
+            &request("https://a.co/x.jpg"),
+            500,
+            br#"{"error":{"message":"failed to reach banana.com"}}"#,
+        )
+        .is_none());
     }
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -427,6 +427,99 @@ async fn chat_default_required_fails_closed_without_verifier() {
 }
 
 #[tokio::test]
+async fn direct_messages_image_fetch_5xx_returns_anthropic_400() {
+    // Direct path (no control middleware) on the Anthropic surface: an upstream 5xx
+    // caused by a client image URL becomes a 400 in the *Anthropic* error envelope,
+    // and the classification survives the buffered path (Findings: surface-aware
+    // envelope + classify on the cleartext body).
+    struct ErrUpstream;
+    #[async_trait]
+    impl UpstreamBackend for ErrUpstream {
+        fn name(&self) -> &str {
+            "err-upstream"
+        }
+        fn url_origin(&self) -> Option<&str> {
+            Some("http://err-upstream")
+        }
+        async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+            let mut headers = std::collections::HashMap::new();
+            headers.insert("content-type".to_string(), "application/json".to_string());
+            Ok(UpstreamResponse {
+                status_code: 500,
+                body: br#"{"error":{"message":"403, message='Forbidden', url='https://img.example/x.jpg'","type":"InternalServerError"}}"#.to_vec(),
+                headers,
+                served_instance_id: None,
+            })
+        }
+        async fn forward_verified_prepared(
+            &self,
+            req: PreparedUpstreamRequest,
+            _event: &UpstreamVerifiedEvent,
+        ) -> Result<UpstreamResponse, UpstreamError> {
+            self.forward(req.request).await
+        }
+    }
+
+    let mut cfg = AciServiceConfig::for_test("private-ai-gateway");
+    cfg.service_capabilities = ServiceCapabilities::default();
+    let svc = Arc::new(
+        AciService::new(
+            Arc::new(StaticKeyProvider::default()),
+            Arc::new(StubQuoter::default()),
+            Arc::new(ErrUpstream),
+            Arc::new(InMemoryReceiptStore::default()),
+            cfg,
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap(),
+    );
+    let app = build_router(svc.clone());
+
+    let body = serde_json::json!({
+        "model": "claude-x",
+        "messages": [{ "role": "user", "content": [
+            { "type": "image", "source": { "type": "url", "url": "https://img.example/x.jpg" } }
+        ]}]
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .header("x-upstream-verification", "none")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // The 400 is receipt-backed (the remap happens in the service before finalize),
+    // so it carries an x-receipt-id and the receipt is retrievable — the response is
+    // still provable, unlike a header-less body swapped in after signing.
+    let receipt_id = resp
+        .headers()
+        .get("x-receipt-id")
+        .expect("image-input 400 must still carry a receipt id")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(svc.get_receipt_by_receipt_id(&receipt_id).is_some());
+    let json: Value = serde_json::from_slice(&body_bytes(resp.into_body()).await).unwrap();
+    // Anthropic envelope shape (not OpenAI): top-level "type":"error".
+    assert_eq!(json["type"], serde_json::json!("error"));
+    assert_eq!(
+        json["error"]["type"],
+        serde_json::json!("invalid_request_error")
+    );
+    assert!(json["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("https://img.example/x.jpg"));
+}
+
+#[tokio::test]
 async fn chat_opt_out_forwards_and_signs_receipt_with_failed_event() {
     let h = make_harness();
     let app = build_router(h.service.clone());

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -501,6 +501,68 @@ async fn total_forward_failure_reports_upstream_failure() {
 }
 
 #[tokio::test]
+async fn image_fetch_5xx_becomes_400_and_is_not_failed_over() {
+    // The upstream can't fetch the client's image URL and (wrongly) reports it as a
+    // 500. That is a bad-input error: the client must get a 400, it must not fail
+    // over across candidates (it would fail identically), and the provider must not
+    // be charged for it (the report carries 400, which control excludes from health).
+    let url = "https://halleonard.example/wl/02116757-wl.jpg";
+    let (control_url, posts) = spawn_control_capturing(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [
+                { "routeId": "openai:a", "format": "openai" },
+                { "routeId": "openai:b", "format": "openai" }
+            ]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let upstream_body = format!(
+        r#"{{"error":{{"message":"403, message='Forbidden', url='{url}'","type":"InternalServerError","param":null,"code":500}}}}"#
+    );
+    let service = build_service_with_upstream(500, upstream_body.into_bytes());
+
+    let mut input = chat_input();
+    input.upstream_required = false;
+    input.params = json!({
+        "model": "gpt-test",
+        "messages": [{
+            "role": "user",
+            "content": [
+                { "type": "text", "text": "describe" },
+                { "type": "image_url", "image_url": { "url": url } }
+            ]
+        }]
+    });
+    input.received_body = serde_json::to_vec(&input.params).unwrap();
+
+    let (status, _, body) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 400, "a bad client image URL is a 400, not a 5xx");
+    assert_eq!(body["error"]["type"], json!("invalid_request_error"));
+    assert!(body["error"]["message"].as_str().unwrap().contains(url));
+
+    // The committed attempt is reported as 400 (client-attributable, not provider).
+    let report = wait_for_post(&posts, |r| {
+        r["status"].as_i64() == Some(400)
+            && r.get("errorSource").map(Value::is_null).unwrap_or(true)
+    })
+    .await;
+    assert_eq!(report["status"].as_i64(), Some(400));
+    // And the request was never failed over: no attempt is reported with the raw 500.
+    let failed_over = posts
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|r| r["status"].as_i64() == Some(500));
+    assert!(
+        !failed_over,
+        "an image-input error must not trigger failover attempts"
+    );
+}
+
+#[tokio::test]
 async fn empty_candidates_returns_model_not_found() {
     let control_url = spawn_control(200, json!({ "allow": true, "candidates": [] })).await;
     let mw = middleware(control_url);


### PR DESCRIPTION
## Problem

When an upstream backend can't fetch a **client-supplied** remote `image_url` (403 Forbidden, DNS failure, …) it reports the failure as an HTTP **500**. That's a client-input error — the gateway was surfacing it to callers as `500`/`502` and, worse, retrying it across every provider and charging it against provider health.

Probes (`gemma4-5xx-probe`):

| Client input | Upstream returns | Was | Now |
|---|---|---|---|
| invalid base64 `data:` image | 400 | 400 ✅ | 400 |
| remote URL that 403s | 500 | 500/502 ❌ | **400** |
| remote URL, host doesn't resolve | 500 | 500/502 ❌ | **400** |

Industry convention agrees (OpenAI `400 invalid_request_error`, Portkey classifies image-download failures as 4xx).

## Approach

- **Detection is URL-correlation based** (`classify_image_input_error`): only remap when the request carried a remote image URL **and** the upstream error message names that URL — or its *domain-like* host matched as a whole token. An unrelated provider 5xx never matches, so we don't blame the client or suppress failover for a real provider fault.
- Covers the **OpenAI chat**, **Anthropic messages** (`source.url`), and **Responses** (`input_image`) image shapes on the shared completion path; `data:` images are skipped. A cheap `contains("image")` guard keeps the JSON parse off the success hot path (classification runs only on error responses).
- **No failover** on these (`should_fail_over`) — a broken URL fails identically on every candidate.
- **Reported to the control plane as 400** so the existing 4xx-exclusion in provider-health metrics leaves the provider unpenalized (`reported_status`).
- The remap is decided **in the service before E2EE encryption and receipt finalize**, so the receipt attests exactly the body/status the client receives, the body is E2EE-encrypted, and the response carries `x-receipt-id` / `x-e2ee-applied`. Direct and middleware paths share one assembly point (`image_input_error_parts`).

The content-blind control plane needs no change.

## Tests

- `errors.rs` unit tests: URL/host correlation, false-positive guards (single-label host, substring host), all three image shapes.
- `middleware_completion.rs`: end-to-end 400 + no failover + reported-status 400.
- `http.rs`: direct `/v1/messages` returns the **Anthropic** error envelope and the 400 is receipt-backed (`x-receipt-id` present, receipt retrievable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)