### PR TITLE
Clean up stale verifier example, comments, doc rot, and harden E2EE

### DIFF
--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -297,9 +297,11 @@ API-version token, `aci/1`: in-body as `api_version` on signed artifacts (so the
 version lives inside the signed bytes, where a header cannot), and as the
 `X-ACI-Version` response header on every HTTP response (stamped by a single
 middleware, error paths included). This is a separate axis from the
-`aci.<purpose>.v1` strings (`aci.identity.v1`, `aci.receipt.v1`,
-`aci.report_data.v1`) — those are cryptographic domain-separation tags for
-signed messages, not API versions, and version independently.
+`aci.<purpose>.v1` strings (`aci.report_data.v1`, `aci.keyset.endorsement.v1`)
+— those are cryptographic domain-separation tags for the two signed payloads
+(the attestation report-data statement and the keyset endorsement), not API
+versions, and version independently. Receipts carry no purpose tag: the
+signature covers the whole canonical receipt, which is self-describing.
 
 Canonical (clean shapes):
 

--- a/examples/verify_aci_artifacts.rs
+++ b/examples/verify_aci_artifacts.rs
@@ -1,19 +1,58 @@
+//! Independently verify ACI artifacts the way a relying party would, following
+//! the layered verification procedure in `spec/aci.md` §10. This is a practical,
+//! readable reference — not a hardened SDK — that shows how the report, receipt,
+//! and attested session fit together.
+//!
+//! What each level checks here:
+//!
+//! * **Level 2 — establish identity (§10.1).** The report's `workload_id`,
+//!   `workload_keyset_digest`, and `report_data` binding plus the keyset
+//!   endorsement, via [`validate_aci_report_binding`]. Verifying the raw
+//!   hardware quote against a TEE vendor root needs a platform DCAP verifier and
+//!   is out of scope for this example; everything downstream is checked against
+//!   the keyset this step establishes.
+//! * **Level 1 — verify the inference (§10.2).** The receipt signature under an
+//!   attested `receipt_signing_keys` entry, the receipt's workload binding, and
+//!   the request/response body hashes against bytes you supply. Transparency
+//!   events are cross-checked: a rewritten `request.forwarded` must be flagged by
+//!   `transparency.request_modified`.
+//! * **Level 3 — deep audit (§10.3).** Given an attested session record,
+//!   recompute its content-addressed `session_id` (§9.2, including the
+//!   null-restoration rule), check that `evidence.data` hashes to
+//!   `evidence.digest`, and confirm the receipt's `upstream.verified` event
+//!   commits to that same session.
+//!
+//! The receipt and session are handled as raw JSON: a verifier checks the
+//! signature over the canonical bytes it actually received (§8.5), so there is
+//! no need to reproject them through typed structs first.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --example verify_aci_artifacts -- \
+//!   --report report.json --receipt receipt.json \
+//!   [--nonce <value>] [--request-body request.json] [--response-body response.json] \
+//!   [--session session.json] [--skip-freshness]
+//! ```
+
 use std::env;
 use std::fs;
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use private_ai_gateway::aci::canonical::sha256_hex;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use private_ai_gateway::aci::canonical::{canonicalize, jcs_sha256_hex, sha256_hex};
 use private_ai_gateway::aci::keys::verify_receipt_signature;
-use private_ai_gateway::aci::receipt::canonical_bytes_for_signing;
-use private_ai_gateway::aci::types::{AttestationReport, Receipt, ReceiptEvent, ReceiptSignature};
+use private_ai_gateway::aci::types::AttestationReport;
 use private_ai_gateway::aci::verifier::validate_aci_report_binding;
-use serde_json::{json, Map, Value};
+use serde::Serialize;
+use serde_json::{json, Value};
 
 #[derive(Debug, Default)]
 struct Args {
     report_path: String,
     receipt_path: String,
+    session_path: Option<String>,
     nonce: Option<String>,
     request_body_path: Option<String>,
     response_body_path: Option<String>,
@@ -33,9 +72,11 @@ fn run() -> Result<(), String> {
         .map_err(|e| format!("failed to read report {}: {e}", args.report_path))?;
     let report: AttestationReport = serde_json::from_slice(&report_bytes)
         .map_err(|e| format!("failed to parse report JSON: {e}"))?;
-    let receipt_value = read_json_file(&args.receipt_path)?;
-    let receipt = parse_receipt_response(receipt_value)?;
+    // Accept the bare canonical receipt or a `{ "receipt": .. }` wrapper.
+    let raw = read_json_file(&args.receipt_path)?;
+    let receipt = raw.get("receipt").cloned().unwrap_or(raw);
 
+    // --- Level 2: establish the workload identity (§10.1) ---
     let now_secs = if args.skip_freshness {
         report.attestation.freshness.fetched_at
     } else {
@@ -52,35 +93,23 @@ fn run() -> Result<(), String> {
     )
     .map_err(|e| format!("ACI report binding failed: {e}"))?;
 
-    let identity_match = receipt.workload_id == validated.workload_id
-        && receipt.workload_keyset_digest == validated.workload_keyset_digest;
-    let receipt_key = report
-        .attestation
-        .workload_keyset
-        .receipt_signing_keys
-        .iter()
-        .find(|key| key.key_id == receipt.signature.key_id)
-        .ok_or_else(|| {
-            format!(
-                "receipt signature key_id {:?} is not in the attested keyset",
-                receipt.signature.key_id
-            )
-        })?;
-    let canonical = canonical_bytes_for_signing(&receipt)
-        .map_err(|e| format!("failed to canonicalize receipt for signing: {e}"))?;
-    let signature = hex::decode(&receipt.signature.value_hex)
-        .map_err(|e| format!("invalid receipt signature hex: {e}"))?;
-    let receipt_signature_valid = verify_receipt_signature(receipt_key, &canonical, &signature);
+    // --- Level 1: verify the inference against that identity (§10.2) ---
+    // The receipt binds back to the established identity (§8.5) rather than
+    // carrying its own attestation.
+    let identity_match = field_str(&receipt, "workload_id") == Some(validated.workload_id.as_str())
+        && field_str(&receipt, "workload_keyset_digest")
+            == Some(validated.workload_keyset_digest.as_str());
+    let receipt_signature_valid = verify_receipt(&receipt, &report)?;
 
-    let request_hash_valid = match &args.request_body_path {
-        Some(path) => Some(compare_body_hash(
-            path,
-            &receipt,
-            "request.received",
-            "body_hash",
-        )?),
-        None => None,
-    };
+    // The request hash covers the body the service observed after TLS / E2EE
+    // termination (§8.3); for E2EE requests that is the decrypted body.
+    let request_hash_valid = args
+        .request_body_path
+        .as_deref()
+        .map(|path| compare_body_hash(path, &receipt, "request.received", "body_hash"))
+        .transpose()?;
+    // For a plaintext response the client's bytes match `wire_hash`; for an E2EE
+    // response the decrypted bytes match `cleartext_hash` instead (§10.2 step 4).
     let response_hash_valid = match &args.response_body_path {
         Some(path) => {
             let body =
@@ -88,50 +117,61 @@ fn run() -> Result<(), String> {
             let expected = sha256_hex(&body);
             let event = event_by_type(&receipt, "response.returned")
                 .ok_or_else(|| "receipt missing response.returned event".to_string())?;
-            let cleartext = event_field_str(event, "cleartext_hash");
-            let wire = event_field_str(event, "wire_hash");
-            Some(cleartext == Some(expected.as_str()) || wire == Some(expected.as_str()))
+            Some(
+                field_str(event, "cleartext_hash") == Some(expected.as_str())
+                    || field_str(event, "wire_hash") == Some(expected.as_str()),
+            )
         }
         None => None,
     };
+    // A `request.forwarded.body_hash` that differs from `request.received` MUST
+    // be accompanied by `transparency.request_modified` (§10.2 step 5).
+    let transparency_consistent = transparency_consistent(&receipt);
 
-    let upstream_events = receipt
-        .event_log
-        .iter()
-        .filter(|event| event.event_type == "upstream.verified")
+    // --- Level 3: audit the upstream (§10.3) ---
+    // Shallow audit: surface each `upstream.verified` event and its typed claims;
+    // local policy would decide what to require (e.g. `tee_attested` asserted
+    // from `hardware_proven`).
+    let upstream_events = events(&receipt)
+        .filter(|event| field_str(event, "type") == Some("upstream.verified"))
         .map(|event| {
             json!({
-                "seq": event.seq,
-                "result": event_field_str(event, "result"),
-                "vendor": event_field_str(event, "vendor"),
-                "model_id": event_field_str(event, "model_id"),
-                "verifier_id": event_field_str(event, "verifier_id"),
-                "evidence": {
-                    "digest": event
-                    .fields
-                    .get("evidence")
-                    .and_then(|evidence| evidence.get("digest"))
-                    .and_then(Value::as_str),
-                },
+                "seq": event.get("seq"),
+                "result": field_str(event, "result"),
+                "upstream_name": field_str(event, "upstream_name"),
+                "provider_type": field_str(event, "provider_type"),
+                "model_id": field_str(event, "model_id"),
+                "url_origin": field_str(event, "url_origin"),
+                "verifier_id": field_str(event, "verifier_id"),
+                "required": event.get("required").and_then(Value::as_bool),
+                "reason": field_str(event, "reason"),
+                "session_id": field_str(event, "session_id"),
                 "channel_binding_count": event
-                    .fields
                     .get("channel_bindings")
                     .and_then(Value::as_array)
                     .map_or(0, Vec::len),
+                "claims": event.get("claims").cloned().unwrap_or(Value::Null),
             })
         })
         .collect::<Vec<_>>();
-    let transparency_events = receipt
-        .event_log
-        .iter()
-        .filter(|event| event.event_type.starts_with("transparency."))
-        .map(|event| json!({ "seq": event.seq, "type": event.event_type }))
+    let transparency_events = events(&receipt)
+        .filter(|event| field_str(event, "type").is_some_and(|t| t.starts_with("transparency.")))
+        .map(|event| json!({ "seq": event.get("seq"), "type": field_str(event, "type") }))
         .collect::<Vec<_>>();
+
+    // Deep audit: recompute the session id and check the evidence digest.
+    let session_audit = match &args.session_path {
+        Some(path) => Some(audit_session(&read_json_file(path)?, &receipt)?),
+        None => None,
+    };
 
     let verified = identity_match
         && receipt_signature_valid
         && request_hash_valid.unwrap_or(true)
-        && response_hash_valid.unwrap_or(true);
+        && response_hash_valid.unwrap_or(true)
+        && transparency_consistent
+        && session_audit.as_ref().is_none_or(SessionAudit::is_ok);
+
     let summary = json!({
         "verified": verified,
         "report_binding_valid": true,
@@ -139,19 +179,15 @@ fn run() -> Result<(), String> {
         "receipt_signature_valid": receipt_signature_valid,
         "request_hash_valid": request_hash_valid,
         "response_hash_valid": response_hash_valid,
+        "transparency_consistent": transparency_consistent,
         "workload_id": validated.workload_id,
         "workload_keyset_digest": validated.workload_keyset_digest,
-        "report_evidence": {
-            "digest": validated
-            .evidence
-            .as_ref()
-            .and_then(|evidence| evidence.get("digest"))
-            .and_then(Value::as_str),
-        },
-        "receipt_id": receipt.receipt_id,
-        "chat_id": receipt.chat_id,
+        "receipt_id": field_str(&receipt, "receipt_id"),
+        "chat_id": receipt.get("chat_id").cloned().unwrap_or(Value::Null),
+        "requested_model": receipt.get("model").cloned().unwrap_or(Value::Null),
         "upstream_events": upstream_events,
         "transparency_events": transparency_events,
+        "session_audit": session_audit,
     });
     println!(
         "{}",
@@ -165,6 +201,177 @@ fn run() -> Result<(), String> {
     }
 }
 
+/// Verify the receipt signature under an attested `receipt_signing_keys` entry.
+/// The signed bytes are the JCS of the whole receipt with only `signature.value`
+/// removed (§8.5) — canonicalize what was received rather than a re-projection.
+fn verify_receipt(receipt: &Value, report: &AttestationReport) -> Result<bool, String> {
+    let signature = receipt
+        .get("signature")
+        .ok_or_else(|| "receipt missing signature".to_string())?;
+    let key_id = signature
+        .get("key_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "receipt signature missing key_id".to_string())?;
+    let receipt_key = report
+        .attestation
+        .workload_keyset
+        .receipt_signing_keys
+        .iter()
+        .find(|key| key.key_id == key_id)
+        .ok_or_else(|| {
+            format!("receipt signature key_id {key_id:?} is not in the attested keyset")
+        })?;
+    let value_hex = signature
+        .get("value")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "receipt signature missing value".to_string())?;
+    let sig = hex::decode(value_hex).map_err(|e| format!("invalid receipt signature hex: {e}"))?;
+
+    let mut unsigned = receipt.clone();
+    if let Some(obj) = unsigned.get_mut("signature").and_then(Value::as_object_mut) {
+        obj.remove("value");
+    }
+    let canonical =
+        canonicalize(&unsigned).map_err(|e| format!("failed to canonicalize receipt: {e}"))?;
+    Ok(verify_receipt_signature(receipt_key, &canonical, &sig))
+}
+
+/// Deep-audit outcome for one attested-session record (§10.3 step 3).
+#[derive(Serialize)]
+struct SessionAudit {
+    session_id: String,
+    recomputed_session_id: String,
+    /// The record's `session_id` equals the id recomputed from its material.
+    session_id_matches: bool,
+    /// `evidence.data` decodes and hashes to `evidence.digest`.
+    evidence_digest_valid: bool,
+    /// Some `upstream.verified` event in the receipt commits to this session id.
+    referenced_by_receipt: bool,
+}
+
+impl SessionAudit {
+    fn is_ok(&self) -> bool {
+        self.session_id_matches && self.evidence_digest_valid && self.referenced_by_receipt
+    }
+}
+
+/// Recompute the content-addressed `session_id` from a fetched record and check
+/// its evidence, then confirm the receipt points at it (§9.2, §10.3).
+fn audit_session(record: &Value, receipt: &Value) -> Result<SessionAudit, String> {
+    let session_id = field_str(record, "session_id")
+        .ok_or_else(|| "session record missing string session_id".to_string())?
+        .to_string();
+    let recomputed_session_id = recompute_session_id(record)?;
+    let referenced_by_receipt = events(receipt)
+        .filter(|event| field_str(event, "type") == Some("upstream.verified"))
+        .any(|event| field_str(event, "session_id") == Some(session_id.as_str()));
+    Ok(SessionAudit {
+        session_id_matches: recomputed_session_id == session_id,
+        session_id,
+        recomputed_session_id,
+        evidence_digest_valid: evidence_digest_matches(record.get("evidence")),
+        referenced_by_receipt,
+    })
+}
+
+/// `session_id = "as_" || hex(sha256(JCS(material)))` over the immutable subset
+/// (§9.2). Timestamps and the re-fetchable evidence bytes are excluded, and the
+/// three optional wire fields (`endpoint`, `identity`, `evidence.digest`) are
+/// restored to JSON `null` when absent — the null-restoration rule.
+fn recompute_session_id(record: &Value) -> Result<String, String> {
+    let required = |key: &str| {
+        record
+            .get(key)
+            .cloned()
+            .ok_or_else(|| format!("session record missing {key:?}"))
+    };
+    let optional = |key: &str| record.get(key).cloned().unwrap_or(Value::Null);
+    let material = json!({
+        "upstream_name": required("upstream_name")?,
+        "endpoint": optional("endpoint"),
+        "verifier_id": required("verifier_id")?,
+        "identity": optional("identity"),
+        "channel_binding": required("channel_binding")?,
+        "claims": required("claims")?,
+        "evidence_digest": record
+            .get("evidence")
+            .and_then(|evidence| evidence.get("digest"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    });
+    let digest = jcs_sha256_hex(&material)
+        .map_err(|e| format!("failed to canonicalize session material: {e}"))?;
+    Ok(format!(
+        "as_{}",
+        digest.strip_prefix("sha256:").unwrap_or(digest.as_str())
+    ))
+}
+
+/// True when there is nothing to check, or `evidence.data` decodes and hashes to
+/// `evidence.digest` (§9.2: a record whose data does not match its digest MUST
+/// be rejected). We only ever emit `data:<content-type>;base64,<...>`.
+fn evidence_digest_matches(evidence: Option<&Value>) -> bool {
+    let Some(evidence) = evidence else {
+        return true;
+    };
+    let (Some(digest), Some(data_uri)) = (
+        evidence.get("digest").and_then(Value::as_str),
+        evidence.get("data").and_then(Value::as_str),
+    ) else {
+        return true;
+    };
+    let Some((_, b64)) = data_uri.split_once(";base64,") else {
+        return true;
+    };
+    match BASE64.decode(b64.as_bytes()) {
+        Ok(bytes) => sha256_hex(&bytes) == digest,
+        Err(_) => false,
+    }
+}
+
+/// §10.2 step 5: any `request.forwarded` that differs from `request.received`
+/// must be flagged with `transparency.request_modified`.
+fn transparency_consistent(receipt: &Value) -> bool {
+    let hash =
+        |event_type| event_by_type(receipt, event_type).and_then(|e| field_str(e, "body_hash"));
+    let rewritten = match (hash("request.received"), hash("request.forwarded")) {
+        (Some(received), Some(forwarded)) => received != forwarded,
+        _ => false,
+    };
+    // The flag is required when rewritten; a flag without a rewrite is allowed.
+    !rewritten || event_by_type(receipt, "transparency.request_modified").is_some()
+}
+
+/// Iterate a receipt's `event_log` (empty when absent or malformed).
+fn events(receipt: &Value) -> impl Iterator<Item = &Value> {
+    receipt
+        .get("event_log")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn event_by_type<'a>(receipt: &'a Value, event_type: &str) -> Option<&'a Value> {
+    events(receipt).find(|event| field_str(event, "type") == Some(event_type))
+}
+
+fn field_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
+fn compare_body_hash(
+    path: &str,
+    receipt: &Value,
+    event_type: &str,
+    field: &str,
+) -> Result<bool, String> {
+    let body = fs::read(path).map_err(|e| format!("failed to read body {path}: {e}"))?;
+    let expected = sha256_hex(&body);
+    let event = event_by_type(receipt, event_type)
+        .ok_or_else(|| format!("receipt missing {event_type} event"))?;
+    Ok(field_str(event, field) == Some(expected.as_str()))
+}
+
 fn parse_args() -> Result<Args, String> {
     let mut args = Args::default();
     let mut iter = env::args().skip(1);
@@ -172,6 +379,7 @@ fn parse_args() -> Result<Args, String> {
         match arg.as_str() {
             "--report" => args.report_path = next_arg(&mut iter, "--report")?,
             "--receipt" => args.receipt_path = next_arg(&mut iter, "--receipt")?,
+            "--session" => args.session_path = Some(next_arg(&mut iter, "--session")?),
             "--nonce" => args.nonce = Some(next_arg(&mut iter, "--nonce")?),
             "--request-body" => {
                 args.request_body_path = Some(next_arg(&mut iter, "--request-body")?)
@@ -185,7 +393,7 @@ fn parse_args() -> Result<Args, String> {
                     "usage: cargo run --example verify_aci_artifacts -- \
                      --report report.json --receipt receipt.json [--nonce value] \
                      [--request-body request.json] [--response-body response.json] \
-                     [--skip-freshness]"
+                     [--session session.json] [--skip-freshness]"
                 );
                 process::exit(0);
             }
@@ -209,124 +417,4 @@ fn next_arg(iter: &mut impl Iterator<Item = String>, flag: &str) -> Result<Strin
 fn read_json_file(path: &str) -> Result<Value, String> {
     let bytes = fs::read(path).map_err(|e| format!("failed to read {path}: {e}"))?;
     serde_json::from_slice(&bytes).map_err(|e| format!("failed to parse JSON {path}: {e}"))
-}
-
-fn parse_receipt_response(value: Value) -> Result<Receipt, String> {
-    let receipt_value = value.get("receipt").cloned().unwrap_or(value);
-    let obj = receipt_value
-        .as_object()
-        .ok_or_else(|| "receipt JSON must be an object".to_string())?;
-    let signature = parse_signature(
-        obj.get("signature")
-            .ok_or_else(|| "receipt missing signature".to_string())?,
-    )?;
-    let event_log = obj
-        .get("event_log")
-        .and_then(Value::as_array)
-        .ok_or_else(|| "receipt missing event_log array".to_string())?
-        .iter()
-        .map(parse_event)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(Receipt {
-        api_version: object_string(obj, "api_version")?,
-        receipt_id: object_string(obj, "receipt_id")?,
-        chat_id: match obj.get("chat_id") {
-            Some(Value::Null) | None => None,
-            Some(Value::String(s)) => Some(s.clone()),
-            _ => return Err("receipt chat_id must be string or null".to_string()),
-        },
-        model: match obj.get("model") {
-            Some(Value::Null) | None => None,
-            Some(Value::String(s)) => Some(s.clone()),
-            _ => return Err("receipt model must be string or null".to_string()),
-        },
-        workload_id: object_string(obj, "workload_id")?,
-        workload_keyset_digest: object_string(obj, "workload_keyset_digest")?,
-        endpoint: object_string(obj, "endpoint")?,
-        method: object_string(obj, "method")?,
-        served_at: obj
-            .get("served_at")
-            .and_then(Value::as_u64)
-            .ok_or_else(|| "receipt served_at must be an integer".to_string())?,
-        event_log,
-        signature,
-    })
-}
-
-fn parse_signature(value: &Value) -> Result<ReceiptSignature, String> {
-    let obj = value
-        .as_object()
-        .ok_or_else(|| "receipt signature must be an object".to_string())?;
-    Ok(ReceiptSignature {
-        algo: object_string(obj, "algo")?,
-        key_id: object_string(obj, "key_id")?,
-        value_hex: object_string(obj, "value")?,
-    })
-}
-
-fn parse_event(value: &Value) -> Result<ReceiptEvent, String> {
-    let obj = value
-        .as_object()
-        .ok_or_else(|| "receipt event must be an object".to_string())?;
-    let seq = obj
-        .get("seq")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| "receipt event missing integer seq".to_string())?;
-    let event_type = obj
-        .get("type")
-        .and_then(Value::as_str)
-        .ok_or_else(|| "receipt event missing string type".to_string())?
-        .to_string();
-
-    if let Some(fields) = obj.get("fields") {
-        return Ok(ReceiptEvent {
-            seq,
-            event_type,
-            fields: fields.clone(),
-        });
-    }
-
-    let mut fields = Map::new();
-    for (key, value) in obj {
-        if key != "seq" && key != "type" {
-            fields.insert(key.clone(), value.clone());
-        }
-    }
-    Ok(ReceiptEvent {
-        seq,
-        event_type,
-        fields: Value::Object(fields),
-    })
-}
-
-fn object_string(obj: &Map<String, Value>, key: &str) -> Result<String, String> {
-    obj.get(key)
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .ok_or_else(|| format!("missing string field {key:?}"))
-}
-
-fn event_by_type<'a>(receipt: &'a Receipt, event_type: &str) -> Option<&'a ReceiptEvent> {
-    receipt
-        .event_log
-        .iter()
-        .find(|event| event.event_type == event_type)
-}
-
-fn event_field_str<'a>(event: &'a ReceiptEvent, field: &str) -> Option<&'a str> {
-    event.fields.get(field).and_then(Value::as_str)
-}
-
-fn compare_body_hash(
-    path: &str,
-    receipt: &Receipt,
-    event_type: &str,
-    field: &str,
-) -> Result<bool, String> {
-    let body = fs::read(path).map_err(|e| format!("failed to read body {path}: {e}"))?;
-    let expected = sha256_hex(&body);
-    let event = event_by_type(receipt, event_type)
-        .ok_or_else(|| format!("receipt missing {event_type} event"))?;
-    Ok(event_field_str(event, field) == Some(expected.as_str()))
 }

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -79,8 +79,9 @@ pub struct MiddlewareForwarded {
     pub upstream_status: u16,
     pub upstream_body: Vec<u8>,
     pub upstream_headers: std::collections::HashMap<String, String>,
-    /// Which route served the request and the attested session id (if any) —
-    /// returned to the caller as headers.
+    /// Which route served the request and the attested session id (if any).
+    /// These are internal routing outcomes, not emitted as response headers;
+    /// the committed reference for what happened is the receipt.
     pub selected_route: String,
     /// Failed-over candidates as (route_id, status), in the order tried. The
     /// committed route is `selected_route`; these are surfaced so the caller can
@@ -94,8 +95,9 @@ pub struct MiddlewareStreamingForwarded {
     pub upstream_status: u16,
     pub upstream_headers: std::collections::HashMap<String, String>,
     pub body: ServiceResponseStream,
-    /// Which route served the request and the attested session id (if any) —
-    /// returned to the caller as headers.
+    /// Which route served the request and the attested session id (if any).
+    /// These are internal routing outcomes, not emitted as response headers;
+    /// the committed reference for what happened is the receipt.
     pub selected_route: String,
     /// Failed-over candidates as (route_id, status), in the order tried. The
     /// committed route is `selected_route`; these are surfaced so the caller can

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,6 +479,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_session_store(session_store)
         .with_revocation_store(revocation_store);
     let service = Arc::new(service_inner);
+    if service.supported_e2ee_versions().is_empty() {
+        // The spec requires E2EE on chat completions; a deployment that
+        // advertises no versions rejects every E2EE request and is not
+        // spec-conformant. Fine for local dev, worth flagging in production.
+        tracing::warn!(
+            "E2EE is disabled (supported_e2ee_versions is empty): E2EE requests will be \
+             rejected and this deployment is not ACI spec-conformant for chat completions"
+        );
+    }
     // The background upstream verification keeps the attested-session store fresh
     // on the same cadence it re-attests for serving, so `/v1/aci/sessions`
     // (preflight) is populated before any traffic. (The completion path also


### PR DESCRIPTION
Cleanups from `docs/reviews/aci-spec-conformance-gaps.md` items 10–12 and 15. Rebased onto current `main`.

- **`examples/verify_aci_artifacts.rs`**: rewritten against current artifact shapes (receipt top-level `model`; `upstream.verified` carries `upstream_name`/`provider_type` + `session_id`/`claims`, no inline evidence or `vendor`). Adds the spec §10 deep audit — recompute the content-addressed `session_id` (§9.2, incl. the null-restoration rule), check `evidence.data` against `evidence.digest`, and confirm the receipt references the session — plus transparency-event consistency. Verified end-to-end against real report/receipt/session artifacts.
- **`wire.rs`**: fix the stale "returned to the caller as headers" comments on `MiddlewareForwarded` / `MiddlewareStreamingForwarded`; no such headers are emitted, the receipt is the committed reference.
- **`docs/attested-session-system.md`**: cite the real domain-separation tags (`aci.report_data.v1`, `aci.keyset.endorsement.v1`) and note receipts carry none.
- **Startup warning** when E2EE is disabled (empty `supported_e2ee_versions`).

The E2EE nonce-floor item (#68) landed independently in #75 as an exact 64-hex-char rule, so it is dropped here.

`cargo fmt`, `cargo clippy --all-targets` (clean), and `cargo test` (343 passing) all green.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)