### PR TITLE
Keyset lifecycle: bounded epoch, monotonic version, revocation

### DIFF
--- a/src/aci/identity.rs
+++ b/src/aci/identity.rs
@@ -7,8 +7,8 @@
 
 use super::canonical::{self, CanonicalError};
 use super::types::{
-    AttestationStatement, KeysetEndorsementPayload, PublicKeyMaterial, WorkloadIdentity,
-    WorkloadKeyset,
+    AttestationStatement, KeysetEndorsementPayload, KeysetRevocationPayload, PublicKeyMaterial,
+    WorkloadIdentity, WorkloadKeyset,
 };
 
 /// Return `"sha256:" || hex(sha256(JCS(identity.public_key)))`.
@@ -63,4 +63,31 @@ pub fn keyset_endorsement_payload(keyset: &WorkloadKeyset) -> Result<Vec<u8>, Ca
         workload_keyset_digest: workload_keyset_digest(keyset)?,
     };
     canonical::canonicalize(&payload.to_canonical_value())
+}
+
+/// Canonical bytes the identity key signs to revoke a keyset digest (§4.7).
+///
+/// Mirrors [`keyset_endorsement_payload`]: the same JCS object shape under the
+/// `aci.keyset.revocation.v1` purpose tag. The caller supplies the digest of
+/// the keyset being repudiated and MUST sign exactly these bytes.
+pub fn keyset_revocation_payload(workload_keyset_digest: &str) -> Result<Vec<u8>, CanonicalError> {
+    let payload = KeysetRevocationPayload {
+        workload_keyset_digest: workload_keyset_digest.to_string(),
+    };
+    canonical::canonicalize(&payload.to_canonical_value())
+}
+
+/// Fingerprint over the keyset's key material — identity, receipt, E2EE, and
+/// TLS keys plus the subject — excluding the rotating `keyset_epoch`.
+///
+/// Two keysets with the same fingerprint carry identical key material; only the
+/// epoch may differ. The launcher uses this to decide, on restart, whether it
+/// is serving the same keys (keep the epoch version) or new ones (bump it),
+/// without the ever-changing `not_after` counting as a key change.
+pub fn keyset_material_fingerprint(keyset: &WorkloadKeyset) -> Result<String, CanonicalError> {
+    let mut value = keyset.to_canonical_value();
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("keyset_epoch");
+    }
+    canonical::jcs_sha256_hex(&value)
 }

--- a/src/aci/keys.rs
+++ b/src/aci/keys.rs
@@ -92,6 +92,13 @@ pub trait KeyProvider: Send + Sync {
     /// MUST match [`KeyProvider::identity_public_key`]`.algo`.
     fn sign_keyset_endorsement(&self, payload: &[u8]) -> Result<Vec<u8>, KeyError>;
 
+    /// Sign the JCS-canonicalised revocation payload from
+    /// [`super::identity::keyset_revocation_payload`] (§4.7). Uses the same
+    /// identity key and signature encoding as
+    /// [`KeyProvider::sign_keyset_endorsement`]; only the signed payload's
+    /// purpose tag differs.
+    fn sign_keyset_revocation(&self, payload: &[u8]) -> Result<Vec<u8>, KeyError>;
+
     fn receipt_keys(&self) -> Vec<KeyedPublicKey>;
 
     /// Sign the JCS canonical bytes of the receipt minus

--- a/src/aci/types.rs
+++ b/src/aci/types.rs
@@ -145,6 +145,7 @@ impl WorkloadKeyset {
 
 pub const REPORT_DATA_PURPOSE: &str = "aci.report_data.v1";
 pub const KEYSET_ENDORSEMENT_PURPOSE: &str = "aci.keyset.endorsement.v1";
+pub const KEYSET_REVOCATION_PURPOSE: &str = "aci.keyset.revocation.v1";
 
 /// The named report-data payload that the TEE quote MUST cover.
 ///
@@ -191,6 +192,24 @@ pub struct KeysetEndorsement {
     pub algo: String,
     #[serde(rename = "value")]
     pub value_hex: String,
+}
+
+/// The named payload the identity key signs to revoke a keyset (§4.7). Same
+/// shape as [`KeysetEndorsementPayload`] under a different purpose tag; a
+/// service repudiates the digest it was serving, and a verifier that obtains
+/// the statement rejects reports and receipts under that digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeysetRevocationPayload {
+    pub workload_keyset_digest: String,
+}
+
+impl KeysetRevocationPayload {
+    pub fn to_canonical_value(&self) -> Value {
+        json!({
+            "purpose": KEYSET_REVOCATION_PURPOSE,
+            "workload_keyset_digest": self.workload_keyset_digest,
+        })
+    }
 }
 
 // ---------- §5 Attestation report ----------

--- a/src/aggregator/keyset_epoch.rs
+++ b/src/aggregator/keyset_epoch.rs
@@ -1,0 +1,225 @@
+//! Managed keyset epoch: bounded expiry plus a monotonic version persisted in
+//! the gateway state directory (§4.2, §4.7).
+//!
+//! The launcher hands the ACI service a concrete [`KeysetEpoch`]. This module
+//! decides that value at startup:
+//!
+//! * `not_after` is bounded — `now + window` — so a keyset stops producing
+//!   acceptable reports without any coordination once the window lapses.
+//! * `version` increases every time the keyset content changes: new key
+//!   material (a different [material fingerprint](crate::aci::identity::keyset_material_fingerprint))
+//!   or a rolled-over expiry window. A restart that serves the *same* keys
+//!   within a still-valid window keeps the version, so verifiers see no
+//!   spurious rollback churn.
+//!
+//! The persisted record carries the version, the current `not_after`, and the
+//! material fingerprint — enough to detect "unchanged" across a restart.
+
+use std::io;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::aci::identity;
+use crate::aci::types::{KeysetEpoch, WorkloadKeyset};
+use crate::aggregator::revocation_store::RevocationStore;
+
+/// Default bounded validity window for a keyset epoch: 30 days (~4 weeks).
+/// On the order of weeks per §4.7 ("a verifier profile SHOULD reject an
+/// implausibly distant expiry"); overridable via gateway config.
+pub const DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+/// The keyset-epoch state persisted alongside the upstream config and session
+/// log in the gateway state directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedKeysetEpoch {
+    pub version: u64,
+    pub not_after: u64,
+    /// Fingerprint of the keyset material (all keys + identity + subject),
+    /// excluding the epoch itself. A change here means new key material and
+    /// forces a version bump.
+    pub material_fingerprint: String,
+}
+
+impl PersistedKeysetEpoch {
+    /// The wire [`KeysetEpoch`] this state represents.
+    pub fn epoch(&self) -> KeysetEpoch {
+        KeysetEpoch {
+            version: self.version,
+            not_after: self.not_after,
+        }
+    }
+}
+
+/// Decide the epoch for the current keyset material given the previously
+/// persisted state.
+///
+/// Same material within a still-valid window keeps the version and expiry;
+/// changed material or an expired window rolls forward to a fresh window with a
+/// bumped version. A missing prior state starts at version 1.
+pub fn resolve_epoch(
+    previous: Option<&PersistedKeysetEpoch>,
+    material_fingerprint: &str,
+    now: u64,
+    window_seconds: u64,
+) -> PersistedKeysetEpoch {
+    match previous {
+        // Same keys, still inside the validity window: unchanged, keep going.
+        Some(prev) if prev.material_fingerprint == material_fingerprint && prev.not_after > now => {
+            prev.clone()
+        }
+        // New keys, or the window rolled over: a new epoch, higher version.
+        Some(prev) => PersistedKeysetEpoch {
+            version: prev.version + 1,
+            not_after: now.saturating_add(window_seconds),
+            material_fingerprint: material_fingerprint.to_string(),
+        },
+        None => PersistedKeysetEpoch {
+            version: 1,
+            not_after: now.saturating_add(window_seconds),
+            material_fingerprint: material_fingerprint.to_string(),
+        },
+    }
+}
+
+/// Roll to the next version, keeping the same material and opening a fresh
+/// window. Used to move past a revoked keyset digest at startup: the same keys
+/// under a new epoch produce a new, un-revoked digest.
+pub fn roll_forward(
+    previous: &PersistedKeysetEpoch,
+    now: u64,
+    window_seconds: u64,
+) -> PersistedKeysetEpoch {
+    PersistedKeysetEpoch {
+        version: previous.version + 1,
+        not_after: now.saturating_add(window_seconds),
+        material_fingerprint: previous.material_fingerprint.clone(),
+    }
+}
+
+/// Read the persisted epoch state, or `None` when the file is absent or empty.
+pub fn load(path: &Path) -> io::Result<Option<PersistedKeysetEpoch>> {
+    match std::fs::read_to_string(path) {
+        Ok(text) if text.trim().is_empty() => Ok(None),
+        Ok(text) => serde_json::from_str(&text).map(Some).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid keyset epoch state {}: {e}", path.display()),
+            )
+        }),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Launcher-side epoch resolution: decide the epoch for the current keyset
+/// material, persist it, and never return one whose keyset digest has been
+/// revoked.
+///
+/// `make_keyset` builds the workload keyset for a candidate epoch — the same
+/// keyset the service later assembles — so the digest checked here matches what
+/// the service serves. If the resolved digest is revoked (an admin revoked it
+/// before this restart), the epoch rolls forward to a fresh version, changing
+/// the digest, until it lands on an un-revoked one. The revocation list is
+/// finite and each roll yields a distinct version, so this terminates.
+pub fn resolve_launcher_epoch(
+    state_path: &Path,
+    make_keyset: impl Fn(KeysetEpoch) -> WorkloadKeyset,
+    revocations: &RevocationStore,
+    now: u64,
+    window_seconds: u64,
+) -> io::Result<KeysetEpoch> {
+    let invalid = |e: crate::aci::canonical::CanonicalError| {
+        io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+    };
+
+    // Fingerprint the epoch-independent key material.
+    let fingerprint = identity::keyset_material_fingerprint(&make_keyset(KeysetEpoch {
+        version: 0,
+        not_after: 0,
+    }))
+    .map_err(invalid)?;
+
+    let previous = load(state_path)?;
+    let mut resolved = resolve_epoch(previous.as_ref(), &fingerprint, now, window_seconds);
+
+    let max_rolls = revocations.list().len() + 1;
+    for _ in 0..=max_rolls {
+        let digest =
+            identity::workload_keyset_digest(&make_keyset(resolved.epoch())).map_err(invalid)?;
+        if !revocations.is_revoked(&digest) {
+            break;
+        }
+        resolved = roll_forward(&resolved, now, window_seconds);
+    }
+
+    if previous.as_ref() != Some(&resolved) {
+        store(state_path, &resolved)?;
+    }
+    Ok(resolved.epoch())
+}
+
+/// Persist the epoch state via a temp file plus atomic rename, so a crash
+/// mid-write never leaves a half-written record.
+pub fn store(path: &Path, state: &PersistedKeysetEpoch) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut text = serde_json::to_string_pretty(state)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    text.push('\n');
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, text)?;
+    std::fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FP_A: &str = "sha256:aaaa";
+    const FP_B: &str = "sha256:bbbb";
+    const WINDOW: u64 = 1000;
+
+    #[test]
+    fn first_resolution_starts_at_version_one() {
+        let epoch = resolve_epoch(None, FP_A, 100, WINDOW);
+        assert_eq!(epoch.version, 1);
+        assert_eq!(epoch.not_after, 1100);
+        assert_eq!(epoch.material_fingerprint, FP_A);
+    }
+
+    #[test]
+    fn same_material_within_window_keeps_version_and_expiry() {
+        let first = resolve_epoch(None, FP_A, 100, WINDOW);
+        // A later restart, still before not_after, with identical keys.
+        let second = resolve_epoch(Some(&first), FP_A, 500, WINDOW);
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn changed_material_bumps_version_and_opens_new_window() {
+        let first = resolve_epoch(None, FP_A, 100, WINDOW);
+        let second = resolve_epoch(Some(&first), FP_B, 500, WINDOW);
+        assert_eq!(second.version, 2);
+        assert_eq!(second.not_after, 1500);
+        assert_eq!(second.material_fingerprint, FP_B);
+    }
+
+    #[test]
+    fn expired_window_bumps_version_even_with_same_material() {
+        let first = resolve_epoch(None, FP_A, 100, WINDOW);
+        // Restart after not_after (1100) has passed: the window rolled over.
+        let second = resolve_epoch(Some(&first), FP_A, 2000, WINDOW);
+        assert_eq!(second.version, 2);
+        assert_eq!(second.not_after, 3000);
+    }
+
+    #[test]
+    fn roll_forward_bumps_version_and_preserves_material() {
+        let first = resolve_epoch(None, FP_A, 100, WINDOW);
+        let rolled = roll_forward(&first, 100, WINDOW);
+        assert_eq!(rolled.version, 2);
+        assert_eq!(rolled.material_fingerprint, FP_A);
+    }
+}

--- a/src/aggregator/mod.rs
+++ b/src/aggregator/mod.rs
@@ -5,7 +5,9 @@
 //! upstream backend. The HTTP layer ([`crate::http`]) dispatches
 //! request work to a single `AciService` instance.
 
+pub mod keyset_epoch;
 pub mod metrics;
+pub mod revocation_store;
 pub mod service;
 pub mod session;
 pub mod session_store;

--- a/src/aggregator/revocation_store.rs
+++ b/src/aggregator/revocation_store.rs
@@ -1,0 +1,212 @@
+//! Issued keyset revocation statements (§4.7) and their persistence.
+//!
+//! An operator revokes the current keyset through the admin surface; the
+//! service signs the [revocation payload](crate::aci::identity::keyset_revocation_payload)
+//! with the identity key and records the statement here. Statements are
+//! transparency artifacts served at `GET /v1/aci/revocations`, so they persist
+//! across restarts in the gateway state directory: a service that publicly
+//! repudiated a keyset must not silently resume serving it after a restart.
+//!
+//! The store also answers "is this digest revoked?", which the service uses to
+//! stop serving a revoked keyset.
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::aci::types::KEYSET_REVOCATION_PURPOSE;
+
+/// The identity-key signature over a revocation payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationSignature {
+    /// Identity-key algorithm; matches the report's `keyset_endorsement.algo`.
+    pub algo: String,
+    #[serde(rename = "value")]
+    pub value_hex: String,
+}
+
+/// One issued keyset revocation statement. Self-describing (§3.1): it carries
+/// the revoked digest, the constant purpose tag, and the identity-key
+/// signature, so a verifier can reconstruct the signed
+/// [payload](crate::aci::identity::keyset_revocation_payload) and check it
+/// under the workload identity without out-of-band context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationStatement {
+    pub workload_id: String,
+    pub workload_keyset_digest: String,
+    /// Always `aci.keyset.revocation.v1`; the domain-separation tag inside the
+    /// signed payload, restated for self-description.
+    #[serde(default = "revocation_purpose")]
+    pub purpose: String,
+    pub revocation: RevocationSignature,
+    /// Unix seconds when the service issued the statement (self-asserted).
+    pub revoked_at: u64,
+}
+
+fn revocation_purpose() -> String {
+    KEYSET_REVOCATION_PURPOSE.to_string()
+}
+
+impl RevocationStatement {
+    pub fn new(
+        workload_id: String,
+        workload_keyset_digest: String,
+        algo: String,
+        value_hex: String,
+        revoked_at: u64,
+    ) -> Self {
+        Self {
+            workload_id,
+            workload_keyset_digest,
+            purpose: revocation_purpose(),
+            revocation: RevocationSignature { algo, value_hex },
+            revoked_at,
+        }
+    }
+}
+
+/// In-memory index of issued revocations, optionally mirrored to a JSON file.
+pub struct RevocationStore {
+    path: Option<PathBuf>,
+    statements: RwLock<Vec<RevocationStatement>>,
+}
+
+impl RevocationStore {
+    /// A store with no backing file (tests, and deployments that do not persist).
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            statements: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Open a file-backed store, loading any previously issued statements.
+    pub fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let statements = match std::fs::read_to_string(&path) {
+            Ok(text) if text.trim().is_empty() => Vec::new(),
+            Ok(text) => serde_json::from_str(&text).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid revocation store {}: {e}", path.display()),
+                )
+            })?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e),
+        };
+        Ok(Self {
+            path: Some(path),
+            statements: RwLock::new(statements),
+        })
+    }
+
+    /// All issued statements, oldest first.
+    pub fn list(&self) -> Vec<RevocationStatement> {
+        self.statements.read().expect("revocation lock").clone()
+    }
+
+    /// Whether a revocation has been issued for `workload_keyset_digest`.
+    pub fn is_revoked(&self, workload_keyset_digest: &str) -> bool {
+        self.statements
+            .read()
+            .expect("revocation lock")
+            .iter()
+            .any(|s| s.workload_keyset_digest == workload_keyset_digest)
+    }
+
+    /// Record a statement and persist the full set. Idempotent per digest: a
+    /// second revocation of the same digest keeps the first and does not
+    /// duplicate it.
+    pub fn record(&self, statement: RevocationStatement) -> io::Result<()> {
+        let snapshot = {
+            let mut guard = self.statements.write().expect("revocation lock");
+            if guard
+                .iter()
+                .any(|s| s.workload_keyset_digest == statement.workload_keyset_digest)
+            {
+                return Ok(());
+            }
+            guard.push(statement);
+            guard.clone()
+        };
+        self.persist(&snapshot)
+    }
+
+    fn persist(&self, statements: &[RevocationStatement]) -> io::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut text = serde_json::to_string_pretty(statements)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        text.push('\n');
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, text)?;
+        std::fs::rename(&tmp, path)
+    }
+}
+
+impl Default for RevocationStore {
+    fn default() -> Self {
+        Self::in_memory()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn statement(digest: &str) -> RevocationStatement {
+        RevocationStatement::new(
+            "sha256:id".to_string(),
+            digest.to_string(),
+            "ed25519".to_string(),
+            "ab".repeat(32),
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn records_and_reports_revocation() {
+        let store = RevocationStore::in_memory();
+        assert!(!store.is_revoked("sha256:one"));
+        store.record(statement("sha256:one")).unwrap();
+        assert!(store.is_revoked("sha256:one"));
+        assert!(!store.is_revoked("sha256:two"));
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[test]
+    fn record_is_idempotent_per_digest() {
+        let store = RevocationStore::in_memory();
+        store.record(statement("sha256:one")).unwrap();
+        store.record(statement("sha256:one")).unwrap();
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[test]
+    fn persists_and_reloads_from_disk() {
+        let dir = std::env::temp_dir().join(format!(
+            "revocation-store-test-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("revocations.json");
+
+        {
+            let store = RevocationStore::open(&path).unwrap();
+            store.record(statement("sha256:one")).unwrap();
+        }
+        // A fresh process reopening the same file sees the statement.
+        let reopened = RevocationStore::open(&path).unwrap();
+        assert!(reopened.is_revoked("sha256:one"));
+        assert_eq!(reopened.list()[0].purpose, KEYSET_REVOCATION_PURPOSE);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -40,6 +40,10 @@ impl AciService {
         nonce: Option<String>,
         domain: Option<&str>,
     ) -> Result<AttestationReport, ServiceError> {
+        // A revoked keyset must stop producing acceptable reports (§4.7).
+        if self.is_keyset_revoked() {
+            return Err(ServiceError::KeysetRevoked);
+        }
         let statement = attestation_statement(&self.keyset, nonce)?;
         let rd = report_data(&statement)?;
         let quote = self.quoter.get_quote(rd).await?;

--- a/src/aggregator/service/errors.rs
+++ b/src/aggregator/service/errors.rs
@@ -29,6 +29,10 @@ pub enum ServiceError {
     Upstream(#[from] UpstreamError),
     #[error("attested session store error: {0}")]
     SessionStore(String),
+    #[error("revocation store error: {0}")]
+    RevocationStore(String),
+    #[error("the current workload keyset has been revoked (§4.7); refusing to serve it")]
+    KeysetRevoked,
     #[error("metrics error: {0}")]
     Metrics(String),
     #[error("missing receipt signing key in keyset")]

--- a/src/aggregator/service/mod.rs
+++ b/src/aggregator/service/mod.rs
@@ -23,6 +23,7 @@ use crate::aci::keys::{KeyProvider, Quoter};
 use crate::aci::types::{WorkloadIdentity, WorkloadKeyset};
 use crate::aci::upstream::UpstreamBackend;
 use crate::aggregator::metrics::{MetricsSnapshot, ServiceMetrics};
+use crate::aggregator::revocation_store::{RevocationStatement, RevocationStore};
 use crate::aggregator::session_store::{InMemorySessionStore, SessionStore};
 
 pub const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
@@ -67,6 +68,7 @@ pub struct AciService {
     upstream_verifier: Option<Arc<dyn UpstreamVerifier>>,
     receipt_store: Arc<dyn ReceiptStore>,
     session_store: Arc<dyn SessionStore>,
+    revocation_store: Arc<RevocationStore>,
     keyset: WorkloadKeyset,
     workload_id: String,
     workload_keyset_digest: String,
@@ -165,6 +167,7 @@ impl AciService {
             upstream_verifier,
             receipt_store,
             session_store: Arc::new(InMemorySessionStore::default()),
+            revocation_store: Arc::new(RevocationStore::in_memory()),
             keyset,
             workload_id,
             workload_keyset_digest,
@@ -183,6 +186,46 @@ impl AciService {
     pub fn with_session_store(mut self, session_store: Arc<dyn SessionStore>) -> Self {
         self.session_store = session_store;
         self
+    }
+
+    /// Swap in a durable revocation store (file-backed in production). Defaults
+    /// to an in-memory store.
+    pub fn with_revocation_store(mut self, revocation_store: Arc<RevocationStore>) -> Self {
+        self.revocation_store = revocation_store;
+        self
+    }
+
+    /// Whether the current keyset digest has been revoked. A revoked service
+    /// stops serving reports and inference under that keyset (§4.7).
+    pub fn is_keyset_revoked(&self) -> bool {
+        self.revocation_store
+            .is_revoked(&self.workload_keyset_digest)
+    }
+
+    /// All revocation statements issued by this service (§4.7), served at
+    /// `GET /v1/aci/revocations`.
+    pub fn revocations(&self) -> Vec<RevocationStatement> {
+        self.revocation_store.list()
+    }
+
+    /// Sign a revocation for the current keyset digest with the identity key,
+    /// persist it, and return the statement (§4.7). Idempotent per digest.
+    /// After this the service stops serving the revoked keyset
+    /// ([`Self::is_keyset_revoked`]).
+    pub fn revoke_current_keyset(&self) -> Result<RevocationStatement, ServiceError> {
+        let payload = identity::keyset_revocation_payload(&self.workload_keyset_digest)?;
+        let signature = self.keys.sign_keyset_revocation(&payload)?;
+        let statement = RevocationStatement::new(
+            self.workload_id.clone(),
+            self.workload_keyset_digest.clone(),
+            self.keys.identity_public_key().algo,
+            hex::encode(signature),
+            self.clock.now_secs(),
+        );
+        self.revocation_store
+            .record(statement.clone())
+            .map_err(|e| ServiceError::RevocationStore(e.to_string()))?;
+        Ok(statement)
     }
 
     pub fn workload_id(&self) -> &str {

--- a/src/dstack.rs
+++ b/src/dstack.rs
@@ -304,6 +304,13 @@ impl KeyProvider for DstackAciProvider {
         Ok(sig.to_bytes().to_vec())
     }
 
+    fn sign_keyset_revocation(&self, payload: &[u8]) -> Result<Vec<u8>, KeyError> {
+        // §4.7 revocation verifies exactly like the endorsement (§4.3): the
+        // identity key over the JCS payload, 64-byte `r || s` for secp256k1.
+        let sig: K256Signature = K256Signer::sign(&self.identity, payload);
+        Ok(sig.to_bytes().to_vec())
+    }
+
     fn receipt_keys(&self) -> Vec<KeyedPublicKey> {
         vec![KeyedPublicKey {
             key_id: self.receipt_key_id.clone(),

--- a/src/http/app/error_responses.rs
+++ b/src/http/app/error_responses.rs
@@ -125,6 +125,16 @@ pub(super) fn unknown_downstream_host_response(err: ServiceError) -> Response {
     error_response(StatusCode::NOT_FOUND, "not_found", err.to_string())
 }
 
+/// The current keyset has been revoked (§4.7); the service refuses to serve
+/// reports or inference under it until it rotates to a fresh epoch on restart.
+pub(super) fn keyset_revoked_response() -> Response {
+    error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "keyset_revoked",
+        "the current workload keyset has been revoked; the service is not serving it",
+    )
+}
+
 pub(super) fn error_response(
     status: StatusCode,
     error_type: &str,

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -31,8 +31,8 @@ use super::backend::{
 };
 use super::error_responses::{
     admin_not_found_response, e2ee_error_response, error_response, insert_str_header,
-    internal_error_response, invalid_signing_algo_response, unknown_downstream_host_response,
-    unsupported_e2ee_response, upstream_config_error_response,
+    internal_error_response, invalid_signing_algo_response, keyset_revoked_response,
+    unknown_downstream_host_response, unsupported_e2ee_response, upstream_config_error_response,
 };
 use super::util::{
     enforce_admin, enforce_owner, extract_bearer, has_e2ee_headers, header_str, request_host_domain,
@@ -200,6 +200,39 @@ pub(super) async fn admin_put_upstreams(
     }
 }
 
+/// Revoke the current workload keyset (§4.7). Guarded by the admin token: the
+/// service signs the revocation payload with the identity key, persists the
+/// statement, and stops serving reports/inference under this keyset. On the
+/// next restart the launcher rolls to a fresh epoch so it can serve again,
+/// while the revoked digest stays listed at `GET /v1/aci/revocations`.
+pub(super) async fn admin_revoke_keyset(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(resp) = enforce_admin(&state, &headers) {
+        return resp;
+    }
+    match state.service.revoke_current_keyset() {
+        Ok(statement) => Json(json!({
+            "api_version": "aci/1",
+            "revoked": statement,
+        }))
+        .into_response(),
+        Err(e) => internal_error_response(e),
+    }
+}
+
+/// Public transparency surface: every keyset revocation statement this service
+/// has issued (§4.7), so a verifier can reject reports and receipts under a
+/// revoked digest. Unauthenticated, like the attested-session endpoints.
+pub(super) async fn aci_revocations(State(state): State<AppState>) -> Response {
+    Json(json!({
+        "api_version": "aci/1",
+        "revocations": state.service.revocations(),
+    }))
+    .into_response()
+}
+
 pub(super) async fn attestation_report(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -318,6 +351,7 @@ pub(super) async fn aci_attestation_report(
         .await
     {
         Ok(report) => Json(report).into_response(),
+        Err(ServiceError::KeysetRevoked) => keyset_revoked_response(),
         Err(
             e @ (ServiceError::DownstreamTlsDomainMissing
             | ServiceError::DownstreamTlsDomainUnknown(_)),
@@ -489,6 +523,12 @@ pub(super) async fn openai_completion_endpoint(
     endpoint_path: &'static str,
     force_buffered: bool,
 ) -> Response {
+    // A revoked keyset backs the receipt-signing, E2EE, and TLS keys this
+    // request would use; stop serving inference under it (§4.7).
+    if state.service.is_keyset_revoked() {
+        return keyset_revoked_response();
+    }
+
     let has_e2ee = has_e2ee_headers(&headers);
     if has_e2ee && state.service.supported_e2ee_versions().is_empty() {
         return unsupported_e2ee_response();

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -34,6 +34,10 @@
 //!   current upstream config, with secrets redacted.
 //! * `PUT  /v1/admin/upstreams` - authenticated admin replacement of
 //!   the single upstream config file.
+//! * `POST /v1/admin/revoke-keyset` - authenticated admin revocation of the
+//!   current workload keyset (§4.7). Signs and persists the revocation
+//!   statement, after which the service stops serving reports/inference under
+//!   the revoked keyset.
 //!
 //! ACI verification artifacts live under the `/v1/aci/` namespace so they do
 //! not pollute the OpenAI surface. The id parameter accepts the gateway
@@ -46,6 +50,8 @@
 //! * `GET  /v1/aci/sessions/{session_id}` - the attested-session record a
 //!   receipt references.
 //! * `GET  /v1/aci/sessions?upstream_name=&model=` - list attested sessions.
+//! * `GET  /v1/aci/revocations` - all issued keyset revocation statements
+//!   (§4.7), a public transparency surface.
 //!
 //! Legacy aliases for dstack-vllm-proxy compatibility:
 //! * `GET  /v1/attestation/report` - report plus legacy e2ee/`signing_address`
@@ -85,10 +91,10 @@ mod handlers;
 mod util;
 
 use handlers::{
-    aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
-    admin_put_upstreams, attestation_report, attested_session, chat_completions, completions,
-    embeddings, embeddings_models, health, messages, metrics, models, models_subpath,
-    receipt_by_chat_id, responses, root,
+    aci_attestation_report, aci_list_sessions, aci_receipt, aci_revocations, admin_get_upstreams,
+    admin_put_upstreams, admin_revoke_keyset, attestation_report, attested_session,
+    chat_completions, completions, embeddings, embeddings_models, health, messages, metrics,
+    models, models_subpath, receipt_by_chat_id, responses, root,
 };
 
 #[derive(Clone)]
@@ -157,11 +163,13 @@ fn build_router_inner(
             "/v1/admin/upstreams",
             get(admin_get_upstreams).put(admin_put_upstreams),
         )
+        .route("/v1/admin/revoke-keyset", post(admin_revoke_keyset))
         // Canonical ACI verification surface (clean shapes).
         .route("/v1/aci/attestation", get(aci_attestation_report))
         .route("/v1/aci/receipts/:id", get(aci_receipt))
         .route("/v1/aci/sessions", get(aci_list_sessions))
         .route("/v1/aci/sessions/:session_id", get(attested_session))
+        .route("/v1/aci/revocations", get(aci_revocations))
         // Legacy dstack-vllm-proxy aliases (vllm-proxy response shapes only;
         // we owe no back-compat to earlier private-ai-gateway paths).
         .route("/v1/attestation/report", get(attestation_report))

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@
 //! | Gateway config path | `PRIVATE_AI_GATEWAY_CONFIG_PATH` |
 //!
 //! Gateway-owned writable files are derived from `state_dir` in the static
-//! config. The active upstream database is `upstreams.json` and the
-//! attested-session log is `sessions.jsonl` inside that directory.
+//! config: the active upstream database `upstreams.json`, the attested-session
+//! log `sessions.jsonl`, the managed keyset-epoch state `keyset-epoch.json`
+//! (§4.2), and the issued keyset revocations `revocations.json` (§4.7).
 //!
 //! When the static config includes a `middleware` section, the gateway runs the
 //! middleware: it consults the control plane at `middleware.control_url`
@@ -28,11 +29,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use private_ai_gateway::aci::keys::{KeyProvider, Quoter};
-use private_ai_gateway::aci::types::{KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki};
+use private_ai_gateway::aci::types::{
+    KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki, WorkloadIdentity, WorkloadKeyset,
+};
 use private_ai_gateway::aci::upstream::{
     DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS, DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
 };
 use private_ai_gateway::aci::verifier::DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS;
+use private_ai_gateway::aggregator::keyset_epoch::{self, DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS};
+use private_ai_gateway::aggregator::revocation_store::RevocationStore;
 use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, Clock, InMemoryReceiptStore, SystemClock, UpstreamVerifier,
 };
@@ -67,6 +72,9 @@ struct GatewayConfigFile {
     state_dir: Option<String>,
     upstream_config_seed_path: Option<String>,
     admin_token: Option<String>,
+    /// Bounded keyset-epoch validity window in seconds (§4.7). Defaults to
+    /// [`DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS`] (~4 weeks).
+    keyset_epoch_window_seconds: Option<u64>,
     tls: GatewayTlsConfig,
     dstack_endpoint: Option<String>,
     middleware: Option<MiddlewareConfig>,
@@ -110,6 +118,14 @@ fn upstream_config_path(state_dir: &Path) -> PathBuf {
 
 fn session_log_path(state_dir: &Path) -> PathBuf {
     state_dir.join("sessions.jsonl")
+}
+
+fn keyset_epoch_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("keyset-epoch.json")
+}
+
+fn revocations_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("revocations.json")
 }
 
 fn resolve_source_provenance() -> Result<SourceProvenance, String> {
@@ -365,15 +381,58 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receipt_store = Arc::new(InMemoryReceiptStore::default());
     let upstream_verifier: Arc<dyn UpstreamVerifier> = upstream_config.verifier();
 
+    // Issued keyset revocations persist in the state dir: a service that
+    // repudiated a keyset must not silently resume serving it after a restart.
+    let revocation_store = Arc::new(
+        RevocationStore::open(revocations_path(&state_dir)).map_err(|err| {
+            invalid_input(format!("failed to open gateway revocation store: {err}"))
+        })?,
+    );
+
+    // Resolve the managed keyset epoch before assembling the keyset. The service
+    // builds the same keyset from these parts plus `config.keyset_epoch`, so the
+    // epoch and digest agree.
+    let keyset_epoch_window_seconds = gateway_config
+        .keyset_epoch_window_seconds
+        .unwrap_or(DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS);
+    if keyset_epoch_window_seconds == 0 {
+        return Err(invalid_input("keyset_epoch_window_seconds must be greater than zero").into());
+    }
+    let identity_subject: Option<String> = None;
+    let keyset_identity = WorkloadIdentity {
+        public_key: keys.identity_public_key(),
+        subject: identity_subject.clone(),
+    };
+    let keyset_receipt_keys = keys.receipt_keys();
+    let keyset_e2ee_keys = keys.e2ee_keys();
+    let keyset_tls_public_keys = tls_public_keys.clone().unwrap_or_else(|| keys.tls_spkis());
+    let make_keyset = |epoch: KeysetEpoch| WorkloadKeyset {
+        workload_identity: keyset_identity.clone(),
+        keyset_epoch: epoch,
+        receipt_signing_keys: keyset_receipt_keys.clone(),
+        e2ee_public_keys: keyset_e2ee_keys.clone(),
+        tls_public_keys: keyset_tls_public_keys.clone(),
+    };
+    let keyset_epoch = keyset_epoch::resolve_launcher_epoch(
+        &keyset_epoch_path(&state_dir),
+        make_keyset,
+        &revocation_store,
+        SystemClock.now_secs(),
+        keyset_epoch_window_seconds,
+    )
+    .map_err(|err| invalid_input(format!("failed to resolve managed keyset epoch: {err}")))?;
+    tracing::info!(
+        version = keyset_epoch.version,
+        not_after = keyset_epoch.not_after,
+        "resolved managed keyset epoch"
+    );
+
     let config = AciServiceConfig {
         vendor: "private-ai-gateway-dev".to_string(),
         tee_type: "tdx".to_string(),
         source_provenance,
-        keyset_epoch: KeysetEpoch {
-            version: 1,
-            not_after: u64::MAX,
-        },
-        identity_subject: None,
+        keyset_epoch,
+        identity_subject,
         service_capabilities: ServiceCapabilities {
             supported_e2ee_versions: vec!["2".to_string()],
         },
@@ -416,7 +475,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "compacted attested-session log on startup"
     );
     spawn_session_log_compaction(session_store.clone(), session_log_path.clone());
-    let service_inner = service_inner.with_session_store(session_store);
+    let service_inner = service_inner
+        .with_session_store(session_store)
+        .with_revocation_store(revocation_store);
     let service = Arc::new(service_inner);
     // The background upstream verification keeps the attested-session store fresh
     // on the same cadence it re-attests for serving, so `/v1/aci/sessions`
@@ -559,8 +620,8 @@ mod tests {
     use private_ai_gateway::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
 
     use super::{
-        load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
-        seed_upstream_config_if_empty, session_log_path,
+        keyset_epoch_path, load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
+        revocations_path, seed_upstream_config_if_empty, session_log_path,
         source_provenance_from_git_launcher_config, upstream_config_path,
     };
 
@@ -772,7 +833,30 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
             session_log_path(&state_dir),
             state_dir.join("sessions.jsonl")
         );
+        assert_eq!(
+            keyset_epoch_path(&state_dir),
+            state_dir.join("keyset-epoch.json")
+        );
+        assert_eq!(
+            revocations_path(&state_dir),
+            state_dir.join("revocations.json")
+        );
         assert!(resolve_state_dir(Some("  ")).is_err());
+    }
+
+    #[test]
+    fn gateway_config_parses_keyset_epoch_window() {
+        let config_path = temp_path("gateway-config-keyset-window");
+        std::fs::write(
+            &config_path,
+            r#"{ "keyset_epoch_window_seconds": 1209600 }"#,
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(config.keyset_epoch_window_seconds, Some(1_209_600));
+        let _ = std::fs::remove_file(config_path);
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -110,6 +110,11 @@ impl KeyProvider for StaticKeyProvider {
         Ok(sig.to_bytes().to_vec())
     }
 
+    fn sign_keyset_revocation(&self, payload: &[u8]) -> Result<Vec<u8>, KeyError> {
+        let sig: K256Signature = K256Signer::sign(&self.identity, payload);
+        Ok(sig.to_bytes().to_vec())
+    }
+
     fn receipt_keys(&self) -> Vec<KeyedPublicKey> {
         vec![KeyedPublicKey {
             key_id: self.receipt_key_id.clone(),

--- a/tests/keyset_epoch.rs
+++ b/tests/keyset_epoch.rs
@@ -1,0 +1,152 @@
+//! Keyset-epoch persistence across simulated gateway restarts (§4.2, §4.7).
+//!
+//! Each "restart" is a fresh `load` → `resolve_epoch` → `store` cycle against
+//! the same on-disk state file, exactly as the launcher runs it at startup.
+
+use private_ai_gateway::aci::identity::{keyset_material_fingerprint, workload_keyset_digest};
+use private_ai_gateway::aci::types::{
+    KeysetEpoch, PublicKeyMaterial, WorkloadIdentity, WorkloadKeyset,
+};
+use private_ai_gateway::aggregator::keyset_epoch::{
+    load, resolve_epoch, resolve_launcher_epoch, store,
+};
+use private_ai_gateway::aggregator::revocation_store::{RevocationStatement, RevocationStore};
+
+const FP_A: &str = "sha256:aaaaaaaa";
+const FP_B: &str = "sha256:bbbbbbbb";
+const WINDOW: u64 = 30 * 24 * 60 * 60;
+
+fn temp_state_path(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "keyset-epoch-test-{name}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("keyset-epoch.json")
+}
+
+/// One launcher boot: read the persisted state, resolve the epoch, and persist
+/// the result. Returns the resolved epoch as the running service would use it.
+fn boot(
+    path: &std::path::Path,
+    fingerprint: &str,
+    now: u64,
+) -> private_ai_gateway::aggregator::keyset_epoch::PersistedKeysetEpoch {
+    let previous = load(path).unwrap();
+    let resolved = resolve_epoch(previous.as_ref(), fingerprint, now, WINDOW);
+    store(path, &resolved).unwrap();
+    resolved
+}
+
+#[test]
+fn version_is_stable_across_restarts_with_unchanged_keys() {
+    let path = temp_state_path("stable");
+
+    let first = boot(&path, FP_A, 1_000_000);
+    assert_eq!(first.version, 1);
+    assert_eq!(first.not_after, 1_000_000 + WINDOW);
+
+    // Restart later but still inside the validity window, same keys: no bump,
+    // and the same expiry — a re-derived `now + window` must not leak in.
+    let second = boot(&path, FP_A, 1_000_500);
+    assert_eq!(second.version, 1);
+    assert_eq!(second.not_after, first.not_after);
+
+    // And once more, still unchanged.
+    let third = boot(&path, FP_A, 1_050_000);
+    assert_eq!(third, second);
+}
+
+#[test]
+fn version_bumps_when_key_material_changes() {
+    let path = temp_state_path("material-change");
+
+    let first = boot(&path, FP_A, 1_000_000);
+    assert_eq!(first.version, 1);
+
+    // A restart with different key material bumps the version and opens a fresh
+    // window, even though the old one had not expired.
+    let second = boot(&path, FP_B, 1_000_500);
+    assert_eq!(second.version, 2);
+    assert_eq!(second.not_after, 1_000_500 + WINDOW);
+    assert_eq!(second.material_fingerprint, FP_B);
+
+    // The bump persists: reloading yields version 2, not a reset.
+    let reloaded = load(&path).unwrap().unwrap();
+    assert_eq!(reloaded.version, 2);
+}
+
+#[test]
+fn version_bumps_when_window_rolls_over() {
+    let path = temp_state_path("window-rollover");
+
+    let first = boot(&path, FP_A, 1_000_000);
+    assert_eq!(first.version, 1);
+
+    // A restart after `not_after` has passed rolls to a new epoch even with the
+    // same keys — the expired window is itself a keyset change.
+    let after_expiry = first.not_after + 1;
+    let second = boot(&path, FP_A, after_expiry);
+    assert_eq!(second.version, 2);
+    assert_eq!(second.not_after, after_expiry + WINDOW);
+}
+
+/// A fixed keyset material whose digest depends only on the epoch, so a version
+/// bump yields a different `workload_keyset_digest`.
+fn make_keyset(epoch: KeysetEpoch) -> WorkloadKeyset {
+    WorkloadKeyset {
+        workload_identity: WorkloadIdentity {
+            public_key: PublicKeyMaterial {
+                algo: "ed25519".to_string(),
+                public_key_hex: "aa".repeat(32),
+            },
+            subject: None,
+        },
+        keyset_epoch: epoch,
+        receipt_signing_keys: Vec::new(),
+        e2ee_public_keys: Vec::new(),
+        tls_public_keys: Vec::new(),
+    }
+}
+
+#[test]
+fn launcher_rolls_past_a_revoked_digest_on_restart() {
+    let path = temp_state_path("revoked-roll");
+    let now = 1_000_000;
+
+    // The material fingerprint the launcher derives, and the digest of the
+    // epoch a first boot would land on (version 1).
+    let fingerprint = keyset_material_fingerprint(&make_keyset(KeysetEpoch {
+        version: 0,
+        not_after: 0,
+    }))
+    .unwrap();
+    let first = resolve_epoch(None, &fingerprint, now, WINDOW);
+    assert_eq!(first.version, 1);
+    let digest_v1 = workload_keyset_digest(&make_keyset(first.epoch())).unwrap();
+
+    // Revoke that digest (as an admin did before this restart), then resolve.
+    let revocations = RevocationStore::in_memory();
+    revocations
+        .record(RevocationStatement::new(
+            "sha256:id".to_string(),
+            digest_v1.clone(),
+            "ed25519".to_string(),
+            "00".repeat(32),
+            now,
+        ))
+        .unwrap();
+
+    let resolved = resolve_launcher_epoch(&path, make_keyset, &revocations, now, WINDOW).unwrap();
+
+    // The launcher rolled to a fresh epoch whose digest is not revoked.
+    assert!(resolved.version >= 2);
+    let resolved_digest = workload_keyset_digest(&make_keyset(resolved.clone())).unwrap();
+    assert_ne!(resolved_digest, digest_v1);
+    assert!(!revocations.is_revoked(&resolved_digest));
+
+    // The rolled epoch persisted, so a subsequent boot is stable on it.
+    let persisted = load(&path).unwrap().unwrap();
+    assert_eq!(persisted.version, resolved.version);
+}

--- a/tests/keyset_revocation.rs
+++ b/tests/keyset_revocation.rs
@@ -1,0 +1,204 @@
+//! Keyset revocation surface (§4.7): admin revoke endpoint, public revocations
+//! list, and the "stop serving a revoked keyset" behavior.
+
+use std::sync::Arc;
+
+mod common;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+};
+use private_ai_gateway::aci::identity::keyset_revocation_payload;
+use private_ai_gateway::aci::keys::{verify_keyset_endorsement, KeyProvider};
+use private_ai_gateway::aggregator::revocation_store::RevocationStore;
+use private_ai_gateway::aggregator::service::{
+    AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
+};
+use private_ai_gateway::aggregator::upstream_config::{
+    UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
+};
+use private_ai_gateway::http::build_router_with_admin;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use common::{StaticKeyProvider, StubQuoter};
+
+const ADMIN_TOKEN: &str = "admin-secret";
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "keyset-revocation-{name}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn runtime_options() -> UpstreamRuntimeOptions {
+    UpstreamRuntimeOptions {
+        verifier_mode: UpstreamVerifierMode::Preverified,
+        accepted_workload_ids: vec![],
+        accepted_image_digests: vec![],
+        accepted_dstack_kms_root_public_keys: vec![],
+        pccs_url: None,
+        verifier_cache_seconds: 300,
+        connect_timeout_seconds: 10,
+        read_timeout_seconds: 600,
+        verifier_request_timeout_seconds: 60,
+    }
+}
+
+struct Harness {
+    app: axum::Router,
+    revocations_path: std::path::PathBuf,
+}
+
+fn build_harness(dir: &std::path::Path) -> Harness {
+    let upstream_path = dir.join("upstreams.json");
+    let revocations_path = dir.join("revocations.json");
+    let manager = Arc::new(UpstreamConfigManager::load(&upstream_path, runtime_options()).unwrap());
+    let revocation_store = Arc::new(RevocationStore::open(&revocations_path).unwrap());
+    let service = Arc::new(
+        AciService::new_with_upstream_verifier(
+            Arc::new(StaticKeyProvider::default()),
+            Arc::new(StubQuoter::default()),
+            manager.backend(),
+            manager.verifier(),
+            Arc::new(InMemoryReceiptStore::default()),
+            AciServiceConfig::for_test("private-ai-gateway"),
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap()
+        .with_revocation_store(revocation_store),
+    );
+    Harness {
+        app: build_router_with_admin(service, manager, Some(ADMIN_TOKEN.to_string())),
+        revocations_path,
+    }
+}
+
+async fn call(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    body: impl Into<Vec<u8>>,
+    auth: Option<&str>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(token) = auth {
+        req = req.header("authorization", format!("Bearer {token}"));
+    }
+    let resp = app
+        .clone()
+        .oneshot(req.body(Body::from(body.into())).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+#[tokio::test]
+async fn revocation_lifecycle_end_to_end() {
+    let dir = temp_dir("lifecycle");
+    let Harness {
+        app,
+        revocations_path,
+    } = build_harness(&dir);
+
+    // Before revocation: an empty transparency list and a served report.
+    let (status, list) = call(&app, "GET", "/v1/aci/revocations", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(list["revocations"].as_array().unwrap().len(), 0);
+
+    let (status, _) = call(&app, "GET", "/v1/aci/attestation", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // The revoke endpoint is admin-guarded.
+    let (status, body) = call(&app, "POST", "/v1/admin/revoke-keyset", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"]["type"], "unauthorized");
+
+    let (status, _) = call(
+        &app,
+        "POST",
+        "/v1/admin/revoke-keyset",
+        Vec::new(),
+        Some("wrong-token"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    // A revoked keyset is not yet in the list, so serving still works.
+    let (status, _) = call(&app, "GET", "/v1/aci/attestation", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Revoke: the returned statement verifies under the identity key.
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/v1/admin/revoke-keyset",
+        Vec::new(),
+        Some(ADMIN_TOKEN),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let revoked = &body["revoked"];
+    assert_eq!(revoked["purpose"], "aci.keyset.revocation.v1");
+    assert_eq!(revoked["revocation"]["algo"], "ecdsa-secp256k1");
+
+    let identity_pk = StaticKeyProvider::default().identity_public_key();
+    let digest = revoked["workload_keyset_digest"].as_str().unwrap();
+    let payload = keyset_revocation_payload(digest).unwrap();
+    let signature = hex::decode(revoked["revocation"]["value"].as_str().unwrap()).unwrap();
+    assert!(
+        verify_keyset_endorsement(&identity_pk, &payload, &signature),
+        "revocation signature must verify under the identity key"
+    );
+
+    // The statement is now public and persisted to disk.
+    let (status, list) = call(&app, "GET", "/v1/aci/revocations", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let statements = list["revocations"].as_array().unwrap();
+    assert_eq!(statements.len(), 1);
+    assert_eq!(statements[0]["workload_keyset_digest"], digest);
+    let reopened = RevocationStore::open(&revocations_path).unwrap();
+    assert!(reopened.is_revoked(digest));
+
+    // Now serving stops: reports and inference both fail closed.
+    let (status, body) = call(&app, "GET", "/v1/aci/attestation", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body["error"]["type"], "keyset_revoked");
+
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/v1/chat/completions",
+        br#"{"model":"demo","messages":[{"role":"user","content":"hi"}]}"#.to_vec(),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body["error"]["type"], "keyset_revoked");
+
+    // Re-revoking the same digest is idempotent — still one statement.
+    let (status, _) = call(
+        &app,
+        "POST",
+        "/v1/admin/revoke-keyset",
+        Vec::new(),
+        Some(ADMIN_TOKEN),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, list) = call(&app, "GET", "/v1/aci/revocations", Vec::new(), None).await;
+    assert_eq!(list["revocations"].as_array().unwrap().len(), 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/spec_vectors.rs
+++ b/tests/spec_vectors.rs
@@ -10,6 +10,7 @@
 use ed25519_dalek::{Signer, SigningKey};
 
 use private_ai_gateway::aci::canonical;
+use private_ai_gateway::aci::identity::keyset_revocation_payload;
 use private_ai_gateway::aci::keys::{KeyError, KeyProvider, ALGO_ED25519};
 use private_ai_gateway::aci::receipt::{
     canonical_bytes_for_signing, ChannelBinding, ReceiptBuilder, UpstreamVerifiedEvent,
@@ -78,6 +79,9 @@ impl KeyProvider for VectorKeys {
         unimplemented!("not exercised by the spec-vector cross-check")
     }
     fn sign_keyset_endorsement(&self, _payload: &[u8]) -> Result<Vec<u8>, KeyError> {
+        unimplemented!("not exercised by the spec-vector cross-check")
+    }
+    fn sign_keyset_revocation(&self, _payload: &[u8]) -> Result<Vec<u8>, KeyError> {
         unimplemented!("not exercised by the spec-vector cross-check")
     }
     fn e2ee_keys(&self) -> Vec<KeyedPublicKey> {
@@ -197,5 +201,27 @@ fn section6_receipt_canonical_digest_and_signature_match_vector() {
     assert_eq!(
         receipt.signature.value_hex,
         RECEIPT_SIGNATURE.replace(char::is_whitespace, "")
+    );
+}
+
+// §4 revocation vector: payload bytes and the Ed25519 identity-key signature.
+const REVOCATION_PAYLOAD: &[u8] = br#"{"purpose":"aci.keyset.revocation.v1","workload_keyset_digest":"sha256:f2fba7e1b1451e0c0231df624f293407692ef939d3e0e55bca723131bea3f1ff"}"#;
+const REVOCATION_SIGNATURE: &str =
+    "5f30e02aa53bb628c7f6410636e9f5e33402d2b0b416a6ed278ea3e6e40b48a9\
+     af6ba6e5e55abb89a7ad4627eca444a73cad9d25e22bf239c9c6b362d48ed50f";
+
+#[test]
+fn section4_keyset_revocation_payload_and_signature_match_vector() {
+    // The revocation payload is built from the revoked keyset digest alone.
+    let payload = keyset_revocation_payload(WORKLOAD_KEYSET_DIGEST).unwrap();
+    assert_eq!(payload, REVOCATION_PAYLOAD);
+
+    // Signed by the identity key (Ed25519 seed 32 × 0x01) exactly like the
+    // endorsement, under a different purpose tag.
+    let identity = SigningKey::from_bytes(&[0x01; 32]);
+    let signature = identity.sign(&payload);
+    assert_eq!(
+        hex::encode(signature.to_bytes()),
+        REVOCATION_SIGNATURE.replace(char::is_whitespace, "")
     );
 }


### PR DESCRIPTION
Closes #65.

Replaces the pinned `keyset_epoch { version: 1, not_after: u64::MAX }` with a managed epoch and adds the §4.7 revocation surface.

## Bounded epoch + monotonic version (§4.2, §4.7)
- `not_after = now + window`, window configurable via `keyset_epoch_window_seconds` (default ~4 weeks).
- `version` persisted in the state dir (`keyset-epoch.json`), alongside the upstream config and session log. The record stores the version, `not_after`, and a fingerprint of the key material (identity + all keys, epoch excluded).
- On restart: same material within a still-valid window keeps the version and expiry (no spurious rollback churn); changed key material or a rolled-over window bumps the version and opens a fresh window.

## Revocation (§4.7)
- New `KeyProvider::sign_keyset_revocation` signs `JCS({"purpose":"aci.keyset.revocation.v1","workload_keyset_digest":...})` with the identity key — a mirror of `sign_keyset_endorsement`, localized to the revocation method in `src/dstack.rs`.
- `POST /v1/admin/revoke-keyset` (admin-token guarded): signs a revocation for the current keyset digest and persists it to `revocations.json`.
- `GET /v1/aci/revocations` (public transparency surface): all issued statements, self-describing so a verifier can reconstruct the signed payload and check it under the identity key.

## Stop serving a revoked keyset
Chosen behavior (simplest sound option): a revoked keyset **fails closed at runtime** and **rotates on restart**.
- At runtime the ACI attestation report (`GET /v1/aci/attestation`) and inference endpoints return `503 keyset_revoked`.
- Revocations persist, so a restart cannot silently resume serving a publicly-repudiated keyset. Instead the launcher **rolls to a fresh epoch** (higher version → new digest) so the service comes back on a new, un-revoked keyset, while the revoked digest stays listed at `/v1/aci/revocations`.

Scope: gating is on the canonical ACI surface; the legacy dstack-vllm-proxy `/v1/attestation/report` compatibility surface is intentionally untouched per the task guardrails.

## Tests
- Epoch persistence across simulated restarts: version stable when unchanged, bumps on material change and on window rollover, plus the revoked-digest roll (`tests/keyset_epoch.rs`, module unit tests).
- Revocation payload bytes + Ed25519 signature match `spec/test-vectors.md` §4 (`tests/spec_vectors.rs`).
- Endpoint behavior end-to-end: admin guard, signature verification under the identity key, persistence, serving-stop for report and inference, idempotency (`tests/keyset_revocation.rs`).

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)