### PR TITLE
E2EE: remove the legacy pipe-AAD mode (LegacyV2)

### DIFF
--- a/spec/aci.md
+++ b/spec/aci.md
@@ -1197,7 +1197,7 @@ and report fields for backward compatibility with pre-ACI clients. The
 reference implementation serves the inherited dstack-vllm-proxy surface:
 `GET /v1/attestation/report` (a legacy report with its own report-data
 layout and injected `signing_address` / `intel_quote` / `nvidia_payload`
-fields), `GET /v1/signature/{id}`, and legacy E2EE modes selected by
+fields), `GET /v1/signature/{id}`, and the no-AAD legacy E2EE mode selected by
 `X-Signing-Algo`.
 
 Compatibility surfaces MUST NOT alter ACI artifacts: canonical report and

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -5,8 +5,7 @@ use serde_json::{json, Value};
 
 use super::e2ee_crypto::{
     decrypt_request_payload, legacy_public_keys_match, normalize_legacy_public_key_for_replay,
-    validate_aci_e2ee_nonce, validate_aci_payload_model, validate_legacy_e2ee_nonce,
-    validate_payload_model, E2eeFieldCrypto,
+    validate_aci_e2ee_nonce, validate_aci_payload_model, E2eeFieldCrypto,
 };
 use super::{
     AciService, E2eeError, E2eePreparedRequest, E2eeReplayKey, E2eeRequestContext,
@@ -375,65 +374,31 @@ impl AciService {
             })
             .ok_or(E2eeError::ModelKeyMismatch)?;
 
+        // The AAD-bound legacy variant (LegacyV2) is removed. Reject requests
+        // that ask for it — via `X-E2EE-Version: 2` or the nonce/timestamp it
+        // required — so they fail loudly rather than silently decrypting with no
+        // AAD; such clients should use the ACI path (`X-E2EE-Version: 2`).
         let version_header = parts.version.unwrap_or("").trim();
-        if !version_header.is_empty()
-            && version_header != E2EE_VERSION_V1
-            && version_header != E2EE_VERSION_V2
+        if (!version_header.is_empty() && version_header != E2EE_VERSION_V1)
+            || parts.nonce.is_some_and(|n| !n.trim().is_empty())
+            || parts.timestamp.is_some_and(|t| !t.trim().is_empty())
         {
             return Err(E2eeError::InvalidVersion);
         }
-        let has_nonce = parts.nonce.is_some_and(|nonce| !nonce.is_empty());
-        let has_timestamp = parts.timestamp.is_some_and(|ts| !ts.is_empty());
-        if has_nonce ^ has_timestamp {
-            return Err(E2eeError::HeaderMissing);
-        }
-        let use_v2 = version_header == E2EE_VERSION_V2 || (has_nonce && has_timestamp);
-        let (version, aad_mode, nonce, timestamp) = if use_v2 {
-            let nonce = parts.nonce.ok_or(E2eeError::HeaderMissing)?;
-            validate_legacy_e2ee_nonce(nonce)?;
-            let timestamp = parts
-                .timestamp
-                .ok_or(E2eeError::HeaderMissing)?
-                .parse::<u64>()
-                .map_err(|_| E2eeError::InvalidTimestamp)?;
-            let now = self.clock.now_secs();
-            if now.abs_diff(timestamp) > 300 {
-                return Err(E2eeError::InvalidTimestamp);
-            }
-            self.claim_e2ee_replay(
-                normalize_legacy_public_key_for_replay(&signing_algo, client_public_key)?,
-                normalize_legacy_public_key_for_replay(&signing_algo, model_public_key)?,
-                nonce.to_string(),
-                now,
-            )?;
-            (
-                E2EE_VERSION_V2.to_string(),
-                E2eeAadMode::LegacyV2,
-                Some(nonce.to_string()),
-                Some(timestamp),
-            )
-        } else {
-            (
-                E2EE_VERSION_V1.to_string(),
-                E2eeAadMode::LegacyV1,
-                None,
-                None,
-            )
-        };
 
         let mut payload: Value =
             serde_json::from_slice(body).map_err(|_| E2eeError::DecryptionFailed)?;
-        let request_model = validate_payload_model(&payload)?;
+        let request_model = validate_aci_payload_model(&payload)?;
         let crypto = E2eeFieldCrypto {
             keys: self.keys.as_ref(),
             decryptor: E2eeDecryptor::Legacy {
                 signing_algo: &signing_algo,
             },
             algo: &signing_algo,
-            aad_mode,
+            aad_mode: E2eeAadMode::LegacyV1,
             model: &request_model,
-            nonce: nonce.as_deref(),
-            timestamp,
+            nonce: None,
+            timestamp: None,
         };
         decrypt_request_payload(&crypto, endpoint_path, &mut payload)?;
         let decrypted_body =
@@ -443,13 +408,13 @@ impl AciService {
         Ok(E2eePreparedRequest {
             decrypted_body,
             context: E2eeRequestContext {
-                version,
+                version: E2EE_VERSION_V1.to_string(),
                 algo: signing_algo,
-                aad_mode,
+                aad_mode: E2eeAadMode::LegacyV1,
                 request_model,
                 client_public_key_hex,
-                nonce,
-                timestamp,
+                nonce: None,
+                timestamp: None,
             },
         })
     }

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -377,7 +377,9 @@ impl AciService {
         // The AAD-bound legacy variant (LegacyV2) is removed. Reject requests
         // that ask for it — via `X-E2EE-Version: 2` or the nonce/timestamp it
         // required — so they fail loudly rather than silently decrypting with no
-        // AAD; such clients should use the ACI path (`X-E2EE-Version: 2`).
+        // AAD. Reaching the ACI path means dropping `X-Signing-Algo` entirely
+        // (it routes here whenever present) and encrypting to a §7.1 suite via
+        // `X-Model-Pub-Key` + `X-E2EE-Version: 2`.
         let version_header = parts.version.unwrap_or("").trim();
         if (!version_header.is_empty() && version_header != E2EE_VERSION_V1)
             || parts.nonce.is_some_and(|n| !n.trim().is_empty())

--- a/src/aggregator/service/e2ee_crypto.rs
+++ b/src/aggregator/service/e2ee_crypto.rs
@@ -22,23 +22,6 @@ pub(super) fn validate_aci_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
     Ok(())
 }
 
-/// Legacy X-Signing-Algo nonce: empty or `|`/CR/LF is rejected because the
-/// legacy AAD is pipe-delimited. Frozen compatibility surface.
-fn validate_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
-    if nonce.is_empty() || aad_component_is_ambiguous(nonce) {
-        return Err(E2eeError::InvalidNonce);
-    }
-    Ok(())
-}
-
-pub(super) fn validate_legacy_e2ee_nonce(nonce: &str) -> Result<(), E2eeError> {
-    validate_e2ee_nonce(nonce)?;
-    if nonce.len() < 16 {
-        return Err(E2eeError::InvalidNonce);
-    }
-    Ok(())
-}
-
 pub(super) fn legacy_public_keys_match(
     signing_algo: &str,
     expected_hex: &str,
@@ -95,21 +78,6 @@ pub(super) fn validate_aci_payload_model(payload: &Value) -> Result<String, E2ee
         .ok_or(E2eeError::InvalidPayloadModel)
 }
 
-/// Legacy model: present, a string, and free of `|`/CR/LF. Frozen.
-pub(super) fn validate_payload_model(payload: &Value) -> Result<String, E2eeError> {
-    let Some(model) = payload.get("model").and_then(Value::as_str) else {
-        return Err(E2eeError::InvalidPayloadModel);
-    };
-    if aad_component_is_ambiguous(model) {
-        return Err(E2eeError::InvalidPayloadModel);
-    }
-    Ok(model.to_string())
-}
-
-fn aad_component_is_ambiguous(value: &str) -> bool {
-    value.contains('|') || value.contains('\r') || value.contains('\n')
-}
-
 /// ACI v2 request AAD (§7.3): the JCS canonicalization of the purpose-tagged
 /// object. `field` is the encrypted location's field path (§7.2).
 fn aci_request_aad(
@@ -150,64 +118,6 @@ fn aci_response_aad(
         "ts": timestamp,
     }))
     .map_err(|_| E2eeError::EncryptionFailed)
-}
-
-/// Legacy pipe-delimited request AAD for chat message content. Frozen.
-fn legacy_request_aad(
-    algo: &str,
-    model: &str,
-    message_index: usize,
-    content_index: Option<usize>,
-    nonce: &str,
-    timestamp: u64,
-) -> String {
-    let content_index = content_index
-        .map(|idx| idx.to_string())
-        .unwrap_or_else(|| "-".to_string());
-    format!(
-        "v2|req|algo={algo}|model={model}|m={message_index}|c={content_index}|n={nonce}|ts={timestamp}"
-    )
-}
-
-/// Legacy pipe-delimited request AAD for prompt / embedding-input fields. Frozen.
-fn legacy_completion_request_aad(
-    algo: &str,
-    model: &str,
-    field_name: &str,
-    nonce: &str,
-    timestamp: u64,
-) -> String {
-    format!("v2|req|algo={algo}|model={model}|field={field_name}|n={nonce}|ts={timestamp}")
-}
-
-/// Legacy pipe-delimited response AAD for embedding data. Frozen.
-fn legacy_embedding_response_aad(
-    algo: &str,
-    model: &str,
-    response_id: &str,
-    data_index: u64,
-    field_name: &str,
-    nonce: &str,
-    timestamp: u64,
-) -> String {
-    format!(
-        "v2|resp|algo={algo}|model={model}|id={response_id}|data={data_index}|field={field_name}|n={nonce}|ts={timestamp}"
-    )
-}
-
-/// Legacy pipe-delimited response AAD for chat / completion fields. Frozen.
-fn legacy_response_aad(
-    algo: &str,
-    model: &str,
-    response_id: &str,
-    choice_index: u64,
-    field_name: &str,
-    nonce: &str,
-    timestamp: u64,
-) -> String {
-    format!(
-        "v2|resp|algo={algo}|model={model}|id={response_id}|choice={choice_index}|field={field_name}|n={nonce}|ts={timestamp}"
-    )
 }
 
 pub(super) struct E2eeFieldCrypto<'a> {
@@ -271,7 +181,7 @@ pub(super) fn decrypt_completion_prompt(
 
     let decrypted_count = match prompt {
         Value::String(ciphertext_hex) => {
-            let aad = completion_request_aad_for_crypto(crypto, "prompt")?;
+            let aad = request_field_aad(crypto, "prompt")?;
             let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
             *ciphertext_hex =
                 String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -284,7 +194,7 @@ pub(super) fn decrypt_completion_prompt(
                     continue;
                 };
                 let field_name = format!("prompt.{index}");
-                let aad = completion_request_aad_for_crypto(crypto, &field_name)?;
+                let aad = request_field_aad(crypto, &field_name)?;
                 let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
                 *ciphertext_hex =
                     String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -311,7 +221,7 @@ pub(super) fn decrypt_embedding_input(
 
     let decrypted_count = match input {
         Value::String(ciphertext_hex) => {
-            let aad = completion_request_aad_for_crypto(crypto, "input")?;
+            let aad = request_field_aad(crypto, "input")?;
             let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
             *ciphertext_hex =
                 String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -327,7 +237,7 @@ pub(super) fn decrypt_embedding_input(
                     continue;
                 };
                 let field_name = format!("input.{index}");
-                let aad = completion_request_aad_for_crypto(crypto, &field_name)?;
+                let aad = request_field_aad(crypto, &field_name)?;
                 let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
                 *ciphertext_hex =
                     String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -353,7 +263,7 @@ pub(super) fn decrypt_content_value(
         // Whole-content encryption, any modality: `messages.{m}.content`.
         Value::String(ciphertext_hex) => {
             let field = format!("messages.{message_index}.content");
-            let aad = content_request_aad(crypto, message_index, None, &field)?;
+            let aad = request_field_aad(crypto, &field)?;
             let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
             let plaintext =
                 String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
@@ -388,32 +298,16 @@ fn decrypt_content_part(
     match part.get("type").and_then(Value::as_str) {
         Some("text") => {
             let field = format!("messages.{message_index}.content.{content_index}.text");
-            decrypt_content_part_field(crypto, message_index, content_index, part, "text", &field)
+            decrypt_content_part_field(crypto, part, "text", &field)
         }
         Some("image_url") if crypto.aad_mode.is_aci() => {
             let field = format!("messages.{message_index}.content.{content_index}.image_url.url");
-            decrypt_content_part_nested(
-                crypto,
-                message_index,
-                content_index,
-                part,
-                "image_url",
-                "url",
-                &field,
-            )
+            decrypt_content_part_nested(crypto, part, "image_url", "url", &field)
         }
         Some("input_audio") if crypto.aad_mode.is_aci() => {
             let field =
                 format!("messages.{message_index}.content.{content_index}.input_audio.data");
-            decrypt_content_part_nested(
-                crypto,
-                message_index,
-                content_index,
-                part,
-                "input_audio",
-                "data",
-                &field,
-            )
+            decrypt_content_part_nested(crypto, part, "input_audio", "data", &field)
         }
         _ => Ok(0),
     }
@@ -422,8 +316,6 @@ fn decrypt_content_part(
 /// Decrypt a direct string member (`text`) of a content part.
 fn decrypt_content_part_field(
     crypto: &E2eeFieldCrypto<'_>,
-    message_index: usize,
-    content_index: usize,
     part: &mut serde_json::Map<String, Value>,
     key: &str,
     field: &str,
@@ -431,7 +323,7 @@ fn decrypt_content_part_field(
     let Some(Value::String(ciphertext_hex)) = part.get_mut(key) else {
         return Ok(0);
     };
-    let aad = content_request_aad(crypto, message_index, Some(content_index), field)?;
+    let aad = request_field_aad(crypto, field)?;
     let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
     *ciphertext_hex = String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
     Ok(1)
@@ -441,8 +333,6 @@ fn decrypt_content_part_field(
 /// content part.
 fn decrypt_content_part_nested(
     crypto: &E2eeFieldCrypto<'_>,
-    message_index: usize,
-    content_index: usize,
     part: &mut serde_json::Map<String, Value>,
     wrapper_key: &str,
     inner_key: &str,
@@ -454,52 +344,15 @@ fn decrypt_content_part_nested(
     let Some(Value::String(ciphertext_hex)) = wrapper.get_mut(inner_key) else {
         return Ok(0);
     };
-    let aad = content_request_aad(crypto, message_index, Some(content_index), field)?;
+    let aad = request_field_aad(crypto, field)?;
     let plaintext = decrypt_e2ee_field(crypto, ciphertext_hex, aad.as_deref())?;
     *ciphertext_hex = String::from_utf8(plaintext).map_err(|_| E2eeError::DecryptionFailed)?;
     Ok(1)
 }
 
-/// AAD for a chat message-content location. ACI uses the JCS field path;
-/// the legacy modes keep the pipe-delimited `m`/`c` form.
-fn content_request_aad(
-    crypto: &E2eeFieldCrypto<'_>,
-    message_index: usize,
-    content_index: Option<usize>,
-    aci_field: &str,
-) -> Result<Option<Vec<u8>>, E2eeError> {
-    match crypto.aad_mode {
-        E2eeAadMode::AciV2 => {
-            let (nonce, timestamp) = crypto.nonce_ts()?;
-            Ok(Some(aci_request_aad(
-                crypto.algo,
-                crypto.model,
-                aci_field,
-                nonce,
-                timestamp,
-            )?))
-        }
-        E2eeAadMode::LegacyV2 => {
-            let (nonce, timestamp) = crypto.nonce_ts()?;
-            Ok(Some(
-                legacy_request_aad(
-                    crypto.algo,
-                    crypto.model,
-                    message_index,
-                    content_index,
-                    nonce,
-                    timestamp,
-                )
-                .into_bytes(),
-            ))
-        }
-        E2eeAadMode::LegacyV1 => Ok(None),
-    }
-}
-
-/// AAD for a prompt / embedding-input field, whose field path (`prompt`,
-/// `prompt.{i}`, `input`, `input.{i}`) is already the field-path component.
-fn completion_request_aad_for_crypto(
+/// AAD for a request field (§7.3): the JCS canonicalization bound to the field
+/// path (§7.2) on the ACI path, and none on the legacy (no-AAD) path.
+fn request_field_aad(
     crypto: &E2eeFieldCrypto<'_>,
     field: &str,
 ) -> Result<Option<Vec<u8>>, E2eeError> {
@@ -513,13 +366,6 @@ fn completion_request_aad_for_crypto(
                 nonce,
                 timestamp,
             )?))
-        }
-        E2eeAadMode::LegacyV2 => {
-            let (nonce, timestamp) = crypto.nonce_ts()?;
-            Ok(Some(
-                legacy_completion_request_aad(crypto.algo, crypto.model, field, nonce, timestamp)
-                    .into_bytes(),
-            ))
         }
         E2eeAadMode::LegacyV1 => Ok(None),
     }
@@ -564,17 +410,9 @@ pub(super) fn encrypt_e2ee_response_body(
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    let response_model = payload
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    if ctx.aad_mode == E2eeAadMode::LegacyV2 && aad_component_is_ambiguous(&response_id) {
-        return Err(E2eeError::EncryptionFailed);
-    }
 
     if endpoint_path == EMBEDDINGS_PATH {
-        encrypt_embedding_data(&mut payload, ctx, &response_model, &response_id)?;
+        encrypt_embedding_data(&mut payload, ctx, &response_id)?;
         return serde_json::to_vec(&payload).map_err(|_| E2eeError::EncryptionFailed);
     }
 
@@ -596,9 +434,7 @@ pub(super) fn encrypt_e2ee_response_body(
                 "text",
                 &format!("choices.{choice_index}.text"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
         } else if let Some(Value::Object(message)) = choice.get_mut("message") {
             encrypt_response_field(
@@ -606,18 +442,14 @@ pub(super) fn encrypt_e2ee_response_body(
                 "content",
                 &format!("choices.{choice_index}.message.content"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
             encrypt_response_field(
                 message,
                 "reasoning_content",
                 &format!("choices.{choice_index}.message.reasoning_content"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
             // Response audio (`message.audio.data`, §7.2) is ACI-only.
             if ctx.aad_mode.is_aci() {
@@ -632,7 +464,6 @@ pub(super) fn encrypt_e2ee_response_body(
 pub(super) fn encrypt_embedding_data(
     payload: &mut Value,
     ctx: &E2eeRequestContext,
-    response_model: &str,
     response_id: &str,
 ) -> Result<(), E2eeError> {
     let Some(items) = payload.get_mut("data").and_then(Value::as_array_mut) else {
@@ -656,7 +487,7 @@ pub(super) fn encrypt_embedding_data(
         // the original type, mirroring how chat content arrays are
         // recovered.
         let plaintext = serde_json::to_vec(embedding).map_err(|_| E2eeError::EncryptionFailed)?;
-        let aad = embedding_response_aad_for_context(ctx, response_model, response_id, data_index)?;
+        let aad = embedding_response_aad_for_context(ctx, response_id, data_index)?;
         let ciphertext_hex = encrypt_response_plaintext(ctx, &plaintext, aad.as_deref())?;
         *embedding = Value::String(ciphertext_hex);
     }
@@ -665,7 +496,6 @@ pub(super) fn encrypt_embedding_data(
 
 fn embedding_response_aad_for_context(
     ctx: &E2eeRequestContext,
-    response_model: &str,
     response_id: &str,
     data_index: u64,
 ) -> Result<Option<Vec<u8>>, E2eeError> {
@@ -681,24 +511,6 @@ fn embedding_response_aad_for_context(
                 nonce,
                 timestamp,
             )?))
-        }
-        E2eeAadMode::LegacyV2 => {
-            if aad_component_is_ambiguous(response_model) {
-                return Err(E2eeError::EncryptionFailed);
-            }
-            let (nonce, timestamp) = response_nonce_ts(ctx)?;
-            Ok(Some(
-                legacy_embedding_response_aad(
-                    &ctx.algo,
-                    response_model,
-                    response_id,
-                    data_index,
-                    "embedding",
-                    nonce,
-                    timestamp,
-                )
-                .into_bytes(),
-            ))
         }
         E2eeAadMode::LegacyV1 => Ok(None),
     }
@@ -743,15 +555,6 @@ pub(super) fn encrypt_e2ee_stream_payload(
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    let response_model = payload
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    if ctx.aad_mode == E2eeAadMode::LegacyV2 && aad_component_is_ambiguous(&response_id) {
-        return Err(E2eeError::EncryptionFailed);
-    }
-
     let Some(choices) = payload.get_mut("choices").and_then(Value::as_array_mut) else {
         return serde_json::to_vec(&payload).map_err(|_| E2eeError::EncryptionFailed);
     };
@@ -770,9 +573,7 @@ pub(super) fn encrypt_e2ee_stream_payload(
                 "text",
                 &format!("choices.{choice_index}.text"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
         } else if let Some(Value::Object(delta)) = choice.get_mut("delta") {
             if delta.get("content").and_then(Value::as_str) == Some("") {
@@ -783,18 +584,14 @@ pub(super) fn encrypt_e2ee_stream_payload(
                 "content",
                 &format!("choices.{choice_index}.delta.content"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
             encrypt_response_field(
                 delta,
                 "reasoning_content",
                 &format!("choices.{choice_index}.delta.reasoning_content"),
                 ctx,
-                &response_model,
                 &response_id,
-                choice_index,
             )?;
         }
     }
@@ -807,21 +604,12 @@ pub(super) fn encrypt_response_field(
     field_name: &str,
     aci_field: &str,
     ctx: &E2eeRequestContext,
-    response_model: &str,
     response_id: &str,
-    choice_index: u64,
 ) -> Result<(), E2eeError> {
     let Some(Value::String(plaintext)) = container.get_mut(field_name) else {
         return Ok(());
     };
-    let aad = response_aad_for_context(
-        ctx,
-        response_model,
-        response_id,
-        choice_index,
-        field_name,
-        aci_field,
-    )?;
+    let aad = response_aad_for_context(ctx, response_id, aci_field)?;
     *plaintext = encrypt_response_plaintext(ctx, plaintext.as_bytes(), aad.as_deref())?;
     Ok(())
 }
@@ -856,10 +644,7 @@ fn encrypt_message_audio_data(
 
 fn response_aad_for_context(
     ctx: &E2eeRequestContext,
-    response_model: &str,
     response_id: &str,
-    choice_index: u64,
-    field_name: &str,
     aci_field: &str,
 ) -> Result<Option<Vec<u8>>, E2eeError> {
     match ctx.aad_mode {
@@ -873,25 +658,6 @@ fn response_aad_for_context(
                 nonce,
                 timestamp,
             )?))
-        }
-        E2eeAadMode::LegacyV2 => {
-            if aad_component_is_ambiguous(field_name) || aad_component_is_ambiguous(response_model)
-            {
-                return Err(E2eeError::EncryptionFailed);
-            }
-            let (nonce, timestamp) = response_nonce_ts(ctx)?;
-            Ok(Some(
-                legacy_response_aad(
-                    &ctx.algo,
-                    response_model,
-                    response_id,
-                    choice_index,
-                    field_name,
-                    nonce,
-                    timestamp,
-                )
-                .into_bytes(),
-            ))
         }
         E2eeAadMode::LegacyV1 => Ok(None),
     }
@@ -917,7 +683,7 @@ pub(super) fn encrypt_response_plaintext(
             encrypt_aci_e2ee_for_public_key(&ctx.algo, &ctx.client_public_key_hex, plaintext, aad)
                 .map_err(|_| E2eeError::EncryptionFailed)
         }
-        E2eeAadMode::LegacyV1 | E2eeAadMode::LegacyV2 => {
+        E2eeAadMode::LegacyV1 => {
             encrypt_legacy_for_public_key(&ctx.algo, &ctx.client_public_key_hex, plaintext, aad)
                 .map_err(|_| E2eeError::EncryptionFailed)
         }

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -37,14 +37,15 @@ pub struct E2eeRequestContext {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum E2eeAadMode {
+    /// The spec ACI v2 path: JCS AAD (§7.3).
     AciV2,
-    LegacyV2,
+    /// The inherited dstack-vllm-proxy path (`X-Signing-Algo`): no AAD (§13).
     LegacyV1,
 }
 
 impl E2eeAadMode {
-    /// The spec ACI v2 path (JCS AAD, §7.3), as opposed to the frozen legacy
-    /// X-Signing-Algo compatibility modes. Per-part multimodal field paths
+    /// The spec ACI v2 path (JCS AAD, §7.3), as opposed to the no-AAD legacy
+    /// X-Signing-Algo compatibility mode. Per-part multimodal field paths
     /// (§7.2) exist only here.
     pub(super) fn is_aci(self) -> bool {
         matches!(self, Self::AciV2)

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -19,11 +19,10 @@ use bytes::Bytes;
 use futures_util::stream;
 use private_ai_gateway::aci::canonical::{canonicalize, sha256_hex};
 use private_ai_gateway::aci::e2ee::{
-    decrypt_legacy_ecdsa_with_secret_key, decrypt_legacy_ed25519_with_secret_key,
-    decrypt_with_secret_key, decrypt_x25519_with_secret_key, ed25519_public_key_hex,
+    decrypt_legacy_ecdsa_with_secret_key, decrypt_with_secret_key, decrypt_x25519_with_secret_key,
     encrypt_for_public_key, encrypt_legacy_for_public_key, encrypt_x25519_for_public_key,
     legacy_ecdsa_public_key_from_secret, public_key_from_secret, x25519_public_key_hex,
-    E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_LEGACY_ED25519, E2EE_ALGO_X25519_AESGCM, E2EE_VERSION_V2,
+    E2EE_ALGO_LEGACY_ECDSA, E2EE_ALGO_X25519_AESGCM, E2EE_VERSION_V2,
 };
 use private_ai_gateway::aci::receipt::{
     UpstreamVerifiedEvent, VerificationResult, EVENT_TRANSPARENCY_REQUEST_MODIFIED,
@@ -538,36 +537,6 @@ fn legacy_ecdsa_request(
             legacy_ecdsa_public_key_from_secret(client_secret),
         ),
         ("x-model-pub-key", model_key),
-    ];
-    (serde_json::to_vec(&body).unwrap(), headers)
-}
-
-fn legacy_ed25519_v2_request(
-    h: &Harness,
-    client_secret: &ed25519_dalek::SigningKey,
-    nonce: &str,
-) -> (Vec<u8>, Vec<(&'static str, String)>) {
-    let model = "aci-model";
-    let timestamp = 1_700_000_000u64;
-    let model_key = legacy_model_public_key(h, E2EE_ALGO_LEGACY_ED25519);
-    let aad = format!("v2|req|algo=ed25519|model={model}|m=0|c=-|n={nonce}|ts={timestamp}");
-    let encrypted_content = encrypt_legacy_for_public_key(
-        E2EE_ALGO_LEGACY_ED25519,
-        &model_key,
-        b"hello",
-        Some(aad.as_bytes()),
-    )
-    .unwrap();
-    let body = serde_json::json!({
-        "model": model,
-        "messages": [{"role": "user", "content": encrypted_content}],
-    });
-    let headers = vec![
-        ("x-signing-algo", E2EE_ALGO_LEGACY_ED25519.to_string()),
-        ("x-client-pub-key", ed25519_public_key_hex(client_secret)),
-        ("x-model-pub-key", model_key),
-        ("x-e2ee-nonce", nonce.to_string()),
-        ("x-e2ee-timestamp", timestamp.to_string()),
     ];
     (serde_json::to_vec(&body).unwrap(), headers)
 }
@@ -1096,43 +1065,23 @@ async fn legacy_ecdsa_e2ee_v1_matches_vllm_proxy_no_aad_shape() {
 }
 
 #[tokio::test]
-async fn legacy_ed25519_e2ee_v2_uses_x25519_and_response_model_aad() {
-    let upstream_response = br#"{"id":"chat-aci-1","object":"chat.completion","model":"private-upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"plain-answer"},"finish_reason":"stop"}]}"#;
-    let h = harness_with_e2ee(RecordingUpstream::with_response_body(upstream_response));
-    let client_secret = ed25519_dalek::SigningKey::from_bytes(&[0x62; 32]);
-    let nonce = "legacy-ed25519-nonce";
-    let (encrypted_body, headers) = legacy_ed25519_v2_request(&h, &client_secret, nonce);
+async fn legacy_signing_algo_with_nonce_is_rejected_as_removed_v2() {
+    // The AAD-bound legacy variant (LegacyV2) is removed: a legacy X-Signing-Algo
+    // request that carries a nonce/timestamp is rejected, rather than silently
+    // decrypted without AAD. Such clients should use the ACI path.
+    let h = harness_with_e2ee(RecordingUpstream::default());
+    let client_secret = k256::SecretKey::from_slice(&[0x62; 32]).unwrap();
+    let (body, mut headers) = legacy_ecdsa_request(&h, &client_secret);
+    headers.push(("x-e2ee-nonce", "any-nonce".to_string()));
+    headers.push(("x-e2ee-timestamp", "1700000000".to_string()));
 
     let resp = h
         .requester
-        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .post_owned_headers("/v1/chat/completions", &body, &headers)
         .await;
-    assert_eq!(resp.status, StatusCode::OK);
-    assert_eq!(header(&resp.headers, "x-e2ee-applied"), "true");
-    assert_eq!(header(&resp.headers, "x-e2ee-version"), "2");
-    assert_eq!(header(&resp.headers, "x-e2ee-algo"), "ed25519");
-
-    let encrypted_response = json_body(&resp);
-    let encrypted_content = encrypted_response["choices"][0]["message"]["content"]
-        .as_str()
-        .unwrap();
-    let legacy_response_aad = "v2|resp|algo=ed25519|model=private-upstream-model|id=chat-aci-1|choice=0|field=content|n=legacy-ed25519-nonce|ts=1700000000";
-    let decrypted_response = decrypt_legacy_ed25519_with_secret_key(
-        &client_secret,
-        encrypted_content,
-        Some(legacy_response_aad.as_bytes()),
-    )
-    .unwrap();
-    assert_eq!(decrypted_response, b"plain-answer");
-
-    let request_model_aad =
-        legacy_response_aad.replace("model=private-upstream-model", "model=aci-model");
-    assert!(decrypt_legacy_ed25519_with_secret_key(
-        &client_secret,
-        encrypted_content,
-        Some(request_model_aad.as_bytes()),
-    )
-    .is_err());
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error_type(&resp), "e2ee_invalid_version");
+    assert!(h.upstream_calls.lock().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -1759,36 +1708,6 @@ fn legacy_ecdsa_embeddings_request(
     (serde_json::to_vec(&body).unwrap(), headers)
 }
 
-fn legacy_ed25519_v2_embeddings_request(
-    h: &Harness,
-    client_secret: &ed25519_dalek::SigningKey,
-    nonce: &str,
-) -> (Vec<u8>, Vec<(&'static str, String)>) {
-    let model = "aci-model";
-    let timestamp = 1_700_000_000u64;
-    let model_key = legacy_model_public_key(h, E2EE_ALGO_LEGACY_ED25519);
-    let aad = format!("v2|req|algo=ed25519|model={model}|field=input|n={nonce}|ts={timestamp}");
-    let encrypted_input = encrypt_legacy_for_public_key(
-        E2EE_ALGO_LEGACY_ED25519,
-        &model_key,
-        b"hello",
-        Some(aad.as_bytes()),
-    )
-    .unwrap();
-    let body = serde_json::json!({
-        "model": model,
-        "input": encrypted_input,
-    });
-    let headers = vec![
-        ("x-signing-algo", E2EE_ALGO_LEGACY_ED25519.to_string()),
-        ("x-client-pub-key", ed25519_public_key_hex(client_secret)),
-        ("x-model-pub-key", model_key),
-        ("x-e2ee-nonce", nonce.to_string()),
-        ("x-e2ee-timestamp", timestamp.to_string()),
-    ];
-    (serde_json::to_vec(&body).unwrap(), headers)
-}
-
 #[tokio::test]
 async fn embeddings_endpoint_forwards_non_stream_and_issues_aci_receipt() {
     let h = harness_with_upstream(RecordingUpstream::with_response_body(
@@ -2015,50 +1934,4 @@ async fn embeddings_endpoint_supports_legacy_v1_e2ee() {
         decrypt_legacy_ecdsa_with_secret_key(&client_secret, encrypted_embedding, None).unwrap();
     let decoded: Value = serde_json::from_slice(&decrypted).unwrap();
     assert_eq!(decoded, serde_json::json!([0.5, -0.25, 1.0]));
-}
-
-#[tokio::test]
-async fn embeddings_endpoint_supports_legacy_ed25519_v2_e2ee() {
-    let upstream_response = br#"{"object":"list","data":[{"object":"embedding","index":0,"embedding":[7.5]}],"model":"private-upstream-model","usage":{"prompt_tokens":1,"total_tokens":1}}"#;
-    let h = harness_with_e2ee(RecordingUpstream::with_response_body(upstream_response));
-    let client_secret = ed25519_dalek::SigningKey::from_bytes(&[0x74; 32]);
-    let nonce = "legacy-ed25519-embed-nonce";
-    let (encrypted_body, headers) = legacy_ed25519_v2_embeddings_request(&h, &client_secret, nonce);
-
-    let resp = h
-        .requester
-        .post_owned_headers("/v1/embeddings", &encrypted_body, &headers)
-        .await;
-    assert_eq!(
-        resp.status,
-        StatusCode::OK,
-        "{}",
-        String::from_utf8_lossy(&resp.body)
-    );
-    assert_eq!(header(&resp.headers, "x-e2ee-applied"), "true");
-    assert_eq!(header(&resp.headers, "x-e2ee-version"), "2");
-    assert_eq!(header(&resp.headers, "x-e2ee-algo"), "ed25519");
-
-    let encrypted_response = json_body(&resp);
-    let encrypted_embedding = encrypted_response["data"][0]["embedding"].as_str().unwrap();
-    // Legacy v2 binds the response model (not the request model) into AAD.
-    let response_aad =
-        "v2|resp|algo=ed25519|model=private-upstream-model|id=|data=0|field=embedding|n=legacy-ed25519-embed-nonce|ts=1700000000";
-    let decrypted = decrypt_legacy_ed25519_with_secret_key(
-        &client_secret,
-        encrypted_embedding,
-        Some(response_aad.as_bytes()),
-    )
-    .unwrap();
-    let decoded: Value = serde_json::from_slice(&decrypted).unwrap();
-    assert_eq!(decoded, serde_json::json!([7.5]));
-
-    // Request-model AAD must NOT decrypt under legacy v2.
-    let wrong_aad = response_aad.replace("model=private-upstream-model", "model=aci-model");
-    assert!(decrypt_legacy_ed25519_with_secret_key(
-        &client_secret,
-        encrypted_embedding,
-        Some(wrong_aad.as_bytes()),
-    )
-    .is_err());
 }

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -1068,7 +1068,8 @@ async fn legacy_ecdsa_e2ee_v1_matches_vllm_proxy_no_aad_shape() {
 async fn legacy_signing_algo_with_nonce_is_rejected_as_removed_v2() {
     // The AAD-bound legacy variant (LegacyV2) is removed: a legacy X-Signing-Algo
     // request that carries a nonce/timestamp is rejected, rather than silently
-    // decrypted without AAD. Such clients should use the ACI path.
+    // decrypted without AAD. Such clients must drop X-Signing-Algo and use the
+    // ACI path instead.
     let h = harness_with_e2ee(RecordingUpstream::default());
     let client_secret = k256::SecretKey::from_slice(&[0x62; 32]).unwrap();
     let (body, mut headers) = legacy_ecdsa_request(&h, &client_secret);


### PR DESCRIPTION
Removes the `X-Signing-Algo` legacy **pipe-delimited-AAD** variant (`LegacyV2`) — the awkward middle mode between the truly-inherited no-AAD v1 and the JCS ACI path. Requested cleanup; it was the most error-prone code in the E2EE module.

## Behavior
- The legacy `X-Signing-Algo` path is now **v1-only** (no AAD, the inherited dstack-vllm-proxy behavior).
- A legacy request that asks for the AAD-bound variant — `X-E2EE-Version: 2`, or a nonce/timestamp — is **rejected** with `e2ee_invalid_version`, so it fails loudly instead of silently decrypting without AAD. Those clients should use the ACI path (`X-E2EE-Version: 2`, JCS).
- The modern ACI path (JCS AAD) and no-AAD legacy v1 are unchanged.

## Deletes
The four `legacy_*_aad` pipe builders, `aad_component_is_ambiguous` and the `|`/CR/LF checks, `validate_legacy_e2ee_nonce`/`validate_e2ee_nonce`, the `LegacyV2` enum variant and its dispatch arms, and the now-dead `response_model` threading (it existed only to bind the upstream model into the v2 AAD). Merges the two request-AAD dispatchers into one `request_field_aad`.

**Net −395 LOC** (+53 / −448), no new deps.

## Verification
`cargo fmt`/`clippy` clean; full suite 28 groups / 0 failures. The two old LegacyV2 success tests are replaced by one regression test that the variant is now rejected (`legacy_signing_algo_with_nonce_is_rejected_as_removed_v2`); the legacy **v1** no-AAD tests still pass unchanged.

Independent of the streaming PR (#78) — this touches only the gateway; #78 touches only the verifier client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)