### PR TITLE
Forward stream_options.include_usage on /v1/completions

### DIFF
--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -992,6 +992,7 @@ fn openai_complete_config() -> ProviderConfig {
         ),
         ("n", vec![pc("n").with_default(json!(1))]),
         ("stream", vec![pc("stream").with_default(json!(false))]),
+        ("stream_options", vec![pc("stream_options")]),
         ("logprobs", vec![pc("logprobs").with_max(5)]),
         ("echo", vec![pc("echo").with_default(json!(false))]),
         ("stop", vec![pc("stop")]),
@@ -1223,6 +1224,21 @@ mod tests {
             None,
         );
         assert_eq!(chat_out["stream_options"], json!({ "include_usage": true }));
+
+        // Legacy /v1/completions must also carry include_usage to upstream, or
+        // usage-only streaming providers (e.g. vLLM) never emit a usage chunk
+        // and the meter records 0 tokens.
+        let complete_out = transform_to_provider_request(
+            ProviderFormat::Openai,
+            &json!({ "model": "m", "prompt": "hi", "stream": true }),
+            Endpoint::Complete,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            complete_out["stream_options"],
+            json!({ "include_usage": true })
+        );
 
         let responses = transform_to_provider_request(
             ProviderFormat::Openai,


### PR DESCRIPTION
## Problem

`inject_stream_options` force-adds `stream_options.include_usage=true` to every streaming request, but `transform_using_provider_config` rebuilds the upstream body from a per-endpoint allowlist and `openai_complete_config` didn't list `stream_options`. So it was dropped for `/v1/completions` (kept for `/v1/chat/completions`, whose config lists it).

Providers that only emit a streaming usage chunk when `include_usage` is set (e.g. vLLM) then send no usage frame, the SSE meter's `last_usage` stays `None`, and the request is logged with 0 input/output tokens despite real generation.

## Fix

Add `stream_options` to `openai_complete_config` and extend the regression test to assert `include_usage` survives for `Endpoint::Complete`.

`cargo test --lib middleware::` — 29 passed.