### PR TITLE
Keys: X25519 E2EE suite + Ed25519 receipt signing

### DIFF
--- a/src/aci/e2ee.rs
+++ b/src/aci/e2ee.rs
@@ -1,13 +1,18 @@
 //! ACI and dstack-vllm-proxy E2EE helpers.
 //!
-//! The wire ciphertext is:
+//! ACI v1 (§7.1) defines two cipher suites — X25519 (RECOMMENDED,
+//! browser-native) and secp256k1 (EVM/dstack-native). Both do ECDH to a
+//! fresh ephemeral key, HKDF-SHA256, and AES-256-GCM; they differ only in
+//! the curve, the ephemeral key encoding, and the HKDF `info` string. The
+//! wire ciphertext of either suite is:
 //!
 //! ```text
-//! ephemeral_uncompressed_secp256k1_public_key || aes_gcm_nonce || ciphertext_tag
+//! ephemeral_public_key || aes_gcm_nonce || ciphertext_tag
 //! ```
 //!
-//! encoded as lowercase hex. The AAD strings are built by the caller
-//! from ACI §7.1.
+//! encoded as lowercase hex, where the ephemeral key is 32 raw bytes for
+//! X25519 and the 65-byte uncompressed SEC1 point for secp256k1. The AAD
+//! strings are built by the caller from ACI §7.3.
 //!
 //! The inherited dstack-vllm-proxy profile uses the legacy `ecdsa`
 //! and `ed25519` labels, different HKDF context strings, and v1
@@ -29,11 +34,13 @@ use super::keys::KeyError;
 
 pub const E2EE_VERSION_V2: &str = "2";
 pub const E2EE_VERSION_V1: &str = "1";
+pub const E2EE_ALGO_X25519_AESGCM: &str = "x25519-aes-256-gcm-hkdf-sha256";
 pub const E2EE_ALGO_SECP256K1_AESGCM: &str = "secp256k1-aes-256-gcm-hkdf-sha256";
 pub const E2EE_ALGO_LEGACY_ECDSA: &str = "ecdsa";
 pub const E2EE_ALGO_LEGACY_ED25519: &str = "ed25519";
 
-const HKDF_INFO: &[u8] = b"aci.e2ee.v2.secp256k1";
+const SECP256K1_HKDF_INFO: &[u8] = b"aci.e2ee.v2.secp256k1";
+const X25519_HKDF_INFO: &[u8] = b"aci.e2ee.v2.x25519";
 const LEGACY_ECDSA_HKDF_INFO: &[u8] = b"ecdsa_encryption";
 const LEGACY_ED25519_HKDF_INFO: &[u8] = b"ed25519_encryption";
 const PUBLIC_KEY_LEN: usize = 65;
@@ -71,6 +78,131 @@ pub fn legacy_ecdsa_public_key_from_secret(secret: &SecretKey) -> String {
 
 pub fn ed25519_public_key_hex(secret: &Ed25519SigningKey) -> String {
     hex::encode(secret.verifying_key().as_bytes())
+}
+
+/// True for the two ACI v1 §7.1 E2EE cipher suites. Other keyset `algo`
+/// values (legacy labels, unknown suites) are ignored for E2EE selection.
+pub fn is_aci_e2ee_suite(algo: &str) -> bool {
+    matches!(algo, E2EE_ALGO_X25519_AESGCM | E2EE_ALGO_SECP256K1_AESGCM)
+}
+
+/// Normalize a §7.1 public key to canonical lowercase hex for the suite's
+/// `algo`: 32-byte raw for X25519, 65-byte uncompressed SEC1 for secp256k1.
+pub fn normalize_aci_e2ee_public_key_hex(algo: &str, value: &str) -> Result<String, KeyError> {
+    match algo {
+        E2EE_ALGO_X25519_AESGCM => normalize_x25519_public_key_hex(value),
+        E2EE_ALGO_SECP256K1_AESGCM => normalize_secp256k1_public_key_hex(value),
+        other => Err(KeyError::UnsupportedAlgo(other.to_string())),
+    }
+}
+
+/// Encrypt one ACI v2 field to a recipient public key under the given §7.1
+/// suite. Used for response fields, keyed by the selected service E2EE key's
+/// `algo`.
+pub fn encrypt_aci_e2ee_for_public_key(
+    algo: &str,
+    recipient_public_key_hex: &str,
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<String, KeyError> {
+    match algo {
+        E2EE_ALGO_X25519_AESGCM => {
+            encrypt_x25519_for_public_key(recipient_public_key_hex, plaintext, aad)
+        }
+        E2EE_ALGO_SECP256K1_AESGCM => {
+            encrypt_for_public_key(recipient_public_key_hex, plaintext, aad)
+        }
+        other => Err(KeyError::UnsupportedAlgo(other.to_string())),
+    }
+}
+
+pub fn normalize_x25519_public_key_hex(value: &str) -> Result<String, KeyError> {
+    let bytes = hex::decode(value.strip_prefix("0x").unwrap_or(value))
+        .map_err(|e| KeyError::Crypto(format!("invalid X25519 public key hex: {e}")))?;
+    let bytes: [u8; X25519_PUBLIC_KEY_LEN] = bytes.as_slice().try_into().map_err(|_| {
+        KeyError::Crypto(format!(
+            "X25519 public key must be 32 bytes, got {}",
+            bytes.len()
+        ))
+    })?;
+    Ok(hex::encode(bytes))
+}
+
+pub fn x25519_public_key_hex(secret: &X25519SecretKey) -> String {
+    hex::encode(X25519PublicKey::from(secret).as_bytes())
+}
+
+pub fn x25519_secret_key_from_bytes(bytes: &[u8]) -> Result<X25519SecretKey, KeyError> {
+    let bytes: [u8; 32] = bytes.try_into().map_err(|_| {
+        KeyError::Crypto(format!(
+            "invalid X25519 E2EE key: must be 32 bytes, got {}",
+            bytes.len()
+        ))
+    })?;
+    Ok(X25519SecretKey::from(bytes))
+}
+
+pub fn encrypt_x25519_for_public_key(
+    recipient_public_key_hex: &str,
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<String, KeyError> {
+    let recipient = x25519_public_key_from_hex(recipient_public_key_hex)?;
+    let ephemeral = X25519SecretKey::from(rand::random::<[u8; 32]>());
+    let ephemeral_public = X25519PublicKey::from(&ephemeral);
+    let shared = ephemeral.diffie_hellman(&recipient);
+    let cipher = x25519_cipher_from_shared_secret(shared.as_bytes())?;
+    let nonce_bytes: [u8; NONCE_LEN] = rand::random();
+    let ciphertext = cipher
+        .encrypt(
+            &nonce_bytes.into(),
+            aes_gcm::aead::Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|e| KeyError::Crypto(format!("X25519 E2EE encrypt failed: {e}")))?;
+
+    let mut out = Vec::with_capacity(X25519_PUBLIC_KEY_LEN + NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(ephemeral_public.as_bytes());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(hex::encode(out))
+}
+
+pub fn decrypt_x25519_with_secret_key(
+    recipient_secret: &X25519SecretKey,
+    ciphertext_hex: &str,
+    aad: &[u8],
+) -> Result<Vec<u8>, KeyError> {
+    let blob = hex::decode(ciphertext_hex.strip_prefix("0x").unwrap_or(ciphertext_hex))
+        .map_err(|e| KeyError::Crypto(format!("invalid X25519 E2EE ciphertext hex: {e}")))?;
+    if blob.len() < X25519_PUBLIC_KEY_LEN + NONCE_LEN + TAG_LEN {
+        return Err(KeyError::Crypto(format!(
+            "X25519 E2EE ciphertext too short: got {} bytes",
+            blob.len()
+        )));
+    }
+    let eph_bytes: [u8; X25519_PUBLIC_KEY_LEN] = blob[..X25519_PUBLIC_KEY_LEN]
+        .try_into()
+        .expect("ephemeral public key length is checked");
+    let eph = X25519PublicKey::from(eph_bytes);
+    let nonce_bytes: [u8; NONCE_LEN] = blob
+        [X25519_PUBLIC_KEY_LEN..X25519_PUBLIC_KEY_LEN + NONCE_LEN]
+        .try_into()
+        .expect("nonce length is checked");
+    let ciphertext = &blob[X25519_PUBLIC_KEY_LEN + NONCE_LEN..];
+    let shared = recipient_secret.diffie_hellman(&eph);
+    let cipher = x25519_cipher_from_shared_secret(shared.as_bytes())?;
+    cipher
+        .decrypt(
+            &nonce_bytes.into(),
+            aes_gcm::aead::Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .map_err(|e| KeyError::Crypto(format!("X25519 E2EE decrypt failed: {e}")))
 }
 
 pub fn encrypt_for_public_key(
@@ -283,7 +415,25 @@ fn public_key_from_hex(value: &str) -> Result<PublicKey, KeyError> {
 fn cipher_from_shared_secret(shared: &[u8]) -> Result<Aes256Gcm, KeyError> {
     let hk = Hkdf::<Sha256>::new(None, shared);
     let mut key = [0u8; 32];
-    hk.expand(HKDF_INFO, &mut key)
+    hk.expand(SECP256K1_HKDF_INFO, &mut key)
+        .map_err(|e| KeyError::Crypto(format!("HKDF expand failed: {e}")))?;
+    Ok(Aes256Gcm::new_from_slice(&key).expect("AES-256 key length is fixed"))
+}
+
+fn x25519_public_key_from_hex(value: &str) -> Result<X25519PublicKey, KeyError> {
+    let normalized = normalize_x25519_public_key_hex(value)?;
+    let bytes: [u8; X25519_PUBLIC_KEY_LEN] = hex::decode(normalized)
+        .expect("normalized X25519 hex decodes")
+        .as_slice()
+        .try_into()
+        .expect("normalized X25519 key is 32 bytes");
+    Ok(X25519PublicKey::from(bytes))
+}
+
+fn x25519_cipher_from_shared_secret(shared: &[u8]) -> Result<Aes256Gcm, KeyError> {
+    let hk = Hkdf::<Sha256>::new(None, shared);
+    let mut key = [0u8; 32];
+    hk.expand(X25519_HKDF_INFO, &mut key)
         .map_err(|e| KeyError::Crypto(format!("HKDF expand failed: {e}")))?;
     Ok(Aes256Gcm::new_from_slice(&key).expect("AES-256 key length is fixed"))
 }
@@ -327,4 +477,60 @@ fn ed25519_private_to_x25519_private_key(secret: &Ed25519SigningKey) -> X25519Se
     scalar[31] &= 127;
     scalar[31] |= 64;
     X25519SecretKey::from(scalar)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn x25519_recipient() -> (X25519SecretKey, String) {
+        let secret = x25519_secret_key_from_bytes(&[0x37u8; 32]).unwrap();
+        let public_hex = x25519_public_key_hex(&secret);
+        (secret, public_hex)
+    }
+
+    #[test]
+    fn x25519_round_trip_recovers_plaintext() {
+        let (secret, public_hex) = x25519_recipient();
+        let aad = b"aci.e2ee.request.v2 aad";
+        let ciphertext = encrypt_x25519_for_public_key(&public_hex, b"hello x25519", aad).unwrap();
+        // Wire format: 32-byte ephemeral pub || 12-byte nonce || ct||tag.
+        let blob = hex::decode(&ciphertext).unwrap();
+        assert!(blob.len() > X25519_PUBLIC_KEY_LEN + NONCE_LEN + TAG_LEN);
+        let plaintext = decrypt_x25519_with_secret_key(&secret, &ciphertext, aad).unwrap();
+        assert_eq!(plaintext, b"hello x25519");
+    }
+
+    #[test]
+    fn x25519_decrypt_rejects_wrong_aad() {
+        let (secret, public_hex) = x25519_recipient();
+        let ciphertext = encrypt_x25519_for_public_key(&public_hex, b"bound", b"aad-a").unwrap();
+        assert!(decrypt_x25519_with_secret_key(&secret, &ciphertext, b"aad-b").is_err());
+    }
+
+    #[test]
+    fn x25519_public_key_accepts_optional_0x_prefix() {
+        let (_secret, public_hex) = x25519_recipient();
+        let prefixed = format!("0x{public_hex}");
+        assert_eq!(
+            normalize_x25519_public_key_hex(&prefixed).unwrap(),
+            public_hex
+        );
+    }
+
+    #[test]
+    fn suite_dispatch_routes_by_algo() {
+        let (secret, public_hex) = x25519_recipient();
+        let aad = b"aad";
+        let ciphertext =
+            encrypt_aci_e2ee_for_public_key(E2EE_ALGO_X25519_AESGCM, &public_hex, b"msg", aad)
+                .unwrap();
+        assert_eq!(
+            decrypt_x25519_with_secret_key(&secret, &ciphertext, aad).unwrap(),
+            b"msg"
+        );
+        assert!(is_aci_e2ee_suite(E2EE_ALGO_X25519_AESGCM));
+        assert!(is_aci_e2ee_suite(E2EE_ALGO_SECP256K1_AESGCM));
+        assert!(!is_aci_e2ee_suite(E2EE_ALGO_LEGACY_ED25519));
+    }
 }

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -15,8 +15,8 @@ use super::{
 use sha2::{Digest, Sha256};
 
 use crate::aci::e2ee::{
-    normalize_secp256k1_public_key_hex, E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519,
-    E2EE_ALGO_SECP256K1_AESGCM, E2EE_VERSION_V1, E2EE_VERSION_V2,
+    is_aci_e2ee_suite, normalize_aci_e2ee_public_key_hex, E2EE_ALGO_LEGACY_ECDSA,
+    E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_SECP256K1_AESGCM, E2EE_VERSION_V1, E2EE_VERSION_V2,
 };
 use crate::aci::identity::{self, attestation_statement, report_data};
 use crate::aci::keys::{
@@ -279,20 +279,27 @@ impl AciService {
             return Err(E2eeError::InvalidTimestamp);
         }
 
-        let client_public_key_hex = normalize_secp256k1_public_key_hex(client_public_key)
-            .map_err(|_| E2eeError::InvalidPublicKey)?;
-        let model_public_key_hex = normalize_secp256k1_public_key_hex(model_public_key)
-            .map_err(|_| E2eeError::InvalidPublicKey)?;
+        // The client selects a §7.1 suite by the `algo` of the keyset entry it
+        // encrypts to (§7.4). Match `X-Model-Pub-Key` against each suite entry
+        // under that suite's own normalization; the first match fixes the suite.
         let selected_key = self
             .keyset
             .e2ee_public_keys
             .iter()
             .find(|key| {
-                key.algo == E2EE_ALGO_SECP256K1_AESGCM
-                    && normalize_secp256k1_public_key_hex(&key.public_key_hex)
-                        .is_ok_and(|normalized| normalized == model_public_key_hex)
+                is_aci_e2ee_suite(&key.algo)
+                    && normalize_aci_e2ee_public_key_hex(&key.algo, model_public_key)
+                        .ok()
+                        .zip(normalize_aci_e2ee_public_key_hex(&key.algo, &key.public_key_hex).ok())
+                        .is_some_and(|(supplied, stored)| supplied == stored)
             })
             .ok_or(E2eeError::ModelKeyMismatch)?;
+        let client_public_key_hex =
+            normalize_aci_e2ee_public_key_hex(&selected_key.algo, client_public_key)
+                .map_err(|_| E2eeError::InvalidPublicKey)?;
+        let model_public_key_hex =
+            normalize_aci_e2ee_public_key_hex(&selected_key.algo, model_public_key)
+                .map_err(|_| E2eeError::InvalidPublicKey)?;
 
         let mut payload: Value =
             serde_json::from_slice(body).map_err(|_| E2eeError::DecryptionFailed)?;

--- a/src/aggregator/service/e2ee_crypto.rs
+++ b/src/aggregator/service/e2ee_crypto.rs
@@ -6,8 +6,8 @@ use super::streaming::E2eeSseTransformer;
 use super::{E2eeError, E2eeRequestContext, COMPLETIONS_PATH, EMBEDDINGS_PATH};
 use crate::aci::canonical::canonicalize;
 use crate::aci::e2ee::{
-    encrypt_for_public_key, encrypt_legacy_for_public_key, normalize_secp256k1_public_key_hex,
-    E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519,
+    encrypt_aci_e2ee_for_public_key, encrypt_legacy_for_public_key,
+    normalize_secp256k1_public_key_hex, E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519,
 };
 use crate::aci::keys::KeyProvider;
 
@@ -909,8 +909,10 @@ pub(super) fn encrypt_response_plaintext(
 ) -> Result<String, E2eeError> {
     match ctx.aad_mode {
         E2eeAadMode::AciV2 => {
+            // The response suite is the request's selected service E2EE key
+            // algo; `client_public_key_hex` is already normalized for it.
             let aad = aad.ok_or(E2eeError::EncryptionFailed)?;
-            encrypt_for_public_key(&ctx.client_public_key_hex, plaintext, aad)
+            encrypt_aci_e2ee_for_public_key(&ctx.algo, &ctx.client_public_key_hex, plaintext, aad)
                 .map_err(|_| E2eeError::EncryptionFailed)
         }
         E2eeAadMode::LegacyV1 | E2eeAadMode::LegacyV2 => {

--- a/src/dstack.rs
+++ b/src/dstack.rs
@@ -16,32 +16,40 @@ use k256::ecdsa::{
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use sha3::Keccak256;
+use x25519_dalek::StaticSecret as X25519SecretKey;
 
 use crate::aci::e2ee::{
     decrypt_legacy_ecdsa_with_secret_key, decrypt_legacy_ed25519_with_secret_key,
-    decrypt_with_secret_key, ed25519_public_key_hex, legacy_ecdsa_public_key_from_secret,
-    public_key_from_secret, secret_key_from_bytes, E2EE_ALGO_LEGACY_ECDSA,
-    E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_SECP256K1_AESGCM,
+    decrypt_with_secret_key, decrypt_x25519_with_secret_key, ed25519_public_key_hex,
+    legacy_ecdsa_public_key_from_secret, public_key_from_secret, secret_key_from_bytes,
+    x25519_public_key_hex, x25519_secret_key_from_bytes, E2EE_ALGO_LEGACY_ECDSA,
+    E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_SECP256K1_AESGCM, E2EE_ALGO_X25519_AESGCM,
 };
 use crate::aci::keys::{
     ethereum_address_from_uncompressed_public_key, KeyError, KeyProvider, LegacySignature, Quote,
-    Quoter, ALGO_ECDSA_SECP256K1, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
+    Quoter, ALGO_ECDSA_SECP256K1, ALGO_ED25519, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
 };
 use crate::aci::types::{KeyedPublicKey, PublicKeyMaterial, TlsSpki};
 
 const IDENTITY_PURPOSE: &str = "aci.identity.v1";
 const RECEIPT_PURPOSE: &str = "aci.receipt.v1";
+const RECEIPT_ED25519_PURPOSE: &str = "aci.receipt.ed25519.v1";
 const E2EE_PURPOSE: &str = "aci.e2ee.v1";
+const E2EE_X25519_PURPOSE: &str = "aci.e2ee.x25519.v1";
 const LEGACY_ED25519_PURPOSE: &str = "aci.legacy.ed25519.v1";
 
 #[derive(Debug, Clone)]
 pub struct DstackAciProviderConfig {
     pub identity_path: String,
     pub receipt_path: String,
+    pub ed25519_receipt_path: String,
     pub e2ee_path: String,
+    pub x25519_e2ee_path: String,
     pub legacy_ed25519_path: String,
     pub receipt_key_id: String,
+    pub ed25519_receipt_key_id: String,
     pub e2ee_key_id: String,
+    pub x25519_e2ee_key_id: String,
     pub legacy_ed25519_key_id: String,
 }
 
@@ -50,10 +58,14 @@ impl Default for DstackAciProviderConfig {
         Self {
             identity_path: "aci/identity/v1".to_string(),
             receipt_path: "aci/receipt/v1".to_string(),
+            ed25519_receipt_path: "aci/receipt-ed25519/v1".to_string(),
             e2ee_path: "aci/e2ee/v1".to_string(),
+            x25519_e2ee_path: "aci/e2ee-x25519/v1".to_string(),
             legacy_ed25519_path: "aci/legacy-ed25519/v1".to_string(),
             receipt_key_id: "dstack-kms-receipt-v1".to_string(),
+            ed25519_receipt_key_id: "dstack-kms-receipt-ed25519-v1".to_string(),
             e2ee_key_id: "dstack-kms-e2ee-v1".to_string(),
+            x25519_e2ee_key_id: "dstack-kms-e2ee-x25519-v1".to_string(),
             legacy_ed25519_key_id: "dstack-kms-legacy-ed25519-v1".to_string(),
         }
     }
@@ -74,14 +86,20 @@ pub struct DstackAciProvider {
     client: Arc<DstackClient>,
     identity: K256SigningKey,
     receipt: K256SigningKey,
+    ed25519_receipt: Ed25519SigningKey,
     e2ee: k256::SecretKey,
+    x25519_e2ee: X25519SecretKey,
     legacy_ed25519: Ed25519SigningKey,
     identity_evidence: KmsKeyEvidence,
     receipt_evidence: KmsKeyEvidence,
+    ed25519_receipt_evidence: KmsKeyEvidence,
     e2ee_evidence: KmsKeyEvidence,
+    x25519_e2ee_evidence: KmsKeyEvidence,
     legacy_ed25519_evidence: KmsKeyEvidence,
     receipt_key_id: String,
+    ed25519_receipt_key_id: String,
     e2ee_key_id: String,
+    x25519_e2ee_key_id: String,
     legacy_ed25519_key_id: String,
 }
 
@@ -104,14 +122,30 @@ impl DstackAciProvider {
                 .await?;
         let (receipt, receipt_evidence) =
             load_kms_signing_key(&client, "receipt", &config.receipt_path, RECEIPT_PURPOSE).await?;
+        let (ed25519_receipt, ed25519_receipt_evidence) = load_kms_ed25519_key(
+            &client,
+            "receipt-ed25519",
+            &config.ed25519_receipt_path,
+            RECEIPT_ED25519_PURPOSE,
+            ALGO_ED25519,
+        )
+        .await?;
         let (e2ee_signing_key, e2ee_evidence) =
             load_kms_signing_key(&client, "e2ee", &config.e2ee_path, E2EE_PURPOSE).await?;
         let e2ee = secret_key_from_bytes(&e2ee_signing_key.to_bytes())?;
+        let (x25519_e2ee, x25519_e2ee_evidence) = load_kms_x25519_key(
+            &client,
+            "e2ee-x25519",
+            &config.x25519_e2ee_path,
+            E2EE_X25519_PURPOSE,
+        )
+        .await?;
         let (legacy_ed25519, legacy_ed25519_evidence) = load_kms_ed25519_key(
             &client,
             "legacy-ed25519",
             &config.legacy_ed25519_path,
             LEGACY_ED25519_PURPOSE,
+            E2EE_ALGO_LEGACY_ED25519,
         )
         .await?;
 
@@ -119,14 +153,20 @@ impl DstackAciProvider {
             client,
             identity,
             receipt,
+            ed25519_receipt,
             e2ee,
+            x25519_e2ee,
             legacy_ed25519,
             identity_evidence,
             receipt_evidence,
+            ed25519_receipt_evidence,
             e2ee_evidence,
+            x25519_e2ee_evidence,
             legacy_ed25519_evidence,
             receipt_key_id: config.receipt_key_id,
+            ed25519_receipt_key_id: config.ed25519_receipt_key_id,
             e2ee_key_id: config.e2ee_key_id,
+            x25519_e2ee_key_id: config.x25519_e2ee_key_id,
             legacy_ed25519_key_id: config.legacy_ed25519_key_id,
         })
     }
@@ -188,7 +228,50 @@ async fn load_kms_ed25519_key(
     role: &'static str,
     path: &str,
     purpose: &'static str,
+    algo: &'static str,
 ) -> Result<(Ed25519SigningKey, KmsKeyEvidence), KeyError> {
+    let (key_bytes, signature_chain) = load_kms_raw32_key(client, role, path, purpose).await?;
+    let key = Ed25519SigningKey::from_bytes(&key_bytes);
+    let public_key_hex = ed25519_public_key_hex(&key);
+    let evidence = KmsKeyEvidence {
+        role,
+        path: path.to_string(),
+        purpose,
+        algo,
+        public_key_hex,
+        signature_chain,
+    };
+    Ok((key, evidence))
+}
+
+async fn load_kms_x25519_key(
+    client: &DstackClient,
+    role: &'static str,
+    path: &str,
+    purpose: &'static str,
+) -> Result<(X25519SecretKey, KmsKeyEvidence), KeyError> {
+    let (key_bytes, signature_chain) = load_kms_raw32_key(client, role, path, purpose).await?;
+    let key = x25519_secret_key_from_bytes(&key_bytes)?;
+    let public_key_hex = x25519_public_key_hex(&key);
+    let evidence = KmsKeyEvidence {
+        role,
+        path: path.to_string(),
+        purpose,
+        algo: E2EE_ALGO_X25519_AESGCM,
+        public_key_hex,
+        signature_chain,
+    };
+    Ok((key, evidence))
+}
+
+/// Release a KMS key and require it to be exactly 32 bytes — the raw scalar for
+/// Ed25519 and X25519 keys alike.
+async fn load_kms_raw32_key(
+    client: &DstackClient,
+    role: &'static str,
+    path: &str,
+    purpose: &'static str,
+) -> Result<([u8; 32], Vec<String>), KeyError> {
     let response = client
         .get_key(Some(path.to_string()), Some(purpose.to_string()))
         .await
@@ -202,17 +285,7 @@ async fn load_kms_ed25519_key(
             key_bytes.len()
         ))
     })?;
-    let key = Ed25519SigningKey::from_bytes(&key_bytes);
-    let public_key_hex = ed25519_public_key_hex(&key);
-    let evidence = KmsKeyEvidence {
-        role,
-        path: path.to_string(),
-        purpose,
-        algo: E2EE_ALGO_LEGACY_ED25519,
-        public_key_hex,
-        signature_chain: response.signature_chain,
-    };
-    Ok((key, evidence))
+    Ok((key_bytes, response.signature_chain))
 }
 
 fn signing_key_from_kms_response(
@@ -305,18 +378,34 @@ impl KeyProvider for DstackAciProvider {
     }
 
     fn receipt_keys(&self) -> Vec<KeyedPublicKey> {
-        vec![KeyedPublicKey {
-            key_id: self.receipt_key_id.clone(),
-            algo: ALGO_ECDSA_SECP256K1.to_string(),
-            public_key_hex: public_key_hex(&self.receipt),
-        }]
+        // Ed25519 is the default (first) signer per §8.5 RECOMMENDED; the
+        // secp256k1 key stays listed for EVM `ecrecover` verifiers.
+        vec![
+            KeyedPublicKey {
+                key_id: self.ed25519_receipt_key_id.clone(),
+                algo: ALGO_ED25519.to_string(),
+                public_key_hex: ed25519_public_key_hex(&self.ed25519_receipt),
+            },
+            KeyedPublicKey {
+                key_id: self.receipt_key_id.clone(),
+                algo: ALGO_ECDSA_SECP256K1.to_string(),
+                public_key_hex: public_key_hex(&self.receipt),
+            },
+        ]
     }
 
     fn sign_receipt(&self, key_id: &str, canonical_bytes: &[u8]) -> Result<Vec<u8>, KeyError> {
+        if key_id == self.ed25519_receipt_key_id {
+            // ed25519: raw 64-byte RFC 8032 signature over canonical_bytes.
+            use ed25519_dalek::Signer;
+            let sig = self.ed25519_receipt.sign(canonical_bytes);
+            return Ok(sig.to_bytes().to_vec());
+        }
         if key_id != self.receipt_key_id {
             return Err(KeyError::UnknownReceiptKeyId(key_id.to_string()));
         }
 
+        // ecdsa-secp256k1: 65-byte recoverable signature over sha256(canonical_bytes).
         let prehash: [u8; 32] = Sha256::digest(canonical_bytes).into();
         let (sig, recid): (K256Signature, RecoveryId) = self
             .receipt
@@ -334,6 +423,11 @@ impl KeyProvider for DstackAciProvider {
                 key_id: self.e2ee_key_id.clone(),
                 algo: E2EE_ALGO_SECP256K1_AESGCM.to_string(),
                 public_key_hex: public_key_from_secret(&self.e2ee),
+            },
+            KeyedPublicKey {
+                key_id: self.x25519_e2ee_key_id.clone(),
+                algo: E2EE_ALGO_X25519_AESGCM.to_string(),
+                public_key_hex: x25519_public_key_hex(&self.x25519_e2ee),
             },
             KeyedPublicKey {
                 key_id: format!("{}-legacy-ecdsa", self.e2ee_key_id),
@@ -354,10 +448,13 @@ impl KeyProvider for DstackAciProvider {
         ciphertext_hex: &str,
         aad: &[u8],
     ) -> Result<Vec<u8>, KeyError> {
-        if key_id != self.e2ee_key_id {
-            return Err(KeyError::UnknownE2eeKeyId(key_id.to_string()));
+        if key_id == self.e2ee_key_id {
+            return decrypt_with_secret_key(&self.e2ee, ciphertext_hex, aad);
         }
-        decrypt_with_secret_key(&self.e2ee, ciphertext_hex, aad)
+        if key_id == self.x25519_e2ee_key_id {
+            return decrypt_x25519_with_secret_key(&self.x25519_e2ee, ciphertext_hex, aad);
+        }
+        Err(KeyError::UnknownE2eeKeyId(key_id.to_string()))
     }
 
     fn decrypt_legacy_e2ee(
@@ -425,8 +522,10 @@ impl KeyProvider for DstackAciProvider {
             "provider": "dstack-kms",
             "keys": [
                 key_evidence_json(&self.identity_evidence),
+                key_evidence_json(&self.ed25519_receipt_evidence),
                 key_evidence_json(&self.receipt_evidence),
                 key_evidence_json(&self.e2ee_evidence),
+                key_evidence_json(&self.x25519_e2ee_evidence),
                 key_evidence_json(&self.legacy_ed25519_evidence),
             ],
         })

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -20,9 +20,10 @@ use futures_util::stream;
 use private_ai_gateway::aci::canonical::{canonicalize, sha256_hex};
 use private_ai_gateway::aci::e2ee::{
     decrypt_legacy_ecdsa_with_secret_key, decrypt_legacy_ed25519_with_secret_key,
-    decrypt_with_secret_key, ed25519_public_key_hex, encrypt_for_public_key,
-    encrypt_legacy_for_public_key, legacy_ecdsa_public_key_from_secret, public_key_from_secret,
-    E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519, E2EE_VERSION_V2,
+    decrypt_with_secret_key, decrypt_x25519_with_secret_key, ed25519_public_key_hex,
+    encrypt_for_public_key, encrypt_legacy_for_public_key, encrypt_x25519_for_public_key,
+    legacy_ecdsa_public_key_from_secret, public_key_from_secret, x25519_public_key_hex,
+    E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_X25519_AESGCM, E2EE_VERSION_V2,
 };
 use private_ai_gateway::aci::receipt::{
     UpstreamVerifiedEvent, VerificationResult, EVENT_TRANSPARENCY_REQUEST_MODIFIED,
@@ -40,6 +41,7 @@ use private_ai_gateway::aggregator::service::{
 use private_ai_gateway::http::build_router;
 use serde_json::Value;
 use tower::ServiceExt;
+use x25519_dalek::StaticSecret as X25519SecretKey;
 
 use common::{event_from_request, verified_event, StaticKeyProvider, StubQuoter};
 
@@ -389,6 +391,48 @@ fn e2ee_chat_request(
     });
     let headers = vec![
         ("x-client-pub-key", public_key_from_secret(client_secret)),
+        ("x-model-pub-key", model_key.public_key_hex.clone()),
+        ("x-e2ee-version", E2EE_VERSION_V2.to_string()),
+        ("x-e2ee-nonce", nonce.to_string()),
+        ("x-e2ee-timestamp", timestamp.to_string()),
+    ];
+    (serde_json::to_vec(&body).unwrap(), headers)
+}
+
+/// Build an X25519-suite E2EE chat request: the client encrypts whole message
+/// content to the keyset's X25519 service key (§7.1 RECOMMENDED suite). Suite
+/// selection is by the `algo` of the matched `X-Model-Pub-Key` entry (§7.4).
+fn e2ee_x25519_chat_request(
+    h: &Harness,
+    client_secret: &X25519SecretKey,
+    nonce: &str,
+) -> (Vec<u8>, Vec<(&'static str, String)>) {
+    let model = "aci-model";
+    let timestamp = 1_700_000_000u64;
+    let model_key = h
+        .service
+        .keyset()
+        .e2ee_public_keys
+        .iter()
+        .find(|k| k.algo == E2EE_ALGO_X25519_AESGCM)
+        .expect("x25519 e2ee key is published")
+        .clone();
+    let aad = aci_request_aad(
+        &model_key.algo,
+        model,
+        "messages.0.content",
+        nonce,
+        timestamp,
+    );
+    let encrypted_content =
+        encrypt_x25519_for_public_key(&model_key.public_key_hex, b"hello", &aad).unwrap();
+    let body = serde_json::json!({
+        "model": model,
+        "stream": false,
+        "messages": [{"role": "user", "content": encrypted_content}],
+    });
+    let headers = vec![
+        ("x-client-pub-key", x25519_public_key_hex(client_secret)),
         ("x-model-pub-key", model_key.public_key_hex.clone()),
         ("x-e2ee-version", E2EE_VERSION_V2.to_string()),
         ("x-e2ee-nonce", nonce.to_string()),
@@ -809,6 +853,71 @@ async fn e2ee_v2_success_sets_e2ee_headers_and_receipt_hashes_cleartext_and_wire
         receipt_event(&receipt, EVENT_TRANSPARENCY_RESPONSE_MODIFIED),
         &serde_json::json!({})
     );
+}
+
+#[tokio::test]
+async fn e2ee_v2_x25519_suite_selected_by_model_key_round_trips() {
+    let h = harness_with_e2ee(RecordingUpstream::with_response_body(E2EE_CHAT_RESPONSE));
+    let client_secret = X25519SecretKey::from([0x71u8; 32]);
+    let nonce = "nonce-x25519";
+    let (encrypted_body, headers) = e2ee_x25519_chat_request(&h, &client_secret, nonce);
+
+    let resp = h
+        .requester
+        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(header(&resp.headers, "x-e2ee-applied"), "true");
+    // The response header follows the suite selected by X-Model-Pub-Key (§7.4).
+    assert_eq!(
+        header(&resp.headers, "x-e2ee-algo"),
+        E2EE_ALGO_X25519_AESGCM
+    );
+
+    let upstream_body = h.upstream_calls.lock().unwrap()[0].body.clone();
+    assert_eq!(
+        serde_json::from_slice::<Value>(&upstream_body).unwrap()["messages"][0]["content"],
+        "hello"
+    );
+
+    // The service encrypts the response back under X25519 to the client key.
+    let encrypted_response = json_body(&resp);
+    let encrypted_content = encrypted_response["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap();
+    let response_aad = aci_response_aad(
+        E2EE_ALGO_X25519_AESGCM,
+        "aci-model",
+        "chat-aci-1",
+        "choices.0.message.content",
+        nonce,
+        1_700_000_000,
+    );
+    let decrypted =
+        decrypt_x25519_with_secret_key(&client_secret, encrypted_content, &response_aad).unwrap();
+    assert_eq!(decrypted, b"plain-answer");
+}
+
+#[tokio::test]
+async fn e2ee_v2_model_key_absent_from_keyset_is_rejected() {
+    let h = harness_with_e2ee(RecordingUpstream::with_response_body(E2EE_CHAT_RESPONSE));
+    let client_secret = X25519SecretKey::from([0x72u8; 32]);
+    let nonce = "nonce-x25519-stranger";
+    let (encrypted_body, mut headers) = e2ee_x25519_chat_request(&h, &client_secret, nonce);
+    // Well-formed X25519 key that is not one of the attested service keys.
+    let stranger = x25519_public_key_hex(&X25519SecretKey::from([0x99u8; 32]));
+    for header in headers.iter_mut() {
+        if header.0 == "x-model-pub-key" {
+            header.1 = stranger.clone();
+        }
+    }
+
+    let resp = h
+        .requester
+        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error_type(&resp), "e2ee_model_key_mismatch");
 }
 
 #[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,17 +11,19 @@ use sha3::Keccak256;
 
 use private_ai_gateway::aci::e2ee::{
     decrypt_legacy_ecdsa_with_secret_key, decrypt_legacy_ed25519_with_secret_key,
-    decrypt_with_secret_key, ed25519_public_key_hex, legacy_ecdsa_public_key_from_secret,
-    public_key_from_secret, secret_key_from_bytes, E2EE_ALGO_LEGACY_ECDSA,
-    E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_SECP256K1_AESGCM,
+    decrypt_with_secret_key, decrypt_x25519_with_secret_key, ed25519_public_key_hex,
+    legacy_ecdsa_public_key_from_secret, public_key_from_secret, secret_key_from_bytes,
+    x25519_public_key_hex, x25519_secret_key_from_bytes, E2EE_ALGO_LEGACY_ECDSA,
+    E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_SECP256K1_AESGCM, E2EE_ALGO_X25519_AESGCM,
 };
 use private_ai_gateway::aci::keys::{
     ethereum_address_from_uncompressed_public_key, KeyError, KeyProvider, LegacySignature, Quote,
-    Quoter, ALGO_ECDSA_SECP256K1, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
+    Quoter, ALGO_ECDSA_SECP256K1, ALGO_ED25519, LEGACY_ALGO_ECDSA, LEGACY_ALGO_ED25519,
 };
 use private_ai_gateway::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
 use private_ai_gateway::aci::types::{KeyedPublicKey, PublicKeyMaterial, TlsSpki};
 use private_ai_gateway::aggregator::service::UpstreamVerificationRequest;
+use x25519_dalek::StaticSecret as X25519SecretKey;
 
 /// A `verified` upstream event with only identity fields and the required flag
 /// set; everything else takes the struct default. Tests override individual
@@ -67,29 +69,48 @@ pub fn event_from_request(
 
 pub struct StaticKeyProvider {
     identity: K256SigningKey,
-    receipt: K256SigningKey,
+    receipt_ed25519: Ed25519SigningKey,
+    receipt_secp256k1: K256SigningKey,
     e2ee: k256::SecretKey,
+    x25519_e2ee: X25519SecretKey,
     legacy_ed25519: Ed25519SigningKey,
-    receipt_key_id: String,
+    ed25519_receipt_key_id: String,
+    secp256k1_receipt_key_id: String,
     e2ee_key_id: String,
+    x25519_e2ee_key_id: String,
 }
 
 impl Default for StaticKeyProvider {
     fn default() -> Self {
         Self {
             identity: K256SigningKey::from_slice(&[0x11; 32]).unwrap(),
-            receipt: K256SigningKey::from_slice(&[0x22; 32]).unwrap(),
+            receipt_ed25519: Ed25519SigningKey::from_bytes(&[0x66; 32]),
+            receipt_secp256k1: K256SigningKey::from_slice(&[0x22; 32]).unwrap(),
             e2ee: secret_key_from_bytes(&[0x44; 32]).unwrap(),
+            x25519_e2ee: x25519_secret_key_from_bytes(&[0x55; 32]).unwrap(),
             legacy_ed25519: Ed25519SigningKey::from_bytes(&[0x33; 32]),
-            receipt_key_id: "static-receipt-key".to_string(),
+            ed25519_receipt_key_id: "static-receipt-ed25519".to_string(),
+            secp256k1_receipt_key_id: "static-receipt-secp256k1".to_string(),
             e2ee_key_id: "static-e2ee-key".to_string(),
+            x25519_e2ee_key_id: "static-e2ee-x25519-key".to_string(),
         }
     }
 }
 
 impl StaticKeyProvider {
+    /// The default receipt key id (Ed25519, §8.5 RECOMMENDED).
     pub fn receipt_key_id(&self) -> &str {
-        &self.receipt_key_id
+        &self.ed25519_receipt_key_id
+    }
+
+    /// The still-listed secp256k1 receipt key id, for exercising that path.
+    pub fn secp256k1_receipt_key_id(&self) -> &str {
+        &self.secp256k1_receipt_key_id
+    }
+
+    /// The X25519 E2EE key id.
+    pub fn x25519_e2ee_key_id(&self) -> &str {
+        &self.x25519_e2ee_key_id
     }
 }
 
@@ -111,20 +132,33 @@ impl KeyProvider for StaticKeyProvider {
     }
 
     fn receipt_keys(&self) -> Vec<KeyedPublicKey> {
-        vec![KeyedPublicKey {
-            key_id: self.receipt_key_id.clone(),
-            algo: ALGO_ECDSA_SECP256K1.to_string(),
-            public_key_hex: public_key_hex(&self.receipt),
-        }]
+        // Ed25519 first = default signer (§8.5); secp256k1 stays listed.
+        vec![
+            KeyedPublicKey {
+                key_id: self.ed25519_receipt_key_id.clone(),
+                algo: ALGO_ED25519.to_string(),
+                public_key_hex: ed25519_public_key_hex(&self.receipt_ed25519),
+            },
+            KeyedPublicKey {
+                key_id: self.secp256k1_receipt_key_id.clone(),
+                algo: ALGO_ECDSA_SECP256K1.to_string(),
+                public_key_hex: public_key_hex(&self.receipt_secp256k1),
+            },
+        ]
     }
 
     fn sign_receipt(&self, key_id: &str, canonical_bytes: &[u8]) -> Result<Vec<u8>, KeyError> {
-        if key_id != self.receipt_key_id {
+        if key_id == self.ed25519_receipt_key_id {
+            use ed25519_dalek::Signer;
+            let sig = self.receipt_ed25519.sign(canonical_bytes);
+            return Ok(sig.to_bytes().to_vec());
+        }
+        if key_id != self.secp256k1_receipt_key_id {
             return Err(KeyError::UnknownReceiptKeyId(key_id.to_string()));
         }
         let prehash: [u8; 32] = Sha256::digest(canonical_bytes).into();
         let (sig, recid): (K256Signature, RecoveryId) = self
-            .receipt
+            .receipt_secp256k1
             .sign_prehash_recoverable(&prehash)
             .map_err(|e| KeyError::Crypto(format!("k256 sign_prehash: {e}")))?;
         let mut out = Vec::with_capacity(65);
@@ -139,6 +173,11 @@ impl KeyProvider for StaticKeyProvider {
                 key_id: self.e2ee_key_id.clone(),
                 algo: E2EE_ALGO_SECP256K1_AESGCM.to_string(),
                 public_key_hex: public_key_from_secret(&self.e2ee),
+            },
+            KeyedPublicKey {
+                key_id: self.x25519_e2ee_key_id.clone(),
+                algo: E2EE_ALGO_X25519_AESGCM.to_string(),
+                public_key_hex: x25519_public_key_hex(&self.x25519_e2ee),
             },
             KeyedPublicKey {
                 key_id: format!("{}-legacy-ecdsa", self.e2ee_key_id),
@@ -159,10 +198,13 @@ impl KeyProvider for StaticKeyProvider {
         ciphertext_hex: &str,
         aad: &[u8],
     ) -> Result<Vec<u8>, KeyError> {
-        if key_id != self.e2ee_key_id {
-            return Err(KeyError::UnknownE2eeKeyId(key_id.to_string()));
+        if key_id == self.e2ee_key_id {
+            return decrypt_with_secret_key(&self.e2ee, ciphertext_hex, aad);
         }
-        decrypt_with_secret_key(&self.e2ee, ciphertext_hex, aad)
+        if key_id == self.x25519_e2ee_key_id {
+            return decrypt_x25519_with_secret_key(&self.x25519_e2ee, ciphertext_hex, aad);
+        }
+        Err(KeyError::UnknownE2eeKeyId(key_id.to_string()))
     }
 
     fn decrypt_legacy_e2ee(

--- a/tests/dstack_live.rs
+++ b/tests/dstack_live.rs
@@ -14,6 +14,7 @@ use private_ai_gateway::aci::canonical::sha256_hex;
 use private_ai_gateway::aci::identity;
 use private_ai_gateway::aci::keys::{
     verify_keyset_endorsement, verify_receipt_signature, KeyProvider, Quoter, ALGO_ECDSA_SECP256K1,
+    ALGO_ED25519,
 };
 use private_ai_gateway::aci::receipt::{
     canonical_bytes_for_signing, EVENT_REQUEST_RECEIVED, EVENT_RESPONSE_RETURNED,
@@ -182,25 +183,33 @@ async fn dstack_live_provider_loads_kms_keys_and_quote() {
     assert_eq!(identity.public_key_hex.len(), 130);
 
     let receipt_keys = provider.receipt_keys();
-    assert_eq!(receipt_keys.len(), 1);
-    assert_eq!(receipt_keys[0].algo, ALGO_ECDSA_SECP256K1);
-    assert_eq!(receipt_keys[0].public_key_hex.len(), 130);
+    assert_eq!(receipt_keys.len(), 2);
+    // Ed25519 is the default (first) receipt signer; secp256k1 stays listed.
+    assert_eq!(receipt_keys[0].algo, ALGO_ED25519);
+    assert_eq!(receipt_keys[0].public_key_hex.len(), 64);
+    assert_eq!(receipt_keys[1].algo, ALGO_ECDSA_SECP256K1);
+    assert_eq!(receipt_keys[1].public_key_hex.len(), 130);
 
     let e2ee_keys = provider.e2ee_keys();
-    assert_eq!(e2ee_keys.len(), 3);
+    assert_eq!(e2ee_keys.len(), 4);
     assert_eq!(
         e2ee_keys[0].algo,
         private_ai_gateway::aci::e2ee::E2EE_ALGO_SECP256K1_AESGCM
     );
     assert_eq!(e2ee_keys[0].public_key_hex.len(), 130);
-    assert_eq!(e2ee_keys[1].algo, "ecdsa");
-    assert_eq!(e2ee_keys[1].public_key_hex.len(), 128);
-    assert_eq!(e2ee_keys[2].algo, "ed25519");
-    assert_eq!(e2ee_keys[2].public_key_hex.len(), 64);
+    assert_eq!(
+        e2ee_keys[1].algo,
+        private_ai_gateway::aci::e2ee::E2EE_ALGO_X25519_AESGCM
+    );
+    assert_eq!(e2ee_keys[1].public_key_hex.len(), 64);
+    assert_eq!(e2ee_keys[2].algo, "ecdsa");
+    assert_eq!(e2ee_keys[2].public_key_hex.len(), 128);
+    assert_eq!(e2ee_keys[3].algo, "ed25519");
+    assert_eq!(e2ee_keys[3].public_key_hex.len(), 64);
 
     let evidence = provider.key_custody_evidence();
     assert_eq!(evidence["provider"], "dstack-kms");
-    assert_eq!(evidence["keys"].as_array().unwrap().len(), 4);
+    assert_eq!(evidence["keys"].as_array().unwrap().len(), 6);
     assert!(evidence["keys"][0]["signature_chain"]
         .as_array()
         .is_some_and(|chain| !chain.is_empty()));

--- a/tests/receipt.rs
+++ b/tests/receipt.rs
@@ -57,6 +57,56 @@ fn signed_receipt_verifies_under_keyset_receipt_key() {
 }
 
 #[test]
+fn default_receipt_signature_is_ed25519() {
+    let keys = keys();
+    // The default receipt key id is the first listed key (§8.5 RECOMMENDED).
+    let key_id = keys.receipt_keys()[0].key_id.clone();
+    let mut b = builder(&keys);
+    b.add_request_received(b"a").unwrap();
+    b.add_request_forwarded(b"a").unwrap();
+    b.add_response_returned(b"b", b"b").unwrap();
+
+    let receipt = b.finalize(&keys, &key_id).unwrap();
+    assert_eq!(receipt.signature.algo, "ed25519");
+    // Ed25519 signatures are a raw 64-byte RFC 8032 pair.
+    let sig = hex::decode(&receipt.signature.value_hex).unwrap();
+    assert_eq!(sig.len(), 64);
+    let canonical_bytes = canonical_bytes_for_signing(&receipt).unwrap();
+    assert!(verify_receipt_signature(
+        &keys.receipt_keys()[0],
+        &canonical_bytes,
+        &sig
+    ));
+}
+
+#[test]
+fn secp256k1_receipt_key_stays_functional() {
+    let keys = keys();
+    let key_id = keys.secp256k1_receipt_key_id().to_string();
+    let mut b = builder(&keys);
+    b.add_request_received(b"a").unwrap();
+    b.add_request_forwarded(b"a").unwrap();
+    b.add_response_returned(b"b", b"b").unwrap();
+
+    let receipt = b.finalize(&keys, &key_id).unwrap();
+    assert_eq!(receipt.signature.algo, "ecdsa-secp256k1");
+    // Recoverable r||s||v is exactly 65 bytes (§8.5).
+    let sig = hex::decode(&receipt.signature.value_hex).unwrap();
+    assert_eq!(sig.len(), 65);
+    let secp256k1_key = keys
+        .receipt_keys()
+        .into_iter()
+        .find(|k| k.key_id == key_id)
+        .unwrap();
+    let canonical_bytes = canonical_bytes_for_signing(&receipt).unwrap();
+    assert!(verify_receipt_signature(
+        &secp256k1_key,
+        &canonical_bytes,
+        &sig
+    ));
+}
+
+#[test]
 fn signed_receipt_canonical_bytes_omit_signature_value() {
     let keys = keys();
     let key_id = keys.receipt_key_id().to_string();


### PR DESCRIPTION
Implements the WebCrypto-native ACI defaults (spec §7.1, §8.5, §7.4) so browser clients can encrypt and verify with the Web Crypto API alone.

## What changed
- **X25519 E2EE suite** (`x25519-aes-256-gcm-hkdf-sha256`, HKDF info `aci.e2ee.v2.x25519`): ECDH on X25519 with 32-byte raw ephemeral keys, HKDF-SHA256, AES-256-GCM; wire format `hex(eph_pub_32 ‖ nonce_12 ‖ ct‖tag)`. Lives in `src/aci/e2ee.rs` next to the secp256k1 suite.
- **Suite selection** (§7.4): the service picks the suite from the `algo` of the `e2ee_public_keys` entry matching `X-Model-Pub-Key`; the AAD `algo` component and `X-E2EE-Algo` response header follow the selected suite. Client keys: X25519 = 32-byte raw hex (optional `0x`).
- **Ed25519 receipt signing** (§8.5 RECOMMENDED): Ed25519 is now the default receipt signer (raw 64-byte RFC 8032 over canonical bytes); the secp256k1 receipt key stays listed and functional for EVM `ecrecover`.
- **dstack provider**: derives an X25519 E2EE key and an Ed25519 receipt key via dstack KMS, publishes both in the keyset with custody evidence.

## Tests
- X25519 encrypt/decrypt round trip incl. AAD binding (unit).
- Suite selection: X25519 key round-trips end-to-end; an out-of-keyset model key is rejected with `e2ee_model_key_mismatch`; existing secp256k1 coverage retained.
- Receipts default to Ed25519 (verify); the secp256k1 receipt path stays functional.

`cargo fmt`, `cargo clippy --all-targets` (clean), and `cargo test` (324 passed) all green.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)