### PR TITLE
TypeScript ACI Level 1 verifier validated against the test vectors

### DIFF
--- a/.github/workflows/verifier-ts.yml
+++ b/.github/workflows/verifier-ts.yml
@@ -1,0 +1,38 @@
+name: verifier-ts
+
+on:
+  pull_request:
+    paths:
+      - 'clients/verifier-ts/**'
+      - '.github/workflows/verifier-ts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'clients/verifier-ts/**'
+      - '.github/workflows/verifier-ts.yml'
+
+defaults:
+  run:
+    working-directory: clients/verifier-ts
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: clients/verifier-ts/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test (spec vectors)
+        run: npm test

--- a/clients/verifier-ts/.gitignore
+++ b/clients/verifier-ts/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+dist-test/
+*.tsbuildinfo

--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -1,0 +1,79 @@
+# @dstack/aci-verifier
+
+A zero-dependency TypeScript verifier for [Attested Confidential Inference
+(ACI)](../../spec/aci.md). It implements **Level 1 — receipt verification**
+(spec §10.2) and the cryptographic-binding subset of **Level 2** (§10.1 checks
+2–6), using only the Web Crypto API (Ed25519, SHA-256) plus a small built-in
+JCS canonicalizer. The same code runs in a browser and in Node 20+; nothing in
+`src/` uses a Node-only API.
+
+Every construction is checked byte-for-byte against
+[spec/test-vectors.md](../../spec/test-vectors.md) — `workload_id`, the keyset
+digest, `report_data`, keyset endorsement and revocation signatures,
+`session_id`, the receipt canonical bytes and signature, and the E2EE AAD
+strings.
+
+## What it verifies
+
+- **Receipts (Level 1, §10.2 checks 1–2):** `verifyReceipt(receipt, keyset)`
+  checks the receipt signature under a key in the established keyset's
+  `receipt_signing_keys`, that `signature.algo` matches that key, and that the
+  receipt's `workload_id` / `workload_keyset_digest` match the established
+  keyset. Body-hash helpers (`checkRequestBodyHash`, `checkResponseWireHash`,
+  `checkResponseCleartextHash`) cover checks 3–4.
+- **Report binding (Level 2, §10.1 checks 2–6, no hardware quote):**
+  `verifyReportBinding(report, nonce)` recomputes `workload_id`, the keyset
+  digest, and `report_data` for the supplied nonce, verifies the keyset
+  endorsement under the identity key, and checks epoch freshness.
+- **Digest & canonicalization primitives:** JCS canonicalization,
+  `computeWorkloadId`, `computeKeysetDigest`, `computeReportData`,
+  `computeSessionId`, `receiptSigningBytes`, and the endorsement/revocation
+  payload builders.
+- **E2EE AAD builders (§7.3):** `requestAad` / `responseAad` for clients that
+  encrypt request/response fields.
+
+## What it does not do
+
+- **No hardware quote verification.** §10.1 check 1 (the TDX/SEV-SNP quote
+  verifies to the vendor root) and the "hardware evidence binds `report_data`"
+  half of check 4 are verifier-profile / Level 2 territory and need primitives
+  outside the Web Crypto API. `verifyReportBinding` proves only the
+  cryptographic *binding* of the report; compose it with a quote verifier and
+  the custody / provenance / channel checks (§10.1 checks 1, 7–10) for full
+  Level 2.
+- **No `ecdsa-secp256k1`.** The curve is not in the Web Crypto API, so any
+  secp256k1 signature or identity key raises `UnsupportedAlgorithmError` — verify
+  those against the reference implementation or a Level 2 profile.
+- **No upstream/session deep audit** (Level 3, §10.3) beyond `computeSessionId`,
+  which lets you recompute and compare a session id a receipt committed to.
+
+Verification failures are reported as `{ ok: false, checks }` — never thrown —
+so a caller cannot pass by forgetting a `try/catch`. Errors are thrown only for
+malformed input or an out-of-scope algorithm.
+
+## Usage
+
+```ts
+import { verifyReceipt, checkResponseWireHash } from '@dstack/aci-verifier';
+
+// `keyset` is a WorkloadKeyset you already trust — from a Level 2 report
+// verification, or published by a party you trust. `receipt` and `responseBytes`
+// come from the inference response you received.
+const result = await verifyReceipt(receipt, keyset);
+if (!result.ok) {
+  throw new Error('receipt failed: ' + JSON.stringify(result.checks));
+}
+
+// §10.2 checks 3–4: the response bytes you saw match what the receipt commits to.
+if (!(await checkResponseWireHash(receipt, responseBytes))) {
+  throw new Error('response bytes do not match the receipt');
+}
+```
+
+## Development
+
+```sh
+npm install
+npm test     # tsc + node:test against every spec vector
+npm run build # emit dist/ (ESM + .d.ts)
+```

--- a/clients/verifier-ts/package-lock.json
+++ b/clients/verifier-ts/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "@dstack/aci-verifier",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dstack/aci-verifier",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dstack/aci-verifier",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Zero-dependency TypeScript ACI Level 1 verifier — Web Crypto (Ed25519, SHA-256) plus a built-in JCS.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/*.test.js",
+    "clean": "rm -rf dist dist-test"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/clients/verifier-ts/src/crypto.ts
+++ b/clients/verifier-ts/src/crypto.ts
@@ -1,0 +1,95 @@
+/**
+ * Cryptographic primitives, all via the Web Crypto API (`globalThis.crypto`) so
+ * the same code runs in browsers and in Node 20+ with no third-party deps.
+ * Only SHA-256 and Ed25519 verification are needed for Level 1.
+ */
+
+import { AciFormatError, UnsupportedAlgorithmError } from './errors.js';
+
+const subtle = globalThis.crypto.subtle;
+
+/** Lowercase-hex encode bytes. */
+export function toHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+/** Decode hex (optionally `0x`-prefixed) to bytes. */
+export function fromHex(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (h.length % 2 !== 0) {
+    throw new AciFormatError(`hex string has odd length: ${hex.length} chars`);
+  }
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = Number.parseInt(h.substr(i * 2, 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new AciFormatError(`invalid hex at offset ${i * 2}: "${h.substr(i * 2, 2)}"`);
+    }
+    out[i] = byte;
+  }
+  return out;
+}
+
+/** SHA-256 of the given bytes. */
+export async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await subtle.digest('SHA-256', bytes as BufferSource));
+}
+
+/** Lowercase-hex SHA-256 of the given bytes. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  return toHex(await sha256(bytes));
+}
+
+/**
+ * `sha256:<lowercase-hex>` digest string of the given bytes — the ACI digest
+ * form (§3) used for `workload_id`, keyset digests, and body hashes.
+ */
+export async function sha256Prefixed(bytes: Uint8Array): Promise<string> {
+  return 'sha256:' + (await sha256Hex(bytes));
+}
+
+/**
+ * Verify an Ed25519 signature (RFC 8032, §4.3/§8.5) over `message`.
+ * `publicKeyRaw` is the 32-byte raw key; `signature` the 64-byte value.
+ * Returns false on a bad signature or malformed key — never throws for those.
+ */
+export async function verifyEd25519(
+  publicKeyRaw: Uint8Array,
+  signature: Uint8Array,
+  message: Uint8Array,
+): Promise<boolean> {
+  let key: CryptoKey;
+  try {
+    key = await subtle.importKey('raw', publicKeyRaw as BufferSource, { name: 'Ed25519' }, false, [
+      'verify',
+    ]);
+  } catch {
+    // A key that will not import cannot verify anything.
+    return false;
+  }
+  try {
+    return await subtle.verify({ name: 'Ed25519' }, key, signature as BufferSource, message as BufferSource);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a signature by ACI signature `algo`, dispatching on the algorithm the
+ * attested keyset entry declares. Only `ed25519` is verifiable here; every other
+ * algorithm (including `ecdsa-secp256k1`) raises {@link UnsupportedAlgorithmError}.
+ */
+export async function verifySignature(
+  algo: string,
+  publicKeyRaw: Uint8Array,
+  signature: Uint8Array,
+  message: Uint8Array,
+  context: string,
+): Promise<boolean> {
+  if (algo === 'ed25519') {
+    return verifyEd25519(publicKeyRaw, signature, message);
+  }
+  throw new UnsupportedAlgorithmError(algo, context);
+}

--- a/clients/verifier-ts/src/digest.ts
+++ b/clients/verifier-ts/src/digest.ts
@@ -1,0 +1,116 @@
+/**
+ * The ACI digest and canonical-signing-bytes constructions (§4.1, §4.2, §4.3,
+ * §4.4, §4.7, §8.5, §9.2). Each returns the exact bytes/strings the spec pins in
+ * spec/test-vectors.md, so they double as the byte-for-byte reference.
+ */
+
+import { jcsBytes } from './jcs.js';
+import type { JcsValue } from './jcs.js';
+import { sha256Hex, sha256Prefixed } from './crypto.js';
+import type { PublicKey, WorkloadKeyset, Receipt, SessionRecord } from './types.js';
+
+/**
+ * `workload_id` — the stable name of a workload (§4.1):
+ * `"sha256:" || hex(sha256(JCS(public_key)))`.
+ */
+export async function computeWorkloadId(publicKey: PublicKey): Promise<string> {
+  return sha256Prefixed(jcsBytes({ algo: publicKey.algo, public_key: publicKey.public_key }));
+}
+
+/**
+ * `workload_keyset_digest` (§4.2): `"sha256:" || hex(sha256(JCS(keyset)))`,
+ * over the whole keyset object as given.
+ */
+export async function computeKeysetDigest(keyset: WorkloadKeyset): Promise<string> {
+  return sha256Prefixed(jcsBytes(keyset as JcsValue));
+}
+
+/**
+ * The attestation statement (§4.4) whose JCS is hashed into `report_data`.
+ * `nonce` is the request's decoded value, or JSON `null` when the query
+ * parameter was omitted (never the string `"null"`); pass `undefined`/`null` for
+ * the omitted case.
+ */
+export function attestationStatement(
+  workloadId: string,
+  workloadKeysetDigest: string,
+  nonce: string | null | undefined,
+): JcsValue {
+  return {
+    purpose: 'aci.report_data.v1',
+    workload_id: workloadId,
+    workload_keyset_digest: workloadKeysetDigest,
+    nonce: nonce ?? null,
+  };
+}
+
+/**
+ * `report_data` (§4.4): `hex(sha256(JCS(attestation_statement)))` — the raw
+ * 32-byte digest as lowercase hex, with no `sha256:` prefix (it names a bare
+ * report-data slot, not an ACI digest string).
+ */
+export async function computeReportData(
+  workloadId: string,
+  workloadKeysetDigest: string,
+  nonce: string | null | undefined,
+): Promise<string> {
+  return sha256Hex(jcsBytes(attestationStatement(workloadId, workloadKeysetDigest, nonce)));
+}
+
+/** JCS bytes of the keyset endorsement payload (§4.3), signed by the identity key. */
+export function keysetEndorsementPayload(workloadKeysetDigest: string): Uint8Array {
+  return jcsBytes({
+    purpose: 'aci.keyset.endorsement.v1',
+    workload_keyset_digest: workloadKeysetDigest,
+  });
+}
+
+/** JCS bytes of the keyset revocation payload (§4.7), signed by the identity key. */
+export function keysetRevocationPayload(workloadKeysetDigest: string): Uint8Array {
+  return jcsBytes({
+    purpose: 'aci.keyset.revocation.v1',
+    workload_keyset_digest: workloadKeysetDigest,
+  });
+}
+
+/**
+ * Canonical bytes a receipt signature covers (§8.5): the JCS of the whole
+ * receipt with only `signature.value` removed (`algo` and `key_id`, and any
+ * other signature fields, are retained). Unknown top-level fields and events are
+ * preserved by canonicalizing the object as given (§3.2).
+ */
+export function receiptSigningBytes(receipt: Receipt): Uint8Array {
+  const { value: _omitted, ...signatureWithoutValue } = receipt.signature;
+  const forSigning: JcsValue = {
+    ...(receipt as unknown as { [k: string]: JcsValue }),
+    signature: signatureWithoutValue as unknown as JcsValue,
+  };
+  return jcsBytes(forSigning);
+}
+
+/**
+ * The content-addressing material for a session id (§9.2). The wire record omits
+ * absent optional fields; the material restores `endpoint`, `identity`, and
+ * `evidence.digest` as JSON `null`, and timestamps / raw evidence bytes are
+ * excluded entirely.
+ */
+export function sessionMaterial(record: SessionRecord): JcsValue {
+  return {
+    upstream_name: record.upstream_name,
+    endpoint: record.endpoint ?? null,
+    verifier_id: record.verifier_id,
+    identity: record.identity ?? null,
+    channel_binding: record.channel_binding,
+    claims: record.claims,
+    evidence_digest: record.evidence?.digest ?? null,
+  };
+}
+
+/**
+ * `session_id` (§9.2): `"as_" || hex(sha256(JCS(material)))`. Recomputing this
+ * from a fetched record and comparing it to the id the signed receipt committed
+ * to is what makes the session tamper-evident — there is no session signature.
+ */
+export async function computeSessionId(record: SessionRecord): Promise<string> {
+  return 'as_' + (await sha256Hex(jcsBytes(sessionMaterial(record))));
+}

--- a/clients/verifier-ts/src/e2ee.ts
+++ b/clients/verifier-ts/src/e2ee.ts
@@ -1,0 +1,73 @@
+/**
+ * E2EE associated-data (AAD) builders (§7.3). The AAD binds each ciphertext to
+ * its field path and request context; it is the JCS of a purpose-tagged object,
+ * so no component needs bespoke escaping. Provided here because clients that
+ * encrypt fields need the exact bytes — the verifier itself does not decrypt.
+ * The X25519 and secp256k1 suites share these builders; `algo` is just a field.
+ */
+
+import { canonicalize, jcsBytes } from './jcs.js';
+
+/** Inputs shared by request and response AAD (§7.3). */
+export interface AadCommon {
+  /** `algo` of the selected service E2EE key. */
+  algo: string;
+  /** The request's top-level `model`, byte-exact. */
+  model: string;
+  /** The encrypted location's field path, e.g. `messages.0.content` (§7.2). */
+  field: string;
+  /** The request's `X-E2EE-Nonce` (string). */
+  nonce: string;
+  /** The request's `X-E2EE-Timestamp` (Unix seconds, integer). */
+  ts: number;
+}
+
+/** Request AAD (§7.3), tag `aci.e2ee.request.v2`. Returns the canonical JCS string. */
+export function requestAadString(params: AadCommon): string {
+  return canonicalize({
+    purpose: 'aci.e2ee.request.v2',
+    algo: params.algo,
+    model: params.model,
+    field: params.field,
+    nonce: params.nonce,
+    ts: params.ts,
+  });
+}
+
+/** Request AAD as UTF-8 bytes — the value passed to AES-GCM. */
+export function requestAad(params: AadCommon): Uint8Array {
+  return jcsBytes({
+    purpose: 'aci.e2ee.request.v2',
+    algo: params.algo,
+    model: params.model,
+    field: params.field,
+    nonce: params.nonce,
+    ts: params.ts,
+  });
+}
+
+/** Response AAD (§7.3), tag `aci.e2ee.response.v2`. Adds the response `id` (`""` when none). */
+export function responseAadString(params: AadCommon & { id: string }): string {
+  return canonicalize({
+    purpose: 'aci.e2ee.response.v2',
+    algo: params.algo,
+    model: params.model,
+    id: params.id,
+    field: params.field,
+    nonce: params.nonce,
+    ts: params.ts,
+  });
+}
+
+/** Response AAD as UTF-8 bytes — the value passed to AES-GCM. */
+export function responseAad(params: AadCommon & { id: string }): Uint8Array {
+  return jcsBytes({
+    purpose: 'aci.e2ee.response.v2',
+    algo: params.algo,
+    model: params.model,
+    id: params.id,
+    field: params.field,
+    nonce: params.nonce,
+    ts: params.ts,
+  });
+}

--- a/clients/verifier-ts/src/errors.ts
+++ b/clients/verifier-ts/src/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Errors raised by the verifier for conditions that are *not* ordinary
+ * verification failures. A failed check (bad signature, wrong hash) is reported
+ * as `ok: false` in the result objects — never thrown — so callers cannot ignore
+ * it by forgetting a try/catch. These errors mean "the input is malformed or the
+ * algorithm is outside this verifier's Level 1 / Web Crypto scope".
+ */
+
+/** Base class for every error this package throws. */
+export class AciError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AciError';
+  }
+}
+
+/** A JCS input violated the ACI subset (e.g. a non-integer number) or a hex/field value would not parse. */
+export class AciFormatError extends AciError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AciFormatError';
+  }
+}
+
+/**
+ * A signature or identity algorithm that ACI defines but this Web-Crypto-only
+ * verifier cannot check. `ecdsa-secp256k1` is the expected case: the curve is
+ * absent from the Web Crypto API, so verify it against the reference
+ * implementation or a Level 2 verifier profile instead.
+ */
+export class UnsupportedAlgorithmError extends AciError {
+  readonly algorithm: string;
+  constructor(algorithm: string, context: string) {
+    super(
+      `unsupported algorithm "${algorithm}" for ${context}: this verifier supports only ed25519 via the Web Crypto API. ` +
+        `secp256k1 is out of scope — verify it against the reference implementation or a Level 2 profile.`,
+    );
+    this.name = 'UnsupportedAlgorithmError';
+    this.algorithm = algorithm;
+  }
+}

--- a/clients/verifier-ts/src/index.ts
+++ b/clients/verifier-ts/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * @dstack/aci-verifier — a zero-dependency ACI Level 1 verifier.
+ *
+ * Level 1 (receipt verification, §10.2) is fully implemented against an
+ * established keyset. {@link verifyReportBinding} adds the cryptographic-binding
+ * checks of Level 2 (§10.1 checks 2–6); the hardware quote, key custody, and
+ * provenance checks (§10.1 checks 1, 7–10) are verifier-profile territory and
+ * out of scope here. All crypto is Web Crypto (Ed25519, SHA-256); `ecdsa-secp256k1`
+ * is unsupported (not in the Web Crypto API) and raises a clear error.
+ */
+
+// Canonicalization (§3)
+export { canonicalize, jcsBytes } from './jcs.js';
+export type { JcsValue } from './jcs.js';
+
+// Crypto primitives (Web Crypto only)
+export {
+  sha256,
+  sha256Hex,
+  sha256Prefixed,
+  verifyEd25519,
+  verifySignature,
+  toHex,
+  fromHex,
+} from './crypto.js';
+
+// Digest & canonical-signing-bytes constructions (§4, §8.5, §9.2)
+export {
+  computeWorkloadId,
+  computeKeysetDigest,
+  attestationStatement,
+  computeReportData,
+  keysetEndorsementPayload,
+  keysetRevocationPayload,
+  receiptSigningBytes,
+  sessionMaterial,
+  computeSessionId,
+} from './digest.js';
+
+// E2EE AAD builders (§7.3)
+export {
+  requestAad,
+  requestAadString,
+  responseAad,
+  responseAadString,
+} from './e2ee.js';
+export type { AadCommon } from './e2ee.js';
+
+// Level 1 receipt verification (§10.2)
+export {
+  verifyReceipt,
+  findEvent,
+  hashBody,
+  checkRequestBodyHash,
+  checkResponseWireHash,
+  checkResponseCleartextHash,
+} from './receipt.js';
+
+// Level 2 report-binding checks (§10.1 checks 2–6, no hardware quote)
+export { verifyReportBinding } from './report.js';
+export type { ReportBindingOptions } from './report.js';
+
+// Errors
+export { AciError, AciFormatError, UnsupportedAlgorithmError } from './errors.js';
+
+// Wire & result types
+export type {
+  PublicKey,
+  WorkloadIdentity,
+  ReceiptSigningKey,
+  WorkloadKeyset,
+  ReceiptSignature,
+  ReceiptEvent,
+  Receipt,
+  Endorsement,
+  Attestation,
+  AttestationReport,
+  SessionEvidence,
+  SessionRecord,
+  Check,
+  ReceiptVerification,
+  ReportVerification,
+} from './types.js';

--- a/clients/verifier-ts/src/jcs.ts
+++ b/clients/verifier-ts/src/jcs.ts
@@ -1,0 +1,69 @@
+/**
+ * JSON Canonicalization Scheme (RFC 8785) for the ACI subset.
+ *
+ * ACI restricts JSON numbers to integers (§3), so this omits ECMAScript number
+ * formatting and instead *rejects* non-integer numbers — a conformant ACI object
+ * never contains one, and rejecting is safer than silently mis-serializing. For
+ * strings we reuse `JSON.stringify`, whose escaping is exactly RFC 8785's
+ * (minimal escapes, `\uXXXX` for other controls, lone surrogates escaped) since
+ * ES2019. Object members are ordered by their UTF-16 code units, which is what
+ * JavaScript's `<` on strings compares, and `undefined`-valued members are
+ * dropped (standard JSON behaviour) — build with explicit `null` where a field
+ * must appear.
+ */
+
+import { AciFormatError } from './errors.js';
+
+/** A value canonicalizable under the ACI JCS subset. */
+export type JcsValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JcsValue[]
+  | { [key: string]: JcsValue | undefined };
+
+/** Canonicalize a value to its RFC 8785 string form. */
+export function canonicalize(value: JcsValue): string {
+  if (value === null) return 'null';
+  switch (typeof value) {
+    case 'boolean':
+      return value ? 'true' : 'false';
+    case 'number':
+      if (!Number.isInteger(value)) {
+        throw new AciFormatError(
+          `JCS: ACI restricts numbers to integers, got ${value} (§3)`,
+        );
+      }
+      // -0 canonicalizes to "0".
+      return Object.is(value, -0) ? '0' : String(value);
+    case 'string':
+      return JSON.stringify(value);
+    case 'object':
+      if (Array.isArray(value)) {
+        return '[' + value.map(canonicalize).join(',') + ']';
+      }
+      return serializeObject(value);
+    default:
+      throw new AciFormatError(`JCS: unsupported type ${typeof value}`);
+  }
+}
+
+function serializeObject(obj: { [key: string]: JcsValue | undefined }): string {
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    // RFC 8785 orders by UTF-16 code units; JS `<` on strings does exactly that.
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  let out = '{';
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i]!;
+    if (i > 0) out += ',';
+    out += JSON.stringify(k) + ':' + canonicalize(obj[k] as JcsValue);
+  }
+  return out + '}';
+}
+
+/** Canonicalize and encode to UTF-8 bytes — the form fed to SHA-256 and signatures. */
+export function jcsBytes(value: JcsValue): Uint8Array {
+  return new TextEncoder().encode(canonicalize(value));
+}

--- a/clients/verifier-ts/src/receipt.ts
+++ b/clients/verifier-ts/src/receipt.ts
@@ -1,0 +1,139 @@
+/**
+ * Level 1 receipt verification (§10.2 checks 1–2) and helpers for the body-hash
+ * checks (§10.2 checks 3–4). "Established identity and keyset" means a keyset the
+ * caller already trusts — from a Level 2 report verification, or published by a
+ * party the client trusts. The recomputed `workload_id` and keyset digest of
+ * that keyset are the values the receipt must match.
+ */
+
+import { receiptSigningBytes, computeWorkloadId, computeKeysetDigest } from './digest.js';
+import { verifySignature, sha256Prefixed } from './crypto.js';
+import { fromHex } from './crypto.js';
+import type { Receipt, ReceiptEvent, WorkloadKeyset, Check, ReceiptVerification } from './types.js';
+
+/**
+ * Verify a receipt against an established keyset — §10.2 checks 1 and 2:
+ *
+ * 1. `signature.key_id` names a key in the keyset's `receipt_signing_keys`,
+ *    `signature.algo` matches that key, and the signature verifies over the
+ *    §8.5 canonical bytes under that key.
+ * 2. The receipt's `workload_id` and `workload_keyset_digest` equal the values
+ *    recomputed from the established keyset (§4.1, §4.2).
+ *
+ * Returns a per-check result — a failed check is `ok: false`, never thrown.
+ * Throws {@link UnsupportedAlgorithmError} only when the signing algorithm is
+ * outside Web Crypto scope (e.g. `ecdsa-secp256k1`).
+ */
+export async function verifyReceipt(
+  receipt: Receipt,
+  keyset: WorkloadKeyset,
+): Promise<ReceiptVerification> {
+  const checks: Check[] = [];
+
+  const establishedWorkloadId = await computeWorkloadId(keyset.workload_identity.public_key);
+  const establishedDigest = await computeKeysetDigest(keyset);
+
+  // Check 2: self-described identity matches the established keyset.
+  checks.push({
+    name: 'workload_id',
+    ok: receipt.workload_id === establishedWorkloadId,
+    ...(receipt.workload_id === establishedWorkloadId
+      ? {}
+      : { detail: `receipt ${receipt.workload_id} != established ${establishedWorkloadId}` }),
+  });
+  checks.push({
+    name: 'workload_keyset_digest',
+    ok: receipt.workload_keyset_digest === establishedDigest,
+    ...(receipt.workload_keyset_digest === establishedDigest
+      ? {}
+      : { detail: `receipt ${receipt.workload_keyset_digest} != established ${establishedDigest}` }),
+  });
+
+  // Check 1: signature under a named receipt signing key.
+  const keyEntry = keyset.receipt_signing_keys.find((k) => k.key_id === receipt.signature.key_id);
+  if (!keyEntry) {
+    checks.push({
+      name: 'signature',
+      ok: false,
+      detail: `signature.key_id "${receipt.signature.key_id}" not in receipt_signing_keys`,
+    });
+  } else if (receipt.signature.algo !== keyEntry.algo) {
+    // §3.1: the attested key decides the algorithm; the receipt may not override it.
+    checks.push({
+      name: 'signature',
+      ok: false,
+      detail: `signature.algo "${receipt.signature.algo}" != keyset entry algo "${keyEntry.algo}"`,
+    });
+  } else {
+    const message = receiptSigningBytes(receipt);
+    const ok = await verifySignature(
+      keyEntry.algo,
+      fromHex(keyEntry.public_key),
+      fromHex(receipt.signature.value),
+      message,
+      'receipt signature (§8.5)',
+    );
+    checks.push({ name: 'signature', ok, ...(ok ? {} : { detail: 'Ed25519 verification failed' }) });
+  }
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
+
+/** Find the first event of a given type in a receipt's event log. */
+export function findEvent(receipt: Receipt, type: string): ReceiptEvent | undefined {
+  return receipt.event_log.find((e) => e.type === type);
+}
+
+/**
+ * `sha256:<hex>` of raw body bytes — the form ACI body hashes use (§3). Accepts a
+ * string (UTF-8 encoded) or raw bytes.
+ */
+export async function hashBody(body: Uint8Array | string): Promise<string> {
+  const bytes = typeof body === 'string' ? new TextEncoder().encode(body) : body;
+  return sha256Prefixed(bytes);
+}
+
+/**
+ * §10.2 check 3: the request bytes the client sent match `request.received.body_hash`.
+ * For E2EE requests, pass the decrypted body as the service observed it (§8.3, §12).
+ * Returns false when the event or its hash is absent.
+ */
+export async function checkRequestBodyHash(
+  receipt: Receipt,
+  requestBody: Uint8Array | string,
+): Promise<boolean> {
+  const event = findEvent(receipt, 'request.received');
+  const expected = event?.body_hash;
+  if (typeof expected !== 'string') return false;
+  return (await hashBody(requestBody)) === expected;
+}
+
+/**
+ * §10.2 check 4: the response bytes the client received match
+ * `response.returned.wire_hash` — for a stream, the in-order raw SSE bytes.
+ * Returns false when the event or its hash is absent.
+ */
+export async function checkResponseWireHash(
+  receipt: Receipt,
+  responseBody: Uint8Array | string,
+): Promise<boolean> {
+  const event = findEvent(receipt, 'response.returned');
+  const expected = event?.wire_hash;
+  if (typeof expected !== 'string') return false;
+  return (await hashBody(responseBody)) === expected;
+}
+
+/**
+ * For E2EE responses, check the decrypted response bytes match
+ * `response.returned.cleartext_hash` (§10.2 check 4, §12). Only meaningful when
+ * the client can reproduce the service's pre-encryption serialization.
+ */
+export async function checkResponseCleartextHash(
+  receipt: Receipt,
+  cleartextBody: Uint8Array | string,
+): Promise<boolean> {
+  const event = findEvent(receipt, 'response.returned');
+  const expected = event?.cleartext_hash;
+  if (typeof expected !== 'string') return false;
+  return (await hashBody(cleartextBody)) === expected;
+}

--- a/clients/verifier-ts/src/report.ts
+++ b/clients/verifier-ts/src/report.ts
@@ -1,0 +1,126 @@
+/**
+ * Level 2 report-binding checks (§10.1 checks 2–6), minus the hardware root of
+ * trust. This verifies the *cryptographic binding* of the report — that its
+ * `workload_id`, keyset digest, `report_data`, and endorsement are internally
+ * consistent and endorsed by the identity key — for the nonce the client
+ * supplied. It does NOT do §10.1 check 1 (the TEE quote verifies to the vendor
+ * root) or the "hardware evidence binds `report_data`" half of check 4: parsing
+ * and checking a TDX/SEV-SNP quote is verifier-profile territory and needs
+ * primitives outside the Web Crypto API. Compose this with a quote verifier and
+ * the custody/provenance/channel checks (§10.1 checks 1, 7–10) for full Level 2.
+ */
+
+import {
+  computeWorkloadId,
+  computeKeysetDigest,
+  computeReportData,
+  keysetEndorsementPayload,
+} from './digest.js';
+import { verifySignature, fromHex } from './crypto.js';
+import type { AttestationReport, Check, ReportVerification } from './types.js';
+
+/** Options for {@link verifyReportBinding}. */
+export interface ReportBindingOptions {
+  /**
+   * Current time in Unix seconds for the freshness check (§10.1 check 6).
+   * Defaults to the local clock. Pass an explicit value for deterministic tests.
+   */
+  now?: number;
+  /**
+   * Whether the profile trusts the platform's declared validity window
+   * (`freshness.fetched_at`/`stale_after`, §5.1). Off by default — recency comes
+   * from the nonce binding, and `fetched_at`/`stale_after` need a securely
+   * synced TEE clock to mean anything.
+   */
+  trustPlatformClock?: boolean;
+}
+
+/**
+ * Verify the report's cryptographic bindings for `nonce` (§10.1 checks 2–6).
+ * `nonce` is the value the verifier supplied to `GET /v1/aci/attestation`, or
+ * `null`/`undefined` when it requested no nonce (§4.4).
+ *
+ * Returns a per-check result and the identity recomputed from the report's
+ * keyset; a failed check is `ok: false`, never thrown. Throws
+ * {@link UnsupportedAlgorithmError} when the identity key algorithm is outside
+ * Web Crypto scope (e.g. `ecdsa-secp256k1`).
+ */
+export async function verifyReportBinding(
+  report: AttestationReport,
+  nonce: string | null | undefined,
+  options: ReportBindingOptions = {},
+): Promise<ReportVerification> {
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const checks: Check[] = [];
+
+  const keyset = report.attestation.workload_keyset;
+  const identityKey = keyset.workload_identity.public_key;
+
+  // Check 2: workload_id == digest of the identity public key in the report's keyset.
+  const workloadId = await computeWorkloadId(identityKey);
+  pushEqual(checks, 'workload_id', report.workload_id, workloadId);
+
+  // Check 3: workload_keyset_digest == digest of the report's keyset.
+  const workloadKeysetDigest = await computeKeysetDigest(keyset);
+  pushEqual(checks, 'workload_keyset_digest', report.workload_keyset_digest, workloadKeysetDigest);
+
+  // Check 4 (binding half): report_data == the §4.4 statement digest for this nonce.
+  // The hardware-evidence-binds-report_data half is out of scope (see file header).
+  const expectedReportData = await computeReportData(workloadId, workloadKeysetDigest, nonce);
+  pushEqual(checks, 'report_data', report.attestation.report_data, expectedReportData);
+
+  // Check 5: keyset endorsement verifies under the identity key, algo matching.
+  const endorsement = report.attestation.keyset_endorsement;
+  if (endorsement.algo !== identityKey.algo) {
+    checks.push({
+      name: 'keyset_endorsement',
+      ok: false,
+      detail: `endorsement.algo "${endorsement.algo}" != identity key algo "${identityKey.algo}"`,
+    });
+  } else {
+    const ok = await verifySignature(
+      identityKey.algo,
+      fromHex(identityKey.public_key),
+      fromHex(endorsement.value),
+      keysetEndorsementPayload(workloadKeysetDigest),
+      'keyset endorsement (§4.3)',
+    );
+    checks.push({
+      name: 'keyset_endorsement',
+      ok,
+      ...(ok ? {} : { detail: 'endorsement signature failed under identity key' }),
+    });
+  }
+
+  // Check 6: freshness. Nonce binding is check 4; here bound the epoch and,
+  // when trusted, the declared validity window.
+  const notAfter = keyset.keyset_epoch.not_after;
+  const epochOk = now < notAfter;
+  checks.push({
+    name: 'keyset_epoch.not_after',
+    ok: epochOk,
+    ...(epochOk ? {} : { detail: `now ${now} >= not_after ${notAfter}` }),
+  });
+  if (options.trustPlatformClock) {
+    const freshness = report.attestation.freshness;
+    const fetchedAt = freshness?.fetched_at;
+    const staleAfter = freshness?.stale_after;
+    const windowOk =
+      typeof fetchedAt === 'number' &&
+      typeof staleAfter === 'number' &&
+      fetchedAt <= now &&
+      now < staleAfter;
+    checks.push({
+      name: 'freshness_window',
+      ok: windowOk,
+      ...(windowOk ? {} : { detail: `now ${now} outside [${fetchedAt}, ${staleAfter})` }),
+    });
+  }
+
+  return { ok: checks.every((c) => c.ok), checks, workloadId, workloadKeysetDigest };
+}
+
+function pushEqual(checks: Check[], name: string, actual: string, expected: string): void {
+  const ok = actual === expected;
+  checks.push({ name, ok, ...(ok ? {} : { detail: `report ${actual} != recomputed ${expected}` }) });
+}

--- a/clients/verifier-ts/src/types.ts
+++ b/clients/verifier-ts/src/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Wire shapes for the ACI artifacts this verifier reads, plus the result types
+ * it returns. These mirror spec/aci.md §4, §5, §8, §9; only the fields the
+ * verifier touches are typed precisely, with an index signature left open so
+ * unknown extension fields (§3.2) survive canonicalization untouched.
+ */
+
+import type { JcsValue } from './jcs.js';
+
+/** A public key object: `{ algo, public_key }` (§4.1). */
+export interface PublicKey {
+  algo: string;
+  public_key: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/** The workload identity (§4.2): the identity public key plus an optional subject. */
+export interface WorkloadIdentity {
+  public_key: PublicKey;
+  subject?: string | null;
+  [key: string]: JcsValue | undefined;
+}
+
+/** A receipt signing key entry (§4.2). */
+export interface ReceiptSigningKey {
+  key_id: string;
+  algo: string;
+  public_key: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/** The workload keyset (§4.2). Digested with JCS to yield `workload_keyset_digest`. */
+export interface WorkloadKeyset {
+  workload_identity: WorkloadIdentity;
+  keyset_epoch: { version: number; not_after: number; [key: string]: JcsValue | undefined };
+  receipt_signing_keys: ReceiptSigningKey[];
+  e2ee_public_keys?: JcsValue[];
+  tls_public_keys?: JcsValue[];
+  [key: string]: JcsValue | undefined;
+}
+
+/** A receipt signature block (§8.2). `value` is dropped for canonical signing bytes (§8.5). */
+export interface ReceiptSignature {
+  algo: string;
+  key_id: string;
+  value: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/** A single receipt event (§8.3). Only `seq`/`type` are fixed; other fields are type-specific. */
+export interface ReceiptEvent {
+  seq: number;
+  type: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/** An inference receipt (§8.2). */
+export interface Receipt {
+  api_version: string;
+  receipt_id: string;
+  workload_id: string;
+  workload_keyset_digest: string;
+  event_log: ReceiptEvent[];
+  signature: ReceiptSignature;
+  [key: string]: JcsValue | undefined;
+}
+
+/** The keyset endorsement / revocation signature block (§4.3, §5.1). */
+export interface Endorsement {
+  algo: string;
+  value: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/** The `attestation` object of a report (§5.1); only the fields Level 1 reads are typed. */
+export interface Attestation {
+  workload_keyset: WorkloadKeyset;
+  report_data: string;
+  keyset_endorsement: Endorsement;
+  freshness?: { fetched_at?: number; stale_after?: number; [key: string]: JcsValue | undefined };
+  [key: string]: JcsValue | undefined;
+}
+
+/** An attestation report (§5.1). */
+export interface AttestationReport {
+  api_version: string;
+  workload_id: string;
+  workload_keyset_digest: string;
+  attestation: Attestation;
+  [key: string]: JcsValue | undefined;
+}
+
+/** A verifier-provided evidence block on a session record (§9.2). */
+export interface SessionEvidence {
+  digest?: string | null;
+  data?: string;
+  [key: string]: JcsValue | undefined;
+}
+
+/**
+ * An attested session record (§9.2). The `session_id` is recomputed from the
+ * named fields; absent optional fields (`endpoint`, `identity`, `evidence.digest`)
+ * are restored as JSON `null` in the content-addressing material.
+ */
+export interface SessionRecord {
+  upstream_name: string;
+  endpoint?: string | null;
+  verifier_id: string;
+  identity?: JcsValue;
+  channel_binding: JcsValue[];
+  claims: JcsValue;
+  evidence?: SessionEvidence | null;
+  [key: string]: JcsValue | undefined;
+}
+
+/** Outcome of one named verification check. */
+export interface Check {
+  /** Stable machine-readable id, e.g. `signature`, `workload_id`. */
+  name: string;
+  ok: boolean;
+  /** Human-readable detail, present when the check fails. */
+  detail?: string;
+}
+
+/** Result of {@link verifyReceipt}: overall pass plus the individual §10.2 checks. */
+export interface ReceiptVerification {
+  ok: boolean;
+  checks: Check[];
+}
+
+/** Result of {@link verifyReportBinding}: overall pass, the §10.1 checks, and the derived identity. */
+export interface ReportVerification {
+  ok: boolean;
+  checks: Check[];
+  /** `workload_id` recomputed from the report's keyset (§4.1). */
+  workloadId: string;
+  /** `workload_keyset_digest` recomputed from the report's keyset (§4.2). */
+  workloadKeysetDigest: string;
+}

--- a/clients/verifier-ts/test/digest.test.ts
+++ b/clients/verifier-ts/test/digest.test.ts
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeWorkloadId,
+  computeKeysetDigest,
+  attestationStatement,
+  computeReportData,
+  canonicalize,
+  receiptSigningBytes,
+  computeSessionId,
+  sessionMaterial,
+  sha256Prefixed,
+} from '../src/index.js';
+import * as fx from './fixtures.js';
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+test('§1 workload_id = sha256(JCS(public_key))', async () => {
+  assert.equal(await computeWorkloadId(fx.IDENTITY_PUBLIC_KEY_OBJ), fx.WORKLOAD_ID);
+});
+
+test('§1 workload_id JCS byte string matches the vector', () => {
+  assert.equal(
+    canonicalize({ algo: 'ed25519', public_key: fx.IDENTITY_PUBLIC_KEY }),
+    `{"algo":"ed25519","public_key":"${fx.IDENTITY_PUBLIC_KEY}"}`,
+  );
+});
+
+test('§2 workload_keyset_digest = sha256(JCS(keyset))', async () => {
+  assert.equal(await computeKeysetDigest(fx.KEYSET), fx.KEYSET_DIGEST);
+});
+
+test('§3 attestation statement JCS matches the vector', () => {
+  assert.equal(
+    canonicalize(attestationStatement(fx.WORKLOAD_ID, fx.KEYSET_DIGEST, fx.ATTESTATION_NONCE)),
+    `{"nonce":"test-nonce","purpose":"aci.report_data.v1","workload_id":"${fx.WORKLOAD_ID}","workload_keyset_digest":"${fx.KEYSET_DIGEST}"}`,
+  );
+});
+
+test('§3 report_data (nonce present)', async () => {
+  assert.equal(
+    await computeReportData(fx.WORKLOAD_ID, fx.KEYSET_DIGEST, fx.ATTESTATION_NONCE),
+    fx.REPORT_DATA_WITH_NONCE,
+  );
+});
+
+test('§3 report_data (nonce omitted → null, not the string "null")', async () => {
+  assert.equal(
+    await computeReportData(fx.WORKLOAD_ID, fx.KEYSET_DIGEST, undefined),
+    fx.REPORT_DATA_NONCE_OMITTED,
+  );
+  assert.equal(
+    await computeReportData(fx.WORKLOAD_ID, fx.KEYSET_DIGEST, null),
+    fx.REPORT_DATA_NONCE_OMITTED,
+  );
+});
+
+test('§5 evidence.digest = sha256(evidence bytes)', async () => {
+  assert.equal(await sha256Prefixed(enc(fx.EVIDENCE_BYTES)), fx.EVIDENCE_DIGEST);
+});
+
+test('§5 session material JCS matches the vector (identity restored to null)', () => {
+  assert.equal(
+    canonicalize(sessionMaterial(fx.SESSION_RECORD)),
+    `{"channel_binding":[{"origin":"https://upstream.example.com","spki_sha256":"${'d1'.repeat(32)}","type":"tls_spki_sha256"}],"claims":{"gpu_attested":{"status":"unknown"},"model_weights_provenance":{"status":"unknown"},"os_known_good":{"status":"unknown"},"serving_software_known_good":{"status":"unknown"},"tcb_up_to_date":{"status":"unknown"},"tee_attested":{"reason":"example quote verified","source":"hardware_proven","status":"asserted"}},"endpoint":"https://upstream.example.com","evidence_digest":"${fx.EVIDENCE_DIGEST}","identity":null,"upstream_name":"demo-upstream","verifier_id":"example/1"}`,
+  );
+});
+
+test('§5 session_id = as_ + sha256(JCS(material))', async () => {
+  assert.equal(await computeSessionId(fx.SESSION_RECORD), fx.SESSION_ID);
+});
+
+test('§6 request/response body hashes', async () => {
+  assert.equal(await sha256Prefixed(enc(fx.REQUEST_BODY)), fx.REQUEST_BODY_HASH);
+  assert.equal(await sha256Prefixed(enc(fx.RESPONSE_BODY)), fx.RESPONSE_BODY_HASH);
+});
+
+test('§6 receipt canonical signing bytes match the vector and hash', async () => {
+  const canonical = new TextDecoder().decode(receiptSigningBytes(fx.RECEIPT));
+  // signature.value is dropped; algo and key_id stay.
+  assert.equal(canonical.includes('"signature":{"algo":"ed25519","key_id":"receipt-1"}'), true);
+  assert.equal(canonical.includes(fx.RECEIPT_SIGNATURE), false);
+  assert.equal(await sha256Prefixed(receiptSigningBytes(fx.RECEIPT)), `sha256:${fx.RECEIPT_CANONICAL_SHA256}`);
+});

--- a/clients/verifier-ts/test/e2ee.test.ts
+++ b/clients/verifier-ts/test/e2ee.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requestAad, requestAadString, responseAad, responseAadString } from '../src/index.js';
+import * as fx from './fixtures.js';
+
+test('§7.3 request AAD matches the vector (string and bytes)', () => {
+  const params = {
+    algo: fx.E2EE_ALGO,
+    model: fx.E2EE_MODEL,
+    field: 'messages.0.content',
+    nonce: fx.E2EE_NONCE,
+    ts: fx.E2EE_TIMESTAMP,
+  };
+  assert.equal(requestAadString(params), fx.REQUEST_AAD);
+  assert.equal(new TextDecoder().decode(requestAad(params)), fx.REQUEST_AAD);
+});
+
+test('§7.3 response AAD matches the vector (adds response id)', () => {
+  const params = {
+    algo: fx.E2EE_ALGO,
+    model: fx.E2EE_MODEL,
+    id: fx.RESPONSE_ID,
+    field: 'choices.0.message.content',
+    nonce: fx.E2EE_NONCE,
+    ts: fx.E2EE_TIMESTAMP,
+  };
+  assert.equal(responseAadString(params), fx.RESPONSE_AAD);
+  assert.equal(new TextDecoder().decode(responseAad(params)), fx.RESPONSE_AAD);
+});

--- a/clients/verifier-ts/test/fixtures.ts
+++ b/clients/verifier-ts/test/fixtures.ts
@@ -1,0 +1,215 @@
+/**
+ * Every value from spec/test-vectors.md §1–§7, in one place so the suite is easy
+ * to refresh when the vectors change. Nothing here is imported by `src/` — these
+ * are test inputs and the expected byte-for-byte outputs.
+ *
+ * Field naming tracks the current spec (§8.4 receipt `upstream.verified` and
+ * §9.2 session record). If the spec renames those fields, update the objects and
+ * expected hashes below together.
+ */
+
+import { fromHex, toHex, type PublicKey, type WorkloadKeyset, type Receipt, type SessionRecord } from '../src/index.js';
+
+// --- Fixed keys (test-vectors.md "Fixed keys") ---------------------------------
+
+/** 32 × 0x01 seed; its Ed25519 public key names the workload identity. */
+export const IDENTITY_SEED = '01'.repeat(32);
+export const IDENTITY_PUBLIC_KEY = '8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c';
+
+/** 32 × 0x02 seed; receipt signing key `receipt-1`. */
+export const RECEIPT_SEED = '02'.repeat(32);
+export const RECEIPT_PUBLIC_KEY = '8139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394';
+
+export const IDENTITY_PUBLIC_KEY_OBJ: PublicKey = { algo: 'ed25519', public_key: IDENTITY_PUBLIC_KEY };
+
+// --- §1 workload_id ------------------------------------------------------------
+
+export const WORKLOAD_ID = 'sha256:57c2c8fa98bcf11441f1eff9ef087db67a5560a026082e96903e15365677b8c0';
+
+// --- §2 workload keyset & digest -----------------------------------------------
+
+/**
+ * The §2 keyset. The e2ee `public_key` "abab…ab (32 placeholder bytes: 32 × ab)"
+ * from the doc expands to the 32-byte hex string below; the tls `spki_sha256` and
+ * the identity/receipt keys are shown in full in the doc.
+ */
+export const KEYSET: WorkloadKeyset = {
+  workload_identity: {
+    public_key: { algo: 'ed25519', public_key: IDENTITY_PUBLIC_KEY },
+    subject: null,
+  },
+  keyset_epoch: { version: 1, not_after: 1800000000 },
+  receipt_signing_keys: [{ key_id: 'receipt-1', algo: 'ed25519', public_key: RECEIPT_PUBLIC_KEY }],
+  e2ee_public_keys: [
+    { key_id: 'e2ee-1', algo: 'x25519-aes-256-gcm-hkdf-sha256', public_key: 'ab'.repeat(32) },
+  ],
+  tls_public_keys: [{ spki_sha256: 'c0'.repeat(32), domain: 'api.example.com' }],
+};
+
+export const KEYSET_DIGEST =
+  'sha256:f2fba7e1b1451e0c0231df624f293407692ef939d3e0e55bca723131bea3f1ff';
+
+// --- §3 attestation statement / report_data ------------------------------------
+
+export const ATTESTATION_NONCE = 'test-nonce';
+export const REPORT_DATA_WITH_NONCE =
+  '0b8cc28d7e989a88b1e969af20aa2b224afdc2c99f24c97c31a4af330c964ecf';
+export const REPORT_DATA_NONCE_OMITTED =
+  'e1818eadad3c28375c625e2fa2d2ffd983d2760c84ce17f8527ddcac884c21b9';
+
+// --- §4 endorsement & revocation -----------------------------------------------
+
+export const ENDORSEMENT_SIGNATURE =
+  '64e0a4f5d7af28dfdacc102d14c13470b4ddbd90708e190fc0e787f07b36f20eda0ef1f42ea96b8a7f290eb64a918574dc914ce06b6ea023d2153275f06fd201';
+export const REVOCATION_SIGNATURE =
+  '5f30e02aa53bb628c7f6410636e9f5e33402d2b0b416a6ed278ea3e6e40b48a9af6ba6e5e55abb89a7ad4627eca444a73cad9d25e22bf239c9c6b362d48ed50f';
+
+// --- §5 attested session -------------------------------------------------------
+
+/** Evidence bytes are ASCII `example-evidence`; its SHA-256 is `evidence.digest`. */
+export const EVIDENCE_BYTES = 'example-evidence';
+export const EVIDENCE_DIGEST =
+  'sha256:80d70e44d0ae1e829fd5f37c3ee4a60dfbea8d3aa18407ea3f34cf7ec91da34d';
+
+/** Channel binding and claims shared by the session record and the receipt's upstream.verified event. */
+const CHANNEL_BINDING = [
+  {
+    origin: 'https://upstream.example.com',
+    spki_sha256: 'd1'.repeat(32),
+    type: 'tls_spki_sha256',
+  },
+];
+const CLAIMS = {
+  gpu_attested: { status: 'unknown' },
+  model_weights_provenance: { status: 'unknown' },
+  os_known_good: { status: 'unknown' },
+  serving_software_known_good: { status: 'unknown' },
+  tcb_up_to_date: { status: 'unknown' },
+  tee_attested: {
+    reason: 'example quote verified',
+    source: 'hardware_proven',
+    status: 'asserted',
+  },
+};
+
+/** Wire session record. `identity` is absent (restored to null in the material). */
+export const SESSION_RECORD: SessionRecord = {
+  upstream_name: 'demo-upstream',
+  endpoint: 'https://upstream.example.com',
+  verifier_id: 'example/1',
+  channel_binding: CHANNEL_BINDING,
+  claims: CLAIMS,
+  evidence: { digest: EVIDENCE_DIGEST },
+};
+
+export const SESSION_ID =
+  'as_2e9011abafe00fc2902aaa5dedf8373f14e2c4f1a456b854ddb475413547188e';
+
+// --- §6 receipt ----------------------------------------------------------------
+
+export const REQUEST_BODY = '{"messages":[{"content":"hi","role":"user"}],"model":"demo-model"}';
+export const REQUEST_BODY_HASH =
+  'sha256:94d809bf47380d8a2eab0eb6e126d4dda9364b0b4725cdf7ead52dd70b2aa87b';
+
+export const RESPONSE_BODY = '{"choices":[],"id":"chatcmpl-123"}';
+export const RESPONSE_BODY_HASH =
+  'sha256:dedfffe5b14d031b8e2c01996d021a15293cb7c63b56be7e4be9e89b6f0a5f61';
+
+export const RECEIPT_CANONICAL_SHA256 =
+  '1cd5a27c330ac3a5a82ac30176ba67349b42a64b00868d75ffd23600bf7e7b7c';
+export const RECEIPT_SIGNATURE =
+  '0861f62296f57a120620e79fc0e91008a187e3793b65be4a0ed355d4617f305e00a19b32463e1feb464f7220bcd37debd892facddc068eebf5ef02202c31910f';
+
+/** The full §6 receipt, signed by `receipt-1`. */
+export const RECEIPT: Receipt = {
+  api_version: 'aci/1',
+  chat_id: 'chatcmpl-123',
+  endpoint: '/v1/chat/completions',
+  event_log: [
+    { body_hash: REQUEST_BODY_HASH, seq: 0, type: 'request.received' },
+    { body_hash: REQUEST_BODY_HASH, seq: 1, type: 'request.forwarded' },
+    {
+      channel_bindings: CHANNEL_BINDING,
+      claims: CLAIMS,
+      model_id: 'demo-model',
+      provider_claims: null,
+      provider_type: null,
+      reason: null,
+      required: true,
+      result: 'verified',
+      seq: 2,
+      session_id: SESSION_ID,
+      type: 'upstream.verified',
+      upstream_name: 'demo-upstream',
+      url_origin: 'https://upstream.example.com',
+      verifier_id: 'example/1',
+    },
+    {
+      cleartext_hash: RESPONSE_BODY_HASH,
+      seq: 3,
+      type: 'response.returned',
+      wire_hash: RESPONSE_BODY_HASH,
+    },
+  ],
+  method: 'POST',
+  model: 'demo-model',
+  receipt_id: 'rcpt-0001',
+  served_at: 1750000000,
+  signature: { algo: 'ed25519', key_id: 'receipt-1', value: RECEIPT_SIGNATURE },
+  workload_id: WORKLOAD_ID,
+  workload_keyset_digest: KEYSET_DIGEST,
+};
+
+// --- §7 E2EE AAD ---------------------------------------------------------------
+
+export const E2EE_ALGO = 'x25519-aes-256-gcm-hkdf-sha256';
+export const E2EE_NONCE = '6e6f6e63652d31323334';
+export const E2EE_TIMESTAMP = 1750000000;
+export const E2EE_MODEL = 'demo-model';
+export const RESPONSE_ID = 'chatcmpl-123';
+
+export const REQUEST_AAD =
+  '{"algo":"x25519-aes-256-gcm-hkdf-sha256","field":"messages.0.content","model":"demo-model","nonce":"6e6f6e63652d31323334","purpose":"aci.e2ee.request.v2","ts":1750000000}';
+export const RESPONSE_AAD =
+  '{"algo":"x25519-aes-256-gcm-hkdf-sha256","field":"choices.0.message.content","id":"chatcmpl-123","model":"demo-model","nonce":"6e6f6e63652d31323334","purpose":"aci.e2ee.response.v2","ts":1750000000}';
+
+// --- Test-only Ed25519 key derivation ------------------------------------------
+
+/** PKCS#8 prefix wrapping a raw Ed25519 32-byte seed (OID 1.3.101.112). */
+const ED25519_PKCS8_PREFIX = '302e020100300506032b657004220420';
+
+/**
+ * Derive an Ed25519 keypair from its 32-byte seed using only Web Crypto — the
+ * seed→public-key mapping and signing live only in tests, so `src/` never needs
+ * private-key handling. Returns the raw public key (hex) and the importable
+ * private key for re-signing the deterministic vectors.
+ */
+export async function ed25519FromSeed(
+  seedHex: string,
+): Promise<{ privateKey: CryptoKey; publicKeyHex: string }> {
+  const pkcs8 = fromHex(ED25519_PKCS8_PREFIX + seedHex);
+  const privateKey = await globalThis.crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8 as BufferSource,
+    { name: 'Ed25519' },
+    true,
+    ['sign'],
+  );
+  const jwk = await globalThis.crypto.subtle.exportKey('jwk', privateKey);
+  const publicKeyHex = toHex(base64UrlToBytes(jwk.x ?? ''));
+  return { privateKey, publicKeyHex };
+}
+
+/** Sign a message with an Ed25519 private key, returning the lowercase-hex signature. */
+export async function ed25519SignHex(privateKey: CryptoKey, message: Uint8Array): Promise<string> {
+  const sig = await globalThis.crypto.subtle.sign({ name: 'Ed25519' }, privateKey, message as BufferSource);
+  return toHex(new Uint8Array(sig));
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/clients/verifier-ts/test/jcs.test.ts
+++ b/clients/verifier-ts/test/jcs.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { canonicalize, AciFormatError } from '../src/index.js';
+
+test('JCS sorts object keys by UTF-16 code unit', () => {
+  assert.equal(canonicalize({ b: 1, a: 2, c: 3 }), '{"a":2,"b":1,"c":3}');
+  // Uppercase sorts before lowercase (code point A=0x41 < a=0x61).
+  assert.equal(canonicalize({ a: 1, A: 2 }), '{"A":2,"a":1}');
+});
+
+test('JCS sorts nested objects recursively and preserves array order', () => {
+  assert.equal(
+    canonicalize({ z: [{ y: 1, x: 2 }], a: 0 }),
+    '{"a":0,"z":[{"x":2,"y":1}]}',
+  );
+});
+
+test('JCS serializes integers, booleans, null, and strings', () => {
+  assert.equal(
+    canonicalize({ n: 1800000000, t: true, f: false, z: null, s: 'hi' }),
+    '{"f":false,"n":1800000000,"s":"hi","t":true,"z":null}',
+  );
+  assert.equal(canonicalize(0), '0');
+  assert.equal(canonicalize(-0), '0');
+  assert.equal(canonicalize(-42), '-42');
+});
+
+test('JCS rejects non-integer numbers (ACI integer-only subset, §3)', () => {
+  assert.throws(() => canonicalize({ x: 1.5 }), AciFormatError);
+  assert.throws(() => canonicalize(Number.NaN), AciFormatError);
+  assert.throws(() => canonicalize(Infinity), AciFormatError);
+});
+
+test('JCS drops undefined-valued members (build with explicit null instead)', () => {
+  assert.equal(canonicalize({ a: 1, b: undefined, c: 3 }), '{"a":1,"c":3}');
+  assert.equal(canonicalize({ a: 1, b: null }), '{"a":1,"b":null}');
+});
+
+test('JCS escapes strings per RFC 8785 (control chars, quote, backslash)', () => {
+  assert.equal(canonicalize('a"b\\c'), '"a\\"b\\\\c"');
+  assert.equal(canonicalize('\n\t'), '"\\n\\t"');
+  assert.equal(canonicalize(String.fromCharCode(1)), '"\\u0001"');
+});

--- a/clients/verifier-ts/test/node-shims.d.ts
+++ b/clients/verifier-ts/test/node-shims.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal ambient declarations for the Node test-runner surface the tests use.
+ * Declared locally so the package needs only `typescript` as a devDependency —
+ * no `@types/node`, which would drag Node globals into the DOM-typed src build.
+ */
+
+declare module 'node:test' {
+  type TestFn = () => void | Promise<void>;
+  export function test(name: string, fn: TestFn): Promise<void>;
+  export function describe(name: string, fn: () => void): void;
+  export function it(name: string, fn: TestFn): void;
+}
+
+declare module 'node:assert/strict' {
+  interface AssertStrict {
+    (value: unknown, message?: string): asserts value;
+    ok(value: unknown, message?: string): asserts value;
+    equal(actual: unknown, expected: unknown, message?: string): void;
+    notEqual(actual: unknown, expected: unknown, message?: string): void;
+    deepEqual(actual: unknown, expected: unknown, message?: string): void;
+    throws(fn: () => unknown, error?: unknown, message?: string): void;
+    rejects(fn: () => Promise<unknown>, error?: unknown, message?: string): Promise<void>;
+  }
+  const assert: AssertStrict;
+  export default assert;
+}

--- a/clients/verifier-ts/test/receipt.test.ts
+++ b/clients/verifier-ts/test/receipt.test.ts
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  verifyReceipt,
+  findEvent,
+  hashBody,
+  checkRequestBodyHash,
+  checkResponseWireHash,
+  checkResponseCleartextHash,
+  UnsupportedAlgorithmError,
+  type Receipt,
+  type WorkloadKeyset,
+} from '../src/index.js';
+import * as fx from './fixtures.js';
+
+test('§10.2 verifyReceipt: valid receipt passes every check', async () => {
+  const result = await verifyReceipt(fx.RECEIPT, fx.KEYSET);
+  assert.equal(result.ok, true, JSON.stringify(result.checks));
+  assert.deepEqual(
+    result.checks.map((c) => c.name).sort(),
+    ['signature', 'workload_id', 'workload_keyset_digest'],
+  );
+});
+
+test('§10.2 check 3/4: body-hash helpers match the receipt events', async () => {
+  assert.equal(await hashBody(fx.REQUEST_BODY), fx.REQUEST_BODY_HASH);
+  assert.equal(await checkRequestBodyHash(fx.RECEIPT, fx.REQUEST_BODY), true);
+  assert.equal(await checkResponseWireHash(fx.RECEIPT, fx.RESPONSE_BODY), true);
+  // Plaintext case: cleartext_hash equals wire_hash.
+  assert.equal(await checkResponseCleartextHash(fx.RECEIPT, fx.RESPONSE_BODY), true);
+});
+
+test('body-hash helpers reject the wrong bytes', async () => {
+  assert.equal(await checkRequestBodyHash(fx.RECEIPT, fx.REQUEST_BODY + ' '), false);
+  assert.equal(await checkResponseWireHash(fx.RECEIPT, '{"choices":[]}'), false);
+});
+
+test('findEvent locates events by type', () => {
+  assert.equal(findEvent(fx.RECEIPT, 'request.received')?.seq, 0);
+  assert.equal(findEvent(fx.RECEIPT, 'upstream.verified')?.seq, 2);
+  assert.equal(findEvent(fx.RECEIPT, 'nope'), undefined);
+});
+
+test('verifyReceipt fails on a tampered signature', async () => {
+  const bad = structuredClone(fx.RECEIPT) as Receipt;
+  bad.signature.value = bad.signature.value.replace(/^../, '00');
+  const result = await verifyReceipt(bad, fx.KEYSET);
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'signature')?.ok, false);
+});
+
+test('verifyReceipt fails on a mismatched workload_id', async () => {
+  const bad = structuredClone(fx.RECEIPT) as Receipt;
+  bad.workload_id = 'sha256:' + '00'.repeat(32);
+  const result = await verifyReceipt(bad, fx.KEYSET);
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'workload_id')?.ok, false);
+});
+
+test('verifyReceipt fails when key_id is not in the keyset', async () => {
+  const bad = structuredClone(fx.RECEIPT) as Receipt;
+  bad.signature.key_id = 'unknown-key';
+  const result = await verifyReceipt(bad, fx.KEYSET);
+  assert.equal(result.ok, false);
+  const sig = result.checks.find((c) => c.name === 'signature');
+  assert.equal(sig?.ok, false);
+  assert.equal(sig?.detail?.includes('unknown-key'), true);
+});
+
+test('verifyReceipt fails when signature.algo disagrees with the keyset entry', async () => {
+  const bad = structuredClone(fx.RECEIPT) as Receipt;
+  bad.signature.algo = 'ecdsa-secp256k1';
+  const result = await verifyReceipt(bad, fx.KEYSET);
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'signature')?.ok, false);
+});
+
+test('verifyReceipt throws when the attested key uses secp256k1', async () => {
+  const keyset = structuredClone(fx.KEYSET) as WorkloadKeyset;
+  keyset.receipt_signing_keys[0]!.algo = 'ecdsa-secp256k1';
+  const receipt = structuredClone(fx.RECEIPT) as Receipt;
+  receipt.signature.algo = 'ecdsa-secp256k1';
+  await assert.rejects(() => verifyReceipt(receipt, keyset), UnsupportedAlgorithmError);
+});

--- a/clients/verifier-ts/test/report.test.ts
+++ b/clients/verifier-ts/test/report.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { verifyReportBinding, UnsupportedAlgorithmError, type AttestationReport } from '../src/index.js';
+import * as fx from './fixtures.js';
+
+/** A report assembled from the §1–§4 vectors: identity, keyset, report_data for `test-nonce`, endorsement. */
+function makeReport(): AttestationReport {
+  return {
+    api_version: 'aci/1',
+    workload_id: fx.WORKLOAD_ID,
+    workload_keyset_digest: fx.KEYSET_DIGEST,
+    attestation: {
+      workload_keyset: structuredClone(fx.KEYSET),
+      report_data: fx.REPORT_DATA_WITH_NONCE,
+      keyset_endorsement: { algo: 'ed25519', value: fx.ENDORSEMENT_SIGNATURE },
+      freshness: { fetched_at: 1750000000, stale_after: 1750003600 },
+    },
+  };
+}
+
+const NOW = 1750001000; // inside the freshness window, before not_after
+
+test('§10.1 checks 2–6: a well-formed report binding passes', async () => {
+  const result = await verifyReportBinding(makeReport(), fx.ATTESTATION_NONCE, { now: NOW });
+  assert.equal(result.ok, true, JSON.stringify(result.checks));
+  assert.equal(result.workloadId, fx.WORKLOAD_ID);
+  assert.equal(result.workloadKeysetDigest, fx.KEYSET_DIGEST);
+});
+
+test('report_data check fails for a different nonce (freshness, check 4/6)', async () => {
+  const result = await verifyReportBinding(makeReport(), 'other-nonce', { now: NOW });
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'report_data')?.ok, false);
+});
+
+test('report_data check accepts the omitted-nonce report', async () => {
+  const report = makeReport();
+  report.attestation.report_data = fx.REPORT_DATA_NONCE_OMITTED;
+  const result = await verifyReportBinding(report, undefined, { now: NOW });
+  assert.equal(result.checks.find((c) => c.name === 'report_data')?.ok, true);
+});
+
+test('an expired keyset epoch fails check 6', async () => {
+  const result = await verifyReportBinding(makeReport(), fx.ATTESTATION_NONCE, { now: 1800000001 });
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'keyset_epoch.not_after')?.ok, false);
+});
+
+test('trustPlatformClock enforces the declared validity window', async () => {
+  const ok = await verifyReportBinding(makeReport(), fx.ATTESTATION_NONCE, {
+    now: NOW,
+    trustPlatformClock: true,
+  });
+  assert.equal(ok.checks.find((c) => c.name === 'freshness_window')?.ok, true);
+
+  const stale = await verifyReportBinding(makeReport(), fx.ATTESTATION_NONCE, {
+    now: 1750009999, // past stale_after
+    trustPlatformClock: true,
+  });
+  assert.equal(stale.checks.find((c) => c.name === 'freshness_window')?.ok, false);
+});
+
+test('a tampered endorsement fails check 5', async () => {
+  const report = makeReport();
+  report.attestation.keyset_endorsement.value = report.attestation.keyset_endorsement.value.replace(
+    /^../,
+    '00',
+  );
+  const result = await verifyReportBinding(report, fx.ATTESTATION_NONCE, { now: NOW });
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((c) => c.name === 'keyset_endorsement')?.ok, false);
+});
+
+test('endorsement.algo must match the identity key algo', async () => {
+  const report = makeReport();
+  report.attestation.keyset_endorsement.algo = 'ecdsa-secp256k1';
+  const result = await verifyReportBinding(report, fx.ATTESTATION_NONCE, { now: NOW });
+  assert.equal(result.checks.find((c) => c.name === 'keyset_endorsement')?.ok, false);
+});
+
+test('a secp256k1 identity key is out of scope: throws', async () => {
+  const report = makeReport();
+  report.attestation.workload_keyset.workload_identity.public_key.algo = 'ecdsa-secp256k1';
+  report.attestation.keyset_endorsement.algo = 'ecdsa-secp256k1';
+  // workload_id/digest recomputation still uses whatever algo string is present;
+  // the endorsement verify is where the unsupported algorithm surfaces.
+  await assert.rejects(
+    () => verifyReportBinding(report, fx.ATTESTATION_NONCE, { now: NOW }),
+    UnsupportedAlgorithmError,
+  );
+});

--- a/clients/verifier-ts/test/signature.test.ts
+++ b/clients/verifier-ts/test/signature.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  verifyEd25519,
+  verifySignature,
+  fromHex,
+  keysetEndorsementPayload,
+  keysetRevocationPayload,
+  receiptSigningBytes,
+  UnsupportedAlgorithmError,
+} from '../src/index.js';
+import * as fx from './fixtures.js';
+
+test('the documented seeds derive the published public keys', async () => {
+  const id = await fx.ed25519FromSeed(fx.IDENTITY_SEED);
+  const rcpt = await fx.ed25519FromSeed(fx.RECEIPT_SEED);
+  assert.equal(id.publicKeyHex, fx.IDENTITY_PUBLIC_KEY);
+  assert.equal(rcpt.publicKeyHex, fx.RECEIPT_PUBLIC_KEY);
+});
+
+test('§4.3 keyset endorsement: signature verifies and re-signs to the vector', async () => {
+  const payload = keysetEndorsementPayload(fx.KEYSET_DIGEST);
+  const ok = await verifyEd25519(fromHex(fx.IDENTITY_PUBLIC_KEY), fromHex(fx.ENDORSEMENT_SIGNATURE), payload);
+  assert.equal(ok, true);
+  // Ed25519 is deterministic: re-signing reproduces the vector byte-for-byte.
+  const id = await fx.ed25519FromSeed(fx.IDENTITY_SEED);
+  assert.equal(await fx.ed25519SignHex(id.privateKey, payload), fx.ENDORSEMENT_SIGNATURE);
+});
+
+test('§4.7 keyset revocation: signature verifies and re-signs to the vector', async () => {
+  const payload = keysetRevocationPayload(fx.KEYSET_DIGEST);
+  const ok = await verifyEd25519(fromHex(fx.IDENTITY_PUBLIC_KEY), fromHex(fx.REVOCATION_SIGNATURE), payload);
+  assert.equal(ok, true);
+  const id = await fx.ed25519FromSeed(fx.IDENTITY_SEED);
+  assert.equal(await fx.ed25519SignHex(id.privateKey, payload), fx.REVOCATION_SIGNATURE);
+});
+
+test('§8.5 receipt signature verifies and re-signs to the vector', async () => {
+  const canonical = receiptSigningBytes(fx.RECEIPT);
+  const ok = await verifyEd25519(fromHex(fx.RECEIPT_PUBLIC_KEY), fromHex(fx.RECEIPT_SIGNATURE), canonical);
+  assert.equal(ok, true);
+  const rcpt = await fx.ed25519FromSeed(fx.RECEIPT_SEED);
+  assert.equal(await fx.ed25519SignHex(rcpt.privateKey, canonical), fx.RECEIPT_SIGNATURE);
+});
+
+test('a tampered payload fails verification', async () => {
+  const payload = keysetEndorsementPayload(fx.KEYSET_DIGEST);
+  const tampered = new Uint8Array(payload);
+  tampered[0] = (tampered[0] ?? 0) ^ 0x01;
+  assert.equal(
+    await verifyEd25519(fromHex(fx.IDENTITY_PUBLIC_KEY), fromHex(fx.ENDORSEMENT_SIGNATURE), tampered),
+    false,
+  );
+});
+
+test('a signature under the wrong key fails verification', async () => {
+  const payload = keysetEndorsementPayload(fx.KEYSET_DIGEST);
+  assert.equal(
+    await verifyEd25519(fromHex(fx.RECEIPT_PUBLIC_KEY), fromHex(fx.ENDORSEMENT_SIGNATURE), payload),
+    false,
+  );
+});
+
+test('secp256k1 is out of scope: verifySignature throws UnsupportedAlgorithmError', async () => {
+  await assert.rejects(
+    () =>
+      verifySignature(
+        'ecdsa-secp256k1',
+        fromHex(fx.RECEIPT_PUBLIC_KEY),
+        fromHex(fx.RECEIPT_SIGNATURE),
+        keysetEndorsementPayload(fx.KEYSET_DIGEST),
+        'test',
+      ),
+    UnsupportedAlgorithmError,
+  );
+});

--- a/clients/verifier-ts/tsconfig.json
+++ b/clients/verifier-ts/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/clients/verifier-ts/tsconfig.test.json
+++ b/clients/verifier-ts/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "outDir": "dist-test",
+    "rootDir": ".",
+    "noEmit": false
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
Adds `clients/verifier-ts/` (`@dstack/aci-verifier`), a zero-dependency TypeScript verifier proving the spec's claim (§4.6) that a browser can verify ACI artifacts with the Web Crypto API alone. It uses only Web Crypto (Ed25519, SHA-256) plus a small built-in JCS, runs in browsers and Node 20+, and doubles as an executable conformance suite for the test vectors.

**Implements**
- **Receipt verification (Level 1, §10.2 checks 1–2):** `verifyReceipt(receipt, keyset)` — signature under an attested `receipt_signing_keys` entry, `signature.algo` binding, and `workload_id`/`workload_keyset_digest` match. Body-hash helpers cover checks 3–4.
- **Report binding (Level 2, §10.1 checks 2–6, no hardware quote):** `verifyReportBinding(report, nonce)` — recomputes `workload_id`, keyset digest, and `report_data` for the supplied nonce, verifies the keyset endorsement, and checks epoch freshness.
- **Primitives:** JCS (integer-only, rejects floats), `workload_id`/keyset-digest/`report_data`/`session_id` digests, endorsement + revocation payloads, receipt canonical signing bytes, and E2EE AAD builders (§7.3).

**Out of scope (documented):** hardware TDX/SEV-SNP quote verification (Level 2 profile territory) and `ecdsa-secp256k1` (not in Web Crypto — raises a clear `UnsupportedAlgorithmError`).

**Tests:** every value in spec/test-vectors.md §1–§7 is checked byte-for-byte (43 tests via `node:test`), with public keys derived from the documented seeds inside the tests. All vectors live in one `test/fixtures.ts`. Verified on Node 20 and 24. A scoped `verifier-ts` CI workflow runs build + tests.

Field naming tracks the current spec; when #66 renames the session/receipt fields, the centralized fixtures and expected hashes refresh together.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)