### PR TITLE
Add measured Privatemode sidecar upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dstack-sdk"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3264,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "dcap-qvl",
+ "dotenvy",
  "dstack-sdk",
  "ed25519-dalek",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ curve25519-dalek = "4"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 aes-gcm = "0.10"
 base64 = "0.22"
+dotenvy = "0.15.7"
 chacha20poly1305 = "0.10"
 flate2 = "1"
 hkdf = "0.12"

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Supported `provider` values:
 | `near-ai` | NEAR AI gateway adapter with TLS binding from the provider report. |
 | `chutes` | Chutes adapter with provider E2EE key verification and encrypted `/e2e/invoke` transport. |
 | `secret-ai` | Direct SecretAI SecretVM adapter with CPU/GPU verification, measured production workload reporting, optional workload pinning, and enforced inference TLS SPKI. See [docs/providers/secret-ai/verification.md](docs/providers/secret-ai/verification.md). |
+| `privatemode` | Privatemode adapter using an official proxy image and Contrast manifest pinned in the same measured dstack Compose. See [docs/providers/privatemode/verification.md](docs/providers/privatemode/verification.md). |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint (one per model) with TLS SPKI binding from the version-2 attestation report. See [docs/providers/phala-direct/verification.md](docs/providers/phala-direct/verification.md). |
 
 ACI service verification policy is set on the upstream entry with
@@ -340,6 +341,9 @@ ACI service verification policy is set on the upstream entry with
 Tinfoil, NEAR AI, Chutes, SecretAI, and PhalaDirect use the Python provider
 verifier bridge. Set `PRIVATE_AI_VERIFIER_DIR` only when you need to override
 the bridge's vendored `confidential_verifier` package with an external checkout.
+Privatemode verification is delegated to the official proxy co-deployed with
+the gateway; the Rust adapter enforces its measured endpoint, manifest, and
+image binding.
 
 For one-command Compose deployments, set `upstream_config_seed_path` in the
 static gateway config to a read-only seed file. The gateway validates and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,13 @@ This directory contains the one-file dstack compose path for launching
 Private AI Gateway through
 [`git-launcher`](https://github.com/Dstack-TEE/dstack-examples/tree/main/git-launcher).
 
+Two complete deployment files are provided:
+
+| File | Services |
+| --- | --- |
+| `compose.yaml` | Gateway only. |
+| `compose.privatemode.yaml` | Gateway plus the official digest-pinned Privatemode proxy in the same measured workload. |
+
 The launcher fetches a pinned `private-ai-gateway` commit, verifies `HEAD`,
 scrubs the checkout, preserves the container environment, and runs the gateway
 repo's own [`../entrypoint.sh`](../entrypoint.sh). The launcher remains
@@ -35,6 +42,55 @@ phala deploy -n private-ai-gateway -c compose.yaml \
   -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
 ```
 
+For Privatemode, use the co-deployed variant. It requires a reviewed manifest
+file and its digest; [`privatemode.env.example`](./privatemode.env.example)
+lists all inputs.
+
+```bash
+export PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN=<long-random-client-token>
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_INFERENCE_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATEMODE_API_KEY=<privatemode-api-key>
+export PRIVATEMODE_MANIFEST_PATH=/absolute/path/to/exact-reviewed-manifest.json
+
+./render-privatemode-compose.sh /tmp/private-ai-gateway-privatemode.json
+phala-h4xuser deploy -n private-ai-gateway \
+  -c /tmp/private-ai-gateway-privatemode.json \
+  -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN="$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -e PRIVATEMODE_API_KEY="$PRIVATEMODE_API_KEY"
+```
+
+Render before deployment so the exact byte-for-byte manifest, its digest, the
+credential digest, admin-token digest, downstream inference-token digest,
+image digest, and git commit are part of the measured Compose. The admin token
+itself is deliberately absent from the rendered file and is passed through
+Phala's encrypted environment instead. The downstream inference token remains
+client-side and is not passed to the deployment; callers send it as the Bearer
+credential on inference requests. The
+Privatemode API key follows the same path into one Compose-managed secret
+mounted into both services. The proxy reads it through its official
+`--apiKey @<file>` interface; the gateway reads it only at startup to verify the
+renderer-derived measured digest, then drops the bytes.
+The renderer replaces the local manifest path with inline JSON content and
+verifies that the rendered bytes retain the source file's SHA-256, including
+whitespace and its final newline.
+Those non-secret content pins are also service labels, ensuring Compose
+recreates both services when a mounted inline config changes instead of
+restarting a container with stale config bytes.
+
+That compose pins
+`ghcr.io/edgelesssys/privatemode/privatemode-proxy` at OCI digest
+`sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307`,
+mounts the same manifest and credential secret into both services, and does not
+publish the proxy port. Add only the mutable model route through the admin API
+after boot; `bearer_token` is forbidden for Privatemode. The official proxy
+loads one credential at startup, so rotating it requires rerendering with the
+new `PRIVATEMODE_API_KEY` and redeploying the gateway and proxy together. A
+gateway-only restart with a secret that does not match measured policy fails
+closed.
+
 For local/dev deploys, you can also copy
 [`gateway.env.example`](./gateway.env.example), fill in its values, and pass it
 as `-e gateway.env`. For production, pass variables with repeated `-e KEY=VALUE`
@@ -44,7 +100,11 @@ arguments so secrets such as admin tokens do not remain in a plaintext env file.
 initial upstream config. dstack measures the raw manifest into `compose_hash`,
 and the published `app_compose` contains variable references rather than their
 values.
-After deployment, the gateway listens on port `8086`.
+After deployment, the gateway listens on port `8086`. The Privatemode variant
+rejects inference requests unless `Authorization: Bearer
+$PRIVATE_AI_GATEWAY_INFERENCE_TOKEN` hashes to the digest measured in its
+static config. Health, attestation, transparency, and model-catalog endpoints
+remain public; the admin API uses its separate admin token.
 
 The gateway consumes two JSON files:
 
@@ -220,8 +280,9 @@ Example seed:
 ]
 ```
 
-Supported provider values are `openai-compatible`, `aci-service`, `tinfoil`,
-`near-ai`, `chutes`, `secret-ai`, and `phala-direct`.
+Supported provider values are `openai-compatible`, `anthropic`, `aci-service`,
+`tinfoil`, `near-ai`, `chutes`, `secret-ai`, `privatemode`, and
+`phala-direct`.
 
 For `aci-service`, `base_url` is the HTTPS origin used for both model traffic and
 `/v1/attestation/report`. The router fetches the report through normal TLS,
@@ -264,9 +325,10 @@ config is part of the trust surface.
 
 ## Toolchain Posture
 
-The current `entrypoint.sh` can bootstrap Rust with apt + rustup inside the
-TEE. That keeps the first deploy path simple, but it is a development-grade
-trust surface.
+The current `entrypoint.sh` can bootstrap a missing native compiler/linker
+with apt + build-essential and Rust with apt + rustup inside the TEE. That
+keeps the first deploy path simple, but it is a development-grade trust
+surface.
 
 The production target is a gateway-owned image that already contains the
 Rust toolchain, or eventually the prebuilt gateway binary. The launcher still

--- a/deploy/compose.privatemode.yaml
+++ b/deploy/compose.privatemode.yaml
@@ -1,0 +1,109 @@
+# dstack deployment with the official Privatemode proxy in the same measured
+# Compose workload as Private AI Gateway. Only the gateway port is published.
+
+services:
+  private-ai-gateway:
+    image: docker.io/dstacktee/git-launcher@sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b
+    command: ["/etc/git-launcher/gateway.conf"]
+    # Compose identifies mounted configs by source name, so also bind their
+    # immutable content pins into the service definition. A pin change then
+    # recreates the container instead of restarting it with stale config bytes.
+    labels:
+      ai.private-gateway.source-commit: ${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
+      ai.private-gateway.admin-token-sha256: ${PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256}
+      ai.private-gateway.inference-token-sha256: ${PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256}
+      ai.private-gateway.privatemode-manifest-sha256: ${PRIVATEMODE_MANIFEST_SHA256:?set PRIVATEMODE_MANIFEST_SHA256 to the reviewed manifest digest}
+      ai.private-gateway.privatemode-credential-sha256: ${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}
+    ports:
+      - "8086:8086"
+    configs:
+      - source: gateway-pin
+        target: /etc/git-launcher/gateway.conf
+      - source: gateway-config
+        target: /etc/private-ai-gateway/gateway.config.json
+      - source: gateway-upstreams
+        target: /etc/private-ai-gateway/upstreams.seed.json
+      - source: privatemode-manifest
+        target: /run/privatemode/manifest.json
+    secrets:
+      - source: privatemode-api-key
+        target: privatemode-api-key
+    environment:
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
+      PRIVATE_AI_GATEWAY_CACHE_DIR: /var/lib/private-ai-gateway/cache
+      PRIVATE_AI_GATEWAY_ENV_FILE: /run/secrets/dstack-encrypted-env
+    volumes:
+      - gateway-checkout:/var/lib/git-launcher
+      - gateway-state:/var/lib/private-ai-gateway
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - /dstack/.host-shared/.decrypted-env:/run/secrets/dstack-encrypted-env:ro
+    depends_on:
+      - privatemode-proxy
+    restart: unless-stopped
+
+  privatemode-proxy:
+    image: ghcr.io/edgelesssys/privatemode/privatemode-proxy@sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307
+    labels:
+      ai.private-gateway.privatemode-manifest-sha256: ${PRIVATEMODE_MANIFEST_SHA256:?set PRIVATEMODE_MANIFEST_SHA256 to the reviewed manifest digest}
+      ai.private-gateway.privatemode-credential-sha256: ${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}
+    command:
+      - --manifestPath
+      - /run/privatemode/manifest.json
+      - --workspace
+      - /var/lib/privatemode
+      - --port
+      - "8080"
+      - --apiKey
+      - "@/run/secrets/privatemode-api-key"
+      - --nvidiaOCSPAllowUnknown=false
+      - --nvidiaOCSPRevokedGracePeriod=0
+    configs:
+      - source: privatemode-manifest
+        target: /run/privatemode/manifest.json
+    tmpfs:
+      - /var/lib/privatemode:mode=0700
+    secrets:
+      - source: privatemode-api-key
+        target: privatemode-api-key
+    restart: unless-stopped
+
+configs:
+  gateway-pin:
+    content: |
+      REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+      COMMIT_SHA=${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
+      WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+
+  gateway-config:
+    content: |
+      {
+        "bind": "0.0.0.0:8086",
+        "state_dir": "/var/lib/private-ai-gateway",
+        "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+        "admin_token_sha256": "${PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256}",
+        "inference_token_sha256": "${PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256}",
+        "dstack_endpoint": "unix:/var/run/dstack.sock",
+        "privatemode_proxy": {
+          "base_url": "http://privatemode-proxy:8080",
+          "manifest_path": "/run/privatemode/manifest.json",
+          "manifest_sha256": "${PRIVATEMODE_MANIFEST_SHA256:?set PRIVATEMODE_MANIFEST_SHA256 to the reviewed manifest digest}",
+          "credential_path": "/run/secrets/privatemode-api-key",
+          "credential_sha256": "${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}",
+          "proxy_image_digest": "sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+        }
+      }
+
+  gateway-upstreams:
+    content: |
+      []
+
+  privatemode-manifest:
+    file: ${PRIVATEMODE_MANIFEST_PATH:?set PRIVATEMODE_MANIFEST_PATH to the exact reviewed manifest file}
+
+volumes:
+  gateway-checkout:
+  gateway-state:
+
+secrets:
+  privatemode-api-key:
+    environment: PRIVATEMODE_API_KEY

--- a/deploy/gateway.config.example.json
+++ b/deploy/gateway.config.example.json
@@ -3,7 +3,16 @@
   "state_dir": "/var/lib/private-ai-gateway",
   "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
   "admin_token": "<long-random-admin-token>",
+  "inference_token_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
   "dstack_endpoint": "unix:/var/run/dstack.sock",
+  "privatemode_proxy": {
+    "base_url": "http://privatemode-proxy:8080",
+    "manifest_path": "/run/privatemode/manifest.json",
+    "manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "credential_path": "/run/secrets/privatemode-api-key",
+    "credential_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "proxy_image_digest": "sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+  },
   "middleware": {
     "control_url": "https://control.example",
     "control_token": "<control-plane-bearer-token>"

--- a/deploy/privatemode.env.example
+++ b/deploy/privatemode.env.example
@@ -1,0 +1,7 @@
+PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha>
+PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
+PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256=<sha256-of-admin-token>
+PRIVATE_AI_GATEWAY_INFERENCE_TOKEN=<long-random-client-token-not-passed-to-deployment>
+PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256=<sha256-of-inference-token>
+PRIVATEMODE_API_KEY=<privatemode-api-key-passed-only-as-encrypted-env>
+PRIVATEMODE_MANIFEST_PATH=</absolute/path/to/exact-reviewed-manifest.json>

--- a/deploy/render-privatemode-compose.sh
+++ b/deploy/render-privatemode-compose.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Render a self-contained measured Compose document while preserving the
+# reviewed Privatemode manifest byte-for-byte.
+
+set -euo pipefail
+
+PROG=render-privatemode-compose.sh
+die() { printf '[%s] error: %s\n' "$PROG" "$*" >&2; exit 1; }
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "required tool not found in PATH: $1"
+}
+
+[[ $# -eq 1 ]] || die "usage: $PROG OUTPUT.json"
+output=$1
+[[ -n $output ]] || die "output path must not be empty"
+
+for name in \
+  PRIVATE_AI_GATEWAY_REPO_COMMIT \
+  PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256 \
+  PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256 \
+  PRIVATEMODE_MANIFEST_PATH \
+  PRIVATEMODE_API_KEY
+do
+  [[ -n ${!name:-} ]] || die "$name must be set"
+done
+
+require_tool docker
+require_tool jq
+require_tool sha256sum
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd)
+manifest_path=$(realpath -- "$PRIVATEMODE_MANIFEST_PATH")
+[[ -f $manifest_path ]] || die "manifest is not a regular file: $manifest_path"
+jq -e . "$manifest_path" >/dev/null || die "manifest is not valid JSON: $manifest_path"
+
+PRIVATEMODE_MANIFEST_PATH=$manifest_path
+PRIVATEMODE_MANIFEST_SHA256=$(sha256sum "$manifest_path" | cut -d' ' -f1)
+PRIVATEMODE_CREDENTIAL_SHA256=$(
+  printf '%s' "$PRIVATEMODE_API_KEY" | sha256sum | cut -d' ' -f1
+)
+export \
+  PRIVATEMODE_MANIFEST_PATH \
+  PRIVATEMODE_MANIFEST_SHA256 \
+  PRIVATEMODE_CREDENTIAL_SHA256
+
+mkdir -p -- "$(dirname -- "$output")"
+tmp=$(mktemp "${output}.tmp.XXXXXX")
+trap 'rm -f -- "$tmp"' EXIT
+
+# `docker compose config` keeps file-backed configs as host paths. Replace that
+# one path with a JSON string loaded by jq --rawfile, which preserves every
+# manifest byte including whitespace and the final newline.
+docker compose -f "$script_dir/compose.privatemode.yaml" config --format json \
+  | jq --rawfile manifest "$manifest_path" '
+      .configs["privatemode-manifest"].content = $manifest
+      | del(.configs["privatemode-manifest"].file)
+    ' >"$tmp"
+
+rendered_manifest_sha256=$(
+  jq -j '.configs["privatemode-manifest"].content' "$tmp" | sha256sum | cut -d' ' -f1
+)
+[[ $rendered_manifest_sha256 == "$PRIVATEMODE_MANIFEST_SHA256" ]] \
+  || die "rendered manifest digest changed: expected $PRIVATEMODE_MANIFEST_SHA256, got $rendered_manifest_sha256"
+
+for secret_name in \
+  PRIVATE_AI_GATEWAY_ADMIN_TOKEN \
+  PRIVATE_AI_GATEWAY_INFERENCE_TOKEN \
+  PRIVATEMODE_API_KEY
+do
+  secret_value=${!secret_name:-}
+  if [[ -n $secret_value ]] && grep -Fq -- "$secret_value" "$tmp"; then
+    die "$secret_name was embedded in the rendered Compose"
+  fi
+done
+
+docker compose -f "$tmp" config --quiet
+mv -- "$tmp" "$output"
+trap - EXIT
+
+printf '[%s] wrote %s (manifest sha256:%s)\n' \
+  "$PROG" "$output" "$PRIVATEMODE_MANIFEST_SHA256" >&2

--- a/deploy/upstreams.example.json
+++ b/deploy/upstreams.example.json
@@ -48,6 +48,14 @@
     "bearer_token": "<phala-direct-api-key>"
   },
   {
+    "name": "privatemode-gpt-oss",
+    "provider": "privatemode",
+    "base_url": "http://privatemode-proxy:8080",
+    "models": {
+      "gpt-oss-120b-private": "gpt-oss-120b"
+    }
+  },
+  {
     "name": "phala-direct-qwen3",
     "provider": "phala-direct",
     "base_url": "https://qwen3.model-b.phala.network",

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -187,16 +187,17 @@ auditor sees the full provider scope. The event carries a stable `provider_type`
 (distinct from the operator's per-endpoint config `name`) that selects the
 mapping. A `failed` result asserts nothing.
 
-| Claim | tinfoil | near-ai | chutes | phala-direct | secret-ai⁴ | generic |
-| --- | --- | --- | --- | --- | --- | --- |
-| `tee_attested` | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ verifier-derived |
-| `tcb_up_to_date` | tri-state¹ | tri-state¹ | tri-state¹ | tri-state¹ | TDX ✅ / SEV unknown | unknown |
-| `serving_software_known_good` | ✅ Sigstore² | unknown | unknown | unknown | optional pin | unknown |
-| `os_known_good` | unknown | unknown | unknown | unknown | ✅ registry | unknown |
-| `gpu_attested` | unknown | unknown | ✅³ | ✅³ | ✅ required | unknown |
-| `model_weights_provenance` | unknown | unknown | unknown | unknown | unknown | unknown |
+| Claim | tinfoil | near-ai | chutes | phala-direct | secret-ai⁴ | privatemode⁵ | generic |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `tee_attested` | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ verifier-derived | ✅ verifier-derived |
+| `tcb_up_to_date` | tri-state¹ | tri-state¹ | tri-state¹ | tri-state¹ | TDX ✅ / SEV unknown | unknown | unknown |
+| `serving_software_known_good` | ✅ Sigstore² | unknown | unknown | unknown | optional pin | unknown | unknown |
+| `os_known_good` | unknown | unknown | unknown | unknown | ✅ registry | unknown | unknown |
+| `gpu_attested` | unknown | unknown | ✅³ | ✅³ | ✅ required | unknown | unknown |
+| `model_weights_provenance` | unknown | unknown | unknown | unknown | unknown | unknown | unknown |
 
-- For the five real provider verifiers `tee_attested` is `HardwareProven`: a
+- For Tinfoil, NEAR AI, Chutes, PhalaDirect, and SecretAI, `tee_attested` is
+  `HardwareProven`: a
   genuine TEE quote was verified and the request channel bound to it. For NEAR AI
   this is the **gateway** TD — a router that fronts many models behind one TEE,
   so its attested session is the gateway *channel*: one session per router, not
@@ -209,6 +210,14 @@ mapping. A `failed` result asserts nothing.
   roadmap item is finer: binding the exact backend instance to a specific request
   (a per-instance, request-bound model attestation on the receipt — see
   [roadmap.md](roadmap.md)).
+- ⁵ Privatemode delegates Contrast verification and E2EE-secret ownership to the
+  official proxy co-deployed inside the gateway's measured dstack Compose. The
+  gateway pins the internal origin, manifest, Coordinator policy, shared
+  credential digest, and proxy OCI image digest, then requires an internal
+  model-list probe before it emits that binding. The proxy applies its static
+  credential outbound; the gateway sends no internal Bearer. It does not
+  independently receive the hardware quote, so the typed claim is
+  `VerifierDerived`; raw manifest facts remain in `claims.extra`.
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status
   **refutes** (the quote proves a stale TCB — the gateway records the bad claim

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -42,8 +42,25 @@ This is the smallest practical container config.
 | `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
+| `admin_token_sha256` | unset | Optional SHA-256 policy for the admin token supplied by config or `PRIVATE_AI_GATEWAY_ADMIN_TOKEN`. Startup fails on a missing or mismatched token. |
+| `inference_token_sha256` | unset | SHA-256 of the downstream bearer accepted by inference POST endpoints; required when `privatemode_proxy` is configured. The high-entropy bearer remains client-side. Missing or mismatched credentials are rejected before request parsing or forwarding. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
 | `middleware` | unset | Optional middleware section. When present, the gateway consults a control plane to route and authorize each request and applies request/response transforms; when unset it serves directly. See [Middleware](#middleware). |
+| `privatemode_proxy` | unset | Static policy for an official Privatemode proxy co-deployed in the same measured dstack Compose. Required before a `privatemode` route can load. |
+
+### Privatemode proxy
+
+`privatemode_proxy` belongs in static deployment config, not the mutable
+upstream database. All fields are required when the section is present.
+
+| Field | Meaning |
+| --- | --- |
+| `privatemode_proxy.base_url` | Internal HTTP(S) origin of the co-deployed proxy. Paths, credentials, queries, and fragments are rejected. |
+| `privatemode_proxy.manifest_path` | Absolute path to the reviewed manifest mounted into the gateway. |
+| `privatemode_proxy.manifest_sha256` | SHA-256 of the exact manifest bytes. The optional `sha256:` prefix is accepted. |
+| `privatemode_proxy.credential_path` | Absolute path to the Compose secret source mounted into both gateway and proxy. The gateway validates and drops its bytes at startup; the proxy owns their use. |
+| `privatemode_proxy.credential_sha256` | SHA-256 of that mounted API credential. The renderer derives it from `PRIVATEMODE_API_KEY`; a mismatch in the live shared secret fails startup. |
+| `privatemode_proxy.proxy_image_digest` | OCI digest of the proxy image pinned in the same Compose, in `sha256:<64-hex>` form. |
 
 ## Middleware
 
@@ -189,6 +206,7 @@ Supported `provider` values:
 | `near-ai` | NEAR AI provider adapter. |
 | `chutes` | Chutes provider adapter. |
 | `secret-ai` | Direct SecretAI SecretVM origin with optional workload pinning; see [SecretAI verification](providers/secret-ai/verification.md). |
+| `privatemode` | Official Privatemode proxy co-deployed in the measured Compose. Forbids `bearer_token` and `path`, and requires a `base_url` exactly matching static `privatemode_proxy.base_url`. |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint. |
 
 Provider verification policy belongs on the upstream entry. For ACI service
@@ -213,6 +231,24 @@ For `aci-service`, `base_url` is the HTTPS origin used for both model traffic an
 derives the attested TLS SPKI binding from that report, then pins that SPKI for
 the actual upstream model request.
 
+For `privatemode`, dstack Compose owns the proxy process, image pin, manifest
+mount, restart policy, and private network. The gateway verifies the static
+manifest pin at startup and refuses a mutable route whose `base_url` differs
+from the static internal origin. It also validates the actual shared Compose
+secret against measured `credential_sha256`. An unauthenticated internal
+model-list probe must succeed before the verifier emits the manifest/image and
+credential binding. Configure at most one
+`privatemode` entry per proxy; place every model using that credential in the
+entry's `models` map. The official proxy loads that credential from a
+Compose-managed secret file at startup. The static `credential_sha256` makes it
+immutable across route removal and gateway-only restarts. Separate credentials
+require separate measured proxy deployments rather than extra entries pointing
+to one service. The backend independently accepts only the encrypted v1.48
+handlers (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, and
+`/v1/messages`) so a mutable route cannot select the proxy's unencrypted model
+catalog.
+See [Privatemode verification](providers/privatemode/verification.md).
+
 ## Environment Variables
 
 The gateway runtime reads only these environment variables. Provider verifier
@@ -222,6 +258,8 @@ bridges may consume provider-specific environment variables such as
 | Variable | Use |
 | --- | --- |
 | `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Selects the static gateway config file. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Optional runtime secret overriding static `admin_token`. |
+| `PRIVATE_AI_GATEWAY_ENV_FILE` | Optional dotenv file consulted for `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` when that variable is absent. The Privatemode Compose points it at dstack's decrypted, TEE-internal deployment environment. |
 | `RUST_LOG` | Tracing filter consumed by `tracing_subscriber`. |
 
 Deployment tooling also uses these variables:
@@ -233,4 +271,9 @@ Deployment tooling also uses these variables:
 | `RUSTUP_HOME` | Optional override for Rustup state. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
 | `CARGO_TARGET_DIR` | Optional override for Cargo build output. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
 | `PRIVATE_AI_GATEWAY_REPO_COMMIT` | Used by `deploy/compose.yaml` interpolation for the git-launcher `COMMIT_SHA` pin. |
-| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Used by `deploy/compose.yaml` interpolation for the static config's `admin_token`. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | `deploy/compose.yaml` interpolates this legacy input; `compose.privatemode.yaml` instead reads it from dstack's TEE-internal decrypted environment file. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256` | Non-secret digest rendered into `compose.privatemode.yaml`; binds the encrypted admin token to measured static policy. |
+| `PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256` | Non-secret digest rendered into `compose.privatemode.yaml`; binds the client-held bearer required by paid inference endpoints. |
+| `PRIVATEMODE_MANIFEST_PATH` | Absolute path to the exact reviewed manifest file. The renderer preserves its bytes in the generated Compose config mounted into both services. |
+| `PRIVATEMODE_MANIFEST_SHA256` | Used by `deploy/compose.privatemode.yaml` to pin those exact manifest bytes in static gateway policy. |
+| `PRIVATEMODE_API_KEY` | Encrypted deployment input mounted as one Compose secret into both services. The renderer derives `PRIVATEMODE_CREDENTIAL_SHA256` for measured static policy; the gateway verifies the live mounted bytes before serving. |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -13,6 +13,7 @@ One directory per upstream provider. Each holds up to two documents:
 | Chutes | Intel TDX + NVIDIA CC | `e2ee_public_key_sha256` | [configuration](chutes/configuration.md), [verification](chutes/verification.md) | [review](chutes/review.md) |
 | NEAR AI | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](near-ai/verification.md) | [review](near-ai/review.md) |
 | Tinfoil | AMD SEV-SNP (or TDX) + NVIDIA CC | `tls_spki_sha256` | [verification](tinfoil/verification.md) | [review](tinfoil/review.md) |
+| Privatemode | AMD SEV-SNP or Intel TDX + NVIDIA CC | `manifest_image_sha256` | [verification](privatemode/verification.md) | [review](privatemode/review.md) |
 | AciService (first-party) | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](aci-service/verification.md) | — (first-party) |
 | PhalaDirect | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](phala-direct/verification.md) | [review](phala-direct/review.md) |
 | SecretAI | AMD SEV-SNP or Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](secret-ai/verification.md) | [review](secret-ai/review.md) |
@@ -49,18 +50,24 @@ partition from Redpill tenant identity.
 
 ## The shared verification model
 
-**A session binding is only trustworthy if it is bound into a verified attestation.**
-Every provider produces exactly one kind of binding, and in every case the bound value
-lives inside (or is digested into) the quote/report whose signature is verified. Each
-`verification.md` states plainly *what is bound* and *what a tamper rejects*.
+**A session binding is only trustworthy if it is bound into a verified attestation or
+an attestation-gated key-release protocol.** Every provider produces exactly one kind
+of binding. The bound value either lives inside the signed quote/report or identifies
+the attested policy that gates the provider's encryption secret. Each `verification.md`
+states plainly *what is bound* and *what a tamper rejects*.
 
-The two binding types:
+The binding types:
 
 - **`tls_spki_sha256`** — SHA-256 fingerprint of the upstream's TLS public key; the
   backend enforces it against the actual upstream HTTPS connection before forwarding.
 - **`e2ee_public_key_sha256`** — SHA-256 of the upstream's end-to-end public key; the
   backend encrypts the request body to that key, so only the attested enclave can
   decrypt.
+- **`manifest_image_sha256`** — SHA-256 of an attestation manifest plus its
+  Coordinator policy hash, shared credential digest, and official proxy OCI
+  image digest. dstack launches the proxy beside the gateway from the same
+  measured Compose, and the gateway accepts only the statically pinned internal
+  service origin.
 
 ### Invariant: verified ⟹ enforceable binding
 

--- a/docs/providers/privatemode/review.md
+++ b/docs/providers/privatemode/review.md
@@ -1,0 +1,160 @@
+# Privatemode provider review
+
+Audit date: 2026-05-26 UTC. Provider behavior was rechecked against
+Privatemode v1.48 and the live manifest on 2026-07-09. The gateway adapter was
+changed to the measured co-deployment boundary on 2026-07-13.
+
+Provider: [Privatemode](https://www.privatemode.ai/) by Edgeless Systems.
+TCB source: [`edgelesssys/privatemode-public`](https://github.com/edgelesssys/privatemode-public).
+Attestation framework: [`edgelesssys/contrast`](https://github.com/edgelesssys/contrast).
+
+## Verdict
+
+**Acceptable with conditions.** Privatemode has one of the strongest engineering
+postures in the surveyed provider set. Its full encryption lifecycle was
+reproduced against production: the client proxy verified the Coordinator,
+obtained the attested Mesh CA, exchanged an inference secret, encrypted a live
+chat request, decrypted the response, and streamed successfully. The public API
+rejected a plaintext request.
+
+Admission conditions:
+
+- Pin a reviewed manifest digest instead of trusting automatic CDN updates.
+- Pin the official proxy OCI image by digest in the same measured dstack
+  Compose as the gateway.
+- Mount the same reviewed manifest into both services and repeat its digest and
+  proxy image digest in static gateway policy.
+- Require every mutable Privatemode route to use the statically pinned internal
+  service origin.
+- Disable HTTP redirects for proxy readiness and forwarding requests.
+- Bind the accepted credential digest in measured static policy and require a
+  coordinated gateway/proxy redeploy to change it, matching the proxy's
+  startup credential ownership semantics.
+- Expose only the gateway listener from the workload network. Version 1.48 of
+  the official proxy has no listen-address flag and opens its configured port on
+  the network namespace's wildcard address.
+- Override the proxy's availability-oriented NVIDIA OCSP defaults: reject
+  unknown status and use no revoked-certificate grace period.
+- Treat the proxy as part of the TCB: the gateway verifies its manifest binding
+  but does not possess the provider E2EE secret.
+
+## Verified trust chain
+
+The observed chain was:
+
+```text
+SEV-SNP or TDX hardware evidence
+  -> Contrast reference values in the pinned manifest
+    -> Coordinator policy admitted
+      -> attested Coordinator supplies Mesh CA
+        -> Secret Service authenticates under that Mesh CA
+          -> inference secret released only to admitted workers
+            -> official proxy encrypts request bodies to those workers
+```
+
+The manifest pins workload policies and hardware reference values. During the
+original audit it included strict SNP guest policy and chip allowlists, TDX
+measurements/platform identities, minimum TCB versions, and separate policies
+for the Coordinator, Secret Service, and model workloads. The 2026-07-09 live
+manifest still contained exactly one Coordinator policy, SNP and TDX reference
+profiles, and one seed-share owner key.
+
+Privatemode's model workers place decryption in an inference-proxy sidecar
+inside the confidential VM. Plaintext is then passed locally to the model
+server. The public edge sees encrypted bodies and routes them to workers.
+
+## Criteria status
+
+Passed:
+
+- Workload identity is measured and admitted under Contrast policy.
+- The inference secret is released through an attested Mesh-CA chain.
+- CPU-TEE and GPU confidential-computing checks gate worker activation.
+- Model workloads and deployment images are published in the TCB source.
+- Builds are reproducible and releases are versioned.
+- The public endpoint rejects unencrypted inference traffic.
+- OpenAI-compatible chat, streaming, embeddings, models, and other documented
+  surfaces are mediated by the official proxy.
+
+Open or conditional:
+
+- The manifest publication channel has no detached signature. In automatic
+  mode the initial trust seed is CDN TLS. The gateway adapter closes this gap
+  operationally by requiring an explicit SHA-256 manifest pin and measured
+  static-manifest mode.
+- The observed manifest has one RSA seed-share owner key. Public ownership,
+  recovery procedure, rotation policy, and quorum expectations should be
+  documented.
+- Privatemode does not expose a per-worker TLS SPKI or public E2EE key for the
+  gateway to pin directly. Its binding is transitive through the manifest,
+  attested Coordinator/Mesh CA, and secret-release protocol.
+- The exact served worker is not named in a per-request signed receipt. ACI
+  records the selected model and verified router-scoped manifest session.
+
+## Live observations from the original audit
+
+- The official proxy completed attestation and became ready in roughly ten
+  seconds.
+- A live chat request and an SSE streaming request succeeded over the encrypted
+  path.
+- A direct plaintext request to the public API returned HTTP 400 with the
+  `privatemode-encrypted: false` signal.
+- Streaming latency was stable in the sampled runs: time to first byte was
+  approximately 0.24 seconds across the tested models, with low run-to-run
+  throughput variance. These figures are operational observations, not
+  security guarantees.
+
+## Adapter validation
+
+The adapter tests run a persistent HTTP service at the same boundary as the
+Compose sidecar. They verify that manifest bytes are checked and retained at
+static-policy construction, the actual shared credential file matches measured
+policy, an unauthenticated internal model-list probe gates verified events, no
+Bearer crosses the gateway-to-proxy hop, and both buffered and streaming
+forwards reject v1.48's unencrypted handlers before network I/O. Remaining
+forwards require the exact receipt binding, and receipts record the manifest,
+Coordinator policy, credential digest, proxy image digest, and internal origin.
+Config tests reject provider credentials, path overrides, and deployment fields
+in mutable upstream config; deployment tests pin the official image while
+ensuring its port is not published.
+
+The earlier child-supervisor prototype was exercised end to end against the
+production service on 2026-07-10, but that process-management boundary is no
+longer part of the adapter. The replacement boundary was deployed and tested on
+Phala Cloud on 2026-07-13:
+
+- CVM `d0639110-1749-4c8f-9d1c-b49bb50afe32`, app ID
+  `900ea355e7a448a2b27ad0a361eb6d71959bd8eb`, ran gateway commit
+  `957b66aec31105a9fa6ca195536338443a24a055` under measured Compose hash
+  `36b3611cdad52124bd5218bb4ccae84200c75dc91d9cc4bda045b79f2084fab1`.
+- The official v1.48.0 proxy loaded the Clawdi-vault-backed API key from a
+  Compose secret, verified the production SNP report, accepted the exact
+  reviewed manifest, obtained its inference secret, and returned HTTP 200 from
+  its proxy-authenticated outbound model-list request.
+- A real `gpt-oss-120b` chat returned HTTP 200 and exactly
+  `compose-sidecar-live-ok`. Signed receipt
+  `rcpt-11a09da8994a59a5826d08a8` recorded the internal origin, manifest SHA-256
+  `b4a4e1c372a507a1771f7f2f9b7c2fa7f04202855588e26f795d0249454572bf`,
+  Coordinator policy
+  `180d10463bdeccaf6c0ae6e0c01d26149f7cd1d2c1b2b4f3352224ef4510b9bf`,
+  and proxy image digest
+  `sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307`.
+
+A later v1.48 source trace found that an inbound Bearer is ignored once
+`--apiKey` has initialized the proxy: the proxy overwrites outbound
+`Authorization` with its static credential. The July 13 run therefore remains
+valid transport and attestation evidence, but its receipt did not independently
+prove the credential digest. The current adapter fixes that gap by mounting one
+secret source into both services, validating its measured digest in the gateway,
+sending no internal Bearer, and recording the credential digest in the channel
+binding.
+
+## Adapter decision
+
+The gateway does not reimplement Contrast or copy only its quote checks. dstack
+owns the official proxy lifecycle as a separate service in the same measured
+Compose. The gateway verifier and forwarding backend share immutable static
+policy for that service. Receipts bind the exact manifest and Coordinator
+policy, shared credential digest, official proxy image digest, and internal
+origin that carried the request. See [verification.md](verification.md) for the
+enforced contract.

--- a/docs/providers/privatemode/verification.md
+++ b/docs/providers/privatemode/verification.md
@@ -1,0 +1,199 @@
+# Privatemode — co-deployed delegated attestation
+
+- **TEE:** AMD SEV-SNP or Intel TDX + NVIDIA Confidential Computing
+- **Session binding:** `manifest_image_sha256`: reviewed Contrast manifest,
+  Coordinator policy, shared credential digest, and official proxy OCI image
+  digest
+- **Verifier:** official `privatemode-proxy` co-deployed in the gateway's
+  measured dstack Compose
+- **Transport:** private Compose HTTP to the proxy; Privatemode full-body E2EE
+  from the proxy to model workers
+- **Audit:** see [review.md](review.md)
+
+## Trust boundary
+
+Privatemode deliberately couples verification and encryption. The official
+proxy verifies the Contrast Coordinator against a manifest, obtains the Mesh
+CA, exchanges an inference secret with the Secret Service, and uses that secret
+to encrypt inference bodies. Reimplementing only the quote check would not bind
+gateway traffic to the secret released by that protocol.
+
+The gateway therefore delegates this protocol to the official proxy, but it
+does not run the proxy as a child process. dstack launches the gateway and proxy
+as separate services in one measured Compose workload. That measurement binds
+the proxy image digest, its command, the manifest mount, and the private network
+topology. The proxy port is not published.
+Its workspace is an unpersisted `tmpfs`, so a service restart cannot silently
+reuse credential or Contrast state from an earlier container generation.
+The proxy is launched with `--nvidiaOCSPAllowUnknown=false` and
+`--nvidiaOCSPRevokedGracePeriod=0`; unknown or revoked NVIDIA certificate
+status therefore fails closed instead of using the availability-oriented
+upstream defaults.
+
+The gateway's static config separately pins:
+
+- the internal proxy origin;
+- the exact manifest path and SHA-256 digest;
+- the SHA-256 digest of the one accepted API credential;
+- the official proxy OCI image digest recorded in the Compose file.
+
+These fields cannot be changed through `PUT /v1/admin/upstreams`. A dynamic
+Privatemode route is accepted only when its `base_url` exactly matches the
+static origin; `bearer_token` is forbidden because the proxy owns provider
+authentication, and `path` is forbidden because v1.48 has both encrypted and
+unencrypted handlers. This prevents an admin-config update from redirecting
+plaintext to a different proxy, injecting a second credential path, or selecting
+an unencrypted proxy handler.
+
+## Verification and forwarding
+
+At startup, the gateway reads the mounted manifest and the same Compose secret
+source mounted into the proxy. It verifies both measured digests, drops the
+credential bytes, and requires exactly one Coordinator policy. When a route is
+verified, the gateway sends an unauthenticated `GET /v1/models` to the pinned
+internal origin using a client that ignores HTTP proxy environment variables.
+The proxy started only after using its static `--apiKey` to complete Contrast
+verification and inference-secret exchange; it attaches that credential to the
+outbound model-list request itself. The gateway must not send an internal
+Bearer: in v1.48 the proxy would ignore it once the static credential exists.
+The client rejects redirects, so a forwarded prompt cannot leave the pinned
+internal origin. The probe has an end-to-end deadline and rejects model-list
+bodies over 1 MiB, including chunked responses without a declared length.
+
+The verifier emits a verified event only after this probe returns a JSON model
+list. The forwarding backend accepts only that exact manifest/image binding,
+then sends OpenAI-compatible requests to the same internal origin. Independently
+of config validation, it permits only the pinned v1.48 encrypted handler set:
+`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, and
+`/v1/messages`. In particular, inference can never target the proxy's
+unencrypted `/v1/models` forwarder. The proxy performs Privatemode full-body
+encryption and response decryption.
+Successful probes use the configured `verifier_cache_seconds` lease. Normal
+requests reuse the binding until expiry, proactive refresh performs a fresh
+probe, and invalidation discards the cached event.
+
+Plain HTTP is intentional at this hop. It is not a remote trust channel: both
+endpoints and their private network are inside the same attested dstack
+workload. Adding a self-signed TLS layer would encrypt the same in-workload hop
+without independently authenticating the measured service. The security
+requirements are instead that the proxy remains in the measured Compose and
+its port is never published.
+
+## Configuration
+
+Use [`deploy/compose.privatemode.yaml`](../../../deploy/compose.privatemode.yaml)
+and set the reviewed manifest file and digest before deployment:
+
+```bash
+export PRIVATE_AI_GATEWAY_REPO_COMMIT=<audited-commit>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<admin-token>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN=<long-random-client-token>
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_INFERENCE_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATEMODE_API_KEY=<privatemode-api-key>
+export PRIVATEMODE_MANIFEST_PATH=/absolute/path/to/exact-reviewed-manifest.json
+
+deploy/render-privatemode-compose.sh /tmp/private-ai-gateway-privatemode.json
+phala-h4xuser deploy -n private-ai-gateway \
+  -c /tmp/private-ai-gateway-privatemode.json \
+  -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN="$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -e PRIVATEMODE_API_KEY="$PRIVATEMODE_API_KEY"
+```
+
+Rendering makes the exact manifest bytes and non-secret pins part of the
+measured Compose. The renderer verifies that inline serialization preserves the
+manifest file's SHA-256, including its whitespace and final newline.
+The admin and Privatemode secrets remain outside it and enter only through the
+encrypted deployment environment. The renderer derives the credential digest
+from `PRIVATEMODE_API_KEY`; Compose mounts one secret source into the gateway
+and the proxy. The gateway verifies the actual mounted bytes against that
+measured digest at startup, while the proxy consumes the same source through
+`--apiKey @<file>`. The downstream inference token never enters the deployment:
+only its digest is measured, and clients present the token as a Bearer
+credential on every inference request.
+
+The measured static gateway config has this shape:
+
+```json
+{
+  "inference_token_sha256": "<sha256-of-high-entropy-client-bearer>",
+  "privatemode_proxy": {
+    "base_url": "http://privatemode-proxy:8080",
+    "manifest_path": "/run/privatemode/manifest.json",
+    "manifest_sha256": "<64-lowercase-hex-characters>",
+    "credential_path": "/run/secrets/privatemode-api-key",
+    "credential_sha256": "<sha256-of-privatemode-api-key>",
+    "proxy_image_digest": "sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+  }
+}
+```
+
+Configure the mutable model route after boot:
+
+```json
+[
+  {
+    "name": "privatemode",
+    "provider": "privatemode",
+    "base_url": "http://privatemode-proxy:8080",
+    "models": {
+      "gpt-oss-120b-private": "gpt-oss-120b"
+    }
+  }
+]
+```
+
+One co-deployed proxy supports one gateway upstream entry. Put all models that
+share its credential in that entry. The official proxy loads one credential
+from its Compose secret file at startup, and the gateway validates that same
+mounted source against static `credential_sha256`. To rotate the key, rerender
+with the new `PRIVATEMODE_API_KEY` and redeploy both services. If distinct
+credentials are required, deploy distinct measured proxy services rather than
+pointing multiple entries at one service.
+
+## Session binding
+
+The verifier emits one binding:
+
+```json
+{
+  "type": "manifest_image_sha256",
+  "provider": "privatemode",
+  "manifest_sha256": "...",
+  "coordinator_policy_hash": "...",
+  "proxy_image_digest": "sha256:...",
+  "credential_sha256": "..."
+}
+```
+
+The event's `url_origin` is the pinned internal service origin. Its verifier id
+is `privatemode-proxy/co-deployed-contrast/v1`. The exact manifest bytes are
+retained as verification evidence.
+
+## Failure behavior
+
+The route fails closed when static proxy policy is absent; the route origin
+differs from the static origin; the manifest is missing, malformed, or has the
+wrong digest; the mounted credential is missing, malformed, or differs from its
+measured digest; the manifest does not contain exactly one Coordinator policy;
+the proxy image digest is malformed; mutable config supplies a bearer or path;
+the model-list probe fails; forwarding targets a handler outside the encrypted
+allowlist; or the verified receipt binding differs from the active deployment.
+
+There is no fallback to the public Privatemode API, an operator-supplied remote
+proxy, an HTTP redirect, or an HTTP proxy from the process environment. Proxy
+error bodies are not exposed in public verification failures. Container
+restart and lifecycle policy belong to Compose.
+
+## Updates
+
+A manifest or proxy-image change alters the channel TCB. Review both changes,
+update the manifest digest and image digest in the measured static deployment,
+and redeploy. A dynamic upstream-config replacement cannot mutate these pins.
+
+## Sources
+
+- [Privatemode attestation overview](https://docs.privatemode.ai/architecture/attestation/overview/)
+- [Privatemode proxy configuration](https://docs.privatemode.ai/api/proxy-configuration/)
+- [Privatemode TCB source](https://github.com/edgelesssys/privatemode-public)
+- [Contrast source](https://github.com/edgelesssys/contrast)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,7 +59,9 @@ An attested session is a verified secure channel, and we never create more than
 one session per channel. The channel boundary a provider attests is a first-class
 property, `UpstreamProvider::attestation_scope()` → `AttestationScope`: per E2EE
 instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
-(NEAR AI) or model router (Tinfoil), where one channel fronts many models. The
+(NEAR AI), model router (Tinfoil), or manifest-bound encryption proxy
+(Privatemode's measured co-deployed proxy), where one channel fronts
+many models. The
 scope is the single source of truth: it drives channel-keyed verification (the
 model is dropped from the verifier cache key for routers, so every model resolves
 to one verified channel and one attested session) and is enforced fail-closed at

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,10 @@
 #   toolchain is our concern, not the launcher's.
 #
 # What it does
-#   1. If `cargo` is not on PATH, this aggregator chooses to bootstrap a
-#      Rust toolchain via apt + rustup. That choice is internal to the
-#      aggregator (see "Aggregator-owned trust surface" below) and would
-#      become dead code under a Rust-capable aggregator image.
+#   1. Installs any missing native build toolchain, and if `cargo` is not on
+#      PATH bootstraps Rust via apt + rustup. Those choices are internal to
+#      the aggregator (see "Aggregator-owned trust surface" below) and would
+#      become dead code under a build-capable aggregator image.
 #   2. Builds in release mode with --locked so Cargo.lock is authoritative
 #      (a rebuild that would require resolver-level changes is a hard
 #      failure, not silent dependency drift).
@@ -35,21 +35,22 @@
 #     hard exit.
 #
 # Aggregator-owned trust surface in this slice
-#   This slice chooses runtime apt + rustup bootstrap so the aggregator
+#   This slice chooses runtime apt + build-essential + rustup bootstrap so the aggregator
 #   can run on top of the stock launcher image unchanged. That choice
-#   brings three things into this aggregator's trust surface that a
-#   pre-built Rust-capable aggregator image would not:
+#   brings four things into this aggregator's trust surface that a
+#   pre-built build-capable aggregator image would not:
 #
 #     * the Ubuntu archive index that apt-get fetches at deploy time;
+#     * the native compiler and linker shipped by build-essential;
 #     * the rustup CDN / signature key shipped by the rustup package;
 #     * whichever rustc the upstream stable channel resolved to at build
 #       time.
 #
-#   The production fix is a Rust-capable aggregator image - owned by
-#   this repo, not by the launcher - that pre-installs rustc/cargo and
+#   The production fix is a build-capable aggregator image - owned by
+#   this repo, not by the launcher - that pre-installs cc/rustc/cargo and
 #   pre-populates the crate cache. When that image exists, the
-#   `if ! command -v cargo` block becomes dead code; everything else in
-#   this script is unchanged. See deploy/README.md for the recipe.
+#   bootstrap below becomes dead code; everything else in this script is
+#   unchanged. See deploy/README.md for the recipe.
 
 set -euo pipefail
 
@@ -79,16 +80,24 @@ export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-$PRIVATE_AI_GATEWAY_CACHE_DIR/target
 mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$CARGO_TARGET_DIR"
 export PATH="$CARGO_HOME/bin:$PATH"
 
-# Aggregator-internal bootstrap: if no Rust toolchain is present in the
-# image we are running on, this aggregator installs one. The launcher is
-# build-system agnostic and does not care what language we are written
-# in; supplying our own toolchain is our responsibility.
-if ! command -v cargo >/dev/null 2>&1; then
-  log "cargo not on PATH; aggregator bootstrapping a Rust toolchain via apt + rustup."
+# Aggregator-internal bootstrap: install the native build toolchain and/or
+# Rust toolchain when the launcher image does not provide them. Cargo alone is
+# insufficient: Rust build scripts and the final link require `cc`.
+need_cc=0
+need_rust=0
+command -v cc >/dev/null 2>&1 || need_cc=1
+command -v cargo >/dev/null 2>&1 || need_rust=1
+
+if ((need_cc || need_rust)); then
+  apt_packages=(ca-certificates)
+  ((need_cc)) && apt_packages+=(build-essential)
+  ((need_rust)) && apt_packages+=(rustup)
+
+  log "installing missing build prerequisites via apt: ${apt_packages[*]}"
   log "WARNING: dev-grade trust path. The Ubuntu archive index, the rustup"
-  log "package, and the upstream Rust stable channel are part of this"
+  log "package, native compiler, and upstream Rust stable channel are part of this"
   log "aggregator's trust surface in this build-in-TEE configuration."
-  log "Production should publish a Rust-capable aggregator image so the"
+  log "Production should publish a build-capable aggregator image so the"
   log "toolchain is covered by an aggregator-owned image digest instead."
   log "See deploy/README.md."
 
@@ -102,8 +111,10 @@ if ! command -v cargo >/dev/null 2>&1; then
   # 24.04 docker base enables main+restricted+universe+multiverse by default,
   # so this just works. If the deploy customised sources.list and removed
   # universe, the apt-get below fails loud and we exit before building.
-  apt-get install -y --no-install-recommends ca-certificates rustup
+  apt-get install -y --no-install-recommends "${apt_packages[@]}"
+fi
 
+if ((need_rust)); then
   # Install a current stable. --no-self-update so rustup does not silently
   # upgrade itself at runtime; --profile minimal keeps the install to
   # rustc + cargo + std.

--- a/scripts/live_e2e/bfcl_v4.py
+++ b/scripts/live_e2e/bfcl_v4.py
@@ -403,62 +403,67 @@ def run_provider_bfcl(
         env=merged_env(),
         artifact_dir=artifact_dir,
     ) as aggregator:
-        (bfcl_project / ".env").write_text(
+        bfcl_env_path = bfcl_project / ".env"
+        bfcl_env_path.write_text(
             "\n".join(
                 [
                     f"OPENAI_BASE_URL={aggregator.base_url.rstrip('/')}/v1",
-                    "OPENAI_API_KEY=aci-local",
+                    f"OPENAI_API_KEY={aggregator.inference_token}",
                     "",
                 ]
             ),
             encoding="utf-8",
         )
+        bfcl_env_path.chmod(0o600)
         env = {
             **os.environ,
             "BFCL_PROJECT_ROOT": str(bfcl_project),
             "OPENAI_BASE_URL": f"{aggregator.base_url.rstrip('/')}/v1",
-            "OPENAI_API_KEY": "aci-local",
+            "OPENAI_API_KEY": aggregator.inference_token,
             "TOKENIZERS_PARALLELISM": "false",
         }
-        generate = run_bfcl(
-            bfcl_dir,
-            [
-                "generate",
-                "--model",
-                bfcl_public_model,
-                "--run-ids",
-                "--allow-overwrite",
-                "--num-threads",
-                str(num_threads),
-                "--result-dir",
-                "result",
-            ],
-            cwd=bfcl_dir,
-            env=env,
-            stdout_path=artifact_dir / "bfcl.generate.stdout",
-            stderr_path=artifact_dir / "bfcl.generate.stderr",
-            timeout_seconds=timeout_seconds,
-        )
-        evaluate = run_bfcl(
-            bfcl_dir,
-            [
-                "evaluate",
-                "--model",
-                bfcl_public_model,
-                "--test-category",
-                ",".join(sampled_categories),
-                "--partial-eval",
-                "--result-dir",
-                "result",
-                "--score-dir",
-                "score",
-            ],
-            cwd=bfcl_dir,
-            env=env,
-            stdout_path=artifact_dir / "bfcl.evaluate.stdout",
-            stderr_path=artifact_dir / "bfcl.evaluate.stderr",
-            timeout_seconds=timeout_seconds,
-        )
+        try:
+            generate = run_bfcl(
+                bfcl_dir,
+                [
+                    "generate",
+                    "--model",
+                    bfcl_public_model,
+                    "--run-ids",
+                    "--allow-overwrite",
+                    "--num-threads",
+                    str(num_threads),
+                    "--result-dir",
+                    "result",
+                ],
+                cwd=bfcl_dir,
+                env=env,
+                stdout_path=artifact_dir / "bfcl.generate.stdout",
+                stderr_path=artifact_dir / "bfcl.generate.stderr",
+                timeout_seconds=timeout_seconds,
+            )
+            evaluate = run_bfcl(
+                bfcl_dir,
+                [
+                    "evaluate",
+                    "--model",
+                    bfcl_public_model,
+                    "--test-category",
+                    ",".join(sampled_categories),
+                    "--partial-eval",
+                    "--result-dir",
+                    "result",
+                    "--score-dir",
+                    "score",
+                ],
+                cwd=bfcl_dir,
+                env=env,
+                stdout_path=artifact_dir / "bfcl.evaluate.stdout",
+                stderr_path=artifact_dir / "bfcl.evaluate.stderr",
+                timeout_seconds=timeout_seconds,
+            )
+        finally:
+            bfcl_env_path.unlink(missing_ok=True)
 
     score = collect_scores(bfcl_project, bfcl_public_model)
     result = {

--- a/scripts/live_e2e/cases/embeddings.py
+++ b/scripts/live_e2e/cases/embeddings.py
@@ -8,7 +8,6 @@ from ..common import Provider, json_bytes, request_json, run_cmd_json, write_byt
 from .attested_sessions import assert_upstream_attested_sessions
 
 
-REQUESTER_TOKEN = "live-e2e-requester"
 PROBE_INPUT = "Reply with exactly one short sentence confirming ACI embeddings lifecycle."
 
 
@@ -17,6 +16,7 @@ def run_embeddings_case(
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     provider_dir = artifact_dir / provider.name / "embeddings"
     body = {
@@ -30,7 +30,7 @@ def run_embeddings_case(
         "POST",
         f"{base_url}/v1/embeddings",
         headers={
-            "Authorization": f"Bearer {REQUESTER_TOKEN}",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,
@@ -67,7 +67,7 @@ def run_embeddings_case(
     receipt_status, _, receipt_body, receipt_json = request_json(
         "GET",
         f"{base_url}/v1/signature/{receipt_id}",
-        headers={"Authorization": f"Bearer {REQUESTER_TOKEN}"},
+        headers={"Authorization": f"Bearer {inference_token}"},
         timeout=120,
     )
     receipt_path = provider_dir / "receipt.json"

--- a/scripts/live_e2e/cases/fidelity_structured_outputs.py
+++ b/scripts/live_e2e/cases/fidelity_structured_outputs.py
@@ -21,6 +21,7 @@ def run_structured_outputs_case(
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     if not provider.has_capability("structured_outputs"):
         return {"provider": provider.name, "status": "skipped", "reason": "capability_absent"}
@@ -71,7 +72,7 @@ def run_structured_outputs_case(
         "POST",
         f"{base_url}/v1/chat/completions",
         headers={
-            "Authorization": "Bearer live-e2e-structured",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,

--- a/scripts/live_e2e/cases/lifecycle.py
+++ b/scripts/live_e2e/cases/lifecycle.py
@@ -8,14 +8,12 @@ from ..common import Provider, json_bytes, request_json, run_cmd_json, write_byt
 from .attested_sessions import assert_upstream_attested_sessions
 
 
-REQUESTER_TOKEN = "live-e2e-requester"
-
-
 def run_lifecycle_case(
     *,
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     provider_dir = artifact_dir / provider.name / "lifecycle"
     body = {
@@ -36,7 +34,7 @@ def run_lifecycle_case(
         "POST",
         f"{base_url}/v1/chat/completions",
         headers={
-            "Authorization": f"Bearer {REQUESTER_TOKEN}",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,
@@ -72,7 +70,7 @@ def run_lifecycle_case(
     receipt_status, _, receipt_body, receipt_json = request_json(
         "GET",
         f"{base_url}/v1/signature/{chat_id}",
-        headers={"Authorization": f"Bearer {REQUESTER_TOKEN}"},
+        headers={"Authorization": f"Bearer {inference_token}"},
         timeout=120,
     )
     receipt_path = provider_dir / "receipt.json"

--- a/scripts/live_e2e/common.py
+++ b/scripts/live_e2e/common.py
@@ -40,6 +40,9 @@ class Provider:
     chutes_chute_ids: dict[str, str]
     chutes_e2ee_discovery_rounds: int | None
     chutes_e2ee_discovery_interval_seconds: int | None
+    privatemode_manifest_path: str | None
+    privatemode_manifest_sha256: str | None
+    privatemode_proxy_image_digest: str | None
 
     @classmethod
     def from_json(cls, value: dict[str, Any]) -> "Provider":
@@ -65,6 +68,15 @@ class Provider:
             ),
             chutes_e2ee_discovery_interval_seconds=optional_int(
                 value, "chutes_e2ee_discovery_interval_seconds"
+            ),
+            privatemode_manifest_path=optional_str(
+                value, "privatemode_manifest_path"
+            ),
+            privatemode_manifest_sha256=optional_str(
+                value, "privatemode_manifest_sha256"
+            ),
+            privatemode_proxy_image_digest=optional_str(
+                value, "privatemode_proxy_image_digest"
             ),
         )
 

--- a/scripts/live_e2e/launch_aggregator.py
+++ b/scripts/live_e2e/launch_aggregator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import os
+import secrets
 import signal
 import subprocess
 import tempfile
@@ -29,6 +31,7 @@ class AggregatorProcess:
         dstack_endpoint: str = DEFAULT_DSTACK_ENDPOINT,
         env: dict[str, str] | None = None,
         artifact_dir: Path | None = None,
+        inference_token: str | None = None,
     ) -> None:
         self.providers = providers
         self.port = port
@@ -36,6 +39,13 @@ class AggregatorProcess:
         self.dstack_endpoint = dstack_endpoint
         self.env = {**os.environ, **(env or {})}
         self.artifact_dir = artifact_dir
+        if inference_token is None:
+            inference_token = secrets.token_urlsafe(32)
+        if not inference_token or inference_token != inference_token.strip():
+            raise ValueError(
+                "inference_token must be non-empty and have no surrounding whitespace"
+            )
+        self.inference_token = inference_token
         self._tmp: tempfile.TemporaryDirectory[str] | None = None
         self._process: subprocess.Popen[bytes] | None = None
         self.gateway_config_path: Path | None = None
@@ -57,16 +67,30 @@ class AggregatorProcess:
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         config = build_upstream_config(self.providers, self.env)
         write_json(self.upstream_seed_path, config, mode=0o600)
-        write_json(
-            self.gateway_config_path,
-            {
-                "bind": f"127.0.0.1:{self.port}",
-                "state_dir": str(self.state_dir),
-                "upstream_config_seed_path": str(self.upstream_seed_path),
-                "dstack_endpoint": self.dstack_endpoint,
-            },
-            mode=0o600,
+        privatemode_credential_path = None
+        privatemode = [
+            provider for provider in self.providers if provider.provider == "privatemode"
+        ]
+        if privatemode:
+            credential = self.env.get(privatemode[0].api_key_env)
+            if not credential:
+                raise RuntimeError(
+                    f"missing API key env var {privatemode[0].api_key_env}"
+                )
+            privatemode_credential_path = tmp_dir / "privatemode-api-key"
+            privatemode_credential_path.write_text(credential, encoding="utf-8")
+            privatemode_credential_path.chmod(0o600)
+        gateway_config = build_gateway_config(
+            self.providers,
+            self.env,
+            port=self.port,
+            state_dir=self.state_dir,
+            upstream_seed_path=self.upstream_seed_path,
+            dstack_endpoint=self.dstack_endpoint,
+            inference_token=self.inference_token,
+            privatemode_credential_path=privatemode_credential_path,
         )
+        write_json(self.gateway_config_path, gateway_config, mode=0o600)
         if self.artifact_dir:
             write_json(
                 self.artifact_dir / "aggregator-upstreams.redacted.json",
@@ -141,6 +165,78 @@ class AggregatorProcess:
         raise TimeoutError(f"aggregator did not become ready: {last_error}; log: {self.log_path}")
 
 
+def build_gateway_config(
+    providers: list[Provider],
+    env: dict[str, str],
+    *,
+    port: int,
+    state_dir: Path,
+    upstream_seed_path: Path,
+    dstack_endpoint: str,
+    inference_token: str,
+    privatemode_credential_path: Path | None,
+) -> dict[str, Any]:
+    gateway_config: dict[str, Any] = {
+        "bind": f"127.0.0.1:{port}",
+        "state_dir": str(state_dir),
+        "upstream_config_seed_path": str(upstream_seed_path),
+        "dstack_endpoint": dstack_endpoint,
+    }
+    privatemode = [
+        provider for provider in providers if provider.provider == "privatemode"
+    ]
+    if not privatemode:
+        return gateway_config
+
+    first = privatemode[0]
+    credential = env.get(first.api_key_env)
+    if not credential:
+        raise RuntimeError(f"missing API key env var {first.api_key_env}")
+    required = {
+        "manifest_path": first.privatemode_manifest_path,
+        "manifest_sha256": first.privatemode_manifest_sha256,
+        "credential_path": str(privatemode_credential_path)
+        if privatemode_credential_path is not None
+        else None,
+        "credential_sha256": hashlib.sha256(
+            credential.encode("utf-8")
+        ).hexdigest(),
+        "proxy_image_digest": first.privatemode_proxy_image_digest,
+    }
+    missing = [name for name, value in required.items() if value is None]
+    if missing:
+        raise RuntimeError(
+            f"Privatemode live E2E is missing static fields: {', '.join(missing)}"
+        )
+    expected = (
+        first.base_url,
+        first.privatemode_manifest_path,
+        first.privatemode_manifest_sha256,
+        first.privatemode_proxy_image_digest,
+    )
+    if any(
+        (
+            provider.base_url,
+            provider.privatemode_manifest_path,
+            provider.privatemode_manifest_sha256,
+            provider.privatemode_proxy_image_digest,
+        )
+        != expected
+        for provider in privatemode[1:]
+    ):
+        raise RuntimeError(
+            "all Privatemode routes must share one static proxy deployment"
+        )
+    gateway_config["inference_token_sha256"] = hashlib.sha256(
+        inference_token.encode("utf-8")
+    ).hexdigest()
+    gateway_config["privatemode_proxy"] = {
+        "base_url": first.base_url,
+        **required,
+    }
+    return gateway_config
+
+
 def build_upstream_config(
     providers: list[Provider],
     env: dict[str, str],
@@ -155,13 +251,14 @@ def build_upstream_config(
             "provider": provider.provider,
             "base_url": provider.base_url,
             "models": {provider.public_model: provider.upstream_model},
-            "bearer_token": token,
             "connect_timeout_seconds": 10,
             "read_timeout_seconds": 600,
             "verifier_request_timeout_seconds": 600
             if provider.provider == "chutes"
             else 120,
         }
+        if provider.provider != "privatemode":
+            item["bearer_token"] = token
         for field in (
             "verification_refresh_seconds",
             "session_refresh_seconds",
@@ -181,6 +278,7 @@ def redact_upstream_config(config: list[dict[str, Any]]) -> list[dict[str, Any]]
     out = []
     for item in config:
         redacted = dict(item)
-        redacted["bearer_token"] = "<redacted>"
+        if "bearer_token" in redacted:
+            redacted["bearer_token"] = "<redacted>"
         out.append(redacted)
     return out

--- a/scripts/live_e2e/provider_verify.py
+++ b/scripts/live_e2e/provider_verify.py
@@ -25,6 +25,20 @@ def verify_provider(
     timeout: int = 300,
     artifact_dir: Path | None = None,
 ) -> dict[str, Any]:
+    if provider.provider == "privatemode":
+        # Privatemode verification is inseparable from the official proxy
+        # co-deployed with the gateway. A standalone Python probe would not bind
+        # that service to the measured deployment and must not compete with it.
+        output = {
+            "status": "performed_by_co_deployed_proxy",
+            "verifier_id": "privatemode-proxy/co-deployed-contrast/v1",
+        }
+        if artifact_dir:
+            write_json(
+                artifact_dir / provider.name / "provider-verifier-output.json",
+                output,
+            )
+        return output
     # The bridge runs from the gateway project (cwd=ROOT) so it uses the gateway's
     # own uv env and the vendored confidential_verifier package. An external verifier
     # checkout is selected only when PRIVATE_AI_VERIFIER_DIR is set in the environment.

--- a/scripts/live_e2e/run.py
+++ b/scripts/live_e2e/run.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 from pathlib import Path
@@ -101,6 +100,7 @@ def main() -> None:
                         base_url=aggregator.base_url,
                         provider=provider,
                         artifact_dir=artifact_dir,
+                        inference_token=aggregator.inference_token,
                     )
                 )
             summary["phases"]["lifecycle"] = lifecycle
@@ -114,6 +114,7 @@ def main() -> None:
                         base_url=aggregator.base_url,
                         provider=provider,
                         artifact_dir=artifact_dir,
+                        inference_token=aggregator.inference_token,
                     )
                 )
             summary["phases"]["embeddings"] = embeddings
@@ -126,6 +127,7 @@ def main() -> None:
                             base_url=aggregator.base_url,
                             provider=provider,
                             artifact_dir=artifact_dir,
+                            inference_token=aggregator.inference_token,
                         )
                     )
                 summary["phases"]["structured_outputs"] = structured

--- a/scripts/live_e2e/streaming_smoke.py
+++ b/scripts/live_e2e/streaming_smoke.py
@@ -50,7 +50,11 @@ def main() -> int:
         }
         print(f"POST {base}/v1/chat/completions  (stream=true, model={provider.public_model})")
         resp = requests.post(
-            f"{base}/v1/chat/completions", json=body, stream=True, timeout=180
+            f"{base}/v1/chat/completions",
+            json=body,
+            headers={"Authorization": f"Bearer {agg.inference_token}"},
+            stream=True,
+            timeout=180,
         )
         raw = bytearray()
         for chunk in resp.iter_content(chunk_size=None):
@@ -72,7 +76,11 @@ def main() -> int:
             print("  FAIL: no x-receipt-id header")
             return 1
 
-        r2 = requests.get(f"{base}/v1/aci/receipts/{receipt_id}", timeout=30)
+        r2 = requests.get(
+            f"{base}/v1/aci/receipts/{receipt_id}",
+            headers={"Authorization": f"Bearer {agg.inference_token}"},
+            timeout=30,
+        )
         if r2.status_code != 200:
             print(f"  FAIL: receipt fetch {r2.status_code}: {r2.text[:300]}")
             return 1

--- a/scripts/live_e2e/tests/__init__.py
+++ b/scripts/live_e2e/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for live E2E orchestration helpers."""

--- a/scripts/live_e2e/tests/test_launch_aggregator.py
+++ b/scripts/live_e2e/tests/test_launch_aggregator.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from live_e2e.common import Provider  # noqa: E402
+from live_e2e.launch_aggregator import (  # noqa: E402
+    AggregatorProcess,
+    build_gateway_config,
+    build_upstream_config,
+    redact_upstream_config,
+)
+
+
+def privatemode_provider() -> Provider:
+    return Provider.from_json(
+        {
+            "name": "privatemode-test",
+            "provider": "privatemode",
+            "base_url": "http://privatemode-proxy:8080",
+            "public_model": "private-model",
+            "upstream_model": "upstream-model",
+            "api_key_env": "PRIVATEMODE_API_KEY",
+            "binding": "manifest_image_sha256",
+            "privatemode_manifest_path": "/run/privatemode/manifest.json",
+            "privatemode_manifest_sha256": "a" * 64,
+            "privatemode_proxy_image_digest": f"sha256:{'b' * 64}",
+        }
+    )
+
+
+class LaunchAggregatorTests(unittest.TestCase):
+    def test_privatemode_config_binds_generated_client_auth_digest(self) -> None:
+        token = "per-run-client-token"
+        config = build_gateway_config(
+            [privatemode_provider()],
+            {"PRIVATEMODE_API_KEY": "provider-credential"},
+            port=18086,
+            state_dir=Path("/tmp/state"),
+            upstream_seed_path=Path("/tmp/upstreams.json"),
+            dstack_endpoint="unix:/tmp/dstack.sock",
+            inference_token=token,
+            privatemode_credential_path=Path("/run/secrets/privatemode-api-key"),
+        )
+
+        self.assertEqual(
+            config["inference_token_sha256"],
+            hashlib.sha256(token.encode("utf-8")).hexdigest(),
+        )
+        self.assertNotIn(token, json.dumps(config, sort_keys=True))
+        self.assertEqual(
+            config["privatemode_proxy"]["credential_sha256"],
+            hashlib.sha256(b"provider-credential").hexdigest(),
+        )
+        self.assertEqual(
+            config["privatemode_proxy"]["credential_path"],
+            "/run/secrets/privatemode-api-key",
+        )
+        upstream = build_upstream_config(
+            [privatemode_provider()],
+            {"PRIVATEMODE_API_KEY": "provider-credential"},
+        )
+        self.assertNotIn("bearer_token", upstream[0])
+        self.assertNotIn("bearer_token", redact_upstream_config(upstream)[0])
+
+    def test_process_generates_a_distinct_high_entropy_token_per_run(self) -> None:
+        first = AggregatorProcess([], port=18086, env={})
+        second = AggregatorProcess([], port=18087, env={})
+
+        self.assertNotEqual(first.inference_token, second.inference_token)
+        self.assertGreaterEqual(len(first.inference_token), 32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -74,9 +74,10 @@ For the upstream hop, ACI v1 standardizes the aggregator's **transparency
 surface**, not its routing policy:
 
 - Before forwarding a prompt, the aggregator MUST verify the selected
-  upstream and obtain an enforceable channel binding (a TLS key pin or an
-  upstream E2EE key). If verification is required and fails, the aggregator
-  MUST NOT forward the prompt (fail closed).
+  upstream and obtain an enforceable channel binding (a TLS key pin, an
+  upstream E2EE key, or an attested manifest that gates an E2EE secret owned by
+  a provider proxy inside the aggregator workload). If verification is required
+  and fails, the aggregator MUST NOT forward the prompt (fail closed).
 - Each receipt records the verification outcome in an `upstream.verified`
   event (§8.4).
 - Each successful verification is captured as an immutable, content-addressed
@@ -873,7 +874,7 @@ appear):
   "upstream_name": "<service-chosen upstream label>",
   "provider_type": "<verifier adapter type or null>",
   "model_id": "<upstream model served>",
-  "url_origin": "<https-origin-or-null>",
+  "url_origin": "<origin-or-null>",
   "verifier_id": "<verifier implementation id>",
   "result": "verified" | "failed",
   "required": true | false,
@@ -896,7 +897,33 @@ upstream. Defined shapes:
 { "type": "tls_spki_sha256",        "origin": "<https-origin>", "spki_sha256": "<hex>" }
 { "type": "tls_certificate_sha256", "origin": "<https-origin>", "certificate_sha256": "<hex>" }
 { "type": "e2ee_public_key_sha256", "provider": "<label>", "key_id": "<optional>", "algorithm": "<algo>", "public_key_sha256": "<hex>" }
+{ "type": "manifest_sha256",        "provider": "<label>", "manifest_sha256": "<hex>", "coordinator_policy_hash": "<hex>", "proxy_binary_sha256": "<hex>", "proxy_tls_certificate_sha256": "<hex>" }
+{ "type": "manifest_image_sha256",  "provider": "<label>", "manifest_sha256": "<hex>", "coordinator_policy_hash": "<hex>", "proxy_image_digest": "sha256:<hex>", "credential_sha256": "<hex>" }
 ```
+
+`manifest_sha256` is the legacy supervised-child binding. Its executable and
+loopback TLS certificate fields remain part of `aci/1` so existing artifacts
+remain readable and enforceable by implementations that support that boundary.
+
+`manifest_image_sha256` is enforceable only when the provider proxy that verified the
+manifest and owns the resulting E2EE secret is inside the aggregator's attested
+workload. The measured deployment MUST launch the exact `proxy_image_digest`
+with the exact manifest and shared credential secret, MUST keep the proxy
+endpoint private to that workload, and the aggregator MUST pin that endpoint in
+static measured policy and route every forward through it. The aggregator MUST
+validate the live shared secret against `credential_sha256` without forwarding
+that credential on the internal hop. It MUST also pin forwarding to handlers
+that the measured proxy version encrypts; a mutable path override or an
+unencrypted catalog/health handler cannot carry inference data.
+Pre-credential-field `aci/1` artifacts remain readable, but do not authorize
+forwarding under this stronger binding. A remote or externally managed proxy, a
+mutable image/manifest after verification, or a manifest used only as
+informational evidence does not satisfy this binding type.
+
+External upstream origins MUST use HTTPS. A plaintext HTTP `url_origin` is
+valid only for a service inside the same measured workload when its binding
+type (such as `manifest_image_sha256`) explicitly binds that deployment and the
+client disables redirects and ambient HTTP proxies.
 
 To a generic verifier this event proves only that the attested aggregator
 *asserted* the outcome; deep audit (§10.3) upgrades it to independently
@@ -1271,7 +1298,7 @@ these sets requires a published extension document.
 | Signature algorithms | `ed25519` (RECOMMENDED), `ecdsa-secp256k1` | Reject |
 | E2EE suites | `x25519-aes-256-gcm-hkdf-sha256` (RECOMMENDED; HKDF info `aci.e2ee.v2.x25519`), `secp256k1-aes-256-gcm-hkdf-sha256` (HKDF info `aci.e2ee.v2.secp256k1`) | Reject; other keyset entries with unknown `algo` are ignored for E2EE |
 | Receipt event types | `request.received`, `request.forwarded`, `response.returned`, `response.received`, `upstream.verified`, `transparency.request_modified`, `transparency.response_modified` | Ignore; preserve for signature recomputation (§3.2) |
-| Channel binding types | `tls_spki_sha256`, `tls_certificate_sha256`, `e2ee_public_key_sha256` | Treat as not enforceable |
+| Channel binding types | `tls_spki_sha256`, `tls_certificate_sha256`, `e2ee_public_key_sha256`, `manifest_sha256`, `manifest_image_sha256` | Treat as not enforceable |
 | Claim names | `tee_attested`, `gpu_attested`, `tcb_up_to_date`, `os_known_good`, `serving_software_known_good`, `model_weights_provenance` | Extra facts live in `claims.extra`; unknown entries are informational |
 | Claim statuses / sources | `asserted`, `refuted`, `unknown` / `hardware_proven`, `verifier_derived`, `provider_asserted`, `operator_asserted` | Treat the claim as `unknown` |
 | TEE types | `tdx`, `sev_snp` | Requires a published verifier extension (§5.2) |

--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -55,7 +55,7 @@ pub struct UpstreamVerifiedEvent {
     /// "tinfoil-glm51") — a label chosen by whoever wrote the config.
     pub upstream_name: String,
     /// The verifier adapter *type* the verification logic keys on (e.g.
-    /// "tinfoil", "near-ai", "chutes", "phala-direct"). Many `upstream_name`
+    /// "tinfoil", "near-ai", "chutes", "privatemode", "phala-direct"). Many `upstream_name`
     /// entries can share one `provider_type` (two configs both pointing at
     /// Tinfoil). Used to map provider evidence onto typed session claims;
     /// `None` for generic/static verifiers that have no provider type.
@@ -113,6 +113,31 @@ pub enum ChannelBinding {
         key_id: Option<String>,
         algorithm: String,
         public_key_sha256: String,
+    },
+    /// Legacy binding for a gateway-supervised provider-proxy child. Retained
+    /// so existing `aci/1` receipts and persisted sessions remain readable.
+    ManifestSha256 {
+        provider: String,
+        manifest_sha256: String,
+        coordinator_policy_hash: String,
+        proxy_binary_sha256: String,
+        proxy_tls_certificate_sha256: String,
+    },
+    /// Digests binding a provider proxy co-deployed in the gateway's measured
+    /// dstack Compose. The proxy verifies the provider's attestation chain and
+    /// owns the resulting E2EE secret. The gateway verifies the exact manifest
+    /// bytes and pins the Compose-owned proxy image digest.
+    ManifestImageSha256 {
+        provider: String,
+        manifest_sha256: String,
+        coordinator_policy_hash: String,
+        proxy_image_digest: String,
+        /// Digest of the exact Compose secret mounted into both the measured
+        /// gateway and proxy. Optional only so receipts issued by an earlier
+        /// `aci/1` deployment remain deserializable; current forwarding
+        /// requires it to be present and equal to static policy.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        credential_sha256: Option<String>,
     },
 }
 

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! The aggregator forwards a chat-completion request to an upstream
 //! after ACI-side hashing. Different upstream providers (Chutes,
-//! Tinfoil, NEAR AI, Phala dstack-vllm-proxy, raw OpenAI-compatible
+//! Tinfoil, NEAR AI, Privatemode, Phala dstack-vllm-proxy, raw OpenAI-compatible
 //! endpoints) speak slightly different dialects on top of the OpenAI
 //! base. We isolate that with the small trait defined here so:
 //!
@@ -29,6 +29,7 @@ use crate::aci::receipt::UpstreamVerifiedEvent;
 
 mod chutes;
 mod openai;
+mod privatemode;
 mod router;
 mod tls;
 
@@ -36,6 +37,9 @@ pub use chutes::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
 };
 pub use openai::OpenAICompatibleBackend;
+pub use privatemode::{
+    PrivatemodeDeploymentConfigError, PrivatemodeProviderBackend, PrivatemodeProxyDeployment,
+};
 pub use router::{ModelRoute, ModelRouterBackend};
 
 use openai::request_model_id;

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -115,6 +115,11 @@ impl OpenAICompatibleBackend {
         self
     }
 
+    pub(super) fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
+    }
+
     fn apply_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.auth {
             Some(UpstreamAuth::Bearer(token)) => {
@@ -316,6 +321,13 @@ impl OpenAICompatibleBackend {
                 } => {
                     return Err(UpstreamError::Transport(format!(
                         "backend {} cannot enforce {provider} E2EE binding {algorithm:?}",
+                        self.name
+                    )));
+                }
+                ChannelBinding::ManifestSha256 { provider, .. }
+                | ChannelBinding::ManifestImageSha256 { provider, .. } => {
+                    return Err(UpstreamError::Transport(format!(
+                        "backend {} cannot enforce {provider} manifest binding",
                         self.name
                     )));
                 }

--- a/src/aci/upstream/privatemode.rs
+++ b/src/aci/upstream/privatemode.rs
@@ -1,0 +1,430 @@
+//! Privatemode transport through an official proxy co-deployed with the gateway.
+//!
+//! The dstack Compose measurement binds the proxy image and its internal
+//! network endpoint. The gateway independently verifies the exact Contrast
+//! manifest and shared credential-secret bytes at startup, records their
+//! digests in receipts, and sends plaintext only to that statically configured
+//! service. The official proxy owns use of the credential, remote attestation,
+//! secret exchange, and Privatemode body encryption.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::{
+    OpenAICompatibleBackend, PreparedUpstreamRequest, UpstreamBackend, UpstreamError,
+    UpstreamRequest, UpstreamResponse, UpstreamStreamResponse,
+};
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
+
+const PROVIDER: &str = "privatemode";
+const DEFAULT_ENCRYPTED_PATH: &str = "/v1/chat/completions";
+const ENCRYPTED_PATHS: &[&str] = &[
+    DEFAULT_ENCRYPTED_PATH,
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/messages",
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivatemodeDeploymentConfigError {
+    #[error("Privatemode proxy base URL must be an HTTP(S) origin: {0}")]
+    InvalidBaseUrl(String),
+    #[error("Privatemode manifest path must be absolute")]
+    RelativeManifestPath,
+    #[error("failed to read Privatemode manifest {path}: {source}")]
+    ReadManifest {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("invalid Privatemode manifest SHA-256 digest: {0}")]
+    InvalidManifestDigest(String),
+    #[error("Privatemode manifest digest {actual} does not match configured digest {expected}")]
+    ManifestDigestMismatch { actual: String, expected: String },
+    #[error("invalid Privatemode manifest: {0}")]
+    InvalidManifest(String),
+    #[error("Privatemode credential path must be absolute")]
+    RelativeCredentialPath,
+    #[error("failed to read Privatemode credential {path}: {source}")]
+    ReadCredential {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("Privatemode credential must be non-empty UTF-8 without surrounding whitespace")]
+    InvalidCredential,
+    #[error("invalid Privatemode credential SHA-256 digest: {0}")]
+    InvalidCredentialDigest(String),
+    #[error("Privatemode credential digest {actual} does not match configured digest {expected}")]
+    CredentialDigestMismatch { actual: String, expected: String },
+    #[error("invalid Privatemode proxy OCI image digest: {0}")]
+    InvalidImageDigest(String),
+}
+
+/// Static, measured deployment policy for one co-deployed Privatemode proxy.
+#[derive(Debug)]
+pub struct PrivatemodeProxyDeployment {
+    base_url: String,
+    manifest: Vec<u8>,
+    manifest_sha256: String,
+    coordinator_policy_hash: String,
+    credential_sha256: String,
+    proxy_image_digest: String,
+}
+
+impl PrivatemodeProxyDeployment {
+    pub fn new(
+        base_url: impl Into<String>,
+        manifest_path: impl AsRef<Path>,
+        accepted_manifest_sha256: impl AsRef<str>,
+        credential_path: impl AsRef<Path>,
+        accepted_credential_sha256: impl AsRef<str>,
+        proxy_image_digest: impl AsRef<str>,
+    ) -> Result<Self, PrivatemodeDeploymentConfigError> {
+        let base_url = normalize_origin(&base_url.into())?;
+
+        let manifest_path = manifest_path.as_ref();
+        if !manifest_path.is_absolute() {
+            return Err(PrivatemodeDeploymentConfigError::RelativeManifestPath);
+        }
+        let manifest = std::fs::read(manifest_path).map_err(|source| {
+            PrivatemodeDeploymentConfigError::ReadManifest {
+                path: manifest_path.display().to_string(),
+                source,
+            }
+        })?;
+        let accepted_manifest_sha256 = normalize_sha256_hex(accepted_manifest_sha256.as_ref())
+            .map_err(PrivatemodeDeploymentConfigError::InvalidManifestDigest)?;
+        let manifest_sha256 = sha256_hex(&manifest);
+        if manifest_sha256 != accepted_manifest_sha256 {
+            return Err(PrivatemodeDeploymentConfigError::ManifestDigestMismatch {
+                actual: manifest_sha256,
+                expected: accepted_manifest_sha256,
+            });
+        }
+        let coordinator_policy_hash = coordinator_policy_hash(&manifest)
+            .map_err(PrivatemodeDeploymentConfigError::InvalidManifest)?;
+
+        let credential_path = credential_path.as_ref();
+        if !credential_path.is_absolute() {
+            return Err(PrivatemodeDeploymentConfigError::RelativeCredentialPath);
+        }
+        let credential = std::fs::read(credential_path).map_err(|source| {
+            PrivatemodeDeploymentConfigError::ReadCredential {
+                path: credential_path.display().to_string(),
+                source,
+            }
+        })?;
+        let credential_text = std::str::from_utf8(&credential)
+            .map_err(|_| PrivatemodeDeploymentConfigError::InvalidCredential)?;
+        if credential_text.is_empty() || credential_text.trim() != credential_text {
+            return Err(PrivatemodeDeploymentConfigError::InvalidCredential);
+        }
+        let credential_sha256 = normalize_sha256_hex(accepted_credential_sha256.as_ref())
+            .map_err(PrivatemodeDeploymentConfigError::InvalidCredentialDigest)?;
+        let actual_credential_sha256 = sha256_hex(&credential);
+        if actual_credential_sha256 != credential_sha256 {
+            return Err(PrivatemodeDeploymentConfigError::CredentialDigestMismatch {
+                actual: actual_credential_sha256,
+                expected: credential_sha256,
+            });
+        }
+        let proxy_image_digest = format!(
+            "sha256:{}",
+            normalize_sha256_hex(proxy_image_digest.as_ref())
+                .map_err(PrivatemodeDeploymentConfigError::InvalidImageDigest)?
+        );
+
+        Ok(Self {
+            base_url,
+            manifest,
+            manifest_sha256: accepted_manifest_sha256,
+            coordinator_policy_hash,
+            credential_sha256,
+            proxy_image_digest,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn manifest_sha256(&self) -> &str {
+        &self.manifest_sha256
+    }
+
+    pub fn manifest_evidence(&self) -> Value {
+        serde_json::json!({
+            "digest": format!("sha256:{}", self.manifest_sha256),
+            "data": format!(
+                "data:application/json;base64,{}",
+                BASE64.encode(&self.manifest)
+            ),
+        })
+    }
+
+    pub fn coordinator_policy_hash(&self) -> &str {
+        &self.coordinator_policy_hash
+    }
+
+    pub fn proxy_image_digest(&self) -> &str {
+        &self.proxy_image_digest
+    }
+
+    pub fn credential_sha256(&self) -> &str {
+        &self.credential_sha256
+    }
+
+    pub(crate) fn forwarding_client(
+        &self,
+        connect_timeout_seconds: u64,
+        read_timeout_seconds: u64,
+    ) -> Result<reqwest::Client, UpstreamError> {
+        reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(connect_timeout_seconds))
+            .read_timeout(Duration::from_secs(read_timeout_seconds))
+            .build()
+            .map_err(|err| UpstreamError::Transport(err.to_string()))
+    }
+
+    pub(crate) fn readiness_client(
+        &self,
+        connect_timeout_seconds: u64,
+        request_timeout_seconds: u64,
+    ) -> Result<reqwest::Client, UpstreamError> {
+        reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(connect_timeout_seconds))
+            .timeout(Duration::from_secs(request_timeout_seconds))
+            .build()
+            .map_err(|err| UpstreamError::Transport(err.to_string()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivatemodeBackendConfigError {
+    #[error("invalid Privatemode backend: {0}")]
+    Backend(String),
+}
+
+pub struct PrivatemodeProviderBackend {
+    inner: OpenAICompatibleBackend,
+    deployment: Arc<PrivatemodeProxyDeployment>,
+}
+
+impl PrivatemodeProviderBackend {
+    pub fn new_with_timeouts(
+        deployment: Arc<PrivatemodeProxyDeployment>,
+        connect_timeout_seconds: u64,
+        read_timeout_seconds: u64,
+    ) -> Result<Self, PrivatemodeBackendConfigError> {
+        let client = deployment
+            .forwarding_client(connect_timeout_seconds, read_timeout_seconds)
+            .map_err(|err| PrivatemodeBackendConfigError::Backend(err.to_string()))?;
+        let inner = OpenAICompatibleBackend::new_with_timeouts(
+            deployment.base_url(),
+            connect_timeout_seconds,
+            read_timeout_seconds,
+        )
+        .map_err(|err| PrivatemodeBackendConfigError::Backend(err.to_string()))?
+        .with_client(client);
+        Ok(Self { inner, deployment })
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.inner = self.inner.with_name(name);
+        self
+    }
+
+    fn enforce_proxy_binding(&self, event: &UpstreamVerifiedEvent) -> Result<(), UpstreamError> {
+        if event.result != VerificationResult::Verified {
+            return Err(binding_mismatch(
+                "Privatemode forwarding requires a verified event",
+            ));
+        }
+        if event.provider_type.as_deref() != Some(PROVIDER) {
+            return Err(binding_mismatch(format!(
+                "verification provider {:?} is not {PROVIDER:?}",
+                event.provider_type
+            )));
+        }
+        if event.url_origin.as_deref() != self.url_origin() {
+            return Err(binding_mismatch(format!(
+                "verified proxy origin {:?} does not match co-deployed service {:?}",
+                event.url_origin,
+                self.url_origin()
+            )));
+        }
+        let [ChannelBinding::ManifestImageSha256 {
+            provider,
+            manifest_sha256,
+            coordinator_policy_hash,
+            proxy_image_digest,
+            credential_sha256,
+        }] = event.channel_bindings.as_slice()
+        else {
+            return Err(binding_mismatch(
+                "Privatemode verification must produce exactly one manifest_image_sha256 binding",
+            ));
+        };
+        if provider != PROVIDER
+            || manifest_sha256 != self.deployment.manifest_sha256()
+            || coordinator_policy_hash != self.deployment.coordinator_policy_hash()
+            || proxy_image_digest != self.deployment.proxy_image_digest()
+            || credential_sha256.as_deref() != Some(self.deployment.credential_sha256())
+        {
+            return Err(binding_mismatch(
+                "Privatemode event does not match the measured proxy deployment",
+            ));
+        }
+        Ok(())
+    }
+
+    fn enforce_encrypted_path(&self, req: &PreparedUpstreamRequest) -> Result<(), UpstreamError> {
+        let path = req
+            .request
+            .path
+            .as_deref()
+            .unwrap_or(DEFAULT_ENCRYPTED_PATH);
+        if ENCRYPTED_PATHS.contains(&path) {
+            return Ok(());
+        }
+        Err(UpstreamError::Routing(format!(
+            "Privatemode refuses path {path:?}: the pinned proxy does not encrypt that handler"
+        )))
+    }
+}
+
+#[async_trait]
+impl UpstreamBackend for PrivatemodeProviderBackend {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn url_origin(&self) -> Option<&str> {
+        self.inner.url_origin()
+    }
+
+    fn prepare(&self, req: UpstreamRequest) -> Result<PreparedUpstreamRequest, UpstreamError> {
+        self.inner.prepare(req)
+    }
+
+    async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        self.enforce_encrypted_path(&req)?;
+        self.enforce_proxy_binding(event)?;
+        self.inner.forward_prepared(req).await
+    }
+
+    async fn models(&self) -> Result<UpstreamResponse, UpstreamError> {
+        self.inner.models().await
+    }
+
+    async fn forward_stream(
+        &self,
+        _req: UpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_stream_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_stream_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        self.enforce_encrypted_path(&req)?;
+        self.enforce_proxy_binding(event)?;
+        self.inner.forward_stream_prepared(req).await
+    }
+}
+
+fn normalize_origin(value: &str) -> Result<String, PrivatemodeDeploymentConfigError> {
+    let mut url = reqwest::Url::parse(value.trim())
+        .map_err(|err| PrivatemodeDeploymentConfigError::InvalidBaseUrl(err.to_string()))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/"
+    {
+        return Err(PrivatemodeDeploymentConfigError::InvalidBaseUrl(
+            "expected scheme, host, and optional port only".to_string(),
+        ));
+    }
+    url.set_path("");
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
+fn normalize_sha256_hex(value: &str) -> Result<String, String> {
+    let value = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
+    let bytes = hex::decode(value).map_err(|err| err.to_string())?;
+    if bytes.len() != 32 {
+        return Err(format!("expected 32 bytes, got {}", bytes.len()));
+    }
+    Ok(hex::encode(bytes))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn coordinator_policy_hash(manifest: &[u8]) -> Result<String, String> {
+    let manifest: Value = serde_json::from_slice(manifest)
+        .map_err(|err| format!("invalid Privatemode manifest JSON: {err}"))?;
+    let policies = manifest
+        .get("Policies")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "Privatemode manifest is missing Policies".to_string())?;
+    let coordinator_policies = policies
+        .iter()
+        .filter(|(_, policy)| policy.get("Role").and_then(Value::as_str) == Some("coordinator"))
+        .map(|(hash, _)| normalize_sha256_hex(hash))
+        .collect::<Result<Vec<_>, _>>()?;
+    match coordinator_policies.as_slice() {
+        [hash] => Ok(hash.clone()),
+        policies => Err(format!(
+            "Privatemode manifest must contain exactly one Coordinator policy, found {}",
+            policies.len()
+        )),
+    }
+}
+
+fn binding_mismatch(message: impl Into<String>) -> UpstreamError {
+    UpstreamError::ChannelBindingMismatch(message.into())
+}
+
+fn verification_required() -> UpstreamError {
+    UpstreamError::ChannelBindingMismatch(
+        "Privatemode forwarding requires an active co-deployed proxy binding".to_string(),
+    )
+}

--- a/src/aci/upstream/tls.rs
+++ b/src/aci/upstream/tls.rs
@@ -29,6 +29,20 @@ pub(super) fn pinned_spki_client(
     connect_timeout_seconds: u64,
     read_timeout_seconds: u64,
 ) -> Result<reqwest::Client, UpstreamError> {
+    pinned_client(
+        accepted_spkis,
+        accepted_certificates,
+        connect_timeout_seconds,
+        read_timeout_seconds,
+    )
+}
+
+fn pinned_client(
+    accepted_spkis: Vec<String>,
+    accepted_certificates: Vec<String>,
+    connect_timeout_seconds: u64,
+    read_timeout_seconds: u64,
+) -> Result<reqwest::Client, UpstreamError> {
     let mut roots = rustls::RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let inner = rustls::client::WebPkiServerVerifier::builder(Arc::new(roots))

--- a/src/aci/verifier/mod.rs
+++ b/src/aci/verifier/mod.rs
@@ -45,7 +45,8 @@ pub use aci_service::{
 pub use external::ProviderVerifierConfigError;
 pub use providers::{
     ChutesProviderVerifier, NearAiProviderVerifier, PhalaDirectProviderVerifier,
-    RoutingUpstreamVerifier, SecretAiProviderVerifier, TinfoilProviderVerifier,
+    PrivatemodeProviderVerifier, RoutingUpstreamVerifier, SecretAiProviderVerifier,
+    TinfoilProviderVerifier,
 };
 pub use report::{validate_aci_report_binding, AciReportValidationError, ValidatedAciReport};
 pub use simple::{PreverifiedUpstreamVerifier, StaticUpstreamVerifier};

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -2,17 +2,20 @@
 //! origin/name routing verifier that dispatches to them.
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use futures_util::StreamExt;
 
 use super::external::ExternalProviderVerifier;
 #[cfg(test)]
 use super::external::ProviderVerifierConfigError;
-use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
-use crate::aci::upstream::ChutesSessionStore;
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
+use crate::aci::upstream::{ChutesSessionStore, PrivatemodeProxyDeployment, UpstreamError};
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
 use crate::aggregator::upstream_config::UpstreamProvider;
+
+const MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct ChutesProviderVerifier {
@@ -309,6 +312,219 @@ impl UpstreamVerifier for SecretAiProviderVerifier {
 
     fn invalidate(&self, request: &UpstreamVerificationRequest) {
         self.verifier.invalidate(request);
+    }
+}
+
+/// Verifier for the exact official Privatemode proxy deployment measured with
+/// the gateway. A successful model-list request proves that the proxy completed
+/// startup, where its static credential established the Contrast
+/// inference-secret exchange, and that its current provider path is live.
+#[derive(Debug, Clone)]
+pub struct PrivatemodeProviderVerifier {
+    deployment: Arc<PrivatemodeProxyDeployment>,
+    client: reqwest::Client,
+    cache_ttl_seconds: u64,
+    cache: Arc<RwLock<Option<CachedPrivatemodeEvent>>>,
+    verify_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedPrivatemodeEvent {
+    expires_at: u64,
+    event: UpstreamVerifiedEvent,
+}
+
+impl CachedPrivatemodeEvent {
+    fn event_for(&self, request: &UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        let mut event = self.event.clone();
+        event.upstream_name = request.upstream_name.clone();
+        event.model_id = request.model_id.clone();
+        event.url_origin = request.url_origin.clone();
+        event.required = request.required;
+        event
+    }
+}
+
+impl PrivatemodeProviderVerifier {
+    pub fn new(
+        deployment: Arc<PrivatemodeProxyDeployment>,
+        connect_timeout_seconds: u64,
+        request_timeout_seconds: u64,
+        cache_ttl_seconds: u64,
+    ) -> Result<Self, UpstreamError> {
+        let client =
+            deployment.readiness_client(connect_timeout_seconds, request_timeout_seconds)?;
+        Ok(Self {
+            deployment,
+            client,
+            cache_ttl_seconds,
+            cache: Arc::new(RwLock::new(None)),
+            verify_lock: Arc::new(tokio::sync::Mutex::new(())),
+        })
+    }
+
+    async fn verify_deployment(
+        &self,
+        request: UpstreamVerificationRequest,
+    ) -> UpstreamVerifiedEvent {
+        if let Err(err) = self.probe().await {
+            return UpstreamVerifiedEvent {
+                upstream_name: request.upstream_name,
+                provider_type: Some("privatemode".to_string()),
+                model_id: request.model_id,
+                url_origin: Some(self.deployment.base_url().to_string()),
+                verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+                result: VerificationResult::Failed,
+                required: request.required,
+                reason: Some(err.to_string()),
+                ..Default::default()
+            };
+        }
+        UpstreamVerifiedEvent {
+            upstream_name: request.upstream_name,
+            provider_type: Some("privatemode".to_string()),
+            model_id: request.model_id,
+            url_origin: Some(self.deployment.base_url().to_string()),
+            verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+            result: VerificationResult::Verified,
+            required: request.required,
+            evidence: Some(self.deployment.manifest_evidence()),
+            channel_bindings: vec![ChannelBinding::ManifestImageSha256 {
+                provider: "privatemode".to_string(),
+                manifest_sha256: self.deployment.manifest_sha256().to_string(),
+                coordinator_policy_hash: self.deployment.coordinator_policy_hash().to_string(),
+                proxy_image_digest: self.deployment.proxy_image_digest().to_string(),
+                credential_sha256: Some(self.deployment.credential_sha256().to_string()),
+            }],
+            provider_claims: Some(serde_json::json!({
+                "trust_boundary": "attested-compose-privatemode-proxy",
+                "proxy_image_digest": self.deployment.proxy_image_digest(),
+                "manifest_sha256": self.deployment.manifest_sha256(),
+                "coordinator_policy_hash": self.deployment.coordinator_policy_hash(),
+                "credential_sha256": self.deployment.credential_sha256(),
+                "request_encryption": "privatemode-oae",
+            })),
+            reason: None,
+        }
+    }
+
+    async fn probe(&self) -> Result<(), UpstreamError> {
+        let response = self
+            .client
+            .get(format!("{}/v1/models", self.deployment.base_url()))
+            .header("accept", "application/json")
+            .send()
+            .await
+            .map_err(|err| {
+                UpstreamError::Transport(format!("Privatemode proxy probe failed: {err}"))
+            })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            return Err(UpstreamError::Transport(format!(
+                "Privatemode proxy attestation probe returned {status}"
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES as u64)
+        {
+            return Err(UpstreamError::Transport(format!(
+                "Privatemode proxy readiness response exceeds {MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES} bytes"
+            )));
+        }
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|err| {
+                UpstreamError::Transport(format!("Privatemode proxy readiness body failed: {err}"))
+            })?;
+            let next_len = body.len().checked_add(chunk.len()).ok_or_else(|| {
+                UpstreamError::Transport(
+                    "Privatemode proxy readiness response length overflowed".to_string(),
+                )
+            })?;
+            if next_len > MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES {
+                return Err(UpstreamError::Transport(format!(
+                    "Privatemode proxy readiness response exceeds {MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES} bytes"
+                )));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let payload: serde_json::Value = serde_json::from_slice(&body).map_err(|err| {
+            UpstreamError::Transport(format!(
+                "Privatemode proxy readiness returned invalid JSON: {err}"
+            ))
+        })?;
+        if !payload.get("data").is_some_and(serde_json::Value::is_array) {
+            return Err(UpstreamError::Transport(
+                "Privatemode proxy readiness returned an invalid model list".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn cached_event(&self, request: &UpstreamVerificationRequest) -> Option<UpstreamVerifiedEvent> {
+        if self.cache_ttl_seconds == 0 {
+            return None;
+        }
+        let cached = self
+            .cache
+            .read()
+            .expect("Privatemode verifier cache poisoned")
+            .clone();
+        match cached {
+            Some(cached) if super::current_unix_secs() < cached.expires_at => {
+                Some(cached.event_for(request))
+            }
+            // Leave an expired entry in place until the serialized verify or
+            // refresh replaces it. Clearing it after dropping the read lock
+            // could erase a fresh event written concurrently by refresh.
+            Some(_) => None,
+            None => None,
+        }
+    }
+
+    fn maybe_cache(&self, event: &UpstreamVerifiedEvent) {
+        if self.cache_ttl_seconds == 0 || event.result != VerificationResult::Verified {
+            return;
+        }
+        *self
+            .cache
+            .write()
+            .expect("Privatemode verifier cache poisoned") = Some(CachedPrivatemodeEvent {
+            expires_at: super::current_unix_secs().saturating_add(self.cache_ttl_seconds),
+            event: event.clone(),
+        });
+    }
+}
+
+#[async_trait]
+impl UpstreamVerifier for PrivatemodeProviderVerifier {
+    async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        if let Some(event) = self.cached_event(&request) {
+            return event;
+        }
+        let _verify_guard = self.verify_lock.lock().await;
+        if let Some(event) = self.cached_event(&request) {
+            return event;
+        }
+        let event = self.verify_deployment(request).await;
+        self.maybe_cache(&event);
+        event
+    }
+
+    async fn refresh(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        let _verify_guard = self.verify_lock.lock().await;
+        let event = self.verify_deployment(request).await;
+        self.maybe_cache(&event);
+        event
+    }
+
+    fn invalidate(&self, _request: &UpstreamVerificationRequest) {
+        *self
+            .cache
+            .write()
+            .expect("Privatemode verifier cache poisoned") = None;
     }
 }
 

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -31,6 +31,35 @@ fn public_key_compressed_hex(key: &SigningKey) -> String {
     hex::encode(key.verifying_key().to_sec1_bytes())
 }
 
+#[tokio::test]
+async fn routing_verifier_prefers_selected_route_name_over_shared_origin() {
+    let origin_verifier = Arc::new(StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
+        verifier_id: "wrong-origin-verifier/v1".to_string(),
+        result: VerificationResult::Verified,
+        ..Default::default()
+    }));
+    let name_verifier = Arc::new(StaticUpstreamVerifier::new(UpstreamVerifiedEvent {
+        verifier_id: "selected-name-verifier/v1".to_string(),
+        result: VerificationResult::Verified,
+        ..Default::default()
+    }));
+    let verifier = RoutingUpstreamVerifier::new()
+        .add_route("other-route", "http://shared-proxy:8080", origin_verifier)
+        .add_route("selected-route", "http://shared-proxy:8080", name_verifier);
+
+    let event = verifier
+        .verify(UpstreamVerificationRequest {
+            upstream_name: "selected-route".to_string(),
+            url_origin: Some("http://shared-proxy:8080".to_string()),
+            model_id: "provider-model".to_string(),
+            forwarded_body_hash: format!("sha256:{}", "11".repeat(32)),
+            required: true,
+        })
+        .await;
+
+    assert_eq!(event.verifier_id, "selected-name-verifier/v1");
+}
+
 fn sign_recoverable(key: &SigningKey, message: &[u8]) -> String {
     let digest = Keccak256::new_with_prefix(message);
     let (signature, recid) = key.sign_digest_recoverable(digest).unwrap();
@@ -97,7 +126,7 @@ fn custody_report(identity: &SigningKey, signature_chain: Vec<String>) -> Attest
 /// and the seam accepts `None`. Stubs mirror that so the real accept paths run.
 fn declared_scope(provider: &str) -> Option<&'static str> {
     match provider {
-        "near-ai" | "tinfoil" | "secret-ai" => Some("router"),
+        "near-ai" | "tinfoil" | "secret-ai" | "privatemode" => Some("router"),
         _ => None,
     }
 }

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -11,12 +11,13 @@ use super::{
 use crate::aci::canonical;
 use crate::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ModelRoute, ModelRouterBackend,
-    OpenAICompatibleBackend, UpstreamBackend,
+    OpenAICompatibleBackend, PrivatemodeProviderBackend, UpstreamBackend,
 };
 use crate::aci::verifier::{
     AciServiceUpstreamVerifier, AciServiceVerifierPolicy, ChutesProviderVerifier,
     NearAiProviderVerifier, PhalaDirectProviderVerifier, PreverifiedUpstreamVerifier,
-    RoutingUpstreamVerifier, SecretAiProviderVerifier, TinfoilProviderVerifier,
+    PrivatemodeProviderVerifier, RoutingUpstreamVerifier, SecretAiProviderVerifier,
+    TinfoilProviderVerifier,
 };
 use crate::aggregator::service::UpstreamVerifier;
 
@@ -79,6 +80,7 @@ fn provider_is_tee(provider: UpstreamProvider) -> bool {
         | UpstreamProvider::Tinfoil
         | UpstreamProvider::NearAi
         | UpstreamProvider::SecretAi
+        | UpstreamProvider::Privatemode
         | UpstreamProvider::PhalaDirect => true,
     }
 }
@@ -107,6 +109,23 @@ fn build_provider_backend(
                 options,
                 session_store,
             )?))
+        }
+        UpstreamProvider::Privatemode => {
+            let deployment = options.privatemode_proxy.clone().ok_or_else(|| {
+                UpstreamConfigError::InvalidConfig(format!(
+                    "Privatemode upstream {:?} requires static privatemode_proxy gateway config",
+                    cfg.name
+                ))
+            })?;
+            enforce_privatemode_deployment(cfg, &deployment)?;
+            let backend = PrivatemodeProviderBackend::new_with_timeouts(
+                deployment,
+                connect_timeout_seconds,
+                read_timeout_seconds,
+            )
+            .map_err(|e| UpstreamConfigError::InvalidConfig(e.to_string()))?
+            .with_name(cfg.name.clone());
+            Ok(Arc::new(backend))
         }
         UpstreamProvider::OpenAiCompatible
         | UpstreamProvider::Anthropic
@@ -262,6 +281,25 @@ fn build_provider_verifier(
                 .with_accepted_workload_ids(cfg.accepted_workload_ids.clone().unwrap_or_default());
                 Some(Arc::new(verifier))
             }
+            UpstreamProvider::Privatemode => {
+                let deployment = options.privatemode_proxy.clone().ok_or_else(|| {
+                    UpstreamConfigError::InvalidConfig(format!(
+                        "Privatemode upstream {:?} requires static privatemode_proxy gateway config",
+                        cfg.name
+                    ))
+                })?;
+                enforce_privatemode_deployment(cfg, &deployment)?;
+                Some(Arc::new(
+                    PrivatemodeProviderVerifier::new(
+                        deployment,
+                        cfg.connect_timeout_seconds
+                            .unwrap_or(options.connect_timeout_seconds),
+                        request_timeout_seconds,
+                        cache_seconds,
+                    )
+                    .map_err(|err| UpstreamConfigError::InvalidConfig(err.to_string()))?,
+                ))
+            }
             UpstreamProvider::PhalaDirect => {
                 let mut verifier = PhalaDirectProviderVerifier::new_with_cache(
                     request_timeout_seconds,
@@ -282,6 +320,21 @@ fn build_provider_verifier(
         }
     }
     Ok(Some(Arc::new(router)))
+}
+
+fn enforce_privatemode_deployment(
+    cfg: &UpstreamConfig,
+    deployment: &crate::aci::upstream::PrivatemodeProxyDeployment,
+) -> Result<(), UpstreamConfigError> {
+    if cfg.base_url.trim_end_matches('/') != deployment.base_url() {
+        return Err(UpstreamConfigError::InvalidConfig(format!(
+            "Privatemode upstream {:?} base_url {:?} does not match static proxy endpoint {:?}",
+            cfg.name,
+            cfg.base_url,
+            deployment.base_url()
+        )));
+    }
+    Ok(())
 }
 
 fn build_global_verifier_for_config(

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::aci::canonical;
 use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
-use crate::aci::upstream::{ChutesSessionStore, UpstreamBackend, UpstreamError};
+use crate::aci::upstream::{
+    ChutesSessionStore, PrivatemodeProxyDeployment, UpstreamBackend, UpstreamError,
+};
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
 
 mod builders;
@@ -165,6 +167,7 @@ pub enum UpstreamProvider {
     Tinfoil,
     NearAi,
     SecretAi,
+    Privatemode,
     PhalaDirect,
 }
 
@@ -173,9 +176,10 @@ impl UpstreamProvider {
     /// must choose its scope rather than inherit a default.
     pub(crate) fn attestation_scope(self) -> AttestationScope {
         match self {
-            UpstreamProvider::NearAi | UpstreamProvider::Tinfoil | UpstreamProvider::SecretAi => {
-                AttestationScope::PerRouter
-            }
+            UpstreamProvider::NearAi
+            | UpstreamProvider::Tinfoil
+            | UpstreamProvider::SecretAi
+            | UpstreamProvider::Privatemode => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
             UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
             // Plain cloud APIs (OpenAI-compatible, Anthropic) have no verifier
@@ -258,6 +262,9 @@ pub struct UpstreamRuntimeOptions {
     pub connect_timeout_seconds: u64,
     pub read_timeout_seconds: u64,
     pub verifier_request_timeout_seconds: u64,
+    /// Statically measured Privatemode sidecar policy. Dynamic upstream config
+    /// may select this deployment but cannot replace its endpoint or pins.
+    pub privatemode_proxy: Option<Arc<PrivatemodeProxyDeployment>>,
 }
 
 /// Connection details for fetching a model's attestation report from its

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -1,4 +1,4 @@
-use super::builders::build_verifier;
+use super::builders::{build_state, build_verifier};
 use super::dynamic::{DynamicUpstreamVerifier, EmptyUpstreamBackend};
 use super::*;
 use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
@@ -78,6 +78,7 @@ fn provider_attestation_scopes() {
     assert_eq!(UpstreamProvider::NearAi.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::Tinfoil.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::SecretAi.attestation_scope(), PerRouter);
+    assert_eq!(UpstreamProvider::Privatemode.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::PhalaDirect.attestation_scope(), PerModel);
     assert_eq!(UpstreamProvider::Chutes.attestation_scope(), PerInstance);
     assert_eq!(
@@ -86,6 +87,9 @@ fn provider_attestation_scopes() {
     );
     assert_eq!(UpstreamProvider::AciService.attestation_scope(), PerModel);
     assert!(UpstreamProvider::NearAi.attestation_scope().is_per_router());
+    assert!(UpstreamProvider::Privatemode
+        .attestation_scope()
+        .is_per_router());
     assert!(!UpstreamProvider::Chutes.attestation_scope().is_per_router());
 }
 
@@ -130,6 +134,223 @@ fn parse_secret_ai_rejects_invalid_origins() {
             "{base_url:?}: {err}"
         );
     }
+}
+
+#[test]
+fn parse_config_forbids_privatemode_credentials_and_keeps_deployment_fields_static() {
+    let valid_text = r#"[{
+          "name": "privatemode",
+          "provider": "privatemode",
+          "base_url": "http://privatemode-proxy:8080",
+          "models": {"public-model": "provider-model"}
+        }]"#;
+    let valid = parse_config_text(valid_text).expect("Privatemode route should parse");
+    assert_eq!(valid[0].provider, UpstreamProvider::Privatemode);
+
+    let mut duplicate: serde_json::Value = serde_json::from_str(valid_text).unwrap();
+    let mut second = duplicate[0].clone();
+    second["name"] = serde_json::json!("privatemode-two");
+    duplicate.as_array_mut().unwrap().push(second);
+    let err = parse_config_text(&duplicate.to_string())
+        .expect_err("one sidecar cannot safely own multiple route credentials");
+    assert!(err
+        .to_string()
+        .contains("only one Privatemode upstream entry"));
+
+    let with_token = valid_text.replace(
+        r#""models": {"public-model": "provider-model"}"#,
+        r#""models": {"public-model": "provider-model"},
+          "bearer_token": "must-not-cross-the-internal-hop""#,
+    );
+    let err =
+        parse_config_text(&with_token).expect_err("Privatemode route bearer must be rejected");
+    assert!(err.to_string().contains("forbids bearer_token"), "{err}");
+
+    let with_path = valid_text.replace(
+        r#""models": {"public-model": "provider-model"}"#,
+        r#""models": {"public-model": "provider-model"},
+          "path": "/v1/models""#,
+    );
+    let err = parse_config_text(&with_path).expect_err("Privatemode route path must be rejected");
+    assert!(err.to_string().contains("forbids path"), "{err}");
+
+    let dynamic_manifest = valid_text.replace(
+        r#"          "models": {"public-model": "provider-model"}"#,
+        r#"          "models": {"public-model": "provider-model"},
+          "privatemode_manifest_path": "/run/privatemode/manifest.json""#,
+    );
+    let err = parse_config_text(&dynamic_manifest)
+        .expect_err("deployment pins must not be accepted through the admin config");
+    assert!(err.to_string().contains("unknown field"), "{err}");
+}
+
+#[test]
+fn privatemode_route_must_match_the_static_proxy_deployment() {
+    let policy_hash = "11".repeat(32);
+    let manifest = serde_json::to_vec(&serde_json::json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let manifest_path = std::env::temp_dir().join(format!(
+        "private-ai-gateway-privatemode-policy-{}-{}.json",
+        std::process::id(),
+        rand::random::<u64>()
+    ));
+    let credential_path = manifest_path.with_extension("credential");
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"secret").unwrap();
+    let deployment = Arc::new(
+        crate::aci::upstream::PrivatemodeProxyDeployment::new(
+            "http://privatemode-proxy:8080",
+            &manifest_path,
+            crate::aci::canonical::sha256_hex(&manifest),
+            &credential_path,
+            crate::aci::canonical::sha256_hex(b"secret"),
+            format!("sha256:{}", "22".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+
+    let mut route = test_upstream_config(
+        "privatemode",
+        UpstreamProvider::Privatemode,
+        "public-model",
+        "provider-model",
+    );
+    route.base_url = deployment.base_url().to_string();
+    let mut options = UpstreamRuntimeOptions {
+        verifier_mode: UpstreamVerifierMode::None,
+        accepted_workload_ids: Vec::new(),
+        accepted_image_digests: Vec::new(),
+        accepted_dstack_kms_root_public_keys: Vec::new(),
+        pccs_url: None,
+        verifier_cache_seconds: 300,
+        connect_timeout_seconds: 10,
+        read_timeout_seconds: 600,
+        verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
+    };
+
+    let err = match build_state(&[route.clone()], &options) {
+        Ok(_) => panic!("Privatemode route without static deployment must fail"),
+        Err(err) => err,
+    };
+    assert!(err
+        .to_string()
+        .contains("requires static privatemode_proxy"));
+
+    options.privatemode_proxy = Some(deployment);
+    build_state(&[route.clone()], &options)
+        .expect("matching static Privatemode deployment should build");
+    route.base_url = "http://different-proxy:8080".to_string();
+    let err = match build_state(&[route], &options) {
+        Ok(_) => panic!("mutable route must not redirect the static proxy"),
+        Err(err) => err,
+    };
+    assert!(err
+        .to_string()
+        .contains("does not match static proxy endpoint"));
+}
+
+#[test]
+fn privatemode_credential_rotation_requires_a_sidecar_redeploy() {
+    let policy_hash = "33".repeat(32);
+    let manifest = serde_json::to_vec(&serde_json::json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let unique = format!("{}-{}", std::process::id(), rand::random::<u64>());
+    let manifest_path = std::env::temp_dir().join(format!(
+        "private-ai-gateway-privatemode-rotation-manifest-{unique}.json"
+    ));
+    let config_path = std::env::temp_dir().join(format!(
+        "private-ai-gateway-privatemode-rotation-config-{unique}.json"
+    ));
+    let credential_path = std::env::temp_dir().join(format!(
+        "private-ai-gateway-privatemode-rotation-credential-{unique}"
+    ));
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"first-credential").unwrap();
+    let deployment = Arc::new(
+        crate::aci::upstream::PrivatemodeProxyDeployment::new(
+            "http://privatemode-proxy:8080",
+            &manifest_path,
+            crate::aci::canonical::sha256_hex(&manifest),
+            &credential_path,
+            crate::aci::canonical::sha256_hex(b"first-credential"),
+            format!("sha256:{}", "44".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let options = UpstreamRuntimeOptions {
+        verifier_mode: UpstreamVerifierMode::None,
+        accepted_workload_ids: Vec::new(),
+        accepted_image_digests: Vec::new(),
+        accepted_dstack_kms_root_public_keys: Vec::new(),
+        pccs_url: None,
+        verifier_cache_seconds: 300,
+        connect_timeout_seconds: 10,
+        read_timeout_seconds: 600,
+        verifier_request_timeout_seconds: 60,
+        privatemode_proxy: Some(deployment),
+    };
+    let manager = UpstreamConfigManager::load(&config_path, options.clone()).unwrap();
+    let mut route = test_upstream_config(
+        "privatemode",
+        UpstreamProvider::Privatemode,
+        "public-model",
+        "provider-model",
+    );
+    route.base_url = "http://privatemode-proxy:8080".to_string();
+
+    manager.replace(vec![route.clone()]).unwrap();
+    manager.replace(Vec::new()).unwrap();
+    manager
+        .replace(vec![route.clone()])
+        .expect("the route never transports the proxy credential");
+
+    manager.replace(Vec::new()).unwrap();
+    drop(manager);
+
+    std::fs::write(&credential_path, b"different-credential").unwrap();
+    let err = crate::aci::upstream::PrivatemodeProxyDeployment::new(
+        "http://privatemode-proxy:8080",
+        &manifest_path,
+        crate::aci::canonical::sha256_hex(&manifest),
+        &credential_path,
+        crate::aci::canonical::sha256_hex(b"first-credential"),
+        format!("sha256:{}", "44".repeat(32)),
+    )
+    .expect_err("a changed Compose secret must fail against the measured digest");
+    assert!(err.to_string().contains("does not match configured digest"));
+
+    let rotated_deployment = Arc::new(
+        crate::aci::upstream::PrivatemodeProxyDeployment::new(
+            "http://privatemode-proxy:8080",
+            &manifest_path,
+            crate::aci::canonical::sha256_hex(&manifest),
+            &credential_path,
+            crate::aci::canonical::sha256_hex(b"different-credential"),
+            format!("sha256:{}", "44".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let mut rotated_options = options;
+    rotated_options.privatemode_proxy = Some(rotated_deployment);
+    let coordinated = UpstreamConfigManager::load(&config_path, rotated_options).unwrap();
+    coordinated
+        .replace(vec![route])
+        .expect("a coordinated secret and measured-policy change can load the same route");
+
+    let _ = std::fs::remove_file(config_path);
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
 }
 
 #[async_trait]
@@ -242,6 +463,7 @@ fn global_aci_service_does_not_require_policy_for_plain_openai_compatible_upstre
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     };
 
     let verifier = build_verifier(&config, &options, &ProviderSessionRegistry::default())
@@ -333,6 +555,7 @@ async fn prewarm_verification_deduplicates_upstream_models() {
             connect_timeout_seconds: 10,
             read_timeout_seconds: 600,
             verifier_request_timeout_seconds: 60,
+            privatemode_proxy: None,
         },
         state,
         session_sink: Arc::new(RwLock::new(None)),

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -154,6 +154,17 @@ pub fn parse_config_text(text: &str) -> Result<Vec<UpstreamConfig>, UpstreamConf
 }
 
 pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamConfigError> {
+    if config
+        .iter()
+        .filter(|upstream| upstream.provider == UpstreamProvider::Privatemode)
+        .count()
+        > 1
+    {
+        return Err(UpstreamConfigError::InvalidConfig(
+            "only one Privatemode upstream entry is supported per co-deployed proxy; put all models that share its credential in that entry"
+                .to_string(),
+        ));
+    }
     let mut names = HashSet::new();
     let mut route_ids = HashSet::new();
     for upstream in config {
@@ -278,6 +289,18 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
         {
             return Err(UpstreamConfigError::InvalidConfig(format!(
                 "upstream {:?} has Chutes E2EE fields but provider is not chutes",
+                upstream.name
+            )));
+        }
+        if upstream.provider == UpstreamProvider::Privatemode && upstream.bearer_token.is_some() {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} provider privatemode forbids bearer_token; the measured proxy reads its credential from the shared Compose secret",
+                upstream.name
+            )));
+        }
+        if upstream.provider == UpstreamProvider::Privatemode && upstream.path.is_some() {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} provider privatemode forbids path; the measured proxy backend pins encrypted handler paths",
                 upstream.name
             )));
         }

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -38,8 +38,8 @@ use super::error_responses::{
     unknown_downstream_host_response, unsupported_e2ee_response, upstream_config_error_response,
 };
 use super::util::{
-    enforce_admin, enforce_owner, extract_bearer, force_tee_true, has_e2ee_headers, header_str,
-    request_host_domain,
+    enforce_admin, enforce_inference, enforce_owner, extract_bearer, force_tee_true,
+    has_e2ee_headers, header_str, request_host_domain,
 };
 use super::AppState;
 use crate::middleware::errors::Surface;
@@ -649,6 +649,10 @@ pub(super) async fn openai_completion_endpoint(
     endpoint_path: &'static str,
     force_buffered: bool,
 ) -> Response {
+    if let Some(response) = enforce_inference(&state, &headers) {
+        return response;
+    }
+
     // A revoked keyset backs the receipt-signing, E2EE, and TLS keys this
     // request would use; stop serving inference under it (§4.7).
     if state.service.is_keyset_revoked() {

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -7,9 +7,9 @@
 //!   `report_data` (URL-decoded UTF-8 string, or JSON `null` when
 //!   absent).
 //! * `POST /v1/chat/completions` - OpenAI-shaped chat-completion
-//!   forwarding with ACI-side hashing and receipt signing. An
-//!   optional `Authorization: Bearer <token>` is recorded on the
-//!   receipt so later lookups can authenticate the original requester.
+//!   forwarding with ACI-side hashing and receipt signing. When an inference
+//!   token digest is configured, `Authorization: Bearer <token>` must match it;
+//!   the bearer also owns the receipt for later authenticated retrieval.
 //! * `POST /v1/completions` - compatibility surface. The aggregator
 //!   forwards legacy prompt completions through the same ACI receipt
 //!   path as chat completions. ACI E2EE is an optional add-on here;
@@ -109,19 +109,27 @@ pub struct AppState {
     pub service: Arc<AciService>,
     pub upstream_config: Option<Arc<UpstreamConfigManager>>,
     pub admin_token: Option<String>,
+    pub inference_token_sha256: Option<[u8; 32]>,
     middleware: Option<Arc<Middleware>>,
 }
 
 pub fn build_router(service: Arc<AciService>) -> Router {
-    build_router_inner(service, None, None, None)
+    build_router_inner(service, None, None, None, None)
 }
 
 pub fn build_router_with_admin(
     service: Arc<AciService>,
     upstream_config: Arc<UpstreamConfigManager>,
     admin_token: Option<String>,
+    inference_token_sha256: Option<[u8; 32]>,
 ) -> Router {
-    build_router_inner(service, Some(upstream_config), admin_token, None)
+    build_router_inner(
+        service,
+        Some(upstream_config),
+        admin_token,
+        inference_token_sha256,
+        None,
+    )
 }
 
 /// Build the gateway router with the middleware, which consults the
@@ -130,12 +138,14 @@ pub fn build_router_with_admin_and_middleware(
     service: Arc<AciService>,
     upstream_config: Arc<UpstreamConfigManager>,
     admin_token: Option<String>,
+    inference_token_sha256: Option<[u8; 32]>,
     middleware: Arc<Middleware>,
 ) -> Router {
     build_router_inner(
         service,
         Some(upstream_config),
         admin_token,
+        inference_token_sha256,
         Some(middleware),
     )
 }
@@ -144,12 +154,14 @@ fn build_router_inner(
     service: Arc<AciService>,
     upstream_config: Option<Arc<UpstreamConfigManager>>,
     admin_token: Option<String>,
+    inference_token_sha256: Option<[u8; 32]>,
     middleware: Option<Arc<Middleware>>,
 ) -> Router {
     let state = AppState {
         service,
         upstream_config,
         admin_token,
+        inference_token_sha256,
         middleware,
     };
     Router::new()

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -5,6 +5,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::Response,
 };
+use sha2::{Digest, Sha256};
 
 use crate::aggregator::service::ReceiptOwner;
 
@@ -130,6 +131,27 @@ pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Res
             StatusCode::FORBIDDEN,
             "forbidden",
             "invalid admin bearer token",
+        ))
+    }
+}
+
+pub(super) fn enforce_inference(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+    let expected = state.inference_token_sha256?;
+    let Some(token) = extract_bearer(headers) else {
+        return Some(error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "inference bearer token required",
+        ));
+    };
+    let actual: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+    if actual == expected {
+        None
+    } else {
+        Some(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "invalid inference bearer token",
         ))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ use private_ai_gateway::aci::types::{
     KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki, WorkloadIdentity, WorkloadKeyset,
 };
 use private_ai_gateway::aci::upstream::{
-    DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS, DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
+    PrivatemodeProxyDeployment, DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+    DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
 };
 use private_ai_gateway::aci::verifier::DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS;
 use private_ai_gateway::aggregator::keyset_epoch::{self, DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS};
@@ -61,6 +62,69 @@ fn env_non_empty(name: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn env_file_non_empty(path: &str, name: &str) -> Result<Option<String>, String> {
+    let entries = dotenvy::from_path_iter(path)
+        .map_err(|err| format!("failed to read encrypted environment file {path}: {err}"))?;
+    let mut value = None;
+    for entry in entries {
+        let (key, candidate) = entry
+            .map_err(|err| format!("failed to parse encrypted environment file {path}: {err}"))?;
+        if key == name {
+            value = Some(candidate);
+        }
+    }
+    Ok(value
+        .map(|candidate| candidate.trim().to_string())
+        .filter(|candidate| !candidate.is_empty()))
+}
+
+fn validate_sha256_secret_policy(
+    name: &str,
+    secret: Option<&str>,
+    expected: Option<&str>,
+) -> Result<(), String> {
+    let Some(expected_bytes) = parse_sha256_policy(name, expected)? else {
+        return Ok(());
+    };
+    let secret = secret.ok_or_else(|| format!("{name}_sha256 requires {name}"))?;
+    let actual: [u8; 32] = Sha256::digest(secret.as_bytes()).into();
+    if actual != expected_bytes {
+        return Err(format!("{name} does not match static {name}_sha256 policy"));
+    }
+    Ok(())
+}
+
+fn parse_sha256_policy(name: &str, expected: Option<&str>) -> Result<Option<[u8; 32]>, String> {
+    let Some(expected) = expected else {
+        return Ok(None);
+    };
+    let expected = expected
+        .trim()
+        .strip_prefix("sha256:")
+        .unwrap_or(expected.trim());
+    let expected_bytes =
+        hex::decode(expected).map_err(|err| format!("invalid {name}_sha256: {err}"))?;
+    expected_bytes
+        .try_into()
+        .map(Some)
+        .map_err(|bytes: Vec<u8>| {
+            format!(
+                "invalid {name}_sha256: expected 32 bytes, got {}",
+                bytes.len()
+            )
+        })
+}
+
+fn validate_inference_auth_policy(
+    privatemode_configured: bool,
+    inference_token_sha256: Option<[u8; 32]>,
+) -> Result<(), String> {
+    if privatemode_configured && inference_token_sha256.is_none() {
+        return Err("privatemode_proxy requires inference_token_sha256".to_string());
+    }
+    Ok(())
+}
+
 fn invalid_input(message: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidInput, message.into())
 }
@@ -72,12 +136,31 @@ struct GatewayConfigFile {
     state_dir: Option<String>,
     upstream_config_seed_path: Option<String>,
     admin_token: Option<String>,
+    admin_token_sha256: Option<String>,
+    /// Optional measured digest of the downstream bearer accepted by inference
+    /// endpoints. The bearer itself remains client-side.
+    inference_token_sha256: Option<String>,
     /// Bounded keyset-epoch validity window in seconds (§4.7). Defaults to
     /// [`DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS`] (~4 weeks).
     keyset_epoch_window_seconds: Option<u64>,
     tls: GatewayTlsConfig,
     dstack_endpoint: Option<String>,
     middleware: Option<MiddlewareConfig>,
+    /// Deployment-owned Privatemode sidecar policy. Unlike upstream routes,
+    /// this is static so the admin API cannot redirect plaintext to another
+    /// proxy or change the measured manifest/image pins.
+    privatemode_proxy: Option<PrivatemodeProxyConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrivatemodeProxyConfig {
+    base_url: String,
+    manifest_path: String,
+    manifest_sha256: String,
+    credential_path: String,
+    credential_sha256: String,
+    proxy_image_digest: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -351,11 +434,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let upstream_config_path = upstream_config_path(&state_dir);
     let session_log_path = session_log_path(&state_dir);
     let upstream_config_seed_path = gateway_config.upstream_config_seed_path.clone();
-    let admin_token = gateway_config.admin_token.clone();
+    let admin_token = match env_non_empty("PRIVATE_AI_GATEWAY_ADMIN_TOKEN") {
+        Some(token) => Some(token),
+        None => match env_non_empty("PRIVATE_AI_GATEWAY_ENV_FILE") {
+            Some(path) => env_file_non_empty(&path, "PRIVATE_AI_GATEWAY_ADMIN_TOKEN")
+                .map_err(invalid_input)?,
+            None => gateway_config.admin_token.clone(),
+        },
+    };
+    validate_sha256_secret_policy(
+        "admin_token",
+        admin_token.as_deref(),
+        gateway_config.admin_token_sha256.as_deref(),
+    )
+    .map_err(invalid_input)?;
+    let inference_token_sha256 = parse_sha256_policy(
+        "inference_token",
+        gateway_config.inference_token_sha256.as_deref(),
+    )
+    .map_err(invalid_input)?;
+    validate_inference_auth_policy(
+        gateway_config.privatemode_proxy.is_some(),
+        inference_token_sha256,
+    )
+    .map_err(invalid_input)?;
     let source_provenance = resolve_source_provenance()?;
     let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
     let dstack_endpoint = gateway_config.dstack_endpoint.clone();
     let middleware_config = gateway_config.middleware.clone();
+    let privatemode_proxy = gateway_config
+        .privatemode_proxy
+        .as_ref()
+        .map(|config| {
+            PrivatemodeProxyDeployment::new(
+                &config.base_url,
+                &config.manifest_path,
+                &config.manifest_sha256,
+                &config.credential_path,
+                &config.credential_sha256,
+                &config.proxy_image_digest,
+            )
+            .map(Arc::new)
+            .map_err(|err| invalid_input(err.to_string()))
+        })
+        .transpose()?;
 
     let provider = Arc::new(
         DstackAciProvider::new(dstack_endpoint, DstackAciProviderConfig::default()).await?,
@@ -375,6 +497,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             connect_timeout_seconds: DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
             read_timeout_seconds: DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
             verifier_request_timeout_seconds: DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS,
+            privatemode_proxy,
         },
     )?);
     let upstream = upstream_config.backend();
@@ -503,9 +626,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             control_url = %middleware_config.control_url,
             "private-ai-gateway middleware enabled"
         );
-        build_router_with_admin_and_middleware(service, upstream_config, admin_token, middleware)
+        build_router_with_admin_and_middleware(
+            service,
+            upstream_config,
+            admin_token,
+            inference_token_sha256,
+            middleware,
+        )
     } else {
-        build_router_with_admin(service, upstream_config, admin_token)
+        build_router_with_admin(
+            service,
+            upstream_config,
+            admin_token,
+            inference_token_sha256,
+        )
     };
 
     tracing::info!(%bind, "private-ai-gateway listening");
@@ -629,9 +763,11 @@ mod tests {
     use private_ai_gateway::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
 
     use super::{
-        keyset_epoch_path, load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
-        revocations_path, seed_upstream_config_if_empty, session_log_path,
+        env_file_non_empty, keyset_epoch_path, load_gateway_config, parse_sha256_policy,
+        resolve_state_dir, resolve_tls_public_keys, revocations_path,
+        seed_upstream_config_if_empty, session_log_path,
         source_provenance_from_git_launcher_config, upstream_config_path,
+        validate_inference_auth_policy, validate_sha256_secret_policy,
     };
 
     const TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -668,6 +804,50 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
         path
     }
 
+    #[test]
+    fn encrypted_env_admin_token_is_parsed_and_digest_bound() {
+        let path = temp_path("gateway-encrypted-env");
+        std::fs::write(
+            &path,
+            "IGNORED=value\nPRIVATE_AI_GATEWAY_ADMIN_TOKEN='admin token'\n",
+        )
+        .unwrap();
+        let token =
+            env_file_non_empty(path.to_str().unwrap(), "PRIVATE_AI_GATEWAY_ADMIN_TOKEN").unwrap();
+        assert_eq!(token.as_deref(), Some("admin token"));
+        let digest = private_ai_gateway::aci::canonical::sha256_hex(b"admin token");
+        validate_sha256_secret_policy("admin_token", token.as_deref(), Some(&digest)).unwrap();
+        let err = validate_sha256_secret_policy("admin_token", Some("different"), Some(&digest))
+            .unwrap_err();
+        assert!(err.contains("does not match static admin_token_sha256"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn inference_token_digest_policy_is_validated_without_loading_the_secret() {
+        let prefixed = private_ai_gateway::aci::canonical::sha256_hex(b"client token");
+        let digest = prefixed.strip_prefix("sha256:").unwrap();
+        let parsed = parse_sha256_policy("inference_token", Some(digest))
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed.as_slice(), hex::decode(digest).unwrap());
+
+        assert_eq!(
+            parse_sha256_policy("inference_token", Some(&prefixed)).unwrap(),
+            Some(parsed)
+        );
+        let err = parse_sha256_policy("inference_token", Some("00")).unwrap_err();
+        assert!(err.contains("expected 32 bytes"));
+    }
+
+    #[test]
+    fn privatemode_static_policy_requires_downstream_inference_auth() {
+        assert!(validate_inference_auth_policy(false, None).is_ok());
+        assert!(validate_inference_auth_policy(true, Some([7; 32])).is_ok());
+        let err = validate_inference_auth_policy(true, None).unwrap_err();
+        assert_eq!(err, "privatemode_proxy requires inference_token_sha256");
+    }
+
     fn temp_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
             "private-ai-gateway-{name}-{}-{}.json",
@@ -693,6 +873,45 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
         let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
 
         assert_eq!(config.state_dir.as_deref(), Some("/gateway/state"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn gateway_config_parses_static_privatemode_proxy_policy() {
+        let config_path = temp_path("gateway-config-privatemode");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"{{
+                    "privatemode_proxy": {{
+                        "base_url": "http://privatemode-proxy:8080",
+                        "manifest_path": "/run/privatemode/manifest.json",
+                        "manifest_sha256": "{}",
+                        "credential_path": "/run/secrets/privatemode-api-key",
+                        "credential_sha256": "{}",
+                        "proxy_image_digest": "sha256:{}"
+                    }}
+                }}"#,
+                "11".repeat(32),
+                "33".repeat(32),
+                "22".repeat(32)
+            ),
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+        let proxy = config
+            .privatemode_proxy
+            .expect("static Privatemode policy should parse");
+        assert_eq!(proxy.base_url, "http://privatemode-proxy:8080");
+        assert_eq!(proxy.manifest_path, "/run/privatemode/manifest.json");
+        assert_eq!(proxy.manifest_sha256, "11".repeat(32));
+        assert_eq!(proxy.credential_path, "/run/secrets/privatemode-api-key");
+        assert_eq!(proxy.credential_sha256, "33".repeat(32));
+        assert_eq!(
+            proxy.proxy_image_digest,
+            format!("sha256:{}", "22".repeat(32))
+        );
         let _ = std::fs::remove_file(config_path);
     }
 

--- a/tests/entrypoint.rs
+++ b/tests/entrypoint.rs
@@ -25,6 +25,121 @@ fn script_text() -> String {
     std::fs::read_to_string(script_path()).expect("entrypoint.sh must exist at repo root")
 }
 
+fn privatemode_compose_text() -> String {
+    std::fs::read_to_string(repo_root().join("deploy/compose.privatemode.yaml"))
+        .expect("Privatemode deployment compose must exist")
+}
+
+#[test]
+fn privatemode_proxy_is_a_pinned_unpublished_compose_service() {
+    let body = privatemode_compose_text();
+    let service = body
+        .split("\n  privatemode-proxy:\n")
+        .nth(1)
+        .and_then(|rest| rest.split("\nconfigs:\n").next())
+        .expect("compose must declare a privatemode-proxy service");
+    assert!(service.contains(
+        "ghcr.io/edgelesssys/privatemode/privatemode-proxy@sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+    ));
+    assert!(
+        !service.contains("ports:"),
+        "proxy port must not be published"
+    );
+    assert!(service.contains("--manifestPath"));
+    assert!(service.contains("--apiKey"));
+    assert!(service.contains("@/run/secrets/privatemode-api-key"));
+    assert!(service.contains("--nvidiaOCSPAllowUnknown=false"));
+    assert!(service.contains("--nvidiaOCSPRevokedGracePeriod=0"));
+    assert!(service.contains("source: privatemode-manifest"));
+    assert!(service.contains("tmpfs:"));
+    assert!(service.contains("source: privatemode-api-key"));
+    assert!(!service.contains("privatemode-state"));
+    assert!(body.contains("environment: PRIVATEMODE_API_KEY"));
+    assert!(!body.contains("--apiKey=${PRIVATEMODE_API_KEY}"));
+}
+
+#[test]
+fn privatemode_gateway_and_proxy_share_measured_pins() {
+    let body = privatemode_compose_text();
+    assert!(body.contains(r#""base_url": "http://privatemode-proxy:8080""#));
+    assert!(body.contains(r#""manifest_path": "/run/privatemode/manifest.json""#));
+    assert!(body.contains(r#""credential_path": "/run/secrets/privatemode-api-key""#));
+    assert!(body.contains("PRIVATEMODE_MANIFEST_SHA256:?"));
+    assert!(body.contains("PRIVATEMODE_CREDENTIAL_SHA256:?"));
+    assert!(body.contains("PRIVATEMODE_MANIFEST_PATH:?"));
+    assert!(body.contains("PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?"));
+    assert!(body.contains("PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?"));
+    assert!(body.contains("/dstack/.host-shared/.decrypted-env"));
+    assert!(body.contains("PRIVATE_AI_GATEWAY_ENV_FILE: /run/secrets/dstack-encrypted-env"));
+    assert!(!body.contains(r#""admin_token": "${PRIVATE_AI_GATEWAY_ADMIN_TOKEN"#));
+    assert_eq!(body.matches("source: privatemode-manifest").count(), 2);
+    assert_eq!(body.matches("source: privatemode-api-key").count(), 2);
+}
+
+#[test]
+fn privatemode_renderer_preserves_exact_manifest_bytes() {
+    let path = repo_root().join("deploy/render-privatemode-compose.sh");
+    let body = std::fs::read_to_string(&path).expect("Privatemode renderer must exist");
+    assert!(body.contains("jq --rawfile manifest"));
+    assert!(body.contains("jq -j"));
+    assert!(body.contains("rendered_manifest_sha256"));
+    assert!(body.contains("PRIVATEMODE_CREDENTIAL_SHA256=$("));
+    assert!(body.contains(r#"printf '%s' "$PRIVATEMODE_API_KEY""#));
+    for secret in [
+        "PRIVATE_AI_GATEWAY_ADMIN_TOKEN",
+        "PRIVATE_AI_GATEWAY_INFERENCE_TOKEN",
+        "PRIVATEMODE_API_KEY",
+    ] {
+        assert!(
+            body.contains(secret),
+            "renderer must reject embedding {secret}"
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path).unwrap().permissions().mode();
+        assert_ne!(mode & 0o111, 0, "Privatemode renderer must be executable");
+    }
+}
+
+#[test]
+fn privatemode_config_pins_force_container_reconciliation() {
+    let body = privatemode_compose_text();
+    let gateway = body
+        .split("\n  private-ai-gateway:\n")
+        .nth(1)
+        .and_then(|rest| rest.split("\n  privatemode-proxy:\n").next())
+        .expect("compose must declare a private-ai-gateway service");
+    let proxy = body
+        .split("\n  privatemode-proxy:\n")
+        .nth(1)
+        .and_then(|rest| rest.split("\nconfigs:\n").next())
+        .expect("compose must declare a privatemode-proxy service");
+
+    for pin in [
+        "ai.private-gateway.source-commit",
+        "ai.private-gateway.admin-token-sha256",
+        "ai.private-gateway.inference-token-sha256",
+        "ai.private-gateway.privatemode-manifest-sha256",
+        "ai.private-gateway.privatemode-credential-sha256",
+    ] {
+        assert!(
+            gateway.contains(pin),
+            "gateway service labels must include {pin} so an inline config change recreates a stale container"
+        );
+    }
+    for pin in [
+        "ai.private-gateway.privatemode-manifest-sha256",
+        "ai.private-gateway.privatemode-credential-sha256",
+    ] {
+        assert!(
+            proxy.contains(pin),
+            "proxy service labels must include {pin} so startup manifest or credential changes recreate a stale proxy"
+        );
+    }
+}
+
 #[test]
 fn entrypoint_sh_exists_and_is_executable() {
     let p = script_path();
@@ -122,6 +237,10 @@ fn entrypoint_sh_apt_install_is_strict() {
     assert!(
         body.contains("apt-get install -y --no-install-recommends"),
         "apt-get install line must use --no-install-recommends to keep the trust surface minimal"
+    );
+    assert!(
+        body.contains("command -v cc") && body.contains("apt_packages+=(build-essential)"),
+        "entrypoint.sh must install a native compiler/linker when the launcher image only supplies Rust"
     );
     assert!(
         body.contains("rustup default stable"),

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -32,6 +32,7 @@ use private_ai_gateway::aggregator::upstream_config::{
 };
 use private_ai_gateway::http::{build_router, build_router_with_admin};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tower::ServiceExt;
 
 use common::{verified_event, StaticKeyProvider, StubQuoter};
@@ -428,6 +429,41 @@ async fn chat_default_required_fails_closed_without_verifier() {
     );
     // Upstream MUST NOT have been called.
     assert!(h.received.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn configured_inference_token_blocks_unauthenticated_paid_forwarding() {
+    let h = make_harness();
+    let manager = load_manager("[]");
+    let expected: [u8; 32] = Sha256::digest(b"client-inference-token").into();
+    let app = build_router_with_admin(h.service.clone(), manager, None, Some(expected));
+
+    for (token, expected_status) in [
+        (None, StatusCode::UNAUTHORIZED),
+        (Some("wrong-token"), StatusCode::FORBIDDEN),
+        (Some("client-inference-token"), StatusCode::OK),
+    ] {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("x-upstream-verification", "none");
+        if let Some(token) = token {
+            request = request.header("authorization", format!("Bearer {token}"));
+        }
+        let response = app
+            .clone()
+            .oneshot(
+                request
+                    .body(Body::from(br#"{"model":"x","messages":[]}"#.to_vec()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), expected_status);
+    }
+
+    assert!(h.received.lock().unwrap().is_some());
 }
 
 #[tokio::test]
@@ -964,10 +1000,11 @@ fn upstream_runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 30,
         verifier_request_timeout_seconds: 30,
+        privatemode_proxy: None,
     }
 }
 
-fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
+fn load_manager(config_json: &str) -> Arc<UpstreamConfigManager> {
     // Unique per call: a coarse system clock can hand concurrent tests the same
     // nanos, so an atomic counter guarantees distinct temp paths.
     static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -977,7 +1014,11 @@ fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
         SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
     ));
     std::fs::write(&path, config_json).unwrap();
-    let manager = Arc::new(UpstreamConfigManager::load(&path, upstream_runtime_options()).unwrap());
+    Arc::new(UpstreamConfigManager::load(&path, upstream_runtime_options()).unwrap())
+}
+
+fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
+    let manager = load_manager(config_json);
     let keys = Arc::new(StaticKeyProvider::default());
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -991,7 +1032,7 @@ fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
         )
         .unwrap(),
     );
-    let app = build_router_with_admin(service.clone(), manager, None);
+    let app = build_router_with_admin(service.clone(), manager, None, None);
     (service, app)
 }
 

--- a/tests/keyset_revocation.rs
+++ b/tests/keyset_revocation.rs
@@ -47,6 +47,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -74,7 +75,7 @@ fn build_harness(dir: &std::path::Path) -> Harness {
         .with_revocation_store(revocation_store),
     );
     Harness {
-        app: build_router_with_admin(service, manager, Some(ADMIN_TOKEN.to_string())),
+        app: build_router_with_admin(service, manager, Some(ADMIN_TOKEN.to_string()), None),
         revocations_path,
     }
 }

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -51,6 +51,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -130,7 +131,7 @@ async fn relays_catalogs_from_control() {
         .unwrap(),
     );
     let (service, manager) = build_service();
-    let app = build_router_with_admin_and_middleware(service, manager, None, middleware);
+    let app = build_router_with_admin_and_middleware(service, manager, None, None, middleware);
 
     let (status, body) = get_json(app.clone(), "/v1/models").await;
     assert_eq!(status, StatusCode::OK);
@@ -164,7 +165,7 @@ async fn relays_catalog_query_string_to_control() {
         .unwrap(),
     );
     let (service, manager) = build_service();
-    let app = build_router_with_admin_and_middleware(service, manager, None, middleware);
+    let app = build_router_with_admin_and_middleware(service, manager, None, None, middleware);
 
     let (status, body) = get_json(app.clone(), "/v1/models?zdr=true").await;
     assert_eq!(status, StatusCode::OK);
@@ -193,7 +194,7 @@ async fn relays_catalog_query_string_to_control() {
 #[tokio::test]
 async fn direct_mode_sub_catalogs_remain_not_found() {
     let (service, manager) = build_service();
-    let app = build_router_with_admin(service, manager, None);
+    let app = build_router_with_admin(service, manager, None, None);
 
     let (status, _) = get_json(app.clone(), "/v1/models/my-namespace").await;
     assert_eq!(status, StatusCode::NOT_FOUND);

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -268,6 +268,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 

--- a/tests/provider_e2e.rs
+++ b/tests/provider_e2e.rs
@@ -6,8 +6,13 @@
 //! struct.
 
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 use std::io::{Read, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
 
 mod common;
 
@@ -16,7 +21,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{HeaderMap, Request, StatusCode},
     response::IntoResponse,
-    routing::{get, post},
+    routing::{any, get, post},
     Json, Router,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -25,6 +30,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Nonce,
 };
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use futures_util::StreamExt;
 use ml_kem::{
     kem::{Decapsulate, Encapsulate, Kem, KeyExport, TryKeyInit},
     ml_kem_768::{
@@ -35,15 +41,18 @@ use ml_kem::{
 };
 use private_ai_gateway::aci::canonical::sha256_hex;
 use private_ai_gateway::aci::receipt::{
-    ChannelBinding, UpstreamVerifiedEvent, EVENT_REQUEST_FORWARDED, EVENT_UPSTREAM_VERIFIED,
+    ChannelBinding, UpstreamVerifiedEvent, VerificationResult, EVENT_REQUEST_FORWARDED,
+    EVENT_UPSTREAM_VERIFIED,
 };
 use private_ai_gateway::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
-    OpenAICompatibleBackend, UpstreamRequest,
+    OpenAICompatibleBackend, PrivatemodeProviderBackend, PrivatemodeProxyDeployment,
+    UpstreamBackend, UpstreamRequest,
 };
-use private_ai_gateway::aci::verifier::StaticUpstreamVerifier;
+use private_ai_gateway::aci::verifier::{PrivatemodeProviderVerifier, StaticUpstreamVerifier};
 use private_ai_gateway::aggregator::service::{
-    AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
+    AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore, UpstreamVerificationRequest,
+    UpstreamVerifier,
 };
 use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfig, UpstreamConfigManager, UpstreamProvider, UpstreamRuntimeOptions,
@@ -103,6 +112,7 @@ struct ProviderCall {
 #[derive(Clone)]
 struct ProviderState {
     calls: Arc<Mutex<Vec<ProviderCall>>>,
+    plaintext_path_hits: Arc<AtomicUsize>,
 }
 
 async fn chat_handler(
@@ -150,6 +160,38 @@ async fn models_handler() -> impl IntoResponse {
     }))
 }
 
+async fn privatemode_models_handler(headers: HeaderMap) -> axum::response::Response {
+    if headers.contains_key("authorization") {
+        let reflected_credential = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("invalid authorization")
+            .to_string();
+        return (StatusCode::BAD_REQUEST, reflected_credential).into_response();
+    }
+    models_handler().await.into_response()
+}
+
+async fn privatemode_chat_handler(
+    State(state): State<ProviderState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    if headers.contains_key("authorization") {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    chat_handler(State(state), headers, body)
+        .await
+        .into_response()
+}
+
+async fn privatemode_plaintext_path_handler(
+    State(state): State<ProviderState>,
+) -> impl IntoResponse {
+    state.plaintext_path_hits.fetch_add(1, Ordering::SeqCst);
+    StatusCode::NO_CONTENT
+}
+
 async fn embeddings_handler(
     State(state): State<ProviderState>,
     headers: HeaderMap,
@@ -192,6 +234,7 @@ async fn serve_openai_provider_fixture() -> (String, Arc<Mutex<Vec<ProviderCall>
         .route("/v1/models", get(models_handler))
         .with_state(ProviderState {
             calls: calls.clone(),
+            plaintext_path_hits: Arc::new(AtomicUsize::new(0)),
         });
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -199,6 +242,119 @@ async fn serve_openai_provider_fixture() -> (String, Arc<Mutex<Vec<ProviderCall>
         axum::serve(listener, app).await.unwrap();
     });
     (format!("http://{addr}"), calls)
+}
+
+async fn serve_privatemode_provider_fixture(
+) -> (String, Arc<Mutex<Vec<ProviderCall>>>, Arc<AtomicUsize>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let plaintext_path_hits = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/v1/chat/completions", post(privatemode_chat_handler))
+        .route(
+            "/v1/models",
+            get(privatemode_models_handler).post(privatemode_plaintext_path_handler),
+        )
+        .with_state(ProviderState {
+            calls: calls.clone(),
+            plaintext_path_hits: plaintext_path_hits.clone(),
+        });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), calls, plaintext_path_hits)
+}
+
+async fn redirect_sink(State(hits): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+    hits.fetch_add(1, Ordering::SeqCst);
+    StatusCode::NO_CONTENT
+}
+
+async fn cross_origin_redirect(State(location): State<String>) -> impl IntoResponse {
+    (StatusCode::TEMPORARY_REDIRECT, [("location", location)])
+}
+
+async fn serve_cross_origin_privatemode_redirect_fixture() -> (String, Arc<AtomicUsize>) {
+    let sink_hits = Arc::new(AtomicUsize::new(0));
+    let sink = Router::new()
+        .route("/credential-sink", any(redirect_sink))
+        .with_state(sink_hits.clone());
+    let sink_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let sink_addr = sink_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(sink_listener, sink).await.unwrap();
+    });
+
+    let redirect = Router::new()
+        .route("/v1/models", get(cross_origin_redirect))
+        .route("/v1/chat/completions", post(cross_origin_redirect))
+        .with_state(format!("http://{sink_addr}/credential-sink"));
+    let redirect_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let redirect_addr = redirect_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(redirect_listener, redirect).await.unwrap();
+    });
+
+    (format!("http://{redirect_addr}"), sink_hits)
+}
+
+async fn oversized_models_with_content_length() -> axum::response::Response {
+    (
+        StatusCode::OK,
+        [("content-type", "application/json")],
+        vec![b' '; 1024 * 1024 + 1],
+    )
+        .into_response()
+}
+
+async fn oversized_chunked_models() -> axum::response::Response {
+    let chunks = futures_util::stream::iter([
+        Ok::<_, Infallible>(Bytes::from(vec![b' '; 768 * 1024])),
+        Ok::<_, Infallible>(Bytes::from(vec![b' '; 768 * 1024])),
+    ]);
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from_stream(chunks))
+        .unwrap()
+}
+
+async fn indefinitely_trickled_models() -> axum::response::Response {
+    let chunks = futures_util::stream::unfold((), |()| async {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        Some((Ok::<_, Infallible>(Bytes::from_static(b" ")), ()))
+    });
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from_stream(chunks))
+        .unwrap()
+}
+
+async fn counted_models(State(hits): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+    hits.fetch_add(1, Ordering::SeqCst);
+    Json(json!({"object": "list", "data": [{"id": "provider-model"}]}))
+}
+
+async fn serve_models_fixture(app: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn serve_counted_models_fixture() -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let base_url = serve_models_fixture(
+        Router::new()
+            .route("/v1/models", get(counted_models))
+            .with_state(hits.clone()),
+    )
+    .await;
+    (base_url, hits)
 }
 
 #[derive(Clone)]
@@ -444,6 +600,7 @@ fn runtime_options(mode: UpstreamVerifierMode) -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -753,6 +910,510 @@ async fn openai_compatible_provider_e2e_via_runtime_config() {
     assert_eq!(upstream_verified["result"], "verified");
 
     let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn privatemode_backend_forwards_buffered_and_streaming_only_with_its_binding() {
+    let (base_url, provider_calls, plaintext_path_hits) =
+        serve_privatemode_provider_fixture().await;
+    let policy_hash = "11".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {
+                "Role": "coordinator",
+                "SANs": ["coordinator", "*"]
+            }
+        },
+        "ReferenceValues": {"snp": [{}]}
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"provider-secret").unwrap();
+    let manifest_digest = sha256_hex(&manifest)
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let credential_digest = sha256_hex(b"provider-secret")
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let image_digest = format!("sha256:{}", "33".repeat(32));
+    let deployment = Arc::new(
+        PrivatemodeProxyDeployment::new(
+            &base_url,
+            &manifest_path,
+            &manifest_digest,
+            &credential_path,
+            &credential_digest,
+            &image_digest,
+        )
+        .unwrap(),
+    );
+    let err = PrivatemodeProxyDeployment::new(
+        &base_url,
+        &manifest_path,
+        &manifest_digest,
+        &credential_path,
+        sha256_hex(b"wrong-secret"),
+        &image_digest,
+    )
+    .expect_err("the measured credential digest must bind the mounted secret");
+    assert!(err.to_string().contains("does not match configured digest"));
+    // Receipt evidence retains the verified startup bytes even if the mounted
+    // path changes after deployment policy construction.
+    std::fs::write(&manifest_path, b"tampered after deployment construction").unwrap();
+    let backend = PrivatemodeProviderBackend::new_with_timeouts(deployment.clone(), 2, 10)
+        .unwrap()
+        .with_name("privatemode-provider");
+    let verifier = PrivatemodeProviderVerifier::new(deployment.clone(), 2, 10, 300).unwrap();
+    let event = verifier
+        .verify(UpstreamVerificationRequest {
+            upstream_name: "privatemode-provider".to_string(),
+            url_origin: Some(base_url.clone()),
+            model_id: "provider-model".to_string(),
+            forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+            required: true,
+        })
+        .await;
+    assert_eq!(event.result.as_str(), "verified");
+    assert_eq!(event.url_origin.as_deref(), Some(base_url.as_str()));
+    assert!(matches!(
+        event.channel_bindings.as_slice(),
+        [ChannelBinding::ManifestImageSha256 {
+            manifest_sha256,
+            coordinator_policy_hash,
+            proxy_image_digest,
+            credential_sha256,
+            ..
+        }] if manifest_sha256 == &manifest_digest
+            && coordinator_policy_hash == &policy_hash
+            && proxy_image_digest == &image_digest
+            && credential_sha256.as_deref() == Some(credential_digest.as_str())
+    ));
+
+    let request = || UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        ..Default::default()
+    };
+    let mut legacy_event = event.clone();
+    let [ChannelBinding::ManifestImageSha256 {
+        credential_sha256, ..
+    }] = legacy_event.channel_bindings.as_mut_slice()
+    else {
+        panic!("expected Privatemode binding");
+    };
+    *credential_sha256 = None;
+    let err = backend
+        .forward_verified_prepared(backend.prepare(request()).unwrap(), &legacy_event)
+        .await
+        .expect_err("a legacy receipt without the credential binding cannot authorize forwarding");
+    assert!(err.to_string().contains("measured proxy deployment"));
+
+    let plaintext_path_request = UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        path: Some("/v1/models".to_string()),
+        ..Default::default()
+    };
+    let prepared = backend.prepare(plaintext_path_request).unwrap();
+    let err = backend
+        .forward_verified_prepared(prepared.clone(), &event)
+        .await
+        .expect_err("buffered forwarding must reject an unencrypted proxy handler");
+    assert!(err.to_string().contains("does not encrypt that handler"));
+    let err = match backend
+        .forward_stream_verified_prepared(prepared, &event)
+        .await
+    {
+        Ok(_) => panic!("streaming forwarding must reject an unencrypted proxy handler"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("does not encrypt that handler"));
+    assert_eq!(plaintext_path_hits.load(Ordering::SeqCst), 0);
+
+    let response = backend
+        .forward_verified_prepared(backend.prepare(request()).unwrap(), &event)
+        .await
+        .unwrap();
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body, CHAT_RESPONSE);
+
+    let response = backend
+        .forward_stream_verified_prepared(backend.prepare(request()).unwrap(), &event)
+        .await
+        .unwrap();
+    assert_eq!(response.status_code, 200);
+    let streamed = response
+        .body
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(streamed, CHAT_RESPONSE);
+
+    let calls = provider_calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|call| call.authorization.is_none()));
+
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+}
+
+#[tokio::test]
+async fn privatemode_never_follows_cross_origin_redirects() {
+    let (base_url, sink_hits) = serve_cross_origin_privatemode_redirect_fixture().await;
+    let policy_hash = "55".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"credential-must-not-leak").unwrap();
+    let manifest_digest = sha256_hex(&manifest)
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let credential_digest = sha256_hex(b"credential-must-not-leak")
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let image_digest = format!("sha256:{}", "66".repeat(32));
+    let deployment = Arc::new(
+        PrivatemodeProxyDeployment::new(
+            &base_url,
+            &manifest_path,
+            &manifest_digest,
+            &credential_path,
+            &credential_digest,
+            &image_digest,
+        )
+        .unwrap(),
+    );
+    let verifier = PrivatemodeProviderVerifier::new(deployment.clone(), 2, 10, 300).unwrap();
+    let readiness = verifier
+        .verify(UpstreamVerificationRequest {
+            upstream_name: "privatemode-provider".to_string(),
+            url_origin: Some(base_url.clone()),
+            model_id: "provider-model".to_string(),
+            forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+            required: true,
+        })
+        .await;
+    assert_eq!(readiness.result, VerificationResult::Failed);
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+
+    let verified = UpstreamVerifiedEvent {
+        upstream_name: "privatemode-provider".to_string(),
+        provider_type: Some("privatemode".to_string()),
+        model_id: "provider-model".to_string(),
+        url_origin: Some(base_url.clone()),
+        verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+        result: VerificationResult::Verified,
+        required: true,
+        channel_bindings: vec![ChannelBinding::ManifestImageSha256 {
+            provider: "privatemode".to_string(),
+            manifest_sha256: manifest_digest,
+            coordinator_policy_hash: policy_hash,
+            proxy_image_digest: image_digest,
+            credential_sha256: Some(credential_digest),
+        }],
+        ..Default::default()
+    };
+    let backend = PrivatemodeProviderBackend::new_with_timeouts(deployment, 2, 10)
+        .unwrap()
+        .with_name("privatemode-provider");
+    let request = || UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        ..Default::default()
+    };
+
+    let buffered = backend
+        .forward_verified_prepared(backend.prepare(request()).unwrap(), &verified)
+        .await
+        .unwrap();
+    assert_eq!(buffered.status_code, 307);
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+
+    let streaming = backend
+        .forward_stream_verified_prepared(backend.prepare(request()).unwrap(), &verified)
+        .await
+        .unwrap();
+    assert_eq!(streaming.status_code, 307);
+    let _ = streaming
+        .body
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+}
+
+#[tokio::test]
+async fn privatemode_readiness_rejects_declared_and_chunked_oversized_bodies() {
+    let declared = serve_models_fixture(
+        Router::new().route("/v1/models", get(oversized_models_with_content_length)),
+    )
+    .await;
+    let chunked =
+        serve_models_fixture(Router::new().route("/v1/models", get(oversized_chunked_models)))
+            .await;
+    let policy_hash = "77".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"provider-secret").unwrap();
+    let manifest_digest = sha256_hex(&manifest);
+
+    for base_url in [declared, chunked] {
+        let deployment = Arc::new(
+            PrivatemodeProxyDeployment::new(
+                &base_url,
+                &manifest_path,
+                &manifest_digest,
+                &credential_path,
+                sha256_hex(b"provider-secret"),
+                format!("sha256:{}", "88".repeat(32)),
+            )
+            .unwrap(),
+        );
+        let event = PrivatemodeProviderVerifier::new(deployment, 2, 10, 0)
+            .unwrap()
+            .verify(UpstreamVerificationRequest {
+                upstream_name: "privatemode-provider".to_string(),
+                url_origin: Some(base_url),
+                model_id: "provider-model".to_string(),
+                forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+                required: true,
+            })
+            .await;
+        assert_eq!(event.result, VerificationResult::Failed);
+        assert!(
+            event
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("exceeds 1048576 bytes")),
+            "unexpected readiness failure: {:?}",
+            event.reason
+        );
+    }
+
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+}
+
+#[tokio::test]
+async fn privatemode_readiness_has_an_end_to_end_deadline() {
+    let base_url =
+        serve_models_fixture(Router::new().route("/v1/models", get(indefinitely_trickled_models)))
+            .await;
+    let policy_hash = "99".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"provider-secret").unwrap();
+    let deployment = Arc::new(
+        PrivatemodeProxyDeployment::new(
+            &base_url,
+            &manifest_path,
+            sha256_hex(&manifest),
+            &credential_path,
+            sha256_hex(b"provider-secret"),
+            format!("sha256:{}", "aa".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let verifier = PrivatemodeProviderVerifier::new(deployment, 1, 1, 0).unwrap();
+    let event = tokio::time::timeout(
+        Duration::from_secs(3),
+        verifier.verify(UpstreamVerificationRequest {
+            upstream_name: "privatemode-provider".to_string(),
+            url_origin: Some(base_url),
+            model_id: "provider-model".to_string(),
+            forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+            required: true,
+        }),
+    )
+    .await
+    .expect("readiness request must honor its total deadline");
+    assert_eq!(event.result, VerificationResult::Failed);
+
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+}
+
+#[tokio::test]
+async fn privatemode_verification_cache_and_refresh_follow_the_configured_lease() {
+    let (base_url, hits) = serve_counted_models_fixture().await;
+    let policy_hash = "ab".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"provider-secret").unwrap();
+    let deployment = Arc::new(
+        PrivatemodeProxyDeployment::new(
+            &base_url,
+            &manifest_path,
+            sha256_hex(&manifest),
+            &credential_path,
+            sha256_hex(b"provider-secret"),
+            format!("sha256:{}", "bc".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let verifier = PrivatemodeProviderVerifier::new(deployment, 2, 10, 300).unwrap();
+    let request = |model_id: &str| UpstreamVerificationRequest {
+        upstream_name: "privatemode-provider".to_string(),
+        url_origin: Some(base_url.clone()),
+        model_id: model_id.to_string(),
+        forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+        required: true,
+    };
+
+    let first = verifier.verify(request("model-a")).await;
+    let cached = verifier.verify(request("model-b")).await;
+    assert_eq!(first.result, VerificationResult::Verified);
+    assert_eq!(cached.result, VerificationResult::Verified);
+    assert_eq!(cached.model_id, "model-b");
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+    let refreshed = verifier.refresh(request("model-c")).await;
+    assert_eq!(refreshed.result, VerificationResult::Verified);
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+    verifier.invalidate(&request("model-d"));
+    let after_invalidate = verifier.verify(request("model-d")).await;
+    assert_eq!(after_invalidate.result, VerificationResult::Verified);
+    assert_eq!(hits.load(Ordering::SeqCst), 3);
+
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
+}
+
+#[tokio::test]
+async fn privatemode_runtime_config_binds_the_measured_sidecar_in_the_receipt() {
+    let (base_url, _provider_calls, _plaintext_path_hits) =
+        serve_privatemode_provider_fixture().await;
+    let policy_hash = "22".repeat(32);
+    let manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&policy_hash): {
+                "Role": "coordinator",
+                "SANs": ["coordinator", "*"]
+            }
+        },
+        "ReferenceValues": {"snp": [{}]}
+    }))
+    .unwrap();
+    let manifest_path = temp_config_path();
+    let credential_path = temp_config_path();
+    std::fs::write(&manifest_path, &manifest).unwrap();
+    std::fs::write(&credential_path, b"provider-secret").unwrap();
+    let manifest_digest = sha256_hex(&manifest)
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let image_digest = format!("sha256:{}", "44".repeat(32));
+    let deployment = Arc::new(
+        PrivatemodeProxyDeployment::new(
+            &base_url,
+            &manifest_path,
+            &manifest_digest,
+            &credential_path,
+            sha256_hex(b"provider-secret"),
+            &image_digest,
+        )
+        .unwrap(),
+    );
+
+    let config_path = temp_config_path();
+    let mut options = runtime_options(UpstreamVerifierMode::None);
+    options.privatemode_proxy = Some(deployment);
+    let manager = Arc::new(UpstreamConfigManager::load(&config_path, options).unwrap());
+    manager
+        .replace(vec![UpstreamConfig {
+            name: "privatemode-provider".to_string(),
+            provider: UpstreamProvider::Privatemode,
+            base_url: base_url.clone(),
+            path: None,
+            models: BTreeMap::from([("public-model".to_string(), "provider-model".to_string())]),
+            bearer_token: None,
+            basic_auth: false,
+            accepted_workload_ids: None,
+            accepted_image_digests: None,
+            accepted_dstack_kms_root_public_keys: None,
+            pccs_url: None,
+            verifier_cache_seconds: None,
+            connect_timeout_seconds: Some(2),
+            read_timeout_seconds: Some(10),
+            verifier_request_timeout_seconds: Some(10),
+            verification_refresh_seconds: Some(0),
+            session_refresh_seconds: None,
+            chutes_e2ee_api_base: None,
+            chutes_chute_ids: None,
+            chutes_e2ee_discovery_rounds: None,
+            chutes_e2ee_discovery_interval_seconds: None,
+        }])
+        .unwrap();
+    let service = service_for_manager(manager);
+    let app = build_router(service.clone());
+    let (status, headers, body) = call(app, "POST", "/v1/chat/completions", CHAT_REQUEST).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(body, CHAT_RESPONSE);
+
+    let receipt_id = headers
+        .get("x-receipt-id")
+        .and_then(|value| value.to_str().ok())
+        .unwrap();
+    let receipt = service.get_receipt_by_receipt_id(receipt_id).unwrap();
+    let event = receipt_event(&receipt, EVENT_UPSTREAM_VERIFIED);
+    assert_eq!(event["result"], "verified");
+    assert_eq!(event["provider_type"], "privatemode");
+    assert_eq!(
+        event["verifier_id"],
+        "privatemode-proxy/co-deployed-contrast/v1"
+    );
+    assert_eq!(
+        event["channel_bindings"][0]["manifest_sha256"],
+        manifest_digest
+    );
+    assert_eq!(
+        event["channel_bindings"][0]["proxy_image_digest"],
+        image_digest
+    );
+    assert_eq!(
+        event["channel_bindings"][0]["coordinator_policy_hash"],
+        policy_hash
+    );
+    assert_eq!(event["url_origin"], base_url);
+
+    let _ = std::fs::remove_file(config_path);
+    let _ = std::fs::remove_file(manifest_path);
+    let _ = std::fs::remove_file(credential_path);
 }
 
 #[tokio::test]

--- a/tests/receipt.rs
+++ b/tests/receipt.rs
@@ -172,6 +172,20 @@ fn upstream_verified_event_records_channel_bindings() {
                 algorithm: "chutes-ml-kem-768".to_string(),
                 public_key_sha256: "cc".repeat(32),
             },
+            ChannelBinding::ManifestSha256 {
+                provider: "privatemode".to_string(),
+                manifest_sha256: "dd".repeat(32),
+                coordinator_policy_hash: "ee".repeat(32),
+                proxy_binary_sha256: "12".repeat(32),
+                proxy_tls_certificate_sha256: "34".repeat(32),
+            },
+            ChannelBinding::ManifestImageSha256 {
+                provider: "privatemode".to_string(),
+                manifest_sha256: "dd".repeat(32),
+                coordinator_policy_hash: "ee".repeat(32),
+                proxy_image_digest: format!("sha256:{}", "ff".repeat(32)),
+                credential_sha256: Some("56".repeat(32)),
+            },
         ],
         provider_claims: Some(serde_json::json!({
             "trust_boundary": "fixture",
@@ -212,9 +226,76 @@ fn upstream_verified_event_records_channel_bindings() {
         "cc".repeat(32)
     );
     assert_eq!(
+        upstream.fields["channel_bindings"][3]["type"],
+        "manifest_sha256"
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][3]["manifest_sha256"],
+        "dd".repeat(32)
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][3]["coordinator_policy_hash"],
+        "ee".repeat(32)
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][3]["proxy_binary_sha256"],
+        "12".repeat(32)
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][3]["proxy_tls_certificate_sha256"],
+        "34".repeat(32)
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][4]["type"],
+        "manifest_image_sha256"
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][4]["proxy_image_digest"],
+        format!("sha256:{}", "ff".repeat(32))
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][4]["credential_sha256"],
+        "56".repeat(32)
+    );
+    assert_eq!(
         upstream.fields["provider_claims"]["trust_boundary"],
         "fixture"
     );
+}
+
+#[test]
+fn legacy_manifest_binding_remains_deserializable_under_aci_v1() {
+    let binding: ChannelBinding = serde_json::from_value(serde_json::json!({
+        "type": "manifest_sha256",
+        "provider": "privatemode",
+        "manifest_sha256": "11".repeat(32),
+        "coordinator_policy_hash": "22".repeat(32),
+        "proxy_binary_sha256": "33".repeat(32),
+        "proxy_tls_certificate_sha256": "44".repeat(32)
+    }))
+    .unwrap();
+
+    assert!(matches!(binding, ChannelBinding::ManifestSha256 { .. }));
+}
+
+#[test]
+fn pre_credential_manifest_image_binding_remains_deserializable_under_aci_v1() {
+    let binding: ChannelBinding = serde_json::from_value(serde_json::json!({
+        "type": "manifest_image_sha256",
+        "provider": "privatemode",
+        "manifest_sha256": "11".repeat(32),
+        "coordinator_policy_hash": "22".repeat(32),
+        "proxy_image_digest": format!("sha256:{}", "33".repeat(32))
+    }))
+    .unwrap();
+
+    assert!(matches!(
+        binding,
+        ChannelBinding::ManifestImageSha256 {
+            credential_sha256: None,
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/tests/upstream_config_admin.rs
+++ b/tests/upstream_config_admin.rs
@@ -42,6 +42,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -86,7 +87,7 @@ async fn admin_can_replace_single_upstream_config_file_at_runtime() {
         )
         .unwrap(),
     );
-    let app = build_router_with_admin(service, manager, Some("admin-secret".to_string()));
+    let app = build_router_with_admin(service, manager, Some("admin-secret".to_string()), None);
 
     let (status, models) = call(app.clone(), "GET", "/v1/models", Vec::new(), None).await;
     assert_eq!(status, StatusCode::OK);


### PR DESCRIPTION
## Summary

- add Privatemode as a measured, separately co-deployed official proxy service instead of starting a child process inside the gateway
- pin the proxy image, exact Contrast manifest bytes, Coordinator policy, shared API-credential digest, and internal origin in static measured policy and receipts
- mount one Compose secret source into both gateway and proxy; the gateway validates its renderer-derived digest at startup and then drops the bytes
- keep provider authentication inside the official proxy: Privatemode routes forbid `bearer_token`, and no `Authorization` header crosses the gateway-to-proxy hop
- allow forwarding only to the exact encrypted handlers in the pinned v1.48 proxy; mutable `path` overrides and unencrypted handlers such as `/v1/models` fail before network I/O
- require a measured high-entropy downstream inference bearer so the public gateway cannot become an unauthenticated paid-inference relay
- honor verifier cache, refresh, and invalidation leases; preserve old receipt deserialization while requiring the stronger credential binding for current forwarding
- document the architecture, verification boundary, deployment renderer, and source-reviewed trust assumptions

## Why

Privatemode's official proxy owns Contrast attestation, secret exchange, provider authentication, and full-body E2EE. Co-deploying that digest-pinned proxy as a separate service in the gateway's measured dstack Compose preserves the reviewed implementation while keeping process execution out of the private AI gateway.

The gateway independently binds what it can enforce: the measured proxy deployment, exact shared credential secret, private origin, encrypted handler set, and the verified event required by buffered and streaming forwarding.

## Rebase and review

- rebased directly onto `main` at `adfda25f436f9b0172b68e69b62069eef8617b83`
- preserved moved-main behavior for SecretAI, exact route-name-plus-origin verification, measured raw `app_compose`, Chutes Basic auth, TEE-only routing, middleware, and streaming
- clean-context native Linus-style review traced the exact pinned Privatemode v1.48 source
- review found and drove fixes for:
  - an inbound-bearer misconception that failed to bind the proxy's real static credential
  - ignored verifier-cache configuration and a narrow concurrent refresh race
  - misleading bearer redaction in live-E2E artifacts
  - a mutable path override that could select the proxy's unencrypted model handler
- reviewer re-read the cumulative diff and explicitly approved HEAD `ac8cdfc73e2f5e2cc139d03f03380bc7bc61c97e` with no remaining findings

## Validation

- `cargo test --locked --all-targets`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `shellcheck entrypoint.sh deploy/render-privatemode-compose.sh scripts/*.sh`
- `python3 -m compileall -q scripts`
- `python3 -m unittest discover -s scripts/live_e2e/tests -v`
- `ruff check` on the changed live-E2E Python files
- real Compose render verified both services share one secret source, the measured label matches the renderer-derived credential SHA-256, and the secret value is absent from rendered output
- prior live Phala deployment with a real Privatemode API key returned HTTP 200 and `compose-sidecar-live-ok`; the source review correctly narrowed that run to transport/attestation evidence because its older receipt predated the corrected credential binding

The ephemeral validation CVM was deleted after evidence capture.
