### PR TITLE
docs: document caller-controlled prefix-cache partitioning

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -42,9 +42,10 @@ Redpill tenant.
   share the serving instance's namespace.
 
 Tinfoil's behavior is attestation-backed. Chutes configuration is control-plane
-evidence and is not bound by its current attestation. To enforce isolation, the
-gateway must override caller values with a stable, opaque tenant partition,
-using `cache_salt` for Chutes and `user_cache_secret` for Tinfoil.
+evidence and is not bound by its current attestation. The intended interface is
+caller-controlled: preserve `cache_salt` for Chutes and translate it to
+`user_cache_secret` for Tinfoil. The gateway should not derive or override the
+partition from Redpill tenant identity.
 
 ## The shared verification model
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -28,6 +28,24 @@ merged. The framework and cross-cutting reviews:
   [router-mode-load-balancing-cache.md](../reviews/router-mode-load-balancing-cache.md),
   and the process in [router-mode-provider-review.md](../router-mode-provider-review.md).
 
+## Prefix-cache tenant isolation
+
+As observed on 2026-07-13, Private AI Gateway does not guarantee per-tenant
+prefix-cache partitioning for the active Kimi-K2.6 providers. The gateway
+preserves a caller's `cache_salt` but does not derive one from the authenticated
+Redpill tenant.
+
+- Tinfoil [replaces `cache_salt`](https://github.com/tinfoilsh/confidential-model-router/blob/v0.0.118/cache_salt.go)
+  with a value derived from Redpill's shared upstream credential. The gateway
+  does not set `user_cache_secret`, so Redpill tenants share one namespace.
+- Chutes passes `cache_salt` to vLLM but does not generate it. Unsalted requests
+  share the serving instance's namespace.
+
+Tinfoil's behavior is attestation-backed. Chutes configuration is control-plane
+evidence and is not bound by its current attestation. To enforce isolation, the
+gateway must override caller values with a stable, opaque tenant partition,
+using `cache_salt` for Chutes and `user_cache_secret` for Tinfoil.
+
 ## The shared verification model
 
 **A session binding is only trustworthy if it is bound into a verified attestation.**


### PR DESCRIPTION
## What changed

- Document the current Kimi-K2.6 prefix-cache behavior for Tinfoil and Chutes.
- Clarify that `cache_salt` should remain caller-controlled rather than be derived from Redpill tenant identity.
- Record the provider-specific mapping: preserve `cache_salt` for Chutes and translate it to `user_cache_secret` for Tinfoil.
- Distinguish Tinfoil's attestation-backed behavior from Chutes control-plane evidence.

## Why

The same caller-supplied `cache_salt` currently behaves differently across the active Kimi-K2.6 providers. The note prevents us from claiming gateway-enforced per-tenant isolation and records the intended portable interface.

## Impact

Documentation only. Implementation is tracked in #83.

## Validation

- `git diff --check`
- Verified the linked Tinfoil router source and current provider behavior during the Kimi-K2.6 provider review

Tracks #83