### PR TITLE
Add proxy middleware auth and preserve completions usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,20 +384,27 @@ Deployment files:
 
 ## Middleware
 
-The gateway runs in no-middleware mode unless middleware is configured. In
-middleware mode the middleware runs in-process, between the frontend and
-backend:
+The gateway runs in no-middleware mode unless middleware is configured. The
+`middleware` section selects one backend:
 
-- Public `/v1/models` and its sub-catalogs are served from the control plane.
-- Public inference requests are decrypted and normalized by the frontend, then
-  handed to the middleware, which consults the control plane to
-  authorize and route the request and shapes the provider request.
-- The middleware selects a configured target route, forwards through the
-  backend, transforms the response, injects usage cost, and reports usage back
-  to the control plane. Verification facts still come from the backend.
-- Streaming responses stay streaming across backend, middleware, and frontend.
-- Middleware-generated OpenAI-compatible responses are passed through downstream
-  E2EE when the original user request used E2EE.
+- `control`: the gateway consults an HTTP control plane at `/consult/pre`,
+  shapes one request body per candidate, and forwards through the verified
+  backend path itself.
+- `proxy`: the gateway sends the full normalized request body to an external
+  data-plane middleware after applying the gateway's OpenAI-compatible request
+  shaping, so PAG-only routing fields such as `provider` are not exposed to the
+  router. The middleware selects a route and calls `POST /internal/forward`
+  with a one-use request id. The gateway then rebuilds the backend request from
+  the stored original request plus the selected route's `format`/`engine`, so
+  final provider shaping remains inside PAG. The internal callback still goes
+  through the verified backend path and records `middleware.forwarded`,
+  `route.selected`, `request.forwarded`, and `upstream.verified` in the receipt.
+
+In both modes, public requests are decrypted and normalized by the frontend
+before middleware sees them, and verification facts still come from the backend.
+Streaming responses stay streaming across middleware, backend, and frontend.
+Middleware-generated OpenAI-compatible responses are passed through downstream
+E2EE when the original user request used E2EE.
 
 The middleware is configured by the `middleware` section of the static gateway
 config; see the [configuration reference](docs/configuration-reference.md#middleware).

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -42,35 +42,100 @@ This is the smallest practical container config.
 | `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
+| `api_token` | unset | Optional Bearer token for public OpenAI-compatible catalog and inference endpoints, including `/v1/models`, `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/messages`, `/v1/responses`, and `/v1/metrics`. When unset, these endpoints keep the upstream default unauthenticated behavior. When set, requests without the matching Bearer token fail closed. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
-| `middleware` | unset | Optional middleware section. When present, the gateway consults a control plane to route and authorize each request and applies request/response transforms; when unset it serves directly. See [Middleware](#middleware). |
+| `middleware` | unset | Optional middleware section. When present, the gateway runs one configured middleware backend; when unset it serves directly. See [Middleware](#middleware). |
 
 ## Middleware
 
-The optional `middleware` section runs the middleware in the request
-path. When present, the gateway consults a control plane at `control_url` to
-authorize and route each request, shapes the provider request, injects response
-cost, and reports usage back to the control plane — all in-process, with no
-out-of-process hop. When the section is omitted the gateway serves directly.
+The optional `middleware` section runs a middleware backend in the request path.
+The backend is selected by `middleware.mode`.
+
+`control` mode is the existing control-plane integration. The gateway consults
+a control plane at `control_url` to authorize and route each request, shapes the
+provider request, injects response cost, and reports usage back to the control
+plane. The gateway still performs the verified upstream forward itself.
+
+`proxy` mode is for request-body-aware data-plane middleware, such as a vLLM
+Router wrapper. The gateway stores a one-use request context, sends an
+OpenAI-compatible shaped request body to `proxy_url`, and expects the middleware
+to call back to `POST /internal/forward` with the chosen target route. PAG-only
+routing fields such as `provider` are stripped before the proxy hop. The
+callback body is not trusted as the final provider-shaped backend request; PAG
+rebuilds that body from the stored original request and the selected route's
+`format`/`engine`, then returns through the normal verified-forward and receipt
+path. The final receipt still records `middleware.forwarded`, `route.selected`,
+`request.forwarded`, and `upstream.verified`.
+
+When the section is omitted the gateway serves directly.
+
+Setting `api_token` also enables public model-id validation for inference
+requests. In `proxy` middleware mode, model-id validation is enabled even when
+`api_token` is unset so the external router receives only configured public
+model ids.
 
 | Field | Default | Use |
 | --- | --- | --- |
-| `middleware.control_url` | required | Base URL of the control plane the gateway consults for routing, authorization, catalogs, and usage reporting. |
+| `middleware.mode` | `control` | `control` for `/consult/pre` candidate ordering, or `proxy` for full data-plane middleware. |
+| `middleware.control_url` | required in `control` mode | Base URL of the control plane the gateway consults for routing, authorization, catalogs, and usage reporting. |
 | `middleware.control_token` | unset | Bearer token sent to the control plane. When unset, no `Authorization` header is sent. |
 | `middleware.control_timeout_ms` | `60000` | Timeout for the pre-request consult and catalog fetches. A failed or timed-out consult fails closed. |
 | `middleware.control_post_timeout_ms` | `10000` | Timeout for the fire-and-forget post-request usage report. |
-| `middleware.sse_keepalive_ms` | `10000` | Idle keep-alive interval for streaming responses; `0` disables the heartbeat. |
+| `middleware.proxy_url` | required in `proxy` mode | Base URL of the external data-plane middleware. Public completion requests are forwarded to this URL with the original `/v1/...` path. |
+| `middleware.internal_token` | required in `proxy` mode | Shared secret required on `POST /internal/forward`. Give this only to the data-plane middleware. |
+| `middleware.proxy_timeout_ms` | `1800000` | Timeout for the external proxy request. |
+| `middleware.sse_keepalive_ms` | `10000` | Idle keep-alive interval for streaming responses finalized by the gateway; `0` disables the heartbeat. |
 
 ```json
 {
   "middleware": {
+    "mode": "control",
     "control_url": "https://control.example",
     "control_token": "<control-plane-bearer-token>"
   }
 }
 ```
 
-Only `control_url` is required.
+Proxy mode:
+
+```json
+{
+  "middleware": {
+    "mode": "proxy",
+    "proxy_url": "http://vllm-router:8100",
+    "internal_token": "<shared-internal-callback-token>"
+  }
+}
+```
+
+When the proxy is a `vllm-project/router` wrapper, regular router mode still
+needs at least one initial worker. Use the wrapper's bootstrap worker as the
+initial `--worker-urls` value, then add and remove real upstream nodes through
+the wrapper admin API so the wrapper can keep PAG upstream config and router
+workers in sync.
+
+In proxy mode the middleware receives:
+
+```text
+X-Private-AI-Gateway-Request-ID: <one-use request id>
+X-Private-AI-Gateway-Internal-Token: <internal_token>
+X-User-Tier: basic|premium, when known
+```
+
+The middleware callback must send:
+
+```text
+POST /internal/forward
+X-Private-AI-Gateway-Internal-Token: <internal_token>
+X-Private-AI-Gateway-Request-ID: <same request id>
+X-Private-AI-Gateway-Targets: <selected route id>
+X-Private-AI-Gateway-Target-Format: openai|anthropic
+X-User-Tier: basic|premium, when known
+```
+
+The callback request body should be the request body received from the proxy
+hop. PAG uses the one-use request id and selected route as the authority, then
+applies its own provider request shaping before forwarding to the upstream.
 
 ## Source Provenance
 

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -36,12 +36,23 @@ use super::error_responses::{
     unknown_downstream_host_response, unsupported_e2ee_response, upstream_config_error_response,
 };
 use super::util::{
-    enforce_admin, enforce_owner, extract_bearer, has_e2ee_headers, header_str, request_host_domain,
+    enforce_admin, enforce_api, enforce_owner, extract_bearer, has_e2ee_headers, header_str,
+    request_host_domain,
 };
 use super::AppState;
+use crate::middleware::completion::InternalForwardRequest;
 use crate::middleware::errors::Surface;
+use crate::middleware::proxy::parse_target_format;
 use crate::middleware::request_transform::Endpoint;
+use crate::middleware::types::{Engine, RouteCandidate};
 use crate::middleware::{hash_api_key, CompletionInput};
+
+const INTERNAL_TOKEN_HEADER: &str = "x-private-ai-gateway-internal-token";
+const INTERNAL_REQUEST_ID_HEADER: &str = "x-private-ai-gateway-request-id";
+const INTERNAL_TARGETS_HEADER: &str = "x-private-ai-gateway-targets";
+const INTERNAL_TARGET_FORMAT_HEADER: &str = "x-private-ai-gateway-target-format";
+const INTERNAL_TARGET_ENGINE_HEADER: &str = "x-private-ai-gateway-target-engine";
+const USER_TIER_HEADER: &str = "x-user-tier";
 
 #[derive(Deserialize)]
 pub(super) struct AttestationQuery {
@@ -76,7 +87,10 @@ pub(super) async fn root(State(state): State<AppState>) -> Json<Value> {
     }))
 }
 
-pub(super) async fn models(State(state): State<AppState>) -> Response {
+pub(super) async fn models(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(response) = enforce_api(&state, &headers) {
+        return response;
+    }
     if let Some(middleware) = state.middleware.clone() {
         return middleware.handle_catalog("/v1/models").await;
     }
@@ -92,8 +106,12 @@ pub(super) async fn models(State(state): State<AppState>) -> Response {
 // than enumerate routes here. Only meaningful in the middleware topology.
 pub(super) async fn models_subpath(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(rest): Path<String>,
 ) -> Response {
+    if let Some(response) = enforce_api(&state, &headers) {
+        return response;
+    }
     let Some(middleware) = state.middleware.clone() else {
         return error_response(
             StatusCode::NOT_FOUND,
@@ -108,7 +126,13 @@ pub(super) async fn models_subpath(
 
 // Embedding model catalog. Only meaningful in the control-plane middleware
 // topology.
-pub(super) async fn embeddings_models(State(state): State<AppState>) -> Response {
+pub(super) async fn embeddings_models(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(response) = enforce_api(&state, &headers) {
+        return response;
+    }
     let Some(middleware) = state.middleware.clone() else {
         return error_response(
             StatusCode::NOT_FOUND,
@@ -119,7 +143,10 @@ pub(super) async fn embeddings_models(State(state): State<AppState>) -> Response
     middleware.handle_catalog("/v1/embeddings/models").await
 }
 
-pub(super) async fn metrics(State(state): State<AppState>) -> Response {
+pub(super) async fn metrics(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(response) = enforce_api(&state, &headers) {
+        return response;
+    }
     match state.service.metrics() {
         Ok(snapshot) => {
             let mut headers = HeaderMap::new();
@@ -127,6 +154,100 @@ pub(super) async fn metrics(State(state): State<AppState>) -> Response {
             (StatusCode::OK, headers, snapshot.body).into_response()
         }
         Err(err) => internal_error_response(err),
+    }
+}
+
+pub(super) async fn internal_forward(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let Some(middleware) = state.middleware.clone() else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "internal middleware forwarding is not enabled",
+        );
+    };
+    let Some(expected) = middleware.internal_token() else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "internal middleware forwarding is not enabled for this middleware backend",
+        );
+    };
+    if header_str(&headers, INTERNAL_TOKEN_HEADER) != Some(expected) {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "invalid internal middleware token",
+        );
+    }
+    let Some(request_id) = header_str(&headers, INTERNAL_REQUEST_ID_HEADER)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "missing x-private-ai-gateway-request-id",
+        );
+    };
+    let Some(route_id) = header_str(&headers, INTERNAL_TARGETS_HEADER)
+        .and_then(first_header_value)
+        .filter(|value| !value.is_empty())
+    else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "missing x-private-ai-gateway-targets",
+        );
+    };
+    let selected_route = RouteCandidate {
+        route_id: route_id.to_string(),
+        format: parse_target_format(header_str(&headers, INTERNAL_TARGET_FORMAT_HEADER)),
+        engine: parse_target_engine(header_str(&headers, INTERNAL_TARGET_ENGINE_HEADER)),
+    };
+    let user_tier = header_str(&headers, USER_TIER_HEADER).and_then(normalize_user_tier);
+
+    middleware
+        .handle_internal_forward(
+            &state.service,
+            InternalForwardRequest {
+                request_id: request_id.to_string(),
+                selected_route,
+                user_tier,
+                body: body.to_vec(),
+            },
+        )
+        .await
+}
+
+fn first_header_value(value: &str) -> Option<&str> {
+    value.split(',').next().map(str::trim)
+}
+
+fn normalize_user_tier(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value.eq_ignore_ascii_case("premium") {
+        return Some("premium".to_string());
+    }
+    Some("basic".to_string())
+}
+
+fn parse_target_engine(value: Option<&str>) -> Option<Engine> {
+    match value
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "sglang" => Some(Engine::Sglang),
+        "vllm" => Some(Engine::Vllm),
+        _ => None,
     }
 }
 
@@ -530,6 +651,10 @@ pub(super) async fn openai_completion_endpoint(
     endpoint_path: &'static str,
     force_buffered: bool,
 ) -> Response {
+    if let Some(response) = enforce_api(&state, &headers) {
+        return response;
+    }
+
     // A revoked keyset backs the receipt-signing, E2EE, and TLS keys this
     // request would use; stop serving inference under it (§4.7).
     if state.service.is_keyset_revoked() {
@@ -588,6 +713,26 @@ pub(super) async fn openai_completion_endpoint(
         (normalized, false) => (normalized, None),
     };
 
+    let user_model = if should_validate_public_model(&state) {
+        let requested_model = match requested_model_from_body(&parsed) {
+            Ok(model) => model,
+            Err(response) => return response,
+        };
+        if !public_model_is_configured(&state, requested_model) {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                "not_found",
+                format!("Unknown model: {requested_model}"),
+            );
+        }
+        Some(requested_model.to_string())
+    } else {
+        parsed
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    };
+
     let upstream_required = match headers
         .get("x-upstream-verification")
         .and_then(|v| v.to_str().ok())
@@ -606,15 +751,12 @@ pub(super) async fn openai_completion_endpoint(
     let requester = extract_bearer(&headers)
         .as_deref()
         .map(ReceiptOwner::from_bearer);
+    let user_tier = header_str(&headers, USER_TIER_HEADER).and_then(normalize_user_tier);
     let context = GatewayRequestContext {
         request_id: generate_request_id(),
-        user_model: parsed
-            .get("model")
-            .and_then(Value::as_str)
-            .map(str::to_string),
+        user_model: user_model.clone(),
         target_route_id: None,
-        // Populated from the x-user-tier header on the internal-forward path.
-        user_tier: None,
+        user_tier: user_tier.clone(),
     };
 
     let stream = !force_buffered
@@ -648,6 +790,7 @@ pub(super) async fn openai_completion_endpoint(
             upstream_required,
             request_id: context.request_id,
             user_model: context.user_model,
+            user_tier,
             stream,
         };
         return middleware.handle_completion(&state.service, input).await;
@@ -668,6 +811,48 @@ pub(super) async fn openai_completion_endpoint(
     )
     .await
 }
+
+fn requested_model_from_body(parsed: &Value) -> Result<&str, Response> {
+    let Some(model) = parsed.get("model") else {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Model parameter is required",
+        ));
+    };
+    let Some(model) = model
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Model parameter must be a non-empty string",
+        ));
+    };
+    Ok(model)
+}
+
+fn should_validate_public_model(state: &AppState) -> bool {
+    state.api_token.is_some()
+        || state
+            .middleware
+            .as_ref()
+            .map_or(false, |middleware| middleware.name() == "proxy")
+}
+
+fn public_model_is_configured(state: &AppState, model: &str) -> bool {
+    let Some(manager) = state.upstream_config.as_ref() else {
+        return true;
+    };
+    manager
+        .snapshot()
+        .upstreams
+        .iter()
+        .any(|upstream| upstream.models.contains_key(model))
+}
+
 pub(super) async fn completions(
     State(state): State<AppState>,
     headers: HeaderMap,

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -93,8 +93,8 @@ mod util;
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, aci_revocations, admin_get_upstreams,
     admin_put_upstreams, admin_revoke_keyset, attestation_report, attested_session,
-    chat_completions, completions, embeddings, embeddings_models, health, messages, metrics,
-    models, models_subpath, receipt_by_chat_id, responses, root,
+    chat_completions, completions, embeddings, embeddings_models, health, internal_forward,
+    messages, metrics, models, models_subpath, receipt_by_chat_id, responses, root,
 };
 
 #[derive(Clone)]
@@ -102,11 +102,12 @@ pub struct AppState {
     pub service: Arc<AciService>,
     pub upstream_config: Option<Arc<UpstreamConfigManager>>,
     pub admin_token: Option<String>,
+    pub api_token: Option<String>,
     middleware: Option<Arc<Middleware>>,
 }
 
 pub fn build_router(service: Arc<AciService>) -> Router {
-    build_router_inner(service, None, None, None)
+    build_router_inner(service, None, None, None, None)
 }
 
 pub fn build_router_with_admin(
@@ -114,7 +115,16 @@ pub fn build_router_with_admin(
     upstream_config: Arc<UpstreamConfigManager>,
     admin_token: Option<String>,
 ) -> Router {
-    build_router_inner(service, Some(upstream_config), admin_token, None)
+    build_router_inner(service, Some(upstream_config), admin_token, None, None)
+}
+
+pub fn build_router_with_admin_and_api(
+    service: Arc<AciService>,
+    upstream_config: Arc<UpstreamConfigManager>,
+    admin_token: Option<String>,
+    api_token: Option<String>,
+) -> Router {
+    build_router_inner(service, Some(upstream_config), admin_token, api_token, None)
 }
 
 /// Build the gateway router with the middleware, which consults the
@@ -129,6 +139,23 @@ pub fn build_router_with_admin_and_middleware(
         service,
         Some(upstream_config),
         admin_token,
+        None,
+        Some(middleware),
+    )
+}
+
+pub fn build_router_with_admin_api_and_middleware(
+    service: Arc<AciService>,
+    upstream_config: Arc<UpstreamConfigManager>,
+    admin_token: Option<String>,
+    api_token: Option<String>,
+    middleware: Arc<Middleware>,
+) -> Router {
+    build_router_inner(
+        service,
+        Some(upstream_config),
+        admin_token,
+        api_token,
         Some(middleware),
     )
 }
@@ -137,12 +164,14 @@ fn build_router_inner(
     service: Arc<AciService>,
     upstream_config: Option<Arc<UpstreamConfigManager>>,
     admin_token: Option<String>,
+    api_token: Option<String>,
     middleware: Option<Arc<Middleware>>,
 ) -> Router {
     let state = AppState {
         service,
         upstream_config,
         admin_token,
+        api_token,
         middleware,
     };
     Router::new()
@@ -157,6 +186,7 @@ fn build_router_inner(
         .route("/v1/embeddings", post(embeddings))
         .route("/v1/messages", post(messages))
         .route("/v1/responses", post(responses))
+        .route("/internal/forward", post(internal_forward))
         // Gateway operations.
         .route("/v1/metrics", get(metrics))
         .route(

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -115,3 +115,25 @@ pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Res
         ))
     }
 }
+
+pub(super) fn enforce_api(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+    let Some(expected) = state.api_token.as_deref() else {
+        return None;
+    };
+    let Some(token) = extract_bearer(headers) else {
+        return Some(error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "api bearer token required",
+        ));
+    };
+    if token == expected {
+        None
+    } else {
+        Some(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "invalid api bearer token",
+        ))
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,4 +2,7 @@
 
 pub mod app;
 
-pub use app::{build_router, build_router_with_admin, build_router_with_admin_and_middleware};
+pub use app::{
+    build_router, build_router_with_admin, build_router_with_admin_and_api,
+    build_router_with_admin_and_middleware, build_router_with_admin_api_and_middleware,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,9 @@ use private_ai_gateway::aggregator::upstream_config::{
     parse_config_text, UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::dstack::{DstackAciProvider, DstackAciProviderConfig};
-use private_ai_gateway::http::{build_router_with_admin, build_router_with_admin_and_middleware};
+use private_ai_gateway::http::{
+    build_router_with_admin_and_api, build_router_with_admin_api_and_middleware,
+};
 use private_ai_gateway::middleware::{Middleware, MiddlewareConfig};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -72,6 +74,7 @@ struct GatewayConfigFile {
     state_dir: Option<String>,
     upstream_config_seed_path: Option<String>,
     admin_token: Option<String>,
+    api_token: Option<String>,
     /// Bounded keyset-epoch validity window in seconds (§4.7). Defaults to
     /// [`DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS`] (~4 weeks).
     keyset_epoch_window_seconds: Option<u64>,
@@ -352,6 +355,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let session_log_path = session_log_path(&state_dir);
     let upstream_config_seed_path = gateway_config.upstream_config_seed_path.clone();
     let admin_token = gateway_config.admin_token.clone();
+    let api_token = gateway_config
+        .api_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string);
     let source_provenance = resolve_source_provenance()?;
     let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
     let dstack_endpoint = gateway_config.dstack_endpoint.clone();
@@ -500,12 +509,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = if let Some(middleware_config) = middleware_config {
         let middleware = Arc::new(Middleware::new(&middleware_config).map_err(invalid_input)?);
         tracing::info!(
-            control_url = %middleware_config.control_url,
+            mode = ?middleware_config.mode,
+            backend = middleware.name(),
             "private-ai-gateway middleware enabled"
         );
-        build_router_with_admin_and_middleware(service, upstream_config, admin_token, middleware)
+        build_router_with_admin_api_and_middleware(
+            service,
+            upstream_config,
+            admin_token,
+            api_token,
+            middleware,
+        )
     } else {
-        build_router_with_admin(service, upstream_config, admin_token)
+        build_router_with_admin_and_api(service, upstream_config, admin_token, api_token)
     };
 
     tracing::info!(%bind, "private-ai-gateway listening");
@@ -627,6 +643,7 @@ fn log_prewarm_results(
 #[cfg(test)]
 mod tests {
     use private_ai_gateway::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
+    use private_ai_gateway::middleware::MiddlewareMode;
 
     use super::{
         keyset_epoch_path, load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
@@ -713,10 +730,42 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
         let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
 
         let middleware = config.middleware.expect("middleware section must parse");
-        assert_eq!(middleware.control_url, "https://control.example");
+        assert_eq!(
+            middleware.control_url.as_deref(),
+            Some("https://control.example")
+        );
         assert_eq!(middleware.control_token.as_deref(), Some("secret"));
         // Optional timeouts default to None and fall back inside the client.
         assert_eq!(middleware.control_timeout_ms, None);
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn gateway_config_parses_proxy_middleware_section() {
+        let config_path = temp_path("gateway-config-proxy-middleware");
+        std::fs::write(
+            &config_path,
+            r#"{
+                "middleware": {
+                    "mode": "proxy",
+                    "proxy_url": "http://vllm-router:8100",
+                    "internal_token": "shared-secret",
+                    "proxy_timeout_ms": 1234
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+
+        let middleware = config.middleware.expect("middleware section must parse");
+        assert_eq!(middleware.mode, MiddlewareMode::Proxy);
+        assert_eq!(
+            middleware.proxy_url.as_deref(),
+            Some("http://vllm-router:8100")
+        );
+        assert_eq!(middleware.internal_token.as_deref(), Some("shared-secret"));
+        assert_eq!(middleware.proxy_timeout_ms, Some(1234));
         let _ = std::fs::remove_file(config_path);
     }
 

--- a/src/middleware/backend.rs
+++ b/src/middleware/backend.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use axum::response::Response;
+
+use crate::aggregator::service::AciService;
+
+use super::completion::{CompletionInput, InternalForwardRequest};
+
+#[async_trait]
+pub trait MiddlewareBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    async fn handle_catalog(&self, v1_path: &str) -> Response;
+
+    async fn handle_completion(&self, service: &AciService, input: CompletionInput) -> Response;
+
+    fn internal_token(&self) -> Option<&str> {
+        None
+    }
+
+    async fn handle_internal_forward(
+        &self,
+        _service: &AciService,
+        _input: InternalForwardRequest,
+    ) -> Response {
+        super::errors::error_response(
+            super::errors::Surface::Openai,
+            404,
+            "not_found",
+            "/internal/forward is not enabled for this middleware backend",
+            None,
+        )
+    }
+}

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -25,10 +25,10 @@ use crate::aggregator::service::{
 
 use super::control::ControlClient;
 use super::errors::{self, Surface};
-use super::request_transform::{build_candidates, Endpoint};
+use super::request_transform::{build_candidates, transform_to_provider_request, Endpoint};
 use super::sse::{KeepAliveStream, MeterStream, StreamReport};
 use super::stream_transform::SseTransformStream;
-use super::types::{ErrorSource, PostReport, ProviderFormat, SpendMode};
+use super::types::{ErrorSource, PostReport, ProviderFormat, RouteCandidate, SpendMode};
 use super::{pricing, response_transform, stream_transform};
 
 /// Everything the completion path needs, computed by the HTTP handler after E2EE
@@ -48,7 +48,59 @@ pub struct CompletionInput {
     pub upstream_required: bool,
     pub request_id: String,
     pub user_model: Option<String>,
+    pub user_tier: Option<String>,
     pub stream: bool,
+}
+
+/// Request context kept by a data-plane proxy middleware until it calls back
+/// into PAG with the selected route.
+#[derive(Clone)]
+pub struct PendingCompletion {
+    pub endpoint: Endpoint,
+    pub endpoint_path: &'static str,
+    pub surface: Surface,
+    pub params: Value,
+    pub received_body: Vec<u8>,
+    pub requester: Option<ReceiptOwner>,
+    pub e2ee: Option<E2eeRequestContext>,
+    pub upstream_required: bool,
+    pub request_id: String,
+    pub user_model: Option<String>,
+    pub user_tier: Option<String>,
+    pub stream: bool,
+}
+
+impl From<CompletionInput> for PendingCompletion {
+    fn from(input: CompletionInput) -> Self {
+        Self {
+            endpoint: input.endpoint,
+            endpoint_path: input.endpoint_path,
+            surface: input.surface,
+            params: input.params,
+            received_body: input.received_body,
+            requester: input.requester,
+            e2ee: input.e2ee,
+            upstream_required: input.upstream_required,
+            request_id: input.request_id,
+            user_model: input.user_model,
+            user_tier: input.user_tier,
+            stream: input.stream,
+        }
+    }
+}
+
+pub struct InternalForwardRequest {
+    pub request_id: String,
+    pub selected_route: RouteCandidate,
+    pub user_tier: Option<String>,
+    pub body: Vec<u8>,
+}
+
+pub struct InternalForwardInput {
+    pub pending: PendingCompletion,
+    pub selected_route: RouteCandidate,
+    pub user_tier: Option<String>,
+    pub body: Vec<u8>,
 }
 
 /// Run the completion flow and produce the client response.
@@ -70,6 +122,7 @@ pub async fn run(
         upstream_required,
         request_id,
         user_model,
+        user_tier,
         stream,
     } = input;
 
@@ -163,7 +216,7 @@ pub async fn run(
         request_id,
         user_model,
         target_route_id: None,
-        user_tier: consult.user_tier.clone(),
+        user_tier: consult.user_tier.clone().or(user_tier),
     };
 
     // The receipt-draft journal is only consumed by the streaming finalizer; the
@@ -420,6 +473,227 @@ pub async fn run(
             }
             service_error_response(surface, endpoint_path, service, &request_id, err, e2ee)
         }
+    }
+}
+
+pub async fn forward_selected(
+    service: &AciService,
+    sse_keepalive_ms: Option<u64>,
+    input: InternalForwardInput,
+) -> Response {
+    let InternalForwardInput {
+        pending,
+        selected_route,
+        user_tier,
+        body: _callback_body,
+    } = input;
+    let PendingCompletion {
+        endpoint,
+        endpoint_path,
+        surface,
+        params,
+        received_body,
+        requester,
+        e2ee,
+        upstream_required,
+        request_id,
+        user_model,
+        user_tier: pending_user_tier,
+        stream,
+    } = pending;
+    let user_tier = user_tier.or(pending_user_tier);
+
+    let selected_format = selected_route.format;
+    let selected_engine = selected_route.engine;
+    let selected_route_id = selected_route.route_id;
+    let body =
+        match transform_to_provider_request(selected_format, &params, endpoint, selected_engine) {
+            Ok(body) => serde_json::to_vec(&body).unwrap_or_default(),
+            Err(err) => {
+                let message = format!("failed to shape provider request: {err}");
+                let body = errors::envelope_bytes(
+                    surface,
+                    errors::error_type(surface, 500),
+                    &message,
+                    Some(&request_id),
+                );
+                return finalize_generated(surface, service, endpoint_path, 500, body, &[], e2ee);
+            }
+        };
+    let context = GatewayRequestContext {
+        request_id: request_id.clone(),
+        user_model,
+        target_route_id: None,
+        user_tier,
+    };
+    let forward_candidates = vec![ForwardCandidate {
+        route_id: selected_route_id.clone(),
+        body,
+    }];
+    let journal = MiddlewareReceiptJournal::default();
+    let result = service
+        .forward_chat_completion_for_middleware(
+            ChatCompletionRequest {
+                context,
+                endpoint_path,
+                received_body: &received_body,
+                forwarded_body: None,
+                upstream_required: Some(upstream_required),
+                upstream_verification_event: None,
+                requester: requester.clone(),
+                e2ee: e2ee.clone(),
+            },
+            forward_candidates,
+            stream,
+            journal.clone(),
+        )
+        .await;
+
+    match result {
+        Ok(MiddlewareForwardResult::Forwarded(forward)) => {
+            let upstream_status = forward.upstream_status;
+            let (client_status, final_body) = if (200..300).contains(&upstream_status) {
+                let upstream_json: Value = match serde_json::from_slice(&forward.upstream_body) {
+                    Ok(value) => value,
+                    Err(_) => {
+                        let message = "upstream returned a malformed success body";
+                        let body = errors::envelope_bytes(
+                            surface,
+                            errors::error_type(surface, 502),
+                            message,
+                            Some(&request_id),
+                        );
+                        return finalize_generated(
+                            surface,
+                            service,
+                            endpoint_path,
+                            502,
+                            body,
+                            &[],
+                            e2ee,
+                        );
+                    }
+                };
+                let transformed = response_transform::transform_response(
+                    selected_format,
+                    endpoint,
+                    upstream_json,
+                );
+                (
+                    upstream_status,
+                    serde_json::to_vec(&transformed).unwrap_or_default(),
+                )
+            } else {
+                let (mapped, body) = errors::normalize_upstream_error_parts(
+                    surface,
+                    upstream_status,
+                    &forward.upstream_body,
+                    &received_body,
+                    Some(&request_id),
+                );
+                (mapped, body)
+            };
+
+            match service.finalize_middleware_receipt(
+                forward.receipt,
+                &final_body,
+                Some("application/json"),
+                requester,
+                e2ee,
+            ) {
+                Ok(finalized) => {
+                    let status =
+                        StatusCode::from_u16(client_status).unwrap_or(StatusCode::BAD_GATEWAY);
+                    let mut headers =
+                        response_headers(&forward.upstream_headers, "application/json");
+                    insert_header(&mut headers, "x-receipt-id", &finalized.receipt.receipt_id);
+                    insert_header(
+                        &mut headers,
+                        "x-private-ai-gateway-selected-route",
+                        &selected_route_id,
+                    );
+                    apply_e2ee_headers(&mut headers, finalized.e2ee.as_ref(), true);
+                    (status, headers, finalized.wire_body).into_response()
+                }
+                Err(err) => {
+                    service_error_response(surface, endpoint_path, service, &request_id, err, None)
+                }
+            }
+        }
+        Ok(MiddlewareForwardResult::Stream(forward)) => {
+            let content_type = forward
+                .upstream_headers
+                .get("content-type")
+                .cloned()
+                .unwrap_or_else(|| "text/event-stream".to_string());
+            let upstream_status = forward.upstream_status;
+            let keepalive = match sse_keepalive_ms.unwrap_or(10_000) {
+                0 => None,
+                ms => Some(Duration::from_millis(ms)),
+            };
+            let response_header_map = response_headers(&forward.upstream_headers, &content_type);
+            let transformed: ServiceResponseStream =
+                match stream_transform::select_stream_transform(selected_format, endpoint) {
+                    Some(transform) => Box::pin(SseTransformStream::new(forward.body, transform)),
+                    None => forward.body,
+                };
+            let kept: ServiceResponseStream =
+                Box::pin(KeepAliveStream::new(transformed, keepalive));
+            let receipt_id = journal.peek_receipt_id();
+            match service.finalize_middleware_response_stream(
+                journal,
+                kept,
+                endpoint_path,
+                Some(&content_type),
+                requester,
+                e2ee,
+            ) {
+                Ok(finalized) => {
+                    let status =
+                        StatusCode::from_u16(upstream_status).unwrap_or(StatusCode::BAD_GATEWAY);
+                    let mut headers = response_header_map;
+                    if let Some(receipt_id) = &receipt_id {
+                        insert_header(&mut headers, "x-receipt-id", receipt_id);
+                        apply_e2ee_headers(&mut headers, finalized.e2ee.as_ref(), true);
+                    } else {
+                        apply_e2ee_headers(&mut headers, finalized.e2ee.as_ref(), false);
+                    }
+                    insert_header(
+                        &mut headers,
+                        "x-private-ai-gateway-selected-route",
+                        &selected_route_id,
+                    );
+                    headers.insert(
+                        HeaderName::from_static("x-accel-buffering"),
+                        HeaderValue::from_static("no"),
+                    );
+                    headers.insert(
+                        HeaderName::from_static("cache-control"),
+                        HeaderValue::from_static("no-cache"),
+                    );
+                    let body = Body::from_stream(
+                        finalized
+                            .body
+                            .map(|chunk| chunk.map_err(|e| std::io::Error::other(e.to_string()))),
+                    );
+                    (status, headers, body).into_response()
+                }
+                Err(err) => {
+                    service_error_response(surface, endpoint_path, service, &request_id, err, None)
+                }
+            }
+        }
+        Ok(MiddlewareForwardResult::UpstreamError(forward)) => {
+            let (status, body) = errors::normalize_upstream_error_parts(
+                surface,
+                forward.upstream_status,
+                &forward.upstream_body,
+                &received_body,
+                Some(&request_id),
+            );
+            finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
+        }
+        Err(err) => service_error_response(surface, endpoint_path, service, &request_id, err, e2ee),
     }
 }
 

--- a/src/middleware/config.rs
+++ b/src/middleware/config.rs
@@ -1,19 +1,40 @@
 //! Configuration for the middleware.
 //!
-//! Selected through the gateway's optional `middleware` config section. When
-//! present, the gateway consults the control plane directly over HTTP, in
-//! process, with no Unix-domain-socket hop.
+//! Selected through the gateway's optional `middleware` config section.
 
 use serde::Deserialize;
 
-/// Middleware settings. `control_url` is required; the rest fall back
-/// to the defaults documented in the configuration reference.
+/// Which middleware backend owns the request path.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MiddlewareMode {
+    /// Existing control-plane mode: PAG asks `/consult/pre` for ordered
+    /// candidates and forwards through its own backend path.
+    Control,
+    /// Data-plane proxy mode: PAG sends the full normalized request to an
+    /// external middleware, which calls back to PAG `/internal/forward` with
+    /// the selected route.
+    Proxy,
+}
+
+impl Default for MiddlewareMode {
+    fn default() -> Self {
+        Self::Control
+    }
+}
+
+/// Middleware settings. Existing `control_url` configs remain valid and default
+/// to `mode = "control"`. `mode = "proxy"` is for request-body-aware
+/// middlewares such as a vLLM Router wrapper.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MiddlewareConfig {
+    #[serde(default)]
+    pub mode: MiddlewareMode,
     /// Base URL of the control plane (`http`/`https`). Consult and catalog paths
-    /// are appended to it.
-    pub control_url: String,
+    /// are appended to it. Required in `control` mode.
+    #[serde(default)]
+    pub control_url: Option<String>,
     /// Optional bearer token for control-plane requests.
     #[serde(default)]
     pub control_token: Option<String>,
@@ -29,4 +50,15 @@ pub struct MiddlewareConfig {
     /// `0` disables the heartbeat.
     #[serde(default)]
     pub sse_keepalive_ms: Option<u64>,
+    /// Base URL of the data-plane middleware. Required in `proxy` mode.
+    #[serde(default)]
+    pub proxy_url: Option<String>,
+    /// Bearer-like shared secret used only on the internal callback from the
+    /// data-plane middleware to `POST /internal/forward`. Required in `proxy`
+    /// mode.
+    #[serde(default)]
+    pub internal_token: Option<String>,
+    /// Timeout for the external proxy request. Defaults to 1_800_000 ms.
+    #[serde(default)]
+    pub proxy_timeout_ms: Option<u64>,
 }

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -57,7 +57,11 @@ pub struct ControlClient {
 
 impl ControlClient {
     pub fn new(config: &MiddlewareConfig) -> Result<Self, String> {
-        let control_url = config.control_url.trim();
+        let control_url = config
+            .control_url
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default();
         if control_url.is_empty() {
             return Err("middleware.control_url must not be empty".to_string());
         }
@@ -257,14 +261,19 @@ fn truncate(text: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::middleware::config::MiddlewareMode;
 
     fn config(url: &str) -> MiddlewareConfig {
         MiddlewareConfig {
-            control_url: url.to_string(),
+            mode: MiddlewareMode::Control,
+            control_url: Some(url.to_string()),
             control_token: None,
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
+            proxy_url: None,
+            internal_token: None,
+            proxy_timeout_ms: None,
         }
     }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -5,16 +5,20 @@
 //! forwards completions through the service in-process, and it relays model
 //! catalogs from the control plane.
 
+pub mod backend;
 pub mod completion;
 pub mod config;
 pub mod control;
 pub mod errors;
 pub mod pricing;
+pub mod proxy;
 pub mod request_transform;
 pub mod response_transform;
 pub mod sse;
 pub mod stream_transform;
 pub mod types;
+
+use std::sync::Arc;
 
 use axum::{
     http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
@@ -22,30 +26,76 @@ use axum::{
 };
 
 pub use completion::CompletionInput;
-pub use config::MiddlewareConfig;
+pub use config::{MiddlewareConfig, MiddlewareMode};
 pub use control::{hash_api_key, ControlClient};
 
 use crate::aggregator::service::AciService;
+use backend::MiddlewareBackend;
 use errors::Surface;
+use proxy::ProxyBackend;
 
 /// Middleware handle held by the gateway's app state.
 pub struct Middleware {
-    control: ControlClient,
-    sse_keepalive_ms: Option<u64>,
+    backend: Arc<dyn MiddlewareBackend>,
 }
 
 impl Middleware {
     pub fn new(config: &MiddlewareConfig) -> Result<Self, String> {
-        Ok(Self {
-            control: ControlClient::new(config)?,
-            sse_keepalive_ms: config.sse_keepalive_ms,
-        })
+        let backend: Arc<dyn MiddlewareBackend> = match config.mode {
+            MiddlewareMode::Control => Arc::new(ControlBackend {
+                control: ControlClient::new(config)?,
+                sse_keepalive_ms: config.sse_keepalive_ms,
+            }),
+            MiddlewareMode::Proxy => Arc::new(ProxyBackend::new(config)?),
+        };
+        Ok(Self { backend })
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.backend.name()
     }
 
     /// Relay a `/v1/...` catalog request to the control plane, which serves
     /// catalogs without the `/v1` prefix. The control body is returned verbatim
     /// with its status and a forced JSON content type.
     pub async fn handle_catalog(&self, v1_path: &str) -> Response {
+        self.backend.handle_catalog(v1_path).await
+    }
+
+    /// Run the completion flow through the configured middleware backend.
+    pub async fn handle_completion(
+        &self,
+        service: &AciService,
+        input: CompletionInput,
+    ) -> Response {
+        self.backend.handle_completion(service, input).await
+    }
+
+    pub fn internal_token(&self) -> Option<&str> {
+        self.backend.internal_token()
+    }
+
+    pub async fn handle_internal_forward(
+        &self,
+        service: &AciService,
+        input: completion::InternalForwardRequest,
+    ) -> Response {
+        self.backend.handle_internal_forward(service, input).await
+    }
+}
+
+struct ControlBackend {
+    control: ControlClient,
+    sse_keepalive_ms: Option<u64>,
+}
+
+#[async_trait::async_trait]
+impl MiddlewareBackend for ControlBackend {
+    fn name(&self) -> &'static str {
+        "control"
+    }
+
+    async fn handle_catalog(&self, v1_path: &str) -> Response {
         let control_path = v1_path.strip_prefix("/v1").unwrap_or(v1_path);
         match self.control.catalog_get(control_path).await {
             Ok(catalog) => {
@@ -68,13 +118,7 @@ impl Middleware {
         }
     }
 
-    /// Run the completion flow: consult the control plane, shape
-    /// candidate bodies, forward through the service, and finalize the response.
-    pub async fn handle_completion(
-        &self,
-        service: &AciService,
-        input: CompletionInput,
-    ) -> Response {
+    async fn handle_completion(&self, service: &AciService, input: CompletionInput) -> Response {
         completion::run(&self.control, service, self.sse_keepalive_ms, input).await
     }
 }
@@ -104,11 +148,15 @@ mod tests {
     async fn handle_catalog_relays_control_response() {
         let base_url = spawn_stub_control().await;
         let middleware = Middleware::new(&MiddlewareConfig {
-            control_url: base_url,
+            mode: MiddlewareMode::Control,
+            control_url: Some(base_url),
             control_token: None,
             control_timeout_ms: Some(2_000),
             control_post_timeout_ms: Some(2_000),
             sse_keepalive_ms: None,
+            proxy_url: None,
+            internal_token: None,
+            proxy_timeout_ms: None,
         })
         .unwrap();
 
@@ -129,11 +177,15 @@ mod tests {
     #[tokio::test]
     async fn handle_catalog_reports_control_unavailable() {
         let middleware = Middleware::new(&MiddlewareConfig {
-            control_url: "http://127.0.0.1:1".to_string(),
+            mode: MiddlewareMode::Control,
+            control_url: Some("http://127.0.0.1:1".to_string()),
             control_token: None,
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
+            proxy_url: None,
+            internal_token: None,
+            proxy_timeout_ms: None,
         })
         .unwrap();
 

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -1,0 +1,320 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{header::CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use futures_util::StreamExt;
+use serde_json::Value;
+
+use crate::aggregator::service::AciService;
+
+use super::{
+    backend::MiddlewareBackend,
+    completion::{
+        forward_selected, CompletionInput, InternalForwardInput, InternalForwardRequest,
+        PendingCompletion,
+    },
+    errors::{self, Surface},
+    request_transform,
+    types::ProviderFormat,
+};
+
+const DEFAULT_PROXY_TIMEOUT_MS: u64 = 1_800_000;
+const REQUEST_ID_HEADER: &str = "x-private-ai-gateway-request-id";
+const INTERNAL_TOKEN_HEADER: &str = "x-private-ai-gateway-internal-token";
+const USER_TIER_HEADER: &str = "x-user-tier";
+
+#[derive(Clone, Default)]
+struct PendingStore {
+    inner: Arc<Mutex<HashMap<String, PendingEntry>>>,
+}
+
+struct PendingEntry {
+    pending: PendingCompletion,
+    expires_at: Instant,
+}
+
+impl PendingStore {
+    fn insert(&self, pending: PendingCompletion, ttl: Duration) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending middleware store poisoned");
+        let now = Instant::now();
+        inner.retain(|_, entry| entry.expires_at > now);
+        inner.insert(
+            pending.request_id.clone(),
+            PendingEntry {
+                pending,
+                expires_at: now + ttl,
+            },
+        );
+    }
+
+    fn take(&self, request_id: &str) -> Option<PendingCompletion> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending middleware store poisoned");
+        let entry = inner.remove(request_id)?;
+        if entry.expires_at <= Instant::now() {
+            return None;
+        }
+        Some(entry.pending)
+    }
+
+    fn remove(&self, request_id: &str) {
+        self.inner
+            .lock()
+            .expect("pending middleware store poisoned")
+            .remove(request_id);
+    }
+}
+
+pub struct ProxyBackend {
+    client: reqwest::Client,
+    base_url: String,
+    internal_token: String,
+    timeout: Duration,
+    sse_keepalive_ms: Option<u64>,
+    pending: PendingStore,
+}
+
+impl ProxyBackend {
+    pub fn new(config: &super::config::MiddlewareConfig) -> Result<Self, String> {
+        let base_url = config
+            .proxy_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "middleware.proxy_url is required in proxy mode".to_string())?;
+        let internal_token = config
+            .internal_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "middleware.internal_token is required in proxy mode".to_string())?;
+        let timeout =
+            Duration::from_millis(config.proxy_timeout_ms.unwrap_or(DEFAULT_PROXY_TIMEOUT_MS));
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|err| format!("failed to build proxy HTTP client: {err}"))?;
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            internal_token: internal_token.to_string(),
+            timeout,
+            sse_keepalive_ms: config.sse_keepalive_ms,
+            pending: PendingStore::default(),
+        })
+    }
+
+    fn endpoint_url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+}
+
+#[async_trait]
+impl MiddlewareBackend for ProxyBackend {
+    fn name(&self) -> &'static str {
+        "proxy"
+    }
+
+    async fn handle_catalog(&self, v1_path: &str) -> Response {
+        match self
+            .client
+            .get(self.endpoint_url(v1_path))
+            .timeout(self.timeout)
+            .send()
+            .await
+        {
+            Ok(response) => relay_response(response),
+            Err(err) => {
+                tracing::error!(error = %err, path = v1_path, "proxy catalog request failed");
+                errors::error_response(
+                    Surface::Openai,
+                    502,
+                    errors::error_type(Surface::Openai, 502),
+                    "middleware proxy unavailable",
+                    None,
+                )
+            }
+        }
+    }
+
+    async fn handle_completion(&self, _service: &AciService, input: CompletionInput) -> Response {
+        let proxy_request = match request_transform::transform_to_provider_request(
+            ProviderFormat::Openai,
+            &input.params,
+            input.endpoint,
+            None,
+        ) {
+            Ok(body) => body,
+            Err(err) => {
+                let message = format!("failed to shape middleware proxy request: {err}");
+                tracing::error!(error = %err, "failed to shape proxy middleware request");
+                return errors::error_response(
+                    input.surface,
+                    500,
+                    errors::error_type(input.surface, 500),
+                    &message,
+                    Some(&input.request_id),
+                );
+            }
+        };
+        let proxy_body = match serde_json::to_vec(&proxy_request) {
+            Ok(body) => body,
+            Err(err) => {
+                tracing::error!(error = %err, "failed to serialize proxy middleware request");
+                return errors::error_response(
+                    input.surface,
+                    500,
+                    errors::error_type(input.surface, 500),
+                    "failed to serialize middleware request",
+                    Some(&input.request_id),
+                );
+            }
+        };
+        let request_id = input.request_id.clone();
+        let surface = input.surface;
+        let endpoint_path = input.endpoint_path;
+        let user_tier = input
+            .user_tier
+            .clone()
+            .or_else(|| user_tier_from_params(&input.params));
+        let pending = PendingCompletion::from(input);
+        self.pending
+            .insert(pending, self.timeout + Duration::from_secs(30));
+
+        let mut request = self
+            .client
+            .post(self.endpoint_url(endpoint_path))
+            .timeout(self.timeout)
+            .header(CONTENT_TYPE, "application/json")
+            .header(REQUEST_ID_HEADER, request_id.as_str())
+            .header(INTERNAL_TOKEN_HEADER, self.internal_token.as_str())
+            .body(proxy_body);
+        if let Some(tier) = &user_tier {
+            request = request.header(USER_TIER_HEADER, tier);
+        }
+
+        match request.send().await {
+            Ok(response) => {
+                self.pending.remove(&request_id);
+                relay_response(response)
+            }
+            Err(err) => {
+                self.pending.remove(&request_id);
+                tracing::error!(error = %err, request_id = %request_id, "proxy middleware request failed");
+                errors::error_response(
+                    surface,
+                    502,
+                    errors::error_type(surface, 502),
+                    "middleware proxy unavailable",
+                    Some(&request_id),
+                )
+            }
+        }
+    }
+
+    fn internal_token(&self) -> Option<&str> {
+        Some(&self.internal_token)
+    }
+
+    async fn handle_internal_forward(
+        &self,
+        service: &AciService,
+        input: InternalForwardRequest,
+    ) -> Response {
+        let Some(pending) = self.pending.take(&input.request_id) else {
+            return errors::error_response(
+                Surface::Openai,
+                404,
+                errors::error_type(Surface::Openai, 404),
+                "middleware request context is missing or expired",
+                Some(&input.request_id),
+            );
+        };
+        forward_selected(
+            service,
+            self.sse_keepalive_ms,
+            InternalForwardInput {
+                pending,
+                selected_route: input.selected_route,
+                user_tier: input.user_tier,
+                body: input.body,
+            },
+        )
+        .await
+    }
+}
+
+fn user_tier_from_params(params: &Value) -> Option<String> {
+    let provider = params.get("provider")?.as_object()?;
+    for key in ["tier", "userTier", "user_tier"] {
+        let Some(value) = provider.get(key).and_then(Value::as_str) else {
+            continue;
+        };
+        let value = value.trim();
+        if value.eq_ignore_ascii_case("premium") {
+            return Some("premium".to_string());
+        }
+        if !value.is_empty() {
+            return Some("basic".to_string());
+        }
+    }
+    None
+}
+
+fn relay_response(response: reqwest::Response) -> Response {
+    let status =
+        StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let headers = relay_headers(response.headers());
+    let body = Body::from_stream(
+        response
+            .bytes_stream()
+            .map(|chunk| chunk.map_err(|err| std::io::Error::other(err.to_string()))),
+    );
+    (status, headers, body).into_response()
+}
+
+fn relay_headers(src: &reqwest::header::HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::new();
+    for (name, value) in src {
+        let lower = name.as_str().to_ascii_lowercase();
+        if matches!(
+            lower.as_str(),
+            "connection" | "transfer-encoding" | "content-length"
+        ) {
+            continue;
+        }
+        let Ok(header_name) = HeaderName::from_bytes(name.as_str().as_bytes()) else {
+            continue;
+        };
+        let Ok(header_value) = HeaderValue::from_bytes(value.as_bytes()) else {
+            continue;
+        };
+        out.insert(header_name, header_value);
+    }
+    out
+}
+
+pub fn parse_target_format(value: Option<&str>) -> ProviderFormat {
+    match value
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "anthropic" => ProviderFormat::Anthropic,
+        _ => ProviderFormat::Openai,
+    }
+}

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1009,6 +1009,7 @@ fn openai_complete_config() -> ProviderConfig {
         ("user", vec![pc("user")]),
         ("seed", vec![pc("seed")]),
         ("suffix", vec![pc("suffix")]),
+        ("include_usage", vec![pc("include_usage")]),
     ]
 }
 
@@ -1217,7 +1218,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_options_injected_for_chat_but_not_responses() {
+    fn stream_options_injected_for_chat_and_completions_but_not_responses() {
         let chat_out = chat(
             ProviderFormat::Openai,
             json!({ "model": "m", "messages": [], "stream": true }),
@@ -1239,6 +1240,19 @@ mod tests {
             complete_out["stream_options"],
             json!({ "include_usage": true })
         );
+
+        let completions = transform_to_provider_request(
+            ProviderFormat::Openai,
+            &json!({ "model": "m", "prompt": "hi", "stream": true, "include_usage": true }),
+            Endpoint::Complete,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            completions["stream_options"],
+            json!({ "include_usage": true })
+        );
+        assert_eq!(completions["include_usage"], json!(true));
 
         let responses = transform_to_provider_request(
             ProviderFormat::Openai,

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -21,7 +21,7 @@ use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::http::{build_router_with_admin, build_router_with_admin_and_middleware};
-use private_ai_gateway::middleware::{Middleware, MiddlewareConfig};
+use private_ai_gateway::middleware::{Middleware, MiddlewareConfig, MiddlewareMode};
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
 use tower::ServiceExt;
@@ -112,11 +112,15 @@ async fn relays_catalogs_from_control() {
     let control_url = spawn_stub_control().await;
     let middleware = Arc::new(
         Middleware::new(&MiddlewareConfig {
-            control_url,
+            mode: MiddlewareMode::Control,
+            control_url: Some(control_url),
             control_token: None,
             control_timeout_ms: Some(2_000),
             control_post_timeout_ms: Some(2_000),
             sse_keepalive_ms: None,
+            proxy_url: None,
+            internal_token: None,
+            proxy_timeout_ms: None,
         })
         .unwrap(),
     );

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -11,6 +11,7 @@ mod common;
 
 use async_trait::async_trait;
 use axum::body::Bytes;
+use axum::http::HeaderMap;
 use axum::{body::to_bytes, routing::post, Json, Router};
 use futures_util::StreamExt;
 use private_ai_gateway::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
@@ -24,11 +25,15 @@ use private_ai_gateway::aggregator::service::{
 use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
+use private_ai_gateway::middleware::completion::InternalForwardRequest;
 use private_ai_gateway::middleware::control::ControlClient;
 use private_ai_gateway::middleware::errors::Surface;
 use private_ai_gateway::middleware::request_transform::Endpoint;
 use private_ai_gateway::middleware::sse::{MeterStream, StreamReport};
-use private_ai_gateway::middleware::{CompletionInput, Middleware, MiddlewareConfig};
+use private_ai_gateway::middleware::types::{Engine, ProviderFormat, RouteCandidate};
+use private_ai_gateway::middleware::{
+    CompletionInput, Middleware, MiddlewareConfig, MiddlewareMode,
+};
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
 
@@ -38,6 +43,7 @@ use common::{event_from_request, StaticKeyProvider, StubQuoter};
 struct MockUpstream {
     status: u16,
     body: Vec<u8>,
+    received: Option<Arc<Mutex<Option<Vec<u8>>>>>,
 }
 
 #[async_trait]
@@ -48,7 +54,10 @@ impl UpstreamBackend for MockUpstream {
     fn url_origin(&self) -> Option<&str> {
         Some("https://mock-upstream.example")
     }
-    async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+    async fn forward(&self, req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        if let Some(received) = &self.received {
+            *received.lock().unwrap() = Some(req.body);
+        }
         let mut headers = HashMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
         Ok(UpstreamResponse {
@@ -94,6 +103,7 @@ fn build_service_failing_verify() -> Arc<AciService> {
             Arc::new(MockUpstream {
                 status: 200,
                 body: b"{}".to_vec(),
+                received: None,
             }),
             Arc::new(FailVerifier),
             Arc::new(InMemoryReceiptStore::default()),
@@ -105,18 +115,31 @@ fn build_service_failing_verify() -> Arc<AciService> {
 }
 
 fn build_service_with_upstream(status: u16, body: Vec<u8>) -> Arc<AciService> {
-    Arc::new(
+    build_service_with_upstream_capture(status, body).0
+}
+
+fn build_service_with_upstream_capture(
+    status: u16,
+    body: Vec<u8>,
+) -> (Arc<AciService>, Arc<Mutex<Option<Vec<u8>>>>) {
+    let received = Arc::new(Mutex::new(None));
+    let service = Arc::new(
         AciService::new_with_upstream_verifier(
             Arc::new(StaticKeyProvider::default()),
             Arc::new(StubQuoter::default()),
-            Arc::new(MockUpstream { status, body }),
+            Arc::new(MockUpstream {
+                status,
+                body,
+                received: Some(received.clone()),
+            }),
             Arc::new(OkVerifier),
             Arc::new(InMemoryReceiptStore::default()),
             AciServiceConfig::for_test("private-ai-gateway"),
             Arc::new(FixedClock(1_700_000_000)),
         )
         .unwrap(),
-    )
+    );
+    (service, received)
 }
 
 fn temp_config_path() -> std::path::PathBuf {
@@ -232,13 +255,92 @@ async fn wait_for_post(posts: &Arc<Mutex<Vec<Value>>>, pred: impl Fn(&Value) -> 
 
 fn middleware(control_url: String) -> Middleware {
     Middleware::new(&MiddlewareConfig {
-        control_url,
+        mode: MiddlewareMode::Control,
+        control_url: Some(control_url),
         control_token: None,
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        proxy_url: None,
+        internal_token: None,
+        proxy_timeout_ms: None,
     })
     .unwrap()
+}
+
+#[derive(Default)]
+struct ProxyObservation {
+    request_id: String,
+    internal_token: String,
+    user_tier: String,
+    body: Value,
+}
+
+type ProxyCallbackTarget = Arc<Mutex<Option<(Arc<Middleware>, Arc<AciService>)>>>;
+
+async fn spawn_proxy_callback(
+    target: ProxyCallbackTarget,
+    observed: Arc<Mutex<Option<ProxyObservation>>>,
+) -> String {
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move |headers: HeaderMap, body: Bytes| {
+            let target = target.clone();
+            let observed = observed.clone();
+            async move {
+                let request_id = headers
+                    .get("x-private-ai-gateway-request-id")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                let internal_token = headers
+                    .get("x-private-ai-gateway-internal-token")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                let user_tier = headers
+                    .get("x-user-tier")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                let callback_body = body.to_vec();
+                let proxy_body: Value = serde_json::from_slice(&callback_body).unwrap();
+                *observed.lock().unwrap() = Some(ProxyObservation {
+                    request_id: request_id.clone(),
+                    internal_token,
+                    user_tier: user_tier.clone(),
+                    body: proxy_body,
+                });
+                let (middleware, service) = target
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .expect("proxy callback target not installed")
+                    .clone();
+                middleware
+                    .handle_internal_forward(
+                        &service,
+                        InternalForwardRequest {
+                            request_id,
+                            selected_route: RouteCandidate {
+                                route_id: "openai:gpt-test".to_string(),
+                                format: ProviderFormat::Openai,
+                                engine: Some(Engine::Vllm),
+                            },
+                            user_tier: Some(user_tier),
+                            body: callback_body,
+                        },
+                    )
+                    .await
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
 }
 
 fn chat_input() -> CompletionInput {
@@ -255,6 +357,7 @@ fn chat_input() -> CompletionInput {
         upstream_required: true,
         request_id: "req-1".to_string(),
         user_model: Some("gpt-test".to_string()),
+        user_tier: None,
         stream: false,
     }
 }
@@ -265,6 +368,109 @@ async fn response_parts(response: axum::response::Response) -> (u16, axum::http:
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
     (status, headers, body)
+}
+
+#[tokio::test]
+async fn proxy_mode_sanitizes_router_body_and_shapes_callback_route() {
+    let target: ProxyCallbackTarget = Arc::new(Mutex::new(None));
+    let observed = Arc::new(Mutex::new(None));
+    let proxy_url = spawn_proxy_callback(target.clone(), observed.clone()).await;
+    let middleware = Arc::new(
+        Middleware::new(&MiddlewareConfig {
+            mode: MiddlewareMode::Proxy,
+            control_url: None,
+            control_token: None,
+            control_timeout_ms: None,
+            control_post_timeout_ms: None,
+            sse_keepalive_ms: None,
+            proxy_url: Some(proxy_url),
+            internal_token: Some("shared-secret".to_string()),
+            proxy_timeout_ms: Some(2_000),
+        })
+        .unwrap(),
+    );
+    let upstream_body = br#"{"id":"chat-1","object":"chat.completion","choices":[]}"#.to_vec();
+    let (service, received) = build_service_with_upstream_capture(200, upstream_body);
+    *target.lock().unwrap() = Some((middleware.clone(), service.clone()));
+
+    let mut input = chat_input();
+    input.upstream_required = false;
+    input.params = json!({
+        "model": "gpt-test",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "provider": { "tier": "premium", "only": ["openai"] },
+        "top_k": 5
+    });
+
+    let (status, headers, body) =
+        response_parts(middleware.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["id"], json!("chat-1"));
+    assert!(headers.get("x-receipt-id").is_some());
+    assert_eq!(
+        headers.get("x-private-ai-gateway-selected-route").unwrap(),
+        "openai:gpt-test"
+    );
+
+    let observed = observed.lock().unwrap().take().unwrap();
+    assert_eq!(observed.request_id, "req-1");
+    assert_eq!(observed.internal_token, "shared-secret");
+    assert_eq!(observed.user_tier, "premium");
+    assert_eq!(observed.body["model"], json!("gpt-test"));
+    assert!(
+        observed.body.get("provider").is_none(),
+        "PAG routing extensions must not be sent to vLLM Router"
+    );
+    assert!(
+        observed.body.get("top_k").is_none(),
+        "engine-specific backend params are applied only after route selection"
+    );
+
+    let backend_body: Value =
+        serde_json::from_slice(&received.lock().unwrap().clone().unwrap()).unwrap();
+    assert_eq!(backend_body["model"], json!("gpt-test"));
+    assert!(backend_body.get("provider").is_none());
+    assert_eq!(
+        backend_body["top_k"],
+        json!(5),
+        "selected vLLM route receives engine-specific shaped params"
+    );
+}
+
+#[tokio::test]
+async fn proxy_mode_forwards_external_user_tier_header() {
+    let target: ProxyCallbackTarget = Arc::new(Mutex::new(None));
+    let observed = Arc::new(Mutex::new(None));
+    let proxy_url = spawn_proxy_callback(target.clone(), observed.clone()).await;
+    let middleware = Arc::new(
+        Middleware::new(&MiddlewareConfig {
+            mode: MiddlewareMode::Proxy,
+            control_url: None,
+            control_token: None,
+            control_timeout_ms: None,
+            control_post_timeout_ms: None,
+            sse_keepalive_ms: None,
+            proxy_url: Some(proxy_url),
+            internal_token: Some("shared-secret".to_string()),
+            proxy_timeout_ms: Some(2_000),
+        })
+        .unwrap(),
+    );
+    let upstream_body = br#"{"id":"chat-1","object":"chat.completion","choices":[]}"#.to_vec();
+    let (service, _received) = build_service_with_upstream_capture(200, upstream_body);
+    *target.lock().unwrap() = Some((middleware.clone(), service.clone()));
+
+    let mut input = chat_input();
+    input.upstream_required = false;
+    input.user_tier = Some("premium".to_string());
+
+    let (status, _, body) =
+        response_parts(middleware.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["id"], json!("chat-1"));
+
+    let observed = observed.lock().unwrap().take().unwrap();
+    assert_eq!(observed.user_tier, "premium");
 }
 
 #[tokio::test]
@@ -399,11 +605,15 @@ async fn buffered_success_transforms_injects_cost_and_meters() {
 async fn meter_stream_injects_cost_classifies_completed_and_reports() {
     let (control_url, posts) = spawn_control_capturing(200, json!({})).await;
     let control = ControlClient::new(&MiddlewareConfig {
-        control_url,
+        mode: MiddlewareMode::Control,
+        control_url: Some(control_url),
         control_token: None,
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        proxy_url: None,
+        internal_token: None,
+        proxy_timeout_ms: None,
     })
     .unwrap();
     let report = StreamReport {

--- a/tests/upstream_config_admin.rs
+++ b/tests/upstream_config_admin.rs
@@ -12,9 +12,9 @@ use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
 };
 use private_ai_gateway::aggregator::upstream_config::{
-    UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
+    parse_config_text, UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
-use private_ai_gateway::http::build_router_with_admin;
+use private_ai_gateway::http::{build_router_with_admin, build_router_with_admin_and_api};
 use serde_json::Value;
 use tower::ServiceExt;
 
@@ -69,6 +69,29 @@ async fn call(
     (status, body)
 }
 
+async fn call_raw(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: impl Into<Vec<u8>>,
+    auth: Option<&str>,
+) -> (StatusCode, Vec<u8>) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(token) = auth {
+        req = req.header("authorization", format!("Bearer {token}"));
+    }
+    let resp = app
+        .oneshot(req.body(Body::from(body.into())).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    (status, bytes.to_vec())
+}
+
 #[tokio::test]
 async fn admin_can_replace_single_upstream_config_file_at_runtime() {
     let path = temp_config_path();
@@ -91,6 +114,9 @@ async fn admin_can_replace_single_upstream_config_file_at_runtime() {
     let (status, models) = call(app.clone(), "GET", "/v1/models", Vec::new(), None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(models["data"].as_array().unwrap().len(), 0);
+
+    let (status, _) = call_raw(app.clone(), "GET", "/v1/metrics", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::OK);
 
     let config = br#"[
       {
@@ -148,6 +174,110 @@ async fn admin_can_replace_single_upstream_config_file_at_runtime() {
     let (status, models) = call(app, "GET", "/v1/models", Vec::new(), None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(models["data"][0]["id"], "public-a");
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn api_token_protects_catalog_and_completion_validates_model() {
+    let path = temp_config_path();
+    let manager = Arc::new(UpstreamConfigManager::load(&path, runtime_options()).unwrap());
+    manager
+        .replace(
+            parse_config_text(
+                r#"[
+                  {
+                    "name": "gpu-a",
+                    "base_url": "https://gpu-a.example",
+                    "models": {"public-a": "upstream-a"}
+                  }
+                ]"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    let keys = Arc::new(StaticKeyProvider::default());
+    let service = Arc::new(
+        AciService::new_with_upstream_verifier(
+            keys,
+            Arc::new(StubQuoter::default()),
+            manager.backend(),
+            manager.verifier(),
+            Arc::new(InMemoryReceiptStore::default()),
+            AciServiceConfig::for_test("private-ai-gateway"),
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap(),
+    );
+    let app = build_router_with_admin_and_api(
+        service,
+        manager,
+        Some("admin-secret".to_string()),
+        Some("api-secret".to_string()),
+    );
+
+    let (status, body) = call(app.clone(), "GET", "/v1/models", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"]["message"], "api bearer token required");
+
+    let (status, body) = call(app.clone(), "GET", "/v1/metrics", Vec::new(), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"]["message"], "api bearer token required");
+
+    let (status, body) = call(
+        app.clone(),
+        "GET",
+        "/v1/models",
+        Vec::new(),
+        Some("wrong-secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"]["message"], "invalid api bearer token");
+
+    let (status, body) = call(
+        app.clone(),
+        "GET",
+        "/v1/metrics",
+        Vec::new(),
+        Some("wrong-secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"]["message"], "invalid api bearer token");
+
+    let (status, models) = call(
+        app.clone(),
+        "GET",
+        "/v1/models",
+        Vec::new(),
+        Some("api-secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models["data"][0]["id"], "public-a");
+
+    let (status, body) = call(
+        app.clone(),
+        "POST",
+        "/v1/chat/completions",
+        br#"{"model":"test","messages":[{"role":"user","content":"hi"}]}"#.to_vec(),
+        Some("api-secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"]["message"], "Unknown model: test");
+
+    let (status, body) = call(
+        app,
+        "POST",
+        "/v1/chat/completions",
+        br#"{"messages":[{"role":"user","content":"hi"}]}"#.to_vec(),
+        Some("api-secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"]["message"], "Model parameter is required");
 
     let _ = std::fs::remove_file(path);
 }


### PR DESCRIPTION
## Summary
- Add an explicit external `proxy` middleware mode for request-body-aware middlewares such as a vLLM Router wrapper.
- Add `POST /internal/forward` for the proxy middleware callback, guarded by `middleware.internal_token` and a one-use request id.
- Add optional `api_token` protection for public OpenAI-compatible endpoints and `/v1/metrics`; when unset, these endpoints keep the upstream default unauthenticated behavior.
- Preserve `/v1/completions` top-level `include_usage` while keeping upstream `stream_options.include_usage` behavior from `main`.

## Default behavior
- No `middleware` config: normal direct mode remains active.
- Existing middleware configs without `mode`: default to `control` mode.
- New proxy path is used only with `middleware.mode = "proxy"` plus `proxy_url` and `internal_token`.
- `api_token` is opt-in. If omitted, public API and `/v1/metrics` are not newly gated.
- Public model-id validation is enabled only when `api_token` is set or when proxy mode is enabled.

## Cleanup from earlier branch
- Removed unrelated `Dockerfile.smoke` Python/uv verifier changes.
- Removed unrelated legacy attestation top-level field changes already covered by the upstream ACI/v2 direction.
- Removed the duplicate `/v1/completions` `stream_options` config entry because `main` already has it.

## Validation
- `git diff --check origin/main..HEAD`
- Confirmed no diff remains for `Dockerfile.smoke`, `src/aci/keys.rs`, `src/aggregator/service/e2ee.rs`, `src/dstack.rs`, `tests/common/mod.rs`, or `tests/http.rs`.
- Confirmed no attestation-only fields remain in the PR diff.

Rust tests were not run locally because this Windows environment does not have `cargo` installed.