### PR TITLE
feat(upstream): add native Anthropic provider (x-api-key auth)

### DIFF
--- a/deploy/upstreams.example.json
+++ b/deploy/upstreams.example.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "anthropic",
+    "provider": "anthropic",
+    "base_url": "https://api.anthropic.com",
+    "path": "/v1/messages",
+    "models": {
+      "anthropic/claude-haiku-4.5": "claude-haiku-4-5"
+    },
+    "bearer_token": "<anthropic-api-key>"
+  },
+  {
     "name": "tinfoil-glm51",
     "provider": "tinfoil",
     "base_url": "https://inference.tinfoil.sh",

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -14,10 +14,23 @@ use super::{
 };
 use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent};
 
+/// Version header required by the native Anthropic API on every request.
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// How the configured credential is attached to upstream requests.
+enum UpstreamAuth {
+    /// `Authorization: Bearer <token>` (OpenAI-compatible APIs).
+    Bearer(String),
+    /// `x-api-key: <key>` plus the required `anthropic-version` header
+    /// (native Anthropic API; it rejects API keys sent as Bearer).
+    AnthropicApiKey(String),
+}
+
 /// The minimal forwarder.
 ///
-/// Sends `req.body` as the request body to `base_url + path`. Adds
-/// an `Authorization: Bearer <token>` header when configured.
+/// Sends `req.body` as the request body to `base_url + path`. Attaches
+/// the configured credential as either a Bearer token or an Anthropic
+/// `x-api-key` header.
 ///
 /// This backend does *not* do upstream attestation. An aggregator
 /// that relies on it MUST run an attested per-upstream verifier
@@ -27,7 +40,7 @@ pub struct OpenAICompatibleBackend {
     name: String,
     base_url: String,
     path: String,
-    bearer_token: Option<String>,
+    auth: Option<UpstreamAuth>,
     client: reqwest::Client,
     connect_timeout_seconds: u64,
     read_timeout_seconds: u64,
@@ -60,7 +73,7 @@ impl OpenAICompatibleBackend {
             name: "openai-compatible".to_string(),
             base_url: base,
             path: "/v1/chat/completions".to_string(),
-            bearer_token: None,
+            auth: None,
             client,
             connect_timeout_seconds,
             read_timeout_seconds,
@@ -82,8 +95,25 @@ impl OpenAICompatibleBackend {
     }
 
     pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
-        self.bearer_token = Some(token.into());
+        self.auth = Some(UpstreamAuth::Bearer(token.into()));
         self
+    }
+
+    pub fn with_anthropic_api_key(mut self, key: impl Into<String>) -> Self {
+        self.auth = Some(UpstreamAuth::AnthropicApiKey(key.into()));
+        self
+    }
+
+    fn apply_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.auth {
+            Some(UpstreamAuth::Bearer(token)) => {
+                builder.header("authorization", format!("Bearer {token}"))
+            }
+            Some(UpstreamAuth::AnthropicApiKey(key)) => builder
+                .header("x-api-key", key.as_str())
+                .header("anthropic-version", ANTHROPIC_VERSION),
+            None => builder,
+        }
     }
 }
 
@@ -330,18 +360,44 @@ impl OpenAICompatibleBackend {
         for (k, v) in req.headers.iter() {
             builder = builder.header(k, v);
         }
-        if let Some(t) = &self.bearer_token {
-            builder = builder.header("authorization", format!("Bearer {t}"));
-        }
-        builder
+        self.apply_auth(builder)
     }
 
     fn get_builder(&self, path: &str, accept: &'static str) -> reqwest::RequestBuilder {
         let url = format!("{}{}", self.base_url, path);
-        let mut builder = self.client.get(&url).header("accept", accept);
-        if let Some(t) = &self.bearer_token {
-            builder = builder.header("authorization", format!("Bearer {t}"));
-        }
-        builder
+        let builder = self.client.get(&url).header("accept", accept);
+        self.apply_auth(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_auth_sends_x_api_key_not_bearer() {
+        let backend = OpenAICompatibleBackend::new("https://api.anthropic.com")
+            .unwrap()
+            .with_anthropic_api_key("sk-test");
+        let req = backend
+            .get_builder("/v1/models", "application/json")
+            .build()
+            .unwrap();
+        assert_eq!(req.headers().get("x-api-key").unwrap(), "sk-test");
+        assert_eq!(
+            req.headers().get("anthropic-version").unwrap(),
+            ANTHROPIC_VERSION
+        );
+        assert!(req.headers().get("authorization").is_none());
+
+        let bearer = OpenAICompatibleBackend::new("https://example.com")
+            .unwrap()
+            .with_bearer_token("tok");
+        let req = bearer
+            .get_builder("/v1/models", "application/json")
+            .build()
+            .unwrap();
+        assert_eq!(req.headers().get("authorization").unwrap(), "Bearer tok");
+        assert!(req.headers().get("x-api-key").is_none());
     }
 }

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -73,7 +73,7 @@ fn build_model_router(
 /// with TLS endpoint binding only.
 fn provider_is_tee(provider: UpstreamProvider) -> bool {
     match provider {
-        UpstreamProvider::OpenAiCompatible => false,
+        UpstreamProvider::OpenAiCompatible | UpstreamProvider::Anthropic => false,
         UpstreamProvider::AciDcap
         | UpstreamProvider::Chutes
         | UpstreamProvider::Tinfoil
@@ -108,6 +108,7 @@ fn build_provider_backend(
             )?))
         }
         UpstreamProvider::OpenAiCompatible
+        | UpstreamProvider::Anthropic
         | UpstreamProvider::AciDcap
         | UpstreamProvider::Tinfoil
         | UpstreamProvider::NearAi
@@ -120,7 +121,11 @@ fn build_provider_backend(
             .map_err(|e| UpstreamConfigError::InvalidConfig(e.to_string()))?
             .with_name(cfg.name.clone());
             if let Some(token) = &cfg.bearer_token {
-                backend = backend.with_bearer_token(token.clone());
+                backend = if cfg.provider == UpstreamProvider::Anthropic {
+                    backend.with_anthropic_api_key(token.clone())
+                } else {
+                    backend.with_bearer_token(token.clone())
+                };
             }
             Ok(Arc::new(backend))
         }
@@ -192,10 +197,7 @@ fn build_provider_verifier(
     options: &UpstreamRuntimeOptions,
     sessions: &ProviderSessionRegistry,
 ) -> Result<Option<Arc<dyn UpstreamVerifier>>, UpstreamConfigError> {
-    if !config
-        .iter()
-        .any(|cfg| cfg.provider != UpstreamProvider::OpenAiCompatible)
-    {
+    if !config.iter().any(|cfg| provider_is_tee(cfg.provider)) {
         return Ok(None);
     }
     let mut router = RoutingUpstreamVerifier::new();
@@ -207,7 +209,9 @@ fn build_provider_verifier(
             .verifier_request_timeout_seconds
             .unwrap_or(options.verifier_request_timeout_seconds);
         let verifier: Option<Arc<dyn UpstreamVerifier>> = match cfg.provider {
-            UpstreamProvider::OpenAiCompatible => build_global_verifier_for_config(cfg, options)?,
+            UpstreamProvider::OpenAiCompatible | UpstreamProvider::Anthropic => {
+                build_global_verifier_for_config(cfg, options)?
+            }
             UpstreamProvider::AciDcap => Some(build_aci_dcap_verifier(cfg, options)?),
             UpstreamProvider::Chutes => {
                 let session_store = sessions.chutes(&cfg.name).ok_or_else(|| {

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -152,6 +152,9 @@ pub enum UpstreamProvider {
     #[default]
     #[serde(rename = "openai-compatible")]
     OpenAiCompatible,
+    /// Native Anthropic API: authenticates with `x-api-key` plus the
+    /// required `anthropic-version` header instead of a Bearer token.
+    Anthropic,
     AciDcap,
     Chutes,
     Tinfoil,
@@ -167,14 +170,14 @@ impl UpstreamProvider {
             UpstreamProvider::NearAi | UpstreamProvider::Tinfoil => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
             UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
-            // OpenAI-compatible has no verifier and ACI/DCAP uses its own, so for
-            // both this only tunes prewarm probe granularity. Per-model is the safe
-            // default — it never collapses channels. ACI's real scope is
-            // service-dependent (router or model), resolved when ACI becomes a
-            // first-party router.
-            UpstreamProvider::OpenAiCompatible | UpstreamProvider::AciDcap => {
-                AttestationScope::PerModel
-            }
+            // Plain cloud APIs (OpenAI-compatible, Anthropic) have no verifier
+            // and ACI/DCAP uses its own, so for all of these this only tunes
+            // prewarm probe granularity. Per-model is the safe default — it
+            // never collapses channels. ACI's real scope is service-dependent
+            // (router or model), resolved when ACI becomes a first-party router.
+            UpstreamProvider::OpenAiCompatible
+            | UpstreamProvider::Anthropic
+            | UpstreamProvider::AciDcap => AttestationScope::PerModel,
         }
     }
 }

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -243,6 +243,17 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
                 upstream.name
             )));
         }
+        // The native Anthropic API only serves /v1/messages; without an
+        // explicit path the router falls back to /v1/chat/completions and
+        // every request 404s with no config-time signal.
+        if upstream.provider == UpstreamProvider::Anthropic
+            && upstream.path.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} provider anthropic requires path (e.g. \"/v1/messages\")",
+                upstream.name
+            )));
+        }
         for (public_model, upstream_model) in &upstream.models {
             if public_model.trim().is_empty() {
                 return Err(UpstreamConfigError::InvalidConfig(format!(


### PR DESCRIPTION
## Problem

Anthropic upstreams were configured as generic `openai-compatible` providers, so the gateway sent `Authorization: Bearer <key>` to `api.anthropic.com`. The native Anthropic API rejects API keys sent as Bearer (it requires `x-api-key`), so every request returned **401** — visible as 401s recorded in `request_logs`.

## Change

Add a native `anthropic` `UpstreamProvider`:

- **Auth**: attaches `x-api-key: <key>` + `anthropic-version: 2023-06-01` instead of `Authorization: Bearer`. Credential attachment is parameterized via a new `UpstreamAuth` enum (Bearer vs Anthropic), which also dedupes the previously-duplicated POST/GET auth wiring in `OpenAICompatibleBackend`.
- **Config validation**: `provider=anthropic` now requires `path` (native Anthropic only serves `/v1/messages`; without it the router silently falls back to `/v1/chat/completions` and 404s with no config-time signal). Mirrors the existing Chutes cross-field validation precedent.
- **Attestation**: classified non-TEE (TLS endpoint binding only), same posture as other plain cloud APIs.
- Example config entry added to `deploy/upstreams.example.json`.

## Scope / follow-ups

This is the gateway half. Two companion changes land in the control/admin repos so the generated config and runtime routing line up:
- **redpill-api**: gateway-upstreams sync now maps `anthropic` → the native `anthropic` gateway provider (was `openai-compatible`) — the actual source of the production 401.
- **private-ai-control**: consult now derives `format: "anthropic"` from `provider_name`, so the middleware performs OpenAI↔Anthropic body conversion (prevents the 400 that would otherwise follow once auth is fixed).

Note: body-format conversion is owned by the control-plane middleware; a middleware-less deployment must send native Anthropic bodies to `/v1/messages`.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite (310 passed / 0 failed) all pass. Added a focused unit test asserting the Anthropic auth path sends `x-api-key` + `anthropic-version` and no `authorization`, and the Bearer path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)