### PR TITLE
verifier-ts: streaming E2EE decryption + full field coverage

### DIFF
--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -85,8 +85,13 @@ if (!v.ok) throw new Error('workload failed verification');
 const chan = await openE2eeChannel(report, v);
 const { body, headers } = await chan.seal({ model, messages }); // encrypts content, sets X-E2EE-*
 // ...POST body + headers to /v1/chat/completions...
-const reply = await chan.open(responseJson);                    // decrypts the reply
+const reply = await chan.open(responseJson);                    // buffered reply
+// For a streamed (SSE) response, decrypt each event's chunk instead:
+//   const chunk = await chan.openChunk(JSON.parse(sseEvent.data));
 ```
+
+`seal` also covers `/v1/completions` (`prompt`) and `/v1/embeddings` (`input`);
+`open` covers `message.audio.data`, completion `text`, and embedding vectors.
 
 ## Development
 

--- a/clients/verifier-ts/src/e2ee-channel.ts
+++ b/clients/verifier-ts/src/e2ee-channel.ts
@@ -2,10 +2,10 @@
  * E2EE channel to a *verified* workload (§7). `openE2eeChannel` refuses unless
  * the report passed {@link verifyReportBinding} — you cannot encrypt to a key
  * that is not in a verified, endorsed keyset. `seal` encrypts the request's
- * message contents to the attested X25519 key and returns the `X-E2EE-*`
- * headers; `open` decrypts the reply. All crypto is Web Crypto (X25519, HKDF,
- * AES-GCM) — no dependencies, runs in the browser. secp256k1 is a separate
- * extension (not in the Web Crypto API).
+ * content fields to the attested X25519 key and returns the `X-E2EE-*` headers;
+ * `open` decrypts a buffered response and `openChunk` decrypts one streamed SSE
+ * chunk. All crypto is Web Crypto (X25519, HKDF, AES-GCM) — no dependencies,
+ * runs in the browser. secp256k1 is a separate extension (not in Web Crypto).
  */
 
 import { requestAad, responseAad } from './e2ee.js';
@@ -22,10 +22,12 @@ type Json = Record<string, unknown>;
 
 /** An encrypted channel bound to one verified workload. */
 export interface E2eeChannel {
-  /** Encrypt a chat request's message contents; returns the body and `X-E2EE-*` headers. */
+  /** Encrypt a request's content fields; returns the body and `X-E2EE-*` headers. */
   seal(request: Json): Promise<{ body: Json; headers: Record<string, string> }>;
-  /** Decrypt the buffered chat response produced for the most recent `seal`. */
+  /** Decrypt a buffered response produced for the most recent `seal`. */
   open(response: Json): Promise<Json>;
+  /** Decrypt one streamed SSE chunk (a `chat.completion.chunk` / completion chunk). */
+  openChunk(chunk: Json): Promise<Json>;
 }
 
 /**
@@ -60,18 +62,26 @@ export async function openE2eeChannel(
       const nonce = toHex(crypto.getRandomValues(new Uint8Array(32)));
       const ts = Math.floor(Date.now() / 1000);
       sent = { model, nonce, ts };
-      const messages = (request.messages as Json[] | undefined) ?? [];
-      const out = await Promise.all(
-        messages.map(async (m, i) => {
-          if (m?.content == null) return m;
-          const field = `messages.${i}.content`;
-          const plaintext = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
-          const aad = requestAad({ algo: ALGO, model, field, nonce, ts });
-          return { ...m, content: await sealField(serviceRaw, enc.encode(plaintext), aad) };
-        }),
-      );
+      const encField = (text: string, field: string) =>
+        sealField(serviceRaw, enc.encode(text), requestAad({ algo: ALGO, model, field, nonce, ts }));
+
+      const body: Json = { ...request };
+      if (Array.isArray(request.messages)) {
+        // Whole-content encryption (§7.2) — the universal form for any modality.
+        body.messages = await Promise.all(
+          (request.messages as Json[]).map(async (m, i) => {
+            if (m?.content == null) return m;
+            const text = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+            return { ...m, content: await encField(text, `messages.${i}.content`) };
+          }),
+        );
+      } else if (request.prompt !== undefined) {
+        body.prompt = await sealStringOrArray(request.prompt, 'prompt', encField); // completions
+      } else if (request.input !== undefined) {
+        body.input = await sealStringOrArray(request.input, 'input', encField); // embeddings
+      }
       return {
-        body: { ...request, messages: out },
+        body,
         headers: {
           'X-E2EE-Version': '2',
           'X-Client-Pub-Key': clientPubHex,
@@ -83,26 +93,113 @@ export async function openE2eeChannel(
     },
 
     async open(response) {
-      if (!sent) throw new Error('open: call seal first');
-      const id = typeof response.id === 'string' ? response.id : '';
-      const choices = (response.choices as Json[] | undefined) ?? [];
-      const out = await Promise.all(
-        choices.map(async (c, i) => {
-          const message = c?.message as Json | undefined;
-          if (!message) return c;
-          const opened: Json = { ...message };
-          for (const f of ['content', 'reasoning_content']) {
-            if (typeof opened[f] !== 'string') continue;
-            const field = `choices.${i}.message.${f}`;
-            const aad = responseAad({ algo: ALGO, model: sent!.model, id, field, nonce: sent!.nonce, ts: sent!.ts });
-            opened[f] = dec.decode(await openField(client.privateKey, opened[f] as string, aad));
-          }
-          return { ...c, message: opened };
-        }),
-      );
-      return { ...response, choices: out };
+      const decField = responseDecryptor(client.privateKey, sent, textFrom(response.id));
+      const body: Json = { ...response };
+      if (Array.isArray(response.choices)) {
+        body.choices = await Promise.all(
+          (response.choices as Json[]).map(async (c, pos) => {
+            const i = indexOf(c, pos);
+            const out: Json = { ...c };
+            if (out.message && typeof out.message === 'object') {
+              const m: Json = { ...(out.message as Json) };
+              await openStr(m, 'content', `choices.${i}.message.content`, decField);
+              await openStr(m, 'reasoning_content', `choices.${i}.message.reasoning_content`, decField);
+              if (m.audio && typeof m.audio === 'object') {
+                const a: Json = { ...(m.audio as Json) };
+                await openStr(a, 'data', `choices.${i}.message.audio.data`, decField);
+                m.audio = a;
+              }
+              out.message = m;
+            } else {
+              await openStr(out, 'text', `choices.${i}.text`, decField); // completions
+            }
+            return out;
+          }),
+        );
+      }
+      if (Array.isArray(response.data)) {
+        // Embeddings: the value is serialized compactly then encrypted (§7.2).
+        body.data = await Promise.all(
+          (response.data as Json[]).map(async (d, pos) => {
+            const i = indexOf(d, pos);
+            const out: Json = { ...d };
+            if (typeof out.embedding === 'string') {
+              out.embedding = JSON.parse(await decField(out.embedding, `data.${i}.embedding`));
+            }
+            return out;
+          }),
+        );
+      }
+      return body;
+    },
+
+    async openChunk(chunk) {
+      const decField = responseDecryptor(client.privateKey, sent, textFrom(chunk.id));
+      const body: Json = { ...chunk };
+      if (Array.isArray(chunk.choices)) {
+        body.choices = await Promise.all(
+          (chunk.choices as Json[]).map(async (c, pos) => {
+            const i = indexOf(c, pos);
+            const out: Json = { ...c };
+            if (out.delta && typeof out.delta === 'object') {
+              const d: Json = { ...(out.delta as Json) };
+              await openStr(d, 'content', `choices.${i}.delta.content`, decField);
+              await openStr(d, 'reasoning_content', `choices.${i}.delta.reasoning_content`, decField);
+              out.delta = d;
+            } else {
+              await openStr(out, 'text', `choices.${i}.text`, decField); // completions stream
+            }
+            return out;
+          }),
+        );
+      }
+      return body;
     },
   };
+}
+
+/** A field decryptor bound to the request context (§7.3) and the response `id`. */
+function responseDecryptor(
+  clientPriv: CryptoKey,
+  sent: { model: string; nonce: string; ts: number } | undefined,
+  id: string,
+): (blobHex: string, field: string) => Promise<string> {
+  if (!sent) throw new Error('open: call seal first');
+  const { model, nonce, ts } = sent;
+  return async (blobHex, field) =>
+    dec.decode(await openField(clientPriv, blobHex, responseAad({ algo: ALGO, model, id, field, nonce, ts })));
+}
+
+/** `choices`/`data` index is the entry's `index` member, else its array position (§7.2). */
+function indexOf(entry: Json, position: number): number {
+  return typeof entry.index === 'number' ? entry.index : position;
+}
+
+function textFrom(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/** Decrypt string member `key` of `obj` at `field`, in place; leave non-strings untouched. */
+async function openStr(
+  obj: Json,
+  key: string,
+  field: string,
+  decField: (blobHex: string, field: string) => Promise<string>,
+): Promise<void> {
+  if (typeof obj[key] === 'string') obj[key] = await decField(obj[key] as string, field);
+}
+
+/** Encrypt a string, or each string element of an array at `name.{i}` (§7.2). */
+async function sealStringOrArray(
+  value: unknown,
+  name: string,
+  encField: (text: string, field: string) => Promise<string>,
+): Promise<unknown> {
+  if (typeof value === 'string') return encField(value, name);
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v, i) => (typeof v === 'string' ? encField(v, `${name}.${i}`) : v)));
+  }
+  return value;
 }
 
 // `Uint8Array` → `BufferSource` (Web Crypto typings friction; see crypto.ts).

--- a/clients/verifier-ts/test/e2ee-channel.test.ts
+++ b/clients/verifier-ts/test/e2ee-channel.test.ts
@@ -77,6 +77,74 @@ test('open decrypts a response encrypted to the client key under the response AA
   assert.equal((opened.choices as any[])[0].message.content, 'the answer');
 });
 
+test('open decrypts all buffered chat fields: content, reasoning_content, audio.data', async () => {
+  const { report, verified } = await fixture();
+  const chan = await openE2eeChannel(report, verified);
+  const { headers } = await chan.seal({ model: 'gpt-x', messages: [{ role: 'user', content: 'hi' }] });
+  const nonce = headers['X-E2EE-Nonce']!, ts = Number(headers['X-E2EE-Timestamp']!), pub = headers['X-Client-Pub-Key']!;
+  const aad = (field: string) => responseAad({ algo: ALGO, model: 'gpt-x', id: 'r1', field, nonce, ts });
+  const opened: any = await chan.open({
+    id: 'r1',
+    choices: [{
+      index: 0,
+      message: {
+        role: 'assistant',
+        content: await serverEncrypt(pub, 'answer', aad('choices.0.message.content')),
+        reasoning_content: await serverEncrypt(pub, 'because', aad('choices.0.message.reasoning_content')),
+        audio: { id: 'a', data: await serverEncrypt(pub, 'AUDIO64', aad('choices.0.message.audio.data')) },
+      },
+    }],
+  });
+  assert.equal(opened.choices[0].message.content, 'answer');
+  assert.equal(opened.choices[0].message.reasoning_content, 'because');
+  assert.equal(opened.choices[0].message.audio.data, 'AUDIO64');
+});
+
+test('open decrypts completions text and embeddings embedding', async () => {
+  const { report, verified } = await fixture();
+  const chan = await openE2eeChannel(report, verified);
+  const { headers } = await chan.seal({ model: 'gpt-x', prompt: 'hi' });
+  const nonce = headers['X-E2EE-Nonce']!, ts = Number(headers['X-E2EE-Timestamp']!), pub = headers['X-Client-Pub-Key']!;
+
+  const cAad = responseAad({ algo: ALGO, model: 'gpt-x', id: 'c1', field: 'choices.0.text', nonce, ts });
+  const oc: any = await chan.open({ id: 'c1', choices: [{ index: 0, text: await serverEncrypt(pub, 'done', cAad) }] });
+  assert.equal(oc.choices[0].text, 'done');
+
+  // Embeddings carry no `id`; the value is compact JSON, encrypted (§7.2).
+  const eAad = responseAad({ algo: ALGO, model: 'gpt-x', id: '', field: 'data.0.embedding', nonce, ts });
+  const oe: any = await chan.open({ data: [{ index: 0, embedding: await serverEncrypt(pub, JSON.stringify([0.5, -0.25]), eAad) }] });
+  assert.deepEqual(oe.data[0].embedding, [0.5, -0.25]);
+});
+
+test('openChunk decrypts streamed chat deltas (content, reasoning_content)', async () => {
+  const { report, verified } = await fixture();
+  const chan = await openE2eeChannel(report, verified);
+  const { headers } = await chan.seal({ model: 'gpt-x', stream: true, messages: [{ role: 'user', content: 'hi' }] });
+  const nonce = headers['X-E2EE-Nonce']!, ts = Number(headers['X-E2EE-Timestamp']!), pub = headers['X-Client-Pub-Key']!;
+  const aad = (field: string) => responseAad({ algo: ALGO, model: 'gpt-x', id: 's1', field, nonce, ts });
+
+  const o1: any = await chan.openChunk({ id: 's1', choices: [{ index: 0, delta: { content: await serverEncrypt(pub, 'hel', aad('choices.0.delta.content')) } }] });
+  const o2: any = await chan.openChunk({ id: 's1', choices: [{ index: 0, delta: { reasoning_content: await serverEncrypt(pub, 'think', aad('choices.0.delta.reasoning_content')) } }] });
+  assert.equal(o1.choices[0].delta.content, 'hel');
+  assert.equal(o2.choices[0].delta.reasoning_content, 'think');
+});
+
+test('seal encrypts completions prompt and embeddings input (string and array)', async () => {
+  const { service, report, verified } = await fixture();
+  const chan = await openE2eeChannel(report, verified);
+
+  const s1 = await chan.seal({ model: 'gpt-x', prompt: 'hello' });
+  const n1 = s1.headers['X-E2EE-Nonce']!, t1 = Number(s1.headers['X-E2EE-Timestamp']!);
+  const pAad = requestAad({ algo: ALGO, model: 'gpt-x', field: 'prompt', nonce: n1, ts: t1 });
+  assert.equal(await serverDecrypt(service.privateKey, s1.body.prompt as string, pAad), 'hello');
+
+  const s2 = await chan.seal({ model: 'gpt-x', input: ['a', 'b'] });
+  const n2 = s2.headers['X-E2EE-Nonce']!, t2 = Number(s2.headers['X-E2EE-Timestamp']!);
+  const arr = s2.body.input as string[];
+  assert.equal(await serverDecrypt(service.privateKey, arr[0]!, requestAad({ algo: ALGO, model: 'gpt-x', field: 'input.0', nonce: n2, ts: t2 })), 'a');
+  assert.equal(await serverDecrypt(service.privateKey, arr[1]!, requestAad({ algo: ALGO, model: 'gpt-x', field: 'input.1', nonce: n2, ts: t2 })), 'b');
+});
+
 test('openE2eeChannel refuses an unverified report', async () => {
   const { report } = await fixture();
   await assert.rejects(() => openE2eeChannel(report, { ok: false, workloadKeysetDigest: report.workload_keyset_digest } as ReportVerification));


### PR DESCRIPTION
Follow-up to the E2EE channel (PR #75). Completes the client-side field coverage from the tracking list.

## Streaming
- **`openChunk(chunk)`** decrypts one streamed SSE chunk: chat `choices.{i}.delta.content` / `delta.reasoning_content`, and completion `choices.{i}.text`. The caller parses SSE data events (a generic concern) and calls `openChunk` per event.

## Full field coverage
Every field the gateway encrypts (spec §7.2) is now handled:
- **Request (`seal`)** — chat `messages.{m}.content` (whole, universal for any modality); `/v1/completions` `prompt`/`prompt.{i}`; `/v1/embeddings` `input`/`input.{i}`.
- **Response (`open`, buffered)** — chat `message.{content,reasoning_content,audio.data}`; completion `text`; embedding vectors (compact-JSON, restored via `JSON.parse`).

Indexes follow the entry's `index` member with array-position fallback (§7.2). All Web Crypto, **no new dependencies**.

Not included (still whole-content covers it, per §7.2): per-part multimodal *request* encryption (`image_url.url` / `input_audio.data`) — whole-content encryption already protects those end to end, so it stays an optional optimization.

## Verification
verifier-ts **50/50** (7 channel tests incl. streaming, audio, completions, embeddings, prompt/input round-trips), `tsc` clean. Diff is 3 files, verifier-ts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)