### PR TITLE
E2EE: JCS AAD migration and multimodal field coverage

### DIFF
--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -5,7 +5,8 @@ use serde_json::{json, Value};
 
 use super::e2ee_crypto::{
     decrypt_request_payload, legacy_public_keys_match, normalize_legacy_public_key_for_replay,
-    validate_e2ee_nonce, validate_legacy_e2ee_nonce, validate_payload_model, E2eeFieldCrypto,
+    validate_aci_e2ee_nonce, validate_aci_payload_model, validate_legacy_e2ee_nonce,
+    validate_payload_model, E2eeFieldCrypto,
 };
 use super::{
     AciService, E2eeError, E2eePreparedRequest, E2eeReplayKey, E2eeRequestContext,
@@ -269,7 +270,7 @@ impl AciService {
         let nonce = parts.nonce.ok_or(E2eeError::HeaderMissing)?;
         let timestamp = parts.timestamp.ok_or(E2eeError::HeaderMissing)?;
 
-        validate_e2ee_nonce(nonce)?;
+        validate_aci_e2ee_nonce(nonce)?;
         let timestamp = timestamp
             .parse::<u64>()
             .map_err(|_| E2eeError::InvalidTimestamp)?;
@@ -295,7 +296,7 @@ impl AciService {
 
         let mut payload: Value =
             serde_json::from_slice(body).map_err(|_| E2eeError::DecryptionFailed)?;
-        let request_model = validate_payload_model(&payload)?;
+        let request_model = validate_aci_payload_model(&payload)?;
         self.claim_e2ee_replay(
             client_public_key_hex.clone(),
             model_public_key_hex.clone(),

--- a/src/aggregator/service/e2ee_crypto.rs
+++ b/src/aggregator/service/e2ee_crypto.rs
@@ -1,16 +1,28 @@
 use super::wire::{E2eeAadMode, E2eeDecryptor};
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::streaming::E2eeSseTransformer;
 use super::{E2eeError, E2eeRequestContext, COMPLETIONS_PATH, EMBEDDINGS_PATH};
+use crate::aci::canonical::canonicalize;
 use crate::aci::e2ee::{
     encrypt_for_public_key, encrypt_legacy_for_public_key, normalize_secp256k1_public_key_hex,
     E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519,
 };
 use crate::aci::keys::KeyProvider;
 
-pub(super) fn validate_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
+/// ACI v2 nonce (§7.5): reject only an empty nonce. With JCS AAD (§7.3) the
+/// old `|`/CR/LF ambiguity checks are unnecessary.
+pub(super) fn validate_aci_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
+    if nonce.is_empty() {
+        return Err(E2eeError::InvalidNonce);
+    }
+    Ok(())
+}
+
+/// Legacy X-Signing-Algo nonce: empty or `|`/CR/LF is rejected because the
+/// legacy AAD is pipe-delimited. Frozen compatibility surface.
+fn validate_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
     if nonce.is_empty() || aad_component_is_ambiguous(nonce) {
         return Err(E2eeError::InvalidNonce);
     }
@@ -71,6 +83,17 @@ pub(super) fn normalize_ed25519_public_key_hex(value: &str) -> Result<String, E2
     Ok(hex::encode(bytes))
 }
 
+/// ACI v2 model (§7.3): present and a string. No ambiguity check — the JCS
+/// AAD needs no escaping.
+pub(super) fn validate_aci_payload_model(payload: &Value) -> Result<String, E2eeError> {
+    payload
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or(E2eeError::InvalidPayloadModel)
+}
+
+/// Legacy model: present, a string, and free of `|`/CR/LF. Frozen.
 pub(super) fn validate_payload_model(payload: &Value) -> Result<String, E2eeError> {
     let Some(model) = payload.get("model").and_then(Value::as_str) else {
         return Err(E2eeError::InvalidPayloadModel);
@@ -81,11 +104,54 @@ pub(super) fn validate_payload_model(payload: &Value) -> Result<String, E2eeErro
     Ok(model.to_string())
 }
 
-pub(super) fn aad_component_is_ambiguous(value: &str) -> bool {
+fn aad_component_is_ambiguous(value: &str) -> bool {
     value.contains('|') || value.contains('\r') || value.contains('\n')
 }
 
-pub(super) fn request_aad(
+/// ACI v2 request AAD (§7.3): the JCS canonicalization of the purpose-tagged
+/// object. `field` is the encrypted location's field path (§7.2).
+fn aci_request_aad(
+    algo: &str,
+    model: &str,
+    field: &str,
+    nonce: &str,
+    timestamp: u64,
+) -> Result<Vec<u8>, E2eeError> {
+    canonicalize(&json!({
+        "purpose": "aci.e2ee.request.v2",
+        "algo": algo,
+        "model": model,
+        "field": field,
+        "nonce": nonce,
+        "ts": timestamp,
+    }))
+    .map_err(|_| E2eeError::DecryptionFailed)
+}
+
+/// ACI v2 response AAD (§7.3): like the request AAD but tagged
+/// `aci.e2ee.response.v2` and additionally binding the response `id`.
+fn aci_response_aad(
+    algo: &str,
+    model: &str,
+    response_id: &str,
+    field: &str,
+    nonce: &str,
+    timestamp: u64,
+) -> Result<Vec<u8>, E2eeError> {
+    canonicalize(&json!({
+        "purpose": "aci.e2ee.response.v2",
+        "algo": algo,
+        "model": model,
+        "id": response_id,
+        "field": field,
+        "nonce": nonce,
+        "ts": timestamp,
+    }))
+    .map_err(|_| E2eeError::EncryptionFailed)
+}
+
+/// Legacy pipe-delimited request AAD for chat message content. Frozen.
+fn legacy_request_aad(
     algo: &str,
     model: &str,
     message_index: usize,
@@ -101,7 +167,8 @@ pub(super) fn request_aad(
     )
 }
 
-pub(super) fn completion_request_aad(
+/// Legacy pipe-delimited request AAD for prompt / embedding-input fields. Frozen.
+fn legacy_completion_request_aad(
     algo: &str,
     model: &str,
     field_name: &str,
@@ -111,7 +178,8 @@ pub(super) fn completion_request_aad(
     format!("v2|req|algo={algo}|model={model}|field={field_name}|n={nonce}|ts={timestamp}")
 }
 
-pub(super) fn embedding_response_aad(
+/// Legacy pipe-delimited response AAD for embedding data. Frozen.
+fn legacy_embedding_response_aad(
     algo: &str,
     model: &str,
     response_id: &str,
@@ -125,7 +193,8 @@ pub(super) fn embedding_response_aad(
     )
 }
 
-pub(super) fn response_aad(
+/// Legacy pipe-delimited response AAD for chat / completion fields. Frozen.
+fn legacy_response_aad(
     algo: &str,
     model: &str,
     response_id: &str,
@@ -147,6 +216,15 @@ pub(super) struct E2eeFieldCrypto<'a> {
     pub(super) model: &'a str,
     pub(super) nonce: Option<&'a str>,
     pub(super) timestamp: Option<u64>,
+}
+
+impl E2eeFieldCrypto<'_> {
+    /// The request nonce and timestamp, required whenever the mode builds AAD.
+    fn nonce_ts(&self) -> Result<(&str, u64), E2eeError> {
+        let nonce = self.nonce.ok_or(E2eeError::DecryptionFailed)?;
+        let timestamp = self.timestamp.ok_or(E2eeError::DecryptionFailed)?;
+        Ok((nonce, timestamp))
+    }
 }
 
 pub(super) fn decrypt_request_payload(
@@ -270,8 +348,10 @@ pub(super) fn decrypt_content_value(
     content: &mut Value,
 ) -> Result<usize, E2eeError> {
     match content {
+        // Whole-content encryption, any modality: `messages.{m}.content`.
         Value::String(ciphertext_hex) => {
-            let aad = request_aad_for_crypto(crypto, message_index, None)?;
+            let field = format!("messages.{message_index}.content");
+            let aad = content_request_aad(crypto, message_index, None, &field)?;
             let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
             let plaintext =
                 String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -281,20 +361,11 @@ pub(super) fn decrypt_content_value(
         Value::Array(items) => {
             let mut decrypted_count = 0usize;
             for (content_index, item) in items.iter_mut().enumerate() {
-                let Some(item) = item.as_object_mut() else {
+                let Some(part) = item.as_object_mut() else {
                     continue;
                 };
-                if item.get("type").and_then(Value::as_str) != Some("text") {
-                    continue;
-                }
-                let Some(Value::String(ciphertext_hex)) = item.get_mut("text") else {
-                    continue;
-                };
-                let aad = request_aad_for_crypto(crypto, message_index, Some(content_index))?;
-                let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
-                *ciphertext_hex =
-                    String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
-                decrypted_count += 1;
+                decrypted_count +=
+                    decrypt_content_part(crypto, message_index, content_index, part)?;
             }
             Ok(decrypted_count)
         }
@@ -302,60 +373,172 @@ pub(super) fn decrypt_content_value(
     }
 }
 
-pub(super) fn request_aad_for_crypto(
+/// Decrypt one structured content part in place. `text` parts are decrypted in
+/// every mode; the per-part `image_url.url` and `input_audio.data` locations
+/// (§7.2) are ACI-only — the legacy compatibility modes never defined field
+/// paths for them, so there they pass through unchanged.
+fn decrypt_content_part(
+    crypto: &E2eeFieldCrypto<'_>,
+    message_index: usize,
+    content_index: usize,
+    part: &mut serde_json::Map<String, Value>,
+) -> Result<usize, E2eeError> {
+    match part.get("type").and_then(Value::as_str) {
+        Some("text") => {
+            let field = format!("messages.{message_index}.content.{content_index}.text");
+            decrypt_content_part_field(crypto, message_index, content_index, part, "text", &field)
+        }
+        Some("image_url") if crypto.aad_mode.is_aci() => {
+            let field = format!("messages.{message_index}.content.{content_index}.image_url.url");
+            decrypt_content_part_nested(
+                crypto,
+                message_index,
+                content_index,
+                part,
+                "image_url",
+                "url",
+                &field,
+            )
+        }
+        Some("input_audio") if crypto.aad_mode.is_aci() => {
+            let field =
+                format!("messages.{message_index}.content.{content_index}.input_audio.data");
+            decrypt_content_part_nested(
+                crypto,
+                message_index,
+                content_index,
+                part,
+                "input_audio",
+                "data",
+                &field,
+            )
+        }
+        _ => Ok(0),
+    }
+}
+
+/// Decrypt a direct string member (`text`) of a content part.
+fn decrypt_content_part_field(
+    crypto: &E2eeFieldCrypto<'_>,
+    message_index: usize,
+    content_index: usize,
+    part: &mut serde_json::Map<String, Value>,
+    key: &str,
+    field: &str,
+) -> Result<usize, E2eeError> {
+    let Some(Value::String(ciphertext_hex)) = part.get_mut(key) else {
+        return Ok(0);
+    };
+    let aad = content_request_aad(crypto, message_index, Some(content_index), field)?;
+    let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
+    *ciphertext_hex = String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
+    Ok(1)
+}
+
+/// Decrypt a nested string member (`image_url.url`, `input_audio.data`) of a
+/// content part.
+fn decrypt_content_part_nested(
+    crypto: &E2eeFieldCrypto<'_>,
+    message_index: usize,
+    content_index: usize,
+    part: &mut serde_json::Map<String, Value>,
+    wrapper_key: &str,
+    inner_key: &str,
+    field: &str,
+) -> Result<usize, E2eeError> {
+    let Some(Value::Object(wrapper)) = part.get_mut(wrapper_key) else {
+        return Ok(0);
+    };
+    let Some(Value::String(ciphertext_hex)) = wrapper.get_mut(inner_key) else {
+        return Ok(0);
+    };
+    let aad = content_request_aad(crypto, message_index, Some(content_index), field)?;
+    let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
+    *ciphertext_hex = String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
+    Ok(1)
+}
+
+/// AAD for a chat message-content location. ACI uses the JCS field path;
+/// the legacy modes keep the pipe-delimited `m`/`c` form.
+fn content_request_aad(
     crypto: &E2eeFieldCrypto<'_>,
     message_index: usize,
     content_index: Option<usize>,
-) -> Result<Option<String>, E2eeError> {
-    if !crypto.aad_mode.uses_aad() {
-        return Ok(None);
+    aci_field: &str,
+) -> Result<Option<Vec<u8>>, E2eeError> {
+    match crypto.aad_mode {
+        E2eeAadMode::AciV2 => {
+            let (nonce, timestamp) = crypto.nonce_ts()?;
+            Ok(Some(aci_request_aad(
+                crypto.algo,
+                crypto.model,
+                aci_field,
+                nonce,
+                timestamp,
+            )?))
+        }
+        E2eeAadMode::LegacyV2 => {
+            let (nonce, timestamp) = crypto.nonce_ts()?;
+            Ok(Some(
+                legacy_request_aad(
+                    crypto.algo,
+                    crypto.model,
+                    message_index,
+                    content_index,
+                    nonce,
+                    timestamp,
+                )
+                .into_bytes(),
+            ))
+        }
+        E2eeAadMode::LegacyV1 => Ok(None),
     }
-    let nonce = crypto.nonce.ok_or(E2eeError::DecryptionFailed)?;
-    let timestamp = crypto.timestamp.ok_or(E2eeError::DecryptionFailed)?;
-    Ok(Some(request_aad(
-        crypto.algo,
-        crypto.model,
-        message_index,
-        content_index,
-        nonce,
-        timestamp,
-    )))
 }
 
-pub(super) fn completion_request_aad_for_crypto(
+/// AAD for a prompt / embedding-input field, whose field path (`prompt`,
+/// `prompt.{i}`, `input`, `input.{i}`) is already the field-path component.
+fn completion_request_aad_for_crypto(
     crypto: &E2eeFieldCrypto<'_>,
-    field_name: &str,
-) -> Result<Option<String>, E2eeError> {
-    if !crypto.aad_mode.uses_aad() {
-        return Ok(None);
+    field: &str,
+) -> Result<Option<Vec<u8>>, E2eeError> {
+    match crypto.aad_mode {
+        E2eeAadMode::AciV2 => {
+            let (nonce, timestamp) = crypto.nonce_ts()?;
+            Ok(Some(aci_request_aad(
+                crypto.algo,
+                crypto.model,
+                field,
+                nonce,
+                timestamp,
+            )?))
+        }
+        E2eeAadMode::LegacyV2 => {
+            let (nonce, timestamp) = crypto.nonce_ts()?;
+            Ok(Some(
+                legacy_completion_request_aad(crypto.algo, crypto.model, field, nonce, timestamp)
+                    .into_bytes(),
+            ))
+        }
+        E2eeAadMode::LegacyV1 => Ok(None),
     }
-    let nonce = crypto.nonce.ok_or(E2eeError::DecryptionFailed)?;
-    let timestamp = crypto.timestamp.ok_or(E2eeError::DecryptionFailed)?;
-    Ok(Some(completion_request_aad(
-        crypto.algo,
-        crypto.model,
-        field_name,
-        nonce,
-        timestamp,
-    )))
 }
 
 pub(super) fn decrypt_e2ee_field(
     crypto: &E2eeFieldCrypto<'_>,
     ciphertext_hex: &str,
-    aad: Option<&str>,
+    aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, E2eeError> {
     match crypto.decryptor {
         E2eeDecryptor::AciV2 { key_id } => {
             let aad = aad.ok_or(E2eeError::DecryptionFailed)?;
             crypto
                 .keys
-                .decrypt_e2ee(key_id, ciphertext_hex, aad.as_bytes())
+                .decrypt_e2ee(key_id, ciphertext_hex, aad)
                 .map_err(|_| E2eeError::DecryptionFailed)
         }
         E2eeDecryptor::Legacy { signing_algo } => crypto
             .keys
-            .decrypt_legacy_e2ee(signing_algo, ciphertext_hex, aad.map(str::as_bytes))
+            .decrypt_legacy_e2ee(signing_algo, ciphertext_hex, aad)
             .map_err(|_| E2eeError::DecryptionFailed),
     }
 }
@@ -384,7 +567,7 @@ pub(super) fn encrypt_e2ee_response_body(
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    if ctx.aad_mode.uses_aad() && aad_component_is_ambiguous(&response_id) {
+    if ctx.aad_mode == E2eeAadMode::LegacyV2 && aad_component_is_ambiguous(&response_id) {
         return Err(E2eeError::EncryptionFailed);
     }
 
@@ -409,6 +592,7 @@ pub(super) fn encrypt_e2ee_response_body(
             encrypt_response_field(
                 choice,
                 "text",
+                &format!("choices.{choice_index}.text"),
                 ctx,
                 &response_model,
                 &response_id,
@@ -418,6 +602,7 @@ pub(super) fn encrypt_e2ee_response_body(
             encrypt_response_field(
                 message,
                 "content",
+                &format!("choices.{choice_index}.message.content"),
                 ctx,
                 &response_model,
                 &response_id,
@@ -426,11 +611,16 @@ pub(super) fn encrypt_e2ee_response_body(
             encrypt_response_field(
                 message,
                 "reasoning_content",
+                &format!("choices.{choice_index}.message.reasoning_content"),
                 ctx,
                 &response_model,
                 &response_id,
                 choice_index,
             )?;
+            // Response audio (`message.audio.data`, §7.2) is ACI-only.
+            if ctx.aad_mode.is_aci() {
+                encrypt_message_audio_data(message, ctx, &response_id, choice_index)?;
+            }
         }
     }
 
@@ -464,51 +654,52 @@ pub(super) fn encrypt_embedding_data(
         // the original type, mirroring how chat content arrays are
         // recovered.
         let plaintext = serde_json::to_vec(embedding).map_err(|_| E2eeError::EncryptionFailed)?;
-        let aad = embedding_response_aad_for_context(
-            ctx,
-            response_model,
-            response_id,
-            data_index,
-            "embedding",
-        )?;
+        let aad = embedding_response_aad_for_context(ctx, response_model, response_id, data_index)?;
         let ciphertext_hex = encrypt_response_plaintext(ctx, &plaintext, aad.as_deref())?;
         *embedding = Value::String(ciphertext_hex);
     }
     Ok(())
 }
 
-pub(super) fn embedding_response_aad_for_context(
+fn embedding_response_aad_for_context(
     ctx: &E2eeRequestContext,
     response_model: &str,
     response_id: &str,
     data_index: u64,
-    field_name: &str,
-) -> Result<Option<String>, E2eeError> {
-    if !ctx.aad_mode.uses_aad() {
-        return Ok(None);
+) -> Result<Option<Vec<u8>>, E2eeError> {
+    match ctx.aad_mode {
+        E2eeAadMode::AciV2 => {
+            let (nonce, timestamp) = response_nonce_ts(ctx)?;
+            let field = format!("data.{data_index}.embedding");
+            Ok(Some(aci_response_aad(
+                &ctx.algo,
+                &ctx.request_model,
+                response_id,
+                &field,
+                nonce,
+                timestamp,
+            )?))
+        }
+        E2eeAadMode::LegacyV2 => {
+            if aad_component_is_ambiguous(response_model) {
+                return Err(E2eeError::EncryptionFailed);
+            }
+            let (nonce, timestamp) = response_nonce_ts(ctx)?;
+            Ok(Some(
+                legacy_embedding_response_aad(
+                    &ctx.algo,
+                    response_model,
+                    response_id,
+                    data_index,
+                    "embedding",
+                    nonce,
+                    timestamp,
+                )
+                .into_bytes(),
+            ))
+        }
+        E2eeAadMode::LegacyV1 => Ok(None),
     }
-    if aad_component_is_ambiguous(field_name) {
-        return Err(E2eeError::EncryptionFailed);
-    }
-    let model = match ctx.aad_mode {
-        E2eeAadMode::AciV2 => ctx.request_model.as_str(),
-        E2eeAadMode::LegacyV2 => response_model,
-        E2eeAadMode::LegacyV1 => return Ok(None),
-    };
-    if aad_component_is_ambiguous(model) {
-        return Err(E2eeError::EncryptionFailed);
-    }
-    let nonce = ctx.nonce.as_deref().ok_or(E2eeError::EncryptionFailed)?;
-    let timestamp = ctx.timestamp.ok_or(E2eeError::EncryptionFailed)?;
-    Ok(Some(embedding_response_aad(
-        &ctx.algo,
-        model,
-        response_id,
-        data_index,
-        field_name,
-        nonce,
-        timestamp,
-    )))
 }
 
 pub(super) fn encrypt_e2ee_final_response(
@@ -555,7 +746,7 @@ pub(super) fn encrypt_e2ee_stream_payload(
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    if ctx.aad_mode.uses_aad() && aad_component_is_ambiguous(&response_id) {
+    if ctx.aad_mode == E2eeAadMode::LegacyV2 && aad_component_is_ambiguous(&response_id) {
         return Err(E2eeError::EncryptionFailed);
     }
 
@@ -575,6 +766,7 @@ pub(super) fn encrypt_e2ee_stream_payload(
             encrypt_response_field(
                 choice,
                 "text",
+                &format!("choices.{choice_index}.text"),
                 ctx,
                 &response_model,
                 &response_id,
@@ -587,6 +779,7 @@ pub(super) fn encrypt_e2ee_stream_payload(
             encrypt_response_field(
                 delta,
                 "content",
+                &format!("choices.{choice_index}.delta.content"),
                 ctx,
                 &response_model,
                 &response_id,
@@ -595,6 +788,7 @@ pub(super) fn encrypt_e2ee_stream_payload(
             encrypt_response_field(
                 delta,
                 "reasoning_content",
+                &format!("choices.{choice_index}.delta.reasoning_content"),
                 ctx,
                 &response_model,
                 &response_id,
@@ -609,73 +803,155 @@ pub(super) fn encrypt_e2ee_stream_payload(
 pub(super) fn encrypt_response_field(
     container: &mut serde_json::Map<String, Value>,
     field_name: &str,
+    aci_field: &str,
     ctx: &E2eeRequestContext,
     response_model: &str,
     response_id: &str,
     choice_index: u64,
 ) -> Result<(), E2eeError> {
-    if aad_component_is_ambiguous(field_name) {
-        return Err(E2eeError::EncryptionFailed);
-    }
     let Some(Value::String(plaintext)) = container.get_mut(field_name) else {
         return Ok(());
     };
-    let aad = response_aad_for_context(ctx, response_model, response_id, choice_index, field_name)?;
+    let aad = response_aad_for_context(
+        ctx,
+        response_model,
+        response_id,
+        choice_index,
+        field_name,
+        aci_field,
+    )?;
     *plaintext = encrypt_response_plaintext(ctx, plaintext.as_bytes(), aad.as_deref())?;
     Ok(())
 }
 
-pub(super) fn response_aad_for_context(
+/// Encrypt `message.audio.data` in place under the `choices.{i}.message.audio.data`
+/// field path. ACI-only; the caller gates on [`E2eeAadMode::is_aci`].
+fn encrypt_message_audio_data(
+    message: &mut serde_json::Map<String, Value>,
+    ctx: &E2eeRequestContext,
+    response_id: &str,
+    choice_index: u64,
+) -> Result<(), E2eeError> {
+    let Some(Value::Object(audio)) = message.get_mut("audio") else {
+        return Ok(());
+    };
+    let Some(Value::String(plaintext)) = audio.get_mut("data") else {
+        return Ok(());
+    };
+    let (nonce, timestamp) = response_nonce_ts(ctx)?;
+    let field = format!("choices.{choice_index}.message.audio.data");
+    let aad = aci_response_aad(
+        &ctx.algo,
+        &ctx.request_model,
+        response_id,
+        &field,
+        nonce,
+        timestamp,
+    )?;
+    *plaintext = encrypt_response_plaintext(ctx, plaintext.as_bytes(), Some(aad.as_slice()))?;
+    Ok(())
+}
+
+fn response_aad_for_context(
     ctx: &E2eeRequestContext,
     response_model: &str,
     response_id: &str,
     choice_index: u64,
     field_name: &str,
-) -> Result<Option<String>, E2eeError> {
-    if !ctx.aad_mode.uses_aad() {
-        return Ok(None);
+    aci_field: &str,
+) -> Result<Option<Vec<u8>>, E2eeError> {
+    match ctx.aad_mode {
+        E2eeAadMode::AciV2 => {
+            let (nonce, timestamp) = response_nonce_ts(ctx)?;
+            Ok(Some(aci_response_aad(
+                &ctx.algo,
+                &ctx.request_model,
+                response_id,
+                aci_field,
+                nonce,
+                timestamp,
+            )?))
+        }
+        E2eeAadMode::LegacyV2 => {
+            if aad_component_is_ambiguous(field_name) || aad_component_is_ambiguous(response_model)
+            {
+                return Err(E2eeError::EncryptionFailed);
+            }
+            let (nonce, timestamp) = response_nonce_ts(ctx)?;
+            Ok(Some(
+                legacy_response_aad(
+                    &ctx.algo,
+                    response_model,
+                    response_id,
+                    choice_index,
+                    field_name,
+                    nonce,
+                    timestamp,
+                )
+                .into_bytes(),
+            ))
+        }
+        E2eeAadMode::LegacyV1 => Ok(None),
     }
-    if aad_component_is_ambiguous(field_name) {
-        return Err(E2eeError::EncryptionFailed);
-    }
-    let model = match ctx.aad_mode {
-        E2eeAadMode::AciV2 => ctx.request_model.as_str(),
-        E2eeAadMode::LegacyV2 => response_model,
-        E2eeAadMode::LegacyV1 => return Ok(None),
-    };
-    if aad_component_is_ambiguous(model) {
-        return Err(E2eeError::EncryptionFailed);
-    }
+}
+
+/// The request nonce and timestamp carried into the response AAD.
+fn response_nonce_ts(ctx: &E2eeRequestContext) -> Result<(&str, u64), E2eeError> {
     let nonce = ctx.nonce.as_deref().ok_or(E2eeError::EncryptionFailed)?;
     let timestamp = ctx.timestamp.ok_or(E2eeError::EncryptionFailed)?;
-    Ok(Some(response_aad(
-        &ctx.algo,
-        model,
-        response_id,
-        choice_index,
-        field_name,
-        nonce,
-        timestamp,
-    )))
+    Ok((nonce, timestamp))
 }
 
 pub(super) fn encrypt_response_plaintext(
     ctx: &E2eeRequestContext,
     plaintext: &[u8],
-    aad: Option<&str>,
+    aad: Option<&[u8]>,
 ) -> Result<String, E2eeError> {
     match ctx.aad_mode {
         E2eeAadMode::AciV2 => {
             let aad = aad.ok_or(E2eeError::EncryptionFailed)?;
-            encrypt_for_public_key(&ctx.client_public_key_hex, plaintext, aad.as_bytes())
+            encrypt_for_public_key(&ctx.client_public_key_hex, plaintext, aad)
                 .map_err(|_| E2eeError::EncryptionFailed)
         }
-        E2eeAadMode::LegacyV1 | E2eeAadMode::LegacyV2 => encrypt_legacy_for_public_key(
-            &ctx.algo,
-            &ctx.client_public_key_hex,
-            plaintext,
-            aad.map(str::as_bytes),
+        E2eeAadMode::LegacyV1 | E2eeAadMode::LegacyV2 => {
+            encrypt_legacy_for_public_key(&ctx.algo, &ctx.client_public_key_hex, plaintext, aad)
+                .map_err(|_| E2eeError::EncryptionFailed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{aci_request_aad, aci_response_aad};
+
+    // Byte-exact expected AAD from spec/test-vectors.md §7 (X25519 suite).
+    const REQUEST_AAD: &str = r#"{"algo":"x25519-aes-256-gcm-hkdf-sha256","field":"messages.0.content","model":"demo-model","nonce":"6e6f6e63652d31323334","purpose":"aci.e2ee.request.v2","ts":1750000000}"#;
+    const RESPONSE_AAD: &str = r#"{"algo":"x25519-aes-256-gcm-hkdf-sha256","field":"choices.0.message.content","id":"chatcmpl-123","model":"demo-model","nonce":"6e6f6e63652d31323334","purpose":"aci.e2ee.response.v2","ts":1750000000}"#;
+
+    #[test]
+    fn request_aad_matches_spec_test_vector() {
+        let aad = aci_request_aad(
+            "x25519-aes-256-gcm-hkdf-sha256",
+            "demo-model",
+            "messages.0.content",
+            "6e6f6e63652d31323334",
+            1_750_000_000,
         )
-        .map_err(|_| E2eeError::EncryptionFailed),
+        .unwrap();
+        assert_eq!(aad, REQUEST_AAD.as_bytes());
+    }
+
+    #[test]
+    fn response_aad_matches_spec_test_vector() {
+        let aad = aci_response_aad(
+            "x25519-aes-256-gcm-hkdf-sha256",
+            "demo-model",
+            "chatcmpl-123",
+            "choices.0.message.content",
+            "6e6f6e63652d31323334",
+            1_750_000_000,
+        )
+        .unwrap();
+        assert_eq!(aad, RESPONSE_AAD.as_bytes());
     }
 }

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -43,8 +43,11 @@ pub(super) enum E2eeAadMode {
 }
 
 impl E2eeAadMode {
-    pub(super) fn uses_aad(self) -> bool {
-        matches!(self, Self::AciV2 | Self::LegacyV2)
+    /// The spec ACI v2 path (JCS AAD, §7.3), as opposed to the frozen legacy
+    /// X-Signing-Algo compatibility modes. Per-part multimodal field paths
+    /// (§7.2) exist only here.
+    pub(super) fn is_aci(self) -> bool {
+        matches!(self, Self::AciV2)
     }
 }
 

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -17,7 +17,7 @@ use axum::http::{HeaderMap, Request, StatusCode};
 use axum::Router;
 use bytes::Bytes;
 use futures_util::stream;
-use private_ai_gateway::aci::canonical::sha256_hex;
+use private_ai_gateway::aci::canonical::{canonicalize, sha256_hex};
 use private_ai_gateway::aci::e2ee::{
     decrypt_legacy_ecdsa_with_secret_key, decrypt_legacy_ed25519_with_secret_key,
     decrypt_with_secret_key, ed25519_public_key_hex, encrypt_for_public_key,
@@ -313,6 +313,41 @@ fn receipt_event<'a>(receipt: &'a Receipt, event_type: &str) -> &'a Value {
         .fields
 }
 
+/// ACI v2 request AAD: JCS of the purpose-tagged object (spec §7.3).
+fn aci_request_aad(algo: &str, model: &str, field: &str, nonce: &str, ts: u64) -> Vec<u8> {
+    canonicalize(&serde_json::json!({
+        "purpose": "aci.e2ee.request.v2",
+        "algo": algo,
+        "model": model,
+        "field": field,
+        "nonce": nonce,
+        "ts": ts,
+    }))
+    .unwrap()
+}
+
+/// ACI v2 response AAD: like the request AAD but tagged `aci.e2ee.response.v2`
+/// and additionally binding the response `id` (spec §7.3).
+fn aci_response_aad(
+    algo: &str,
+    model: &str,
+    id: &str,
+    field: &str,
+    nonce: &str,
+    ts: u64,
+) -> Vec<u8> {
+    canonicalize(&serde_json::json!({
+        "purpose": "aci.e2ee.response.v2",
+        "algo": algo,
+        "model": model,
+        "id": id,
+        "field": field,
+        "nonce": nonce,
+        "ts": ts,
+    }))
+    .unwrap()
+}
+
 fn e2ee_request(
     h: &Harness,
     client_secret: &k256::SecretKey,
@@ -338,12 +373,15 @@ fn e2ee_chat_request(
     let model = "aci-model";
     let timestamp = 1_700_000_000u64;
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let aad = format!(
-        "v2|req|algo={}|model={model}|m=0|c=-|n={nonce}|ts={timestamp}",
-        model_key.algo
+    let aad = aci_request_aad(
+        &model_key.algo,
+        model,
+        "messages.0.content",
+        nonce,
+        timestamp,
     );
     let encrypted_content =
-        encrypt_for_public_key(&model_key.public_key_hex, b"hello", aad.as_bytes()).unwrap();
+        encrypt_for_public_key(&model_key.public_key_hex, b"hello", &aad).unwrap();
     let body = serde_json::json!({
         "model": model,
         "stream": stream,
@@ -384,12 +422,9 @@ fn e2ee_completion_request_with_stream(
     let model = "aci-model";
     let timestamp = 1_700_000_000u64;
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let aad = format!(
-        "v2|req|algo={}|model={model}|field=prompt|n={nonce}|ts={timestamp}",
-        model_key.algo
-    );
+    let aad = aci_request_aad(&model_key.algo, model, "prompt", nonce, timestamp);
     let encrypted_prompt =
-        encrypt_for_public_key(&model_key.public_key_hex, b"hello", aad.as_bytes()).unwrap();
+        encrypt_for_public_key(&model_key.public_key_hex, b"hello", &aad).unwrap();
     let body = serde_json::json!({
         "model": model,
         "prompt": encrypted_prompt,
@@ -405,21 +440,17 @@ fn e2ee_completion_request_with_stream(
     (serde_json::to_vec(&body).unwrap(), headers)
 }
 
-fn e2ee_response_aad(h: &Harness, nonce: &str, choice_index: u64, field_name: &str) -> String {
-    e2ee_response_aad_with_id(h, nonce, "chat-aci-1", choice_index, field_name)
-}
-
-fn e2ee_response_aad_with_id(
-    h: &Harness,
-    nonce: &str,
-    response_id: &str,
-    choice_index: u64,
-    field_name: &str,
-) -> String {
+/// ACI v2 response AAD bound to the request model `aci-model`, for the given
+/// response id and full field path (spec §7.2, §7.3).
+fn e2ee_response_aad(h: &Harness, nonce: &str, response_id: &str, field: &str) -> Vec<u8> {
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    format!(
-        "v2|resp|algo={}|model=aci-model|id={response_id}|choice={choice_index}|field={field_name}|n={nonce}|ts=1700000000",
-        model_key.algo
+    aci_response_aad(
+        &model_key.algo,
+        "aci-model",
+        response_id,
+        field,
+        nonce,
+        1_700_000_000,
     )
 }
 
@@ -751,10 +782,9 @@ async fn e2ee_v2_success_sets_e2ee_headers_and_receipt_hashes_cleartext_and_wire
     let encrypted_content = encrypted_response["choices"][0]["message"]["content"]
         .as_str()
         .unwrap();
-    let response_aad = e2ee_response_aad(&h, nonce, 0, "content");
+    let response_aad = e2ee_response_aad(&h, nonce, "chat-aci-1", "choices.0.message.content");
     let decrypted_response =
-        decrypt_with_secret_key(&client_secret, encrypted_content, response_aad.as_bytes())
-            .unwrap();
+        decrypt_with_secret_key(&client_secret, encrypted_content, &response_aad).unwrap();
     assert_eq!(decrypted_response, b"plain-answer");
 
     let receipt_id = header(&resp.headers, "x-receipt-id");
@@ -799,19 +829,115 @@ async fn e2ee_v2_response_aad_uses_request_model_not_upstream_response_model() {
     let encrypted_content = encrypted_response["choices"][0]["message"]["content"]
         .as_str()
         .unwrap();
-    let request_model_aad = e2ee_response_aad(&h, nonce, 0, "content");
-    let decrypted_response = decrypt_with_secret_key(
-        &client_secret,
-        encrypted_content,
-        request_model_aad.as_bytes(),
-    )
-    .unwrap();
+    let request_model_aad = e2ee_response_aad(&h, nonce, "chat-aci-1", "choices.0.message.content");
+    let decrypted_response =
+        decrypt_with_secret_key(&client_secret, encrypted_content, &request_model_aad).unwrap();
     assert_eq!(decrypted_response, b"plain-answer");
 
-    let wrong_aad = request_model_aad.replace("model=aci-model", "model=private-upstream-model");
-    assert!(
-        decrypt_with_secret_key(&client_secret, encrypted_content, wrong_aad.as_bytes()).is_err()
+    // The response AAD binds the request model, so the upstream response model
+    // must not decrypt it.
+    let model_key = &h.service.keyset().e2ee_public_keys[0];
+    let wrong_aad = aci_response_aad(
+        &model_key.algo,
+        "private-upstream-model",
+        "chat-aci-1",
+        "choices.0.message.content",
+        nonce,
+        1_700_000_000,
     );
+    assert!(decrypt_with_secret_key(&client_secret, encrypted_content, &wrong_aad).is_err());
+}
+
+#[tokio::test]
+async fn e2ee_v2_decrypts_multimodal_image_and_audio_parts() {
+    // Per-part decryption of `image_url.url` and `input_audio.data`
+    // alongside a text part (spec §7.2).
+    let h = harness_with_e2ee(RecordingUpstream::with_response_body(E2EE_CHAT_RESPONSE));
+    let client_secret = k256::SecretKey::from_slice(&[0x64; 32]).unwrap();
+    let nonce = "nonce-multimodal";
+    let timestamp = 1_700_000_000u64;
+    let model_key = &h.service.keyset().e2ee_public_keys[0];
+    let algo = model_key.algo.clone();
+    let pub_key = model_key.public_key_hex.clone();
+
+    let enc = |field: &str, plaintext: &[u8]| {
+        let aad = aci_request_aad(&algo, "aci-model", field, nonce, timestamp);
+        encrypt_for_public_key(&pub_key, plaintext, &aad).unwrap()
+    };
+    let text_ct = enc("messages.0.content.0.text", b"look at this");
+    let image_ct = enc(
+        "messages.0.content.1.image_url.url",
+        b"data:image/png;base64,iVBORw0KGgo=",
+    );
+    let audio_ct = enc("messages.0.content.2.input_audio.data", b"UklGRAAAAABXQVZF");
+    let body = serde_json::json!({
+        "model": "aci-model",
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": text_ct},
+            {"type": "image_url", "image_url": {"url": image_ct}},
+            {"type": "input_audio", "input_audio": {"data": audio_ct, "format": "wav"}},
+        ]}],
+    });
+    let headers = vec![
+        ("x-client-pub-key", public_key_from_secret(&client_secret)),
+        ("x-model-pub-key", pub_key.clone()),
+        ("x-e2ee-version", E2EE_VERSION_V2.to_string()),
+        ("x-e2ee-nonce", nonce.to_string()),
+        ("x-e2ee-timestamp", timestamp.to_string()),
+    ];
+
+    let resp = h
+        .requester
+        .post_owned_headers(
+            "/v1/chat/completions",
+            &serde_json::to_vec(&body).unwrap(),
+            &headers,
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "{}",
+        String::from_utf8_lossy(&resp.body)
+    );
+
+    let upstream_body = h.upstream_calls.lock().unwrap()[0].body.clone();
+    let upstream: Value = serde_json::from_slice(&upstream_body).unwrap();
+    let content = &upstream["messages"][0]["content"];
+    assert_eq!(content[0]["text"], "look at this");
+    assert_eq!(
+        content[1]["image_url"]["url"],
+        "data:image/png;base64,iVBORw0KGgo="
+    );
+    assert_eq!(content[2]["input_audio"]["data"], "UklGRAAAAABXQVZF");
+    // Non-encrypted sibling members pass through untouched.
+    assert_eq!(content[2]["input_audio"]["format"], "wav");
+}
+
+#[tokio::test]
+async fn e2ee_v2_response_encrypts_message_audio_data() {
+    // Buffered chat responses encrypt `choices.{i}.message.audio.data` (§7.2).
+    let audio_response = br#"{"id":"chat-aci-1","object":"chat.completion","model":"aci-model","choices":[{"index":0,"message":{"role":"assistant","audio":{"id":"audio-1","data":"QUJDMTIzYXVkaW8="}},"finish_reason":"stop"}]}"#;
+    let h = harness_with_e2ee(RecordingUpstream::with_response_body(audio_response));
+    let client_secret = k256::SecretKey::from_slice(&[0x65; 32]).unwrap();
+    let nonce = "nonce-response-audio";
+    let (encrypted_body, headers) = e2ee_request(&h, &client_secret, nonce);
+
+    let resp = h
+        .requester
+        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(header(&resp.headers, "x-e2ee-applied"), "true");
+
+    let encrypted_response = json_body(&resp);
+    let encrypted_audio = encrypted_response["choices"][0]["message"]["audio"]["data"]
+        .as_str()
+        .expect("message.audio.data must be an encrypted hex string");
+    assert_ne!(encrypted_audio, "QUJDMTIzYXVkaW8=");
+    let audio_aad = e2ee_response_aad(&h, nonce, "chat-aci-1", "choices.0.message.audio.data");
+    let decrypted = decrypt_with_secret_key(&client_secret, encrypted_audio, &audio_aad).unwrap();
+    assert_eq!(decrypted, b"QUJDMTIzYXVkaW8=");
 }
 
 #[tokio::test]
@@ -961,7 +1087,9 @@ async fn e2ee_v2_invalid_payload_model_is_rejected_before_upstream() {
     let h = harness_with_e2ee(RecordingUpstream::default());
     let client_secret = k256::SecretKey::from_slice(&[0x59; 32]).unwrap();
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let invalid = br#"{"model":"bad|model","messages":[]}"#;
+    // JCS AAD needs no escaping, so `model` is rejected only when it is absent
+    // or not a string (spec §7.3), never for its contents.
+    let invalid = br#"{"model":123,"messages":[]}"#;
     let client_pub = public_key_from_secret(&client_secret);
     let resp = h
         .requester
@@ -1076,22 +1204,22 @@ async fn e2ee_v2_streaming_chat_encrypts_sse_events_and_hashes_cleartext_and_wir
         .as_str()
         .unwrap();
     assert_ne!(encrypted_content, "hel");
-    let content_aad = e2ee_response_aad_with_id(&h, nonce, "chat-stream-1", 0, "content");
+    let content_aad = e2ee_response_aad(&h, nonce, "chat-stream-1", "choices.0.delta.content");
     let decrypted_content =
-        decrypt_with_secret_key(&client_secret, encrypted_content, content_aad.as_bytes()).unwrap();
+        decrypt_with_secret_key(&client_secret, encrypted_content, &content_aad).unwrap();
     assert_eq!(decrypted_content, b"hel");
 
     let encrypted_reasoning = events[1]["choices"][0]["delta"]["reasoning_content"]
         .as_str()
         .unwrap();
-    let reasoning_aad =
-        e2ee_response_aad_with_id(&h, nonce, "chat-stream-1", 0, "reasoning_content");
-    let decrypted_reasoning = decrypt_with_secret_key(
-        &client_secret,
-        encrypted_reasoning,
-        reasoning_aad.as_bytes(),
-    )
-    .unwrap();
+    let reasoning_aad = e2ee_response_aad(
+        &h,
+        nonce,
+        "chat-stream-1",
+        "choices.0.delta.reasoning_content",
+    );
+    let decrypted_reasoning =
+        decrypt_with_secret_key(&client_secret, encrypted_reasoning, &reasoning_aad).unwrap();
     assert_eq!(decrypted_reasoning, b"think");
     assert!(events[2]["choices"][0]["delta"].get("content").is_none());
 
@@ -1249,9 +1377,9 @@ async fn completions_endpoint_supports_e2ee_as_optional_add_on() {
 
     let encrypted_response = json_body(&resp);
     let encrypted_text = encrypted_response["choices"][0]["text"].as_str().unwrap();
-    let response_aad = "v2|resp|algo=secp256k1-aes-256-gcm-hkdf-sha256|model=aci-model|id=cmpl-aci-1|choice=0|field=text|n=nonce-completion|ts=1700000000";
+    let response_aad = e2ee_response_aad(&h, nonce, "cmpl-aci-1", "choices.0.text");
     let decrypted_response =
-        decrypt_with_secret_key(&client_secret, encrypted_text, response_aad.as_bytes()).unwrap();
+        decrypt_with_secret_key(&client_secret, encrypted_text, &response_aad).unwrap();
     assert_eq!(decrypted_response, b"completion-answer");
 
     let receipt_id = header(&resp.headers, "x-receipt-id");
@@ -1307,9 +1435,8 @@ async fn completions_endpoint_streaming_supports_e2ee_as_optional_add_on() {
     let events = sse_json_events(&resp.body);
     assert_eq!(events.len(), 1);
     let encrypted_text = events[0]["choices"][0]["text"].as_str().unwrap();
-    let aad = "v2|resp|algo=secp256k1-aes-256-gcm-hkdf-sha256|model=aci-model|id=cmpl-stream-1|choice=0|field=text|n=nonce-completion-stream|ts=1700000000";
-    let decrypted_text =
-        decrypt_with_secret_key(&client_secret, encrypted_text, aad.as_bytes()).unwrap();
+    let aad = e2ee_response_aad(&h, nonce, "cmpl-stream-1", "choices.0.text");
+    let decrypted_text = decrypt_with_secret_key(&client_secret, encrypted_text, &aad).unwrap();
     assert_eq!(decrypted_text, b"completion-stream");
 
     let upstream_body = h.upstream_calls.lock().unwrap()[0].body.clone();
@@ -1417,12 +1544,9 @@ fn e2ee_embeddings_request_string(
     let model = "aci-model";
     let timestamp = 1_700_000_000u64;
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let aad = format!(
-        "v2|req|algo={}|model={model}|field=input|n={nonce}|ts={timestamp}",
-        model_key.algo
-    );
+    let aad = aci_request_aad(&model_key.algo, model, "input", nonce, timestamp);
     let encrypted_input =
-        encrypt_for_public_key(&model_key.public_key_hex, b"hello", aad.as_bytes()).unwrap();
+        encrypt_for_public_key(&model_key.public_key_hex, b"hello", &aad).unwrap();
     let body = serde_json::json!({
         "model": model,
         "input": encrypted_input,
@@ -1445,18 +1569,10 @@ fn e2ee_embeddings_request_array(
     let model = "aci-model";
     let timestamp = 1_700_000_000u64;
     let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let aad_0 = format!(
-        "v2|req|algo={}|model={model}|field=input.0|n={nonce}|ts={timestamp}",
-        model_key.algo
-    );
-    let aad_1 = format!(
-        "v2|req|algo={}|model={model}|field=input.1|n={nonce}|ts={timestamp}",
-        model_key.algo
-    );
-    let enc_0 =
-        encrypt_for_public_key(&model_key.public_key_hex, b"first", aad_0.as_bytes()).unwrap();
-    let enc_1 =
-        encrypt_for_public_key(&model_key.public_key_hex, b"second", aad_1.as_bytes()).unwrap();
+    let aad_0 = aci_request_aad(&model_key.algo, model, "input.0", nonce, timestamp);
+    let aad_1 = aci_request_aad(&model_key.algo, model, "input.1", nonce, timestamp);
+    let enc_0 = encrypt_for_public_key(&model_key.public_key_hex, b"first", &aad_0).unwrap();
+    let enc_1 = encrypt_for_public_key(&model_key.public_key_hex, b"second", &aad_1).unwrap();
     let body = serde_json::json!({
         "model": model,
         "input": [enc_0, enc_1],
@@ -1658,14 +1774,9 @@ async fn embeddings_endpoint_supports_aci_v2_e2ee_with_string_input() {
     let encrypted_embedding = encrypted_response["data"][0]["embedding"]
         .as_str()
         .expect("data[0].embedding must be encrypted hex string after E2EE");
-    let model_key = &h.service.keyset().e2ee_public_keys[0];
-    let response_aad = format!(
-        "v2|resp|algo={}|model=aci-model|id=|data=0|field=embedding|n={nonce}|ts=1700000000",
-        model_key.algo
-    );
+    let response_aad = e2ee_response_aad(&h, nonce, "", "data.0.embedding");
     let decrypted =
-        decrypt_with_secret_key(&client_secret, encrypted_embedding, response_aad.as_bytes())
-            .unwrap();
+        decrypt_with_secret_key(&client_secret, encrypted_embedding, &response_aad).unwrap();
     let decoded: Value = serde_json::from_slice(&decrypted).unwrap();
     assert_eq!(decoded, serde_json::json!([0.5, -0.25, 1.0]));
 
@@ -1708,18 +1819,13 @@ async fn embeddings_endpoint_supports_aci_v2_e2ee_with_array_input() {
     assert_eq!(upstream_json["input"][0], "first");
     assert_eq!(upstream_json["input"][1], "second");
 
-    let model_key = &h.service.keyset().e2ee_public_keys[0];
     let encrypted_response = json_body(&resp);
     for (idx, expected) in [(0u64, [1.0]), (1u64, [2.0])] {
         let ciphertext = encrypted_response["data"][idx as usize]["embedding"]
             .as_str()
             .unwrap();
-        let response_aad = format!(
-            "v2|resp|algo={}|model=aci-model|id=|data={idx}|field=embedding|n={nonce}|ts=1700000000",
-            model_key.algo
-        );
-        let plaintext =
-            decrypt_with_secret_key(&client_secret, ciphertext, response_aad.as_bytes()).unwrap();
+        let response_aad = e2ee_response_aad(&h, nonce, "", &format!("data.{idx}.embedding"));
+        let plaintext = decrypt_with_secret_key(&client_secret, ciphertext, &response_aad).unwrap();
         let decoded: Value = serde_json::from_slice(&plaintext).unwrap();
         assert_eq!(decoded, serde_json::json!(expected));
     }


### PR DESCRIPTION
Migrates the ACI v2 (`X-E2EE-Version`) E2EE AAD from the inherited pipe-delimited strings to the spec's JCS purpose-tagged object with a single field-path component (spec §7.3), and extends coverage to per-part image/audio request fields and response audio (spec §7.2).

- **AAD** — each ACI v2 ciphertext binds a JCS object (`aci.e2ee.request.v2` / `aci.e2ee.response.v2`) whose `field` is the location's field path; the `|`/CR/LF ambiguity checks are dropped (`model` still must be a present string, nonce still non-empty).
- **Multimodal** — request-side decryption of `messages.{m}.content.{c}.image_url.url` and `input_audio.data`, and response-side encryption of `choices.{i}.message.audio.data`.
- The legacy `X-Signing-Algo` path keeps its pipe-delimited AAD and validation exactly as-is.
- New unit tests assert the request/response AAD bytes equal spec/test-vectors.md §7 byte-for-byte; new integration tests round-trip the multimodal fields.

Closes #61
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)