### PR TITLE
fix(middleware): attribute streaming upstream non-2xx to the serving route

### DIFF
--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -16,7 +16,8 @@ use super::{
     ForwardCandidate, MiddlewareForwardResult, MiddlewareForwarded,
     MiddlewareGeneratedFinalization, MiddlewareReceiptDraft, MiddlewareReceiptFinalization,
     MiddlewareReceiptJournal, MiddlewareStreamFinalization, MiddlewareStreamingForwarded,
-    ReceiptOwner, ServiceError, ServiceResponseStream, StreamingUpstreamError,
+    MiddlewareUpstreamError, ReceiptOwner, ServiceError, ServiceResponseStream,
+    StreamingUpstreamError,
 };
 use crate::aci::receipt::{ReceiptBuilder, TransparencyEventKind, UpstreamVerifiedEvent};
 use crate::aci::upstream::{UpstreamError, UpstreamRequest};
@@ -295,13 +296,17 @@ impl AciService {
                     }
                     self.metrics
                         .record_stream_error(endpoint_path, StreamErrorKind::UpstreamNon2xx);
-                    return Ok(MiddlewareForwardResult::UpstreamError(
-                        StreamingUpstreamError {
-                            upstream_status: status,
-                            upstream_headers,
-                            upstream_body,
+                    return Ok(MiddlewareForwardResult::UpstreamError(Box::new(
+                        MiddlewareUpstreamError {
+                            error: StreamingUpstreamError {
+                                upstream_status: status,
+                                upstream_headers,
+                                upstream_body,
+                            },
+                            selected_route: route_id,
+                            failed_attempts,
                         },
-                    ));
+                    )));
                 }
 
                 // Commit this candidate.

--- a/src/aggregator/service/mod.rs
+++ b/src/aggregator/service/mod.rs
@@ -57,8 +57,8 @@ pub use wire::{
     LegacySignatureResult, MiddlewareForwardResult, MiddlewareForwarded,
     MiddlewareGeneratedFinalization, MiddlewareReceiptDraft, MiddlewareReceiptFinalization,
     MiddlewareReceiptJournal, MiddlewareStreamFinalization, MiddlewareStreamingForwarded,
-    ServiceResponseStream, StreamingForwardResult, StreamingForwardStream, StreamingUpstreamError,
-    UpstreamVerificationRequest, UpstreamVerifier,
+    MiddlewareUpstreamError, ServiceResponseStream, StreamingForwardResult, StreamingForwardStream,
+    StreamingUpstreamError, UpstreamVerificationRequest, UpstreamVerifier,
 };
 
 pub struct AciService {

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -70,7 +70,7 @@ pub struct ForwardResult {
 pub enum MiddlewareForwardResult {
     Forwarded(Box<MiddlewareForwarded>),
     Stream(Box<MiddlewareStreamingForwarded>),
-    UpstreamError(StreamingUpstreamError),
+    UpstreamError(Box<MiddlewareUpstreamError>),
 }
 
 pub struct MiddlewareForwarded {
@@ -205,6 +205,21 @@ pub struct StreamingUpstreamError {
     pub upstream_status: u16,
     pub upstream_headers: std::collections::HashMap<String, String>,
     pub upstream_body: Vec<u8>,
+}
+
+/// A streaming non-2xx on the middleware path, carrying the same route
+/// attribution as the `Forwarded`/`Stream` variants. No receipt is issued (there
+/// is no completed inference stream to bind), but the attempt still reached an
+/// upstream, so the caller must be able to report *which* route produced the
+/// status — an unattributed report cannot count against any route's health, which
+/// would leave the load behind upstream 429s invisible and never shed.
+pub struct MiddlewareUpstreamError {
+    pub error: StreamingUpstreamError,
+    /// The route that produced the non-2xx (the last one tried).
+    pub selected_route: String,
+    /// Candidates failed over before this one, as (route_id, status), in the
+    /// order tried. Same contract as the sibling variants' field.
+    pub failed_attempts: Vec<(String, u16)>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -191,10 +191,15 @@ pub async fn run(
     match result {
         Ok(MiddlewareForwardResult::Forwarded(forward)) => {
             let upstream_status = forward.upstream_status;
-            let attempt_index = candidates
-                .iter()
-                .position(|c| c.route_id == forward.selected_route)
-                .unwrap_or(0) as u32;
+            // The forwarder tries candidates in order and pushes exactly one
+            // `failed_attempts` entry per candidate it abandons, so the serving
+            // candidate's index is the number of attempts before it (all three
+            // arms derive it this way). Derived, not looked up by route id: the
+            // candidate list is not deduped here, and a repeated route id would
+            // resolve to the earlier copy — colliding with that attempt's report
+            // under control's (request_id, attempt, status) idempotency gate and
+            // mislabeling a failed-over serve as a first-choice one.
+            let attempt_index = forward.failed_attempts.len() as u32;
             let selected_format = candidates
                 .iter()
                 .find(|c| c.route_id == forward.selected_route)
@@ -310,10 +315,7 @@ pub async fn run(
                 .cloned()
                 .unwrap_or_else(|| "text/event-stream".to_string());
             let upstream_status = forward.upstream_status;
-            let attempt_index = candidates
-                .iter()
-                .position(|c| c.route_id == forward.selected_route)
-                .unwrap_or(0) as u32;
+            let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
 
             let report = StreamReport {
@@ -407,13 +409,6 @@ pub async fn run(
                 &received_body,
                 Some(&request_id),
             );
-            // The forwarder tries candidates in order and pushes exactly one
-            // `failed_attempts` entry per candidate it abandons, so the serving
-            // candidate's index is the number of attempts before it. Derived,
-            // not looked up by route id: a route id repeated in the candidate
-            // list would resolve to the earlier copy, and control dedupes
-            // reports by (request_id, attempt, status) — a tie would silently
-            // drop one of the two 429s this arm exists to record.
             let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
             meter.upstream_error(

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -407,10 +407,14 @@ pub async fn run(
                 &received_body,
                 Some(&request_id),
             );
-            let attempt_index = candidates
-                .iter()
-                .position(|c| c.route_id == forward.selected_route)
-                .unwrap_or(0) as u32;
+            // The forwarder tries candidates in order and pushes exactly one
+            // `failed_attempts` entry per candidate it abandons, so the serving
+            // candidate's index is the number of attempts before it. Derived,
+            // not looked up by route id: a route id repeated in the candidate
+            // list would resolve to the earlier copy, and control dedupes
+            // reports by (request_id, attempt, status) — a tie would silently
+            // drop one of the two 429s this arm exists to record.
+            let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
             meter.upstream_error(
                 reported_status(status, forward.error.upstream_status),

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -397,16 +397,26 @@ pub async fn run(
             }
         }
         Ok(MiddlewareForwardResult::UpstreamError(forward)) => {
-            // Streaming non-2xx: attribution is not carried on this variant, so the
-            // report records the status with no selected route (parity).
+            // Streaming non-2xx: no receipt (no completed stream to bind), but the
+            // attempt did reach an upstream, so it reports the serving route and
+            // every failed-over candidate exactly like the Stream arm.
             let (status, body) = errors::normalize_upstream_error_parts(
                 surface,
-                forward.upstream_status,
-                &forward.upstream_body,
+                forward.error.upstream_status,
+                &forward.error.upstream_body,
                 &received_body,
                 Some(&request_id),
             );
-            meter.upstream_error(reported_status(status, forward.upstream_status));
+            let attempt_index = candidates
+                .iter()
+                .position(|c| c.route_id == forward.selected_route)
+                .unwrap_or(0) as u32;
+            meter.failed_attempts(&forward.failed_attempts, true);
+            meter.upstream_error(
+                reported_status(status, forward.error.upstream_status),
+                attempt_index,
+                &forward.selected_route,
+            );
             finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
         }
         // All candidates failed. Record an upstream-attributed failure so the
@@ -476,10 +486,12 @@ impl Meter<'_> {
         });
     }
 
-    fn upstream_error(&self, status: u16) {
+    fn upstream_error(&self, status: u16, attempt_index: u32, selected_route_id: &str) {
         self.spawn(PostReport {
             status,
             is_streaming: Some(true),
+            attempt_index: Some(attempt_index),
+            selected_route_id: Some(selected_route_id.to_string()),
             ..self.base()
         });
     }

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -501,6 +501,45 @@ async fn total_forward_failure_reports_upstream_failure() {
 }
 
 #[tokio::test]
+async fn streaming_upstream_non_2xx_reports_the_serving_route() {
+    // A streaming request whose upstream answers non-2xx issues no receipt, but it
+    // did reach an upstream: the report must name the route that produced the
+    // status, or the failure cannot count against that route's health and the
+    // load behind the 429s is never shed.
+    let (control_url, posts) = spawn_control_capturing(
+        200,
+        json!({ "allow": true, "candidates": [{ "routeId": "openai:gpt", "format": "openai" }] }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let service = build_service_with_upstream(429, br#"{"error":"rate limited"}"#.to_vec());
+    let mut input = chat_input();
+    input.upstream_required = false;
+    input.stream = true;
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 429, "the upstream status must reach the client");
+
+    let report = wait_for_post(&posts, |r| r["status"].as_i64() == Some(429)).await;
+    assert_eq!(
+        report["selectedRouteId"],
+        json!("openai:gpt"),
+        "an unattributed upstream 429 counts against no route's health"
+    );
+    assert_eq!(report["isStreaming"], json!(true));
+    assert_eq!(report["attemptIndex"], json!(0));
+    // A real upstream attempt, not a gateway-generated failure: error_source
+    // stays empty so the status is attributed to the route itself.
+    assert!(
+        report
+            .get("errorSource")
+            .map(Value::is_null)
+            .unwrap_or(true),
+        "a real upstream attempt must not be tagged as a gateway failure"
+    );
+}
+
+#[tokio::test]
 async fn image_fetch_5xx_becomes_400_and_is_not_failed_over() {
     // The upstream can't fetch the client's image URL and (wrongly) reports it as a
     // 500. That is a bad-input error: the client must get a 400, it must not fail

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -540,6 +540,53 @@ async fn streaming_upstream_non_2xx_reports_the_serving_route() {
 }
 
 #[tokio::test]
+async fn repeated_route_id_still_reports_distinct_attempt_indices() {
+    // Failover exhausted: every candidate 429s, and each attempt must reach
+    // control as its own attributed report — the failed-over one via
+    // failed_attempts, the last via upstream_error. The gateway does not dedupe
+    // `candidates` — it forwards whatever control supplies, and control
+    // implementations are swappable (the open-source stack ships its own). A
+    // route id repeated in the list must still yield one report per attempt:
+    // control dedupes by (request_id, attempt, status), so two 429s sharing an
+    // attempt index would silently collapse into one, under-counting the
+    // pressure signal by half. The index is therefore derived from the number
+    // of prior attempts, never looked up by route id.
+    let (control_url, posts) = spawn_control_capturing(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [
+                { "routeId": "openai:dup", "format": "openai" },
+                { "routeId": "openai:dup", "format": "openai" }
+            ]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let service = build_service_with_upstream(429, br#"{"error":"rate limited"}"#.to_vec());
+    let mut input = chat_input();
+    input.upstream_required = false;
+    input.stream = true;
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 429);
+
+    wait_for_post(&posts, |r| r["attemptIndex"].as_i64() == Some(1)).await;
+    let indices: Vec<i64> = posts
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|r| r["status"].as_i64() == Some(429))
+        .filter_map(|r| r["attemptIndex"].as_i64())
+        .collect();
+    assert_eq!(
+        indices,
+        vec![0, 1],
+        "both 429s against the repeated route must carry distinct attempt indices"
+    );
+}
+
+#[tokio::test]
 async fn image_fetch_5xx_becomes_400_and_is_not_failed_over() {
     // The upstream can't fetch the client's image URL and (wrongly) reports it as a
     // 500. That is a bad-input error: the client must get a 400, it must not fail


### PR DESCRIPTION
## Problem

On the middleware path, a streaming request whose upstream answers non-2xx returns `MiddlewareForwardResult::UpstreamError`, which carried no route attribution. The resulting report had an empty `selectedRouteId`, so the failure counted against no route's health — upstream 429s stayed invisible and the load causing them was never shed.

## Change

- Wrap the variant in a new `MiddlewareUpstreamError` carrying `selected_route` and `failed_attempts`, the same contract as the sibling `Forwarded`/`Stream` variants. The inner `StreamingUpstreamError` stays as-is since the non-middleware forward path still uses it without this contract.
- The completion handler's `UpstreamError` arm now reports the serving route, its attempt index, and every failed-over candidate exactly like the `Stream` arm. `error_source` stays empty: this is a real upstream attempt, not a gateway-generated failure.
- All three arms (`Forwarded`, `Stream`, `UpstreamError`) derive the attempt index from the number of prior attempts rather than looking the serving route up by id: the forwarder pushes exactly one `failed_attempts` entry per abandoned candidate, and the candidate list is not deduped here — a repeated route id would resolve to the earlier copy, colliding with that attempt's report under report deduplication and mislabeling a failed-over serve as a first-choice one.

## Testing

- `streaming_upstream_non_2xx_reports_the_serving_route`: the 429 report names the serving route with `attemptIndex` 0, `isStreaming` true, and no `errorSource`.
- `repeated_route_id_still_reports_distinct_attempt_indices`: failover exhausted across a repeated route id still yields one report per attempt with distinct indices.

Full `middleware_completion` suite passes (12/12), clippy and fmt clean.