### PR TITLE
fix(middleware): parse SSE streams per spec in the cross-format transforms

### DIFF
--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -33,7 +33,7 @@ use super::types::{PostReport, SpendMode};
 /// request OOMs. A single SSE line above this is pathological (legitimate events
 /// — even large tool-call arguments or embedded data — stay far below it), so we
 /// treat the overflow as an upstream failure rather than keep buffering.
-const MAX_SSE_LINE_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_SSE_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Terminal classification of a stream: how the response body actually ended.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -19,11 +19,12 @@ use serde_json::{json, Value};
 use crate::aggregator::service::{ServiceError, ServiceResponseStream};
 
 use super::request_transform::Endpoint;
+use super::sse::MAX_SSE_LINE_BYTES;
 use super::types::ProviderFormat;
 
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
-/// Which streaming transform applies, plus the SSE split delimiter it expects.
+/// Which streaming transform applies.
 #[derive(Debug, Clone, Copy)]
 pub enum StreamTransform {
     AnthropicToOpenaiChat,
@@ -32,14 +33,6 @@ pub enum StreamTransform {
 }
 
 impl StreamTransform {
-    fn split_pattern(self) -> &'static [u8] {
-        match self {
-            // Native Anthropic legacy completion streams use CRLF-CRLF.
-            StreamTransform::AnthropicCompleteToOpenai => b"\r\n\r\n",
-            _ => b"\n\n",
-        }
-    }
-
     fn provider(self) -> &'static str {
         match self {
             StreamTransform::OpenaiToAnthropicMessages => "openai",
@@ -47,27 +40,33 @@ impl StreamTransform {
         }
     }
 
+    // Parse a raw event text (lines joined by `\n`) and transform it.
     // `Err(())` means the provider sent an unparseable event; on the Anthropic
     // paths this ends the stream and classifies it failed rather than skipping.
+    // Each transform dispatches known control events by name first, then skips
+    // any event whose payload is empty (per the SSE spec an empty data buffer
+    // aborts dispatch — covers `: PROCESSING` heartbeats, ignored fields, and
+    // name-only or empty-`data:` keep-alives).
     fn apply(
         self,
         event: &str,
         fallback_id: &str,
         state: &mut StreamState,
     ) -> Result<Option<String>, ()> {
+        let event = parse_event(event);
         match self {
             StreamTransform::AnthropicToOpenaiChat => {
-                anthropic_chat_stream(event, fallback_id, state, STRICT_OPENAI_COMPLIANCE)
+                anthropic_chat_stream(&event, fallback_id, state, STRICT_OPENAI_COMPLIANCE)
             }
             StreamTransform::OpenaiToAnthropicMessages => {
                 // Parse errors here are caught and the event is skipped.
                 Ok(openai_to_anthropic_messages_stream(
-                    event,
+                    &event,
                     fallback_id,
                     state,
                 ))
             }
-            StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(event),
+            StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(&event),
         }
     }
 }
@@ -121,16 +120,69 @@ fn now_millis() -> u128 {
         .unwrap_or(0)
 }
 
-// Strip a leading `event: ...` line and a leading `data: ` prefix, then trim.
-fn strip_event_and_data(event: &str) -> &str {
-    let mut text = event.trim();
-    if text.starts_with("event: ") {
-        text = match text.find('\n') {
-            Some(nl) => text[nl + 1..].trim_start_matches(['\r', '\n']),
-            None => "",
-        };
+/// One SSE event reduced to the fields the transforms consume: the last
+/// `event:` name and the `data:` lines joined with `\n` (per the SSE spec).
+struct ParsedEvent {
+    name: Option<String>,
+    data: Option<String>,
+}
+
+// Parse an event's text per the SSE field rules: `:`-prefixed lines are
+// comments, a field's value starts after the colon with at most one leading
+// space stripped, and every field other than `event:`/`data:` (`id:`,
+// `retry:`, vendor extensions) is ignored per the spec. Lines with no field
+// shape at all — bare `[DONE]`, bare JSON (colons inside JSON do not make it a
+// field: a `{`/`[`/`"` opener marks a payload line), plain garbage — are
+// collected and become the data when no `data:` field is present, so a
+// prefix-less payload survives even when a comment or `event:` line shares
+// the event block, and garbage still reaches the transforms' fail-fast parse.
+fn parse_event(event: &str) -> ParsedEvent {
+    let mut name = None;
+    let mut data: Option<String> = None;
+    let mut bare: Option<String> = None;
+    for line in event.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+        // Judge the JSON opener on the trimmed line (upstreams may indent a
+        // bare payload) but keep the raw line as the payload.
+        let json_like = matches!(
+            line.trim_start().as_bytes().first(),
+            Some(b'{' | b'[' | b'"')
+        );
+        let colon = if json_like { None } else { line.find(':') };
+        match colon {
+            Some(idx) => {
+                let value = &line[idx + 1..];
+                let value = value.strip_prefix(' ').unwrap_or(value);
+                match &line[..idx] {
+                    // The name is trimmed: exact-match dispatch must tolerate
+                    // trailing whitespace an upstream leaves after the value.
+                    "event" => name = Some(value.trim().to_string()),
+                    "data" => {
+                        let buf = data.get_or_insert_with(String::new);
+                        if !buf.is_empty() {
+                            buf.push('\n');
+                        }
+                        buf.push_str(value);
+                    }
+                    _ => {}
+                }
+            }
+            None => {
+                let buf = bare.get_or_insert_with(String::new);
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(line);
+            }
+        }
     }
-    text.strip_prefix("data: ").unwrap_or(text).trim()
+    if data.is_none() {
+        data = bare.filter(|b| !b.trim().is_empty());
+    }
+    ParsedEvent { name, data }
 }
 
 fn i64_field(value: &Value, key: &str) -> i64 {
@@ -164,22 +216,22 @@ fn map_finish_reason(finish_reason: Option<&str>) -> &'static str {
 // ── Anthropic Messages SSE → OpenAI chat.completion.chunk ────────────────────
 
 fn anthropic_chat_stream(
-    event: &str,
+    event: &ParsedEvent,
     fallback_id: &str,
     state: &mut StreamState,
     strict: bool,
 ) -> Result<Option<String>, ()> {
-    let chunk = event.trim();
-    if chunk.starts_with("event: ping") || chunk.starts_with("event: content_block_stop") {
+    match event.name.as_deref() {
+        Some("ping") | Some("content_block_stop") => return Ok(None),
+        Some("message_stop") => return Ok(Some("data: [DONE]\n\n".to_string())),
+        _ => {}
+    }
+    let payload = event.data.as_deref().unwrap_or("").trim();
+    // No payload → no dispatch (name-only keep-alives included); a non-empty
+    // malformed payload must still fail the stream rather than be skipped.
+    if payload.is_empty() {
         return Ok(None);
     }
-    if chunk.starts_with("event: message_stop") {
-        return Ok(Some("data: [DONE]\n\n".to_string()));
-    }
-
-    let payload = strip_event_and_data(chunk);
-    // A malformed provider event must fail the stream here rather than be
-    // silently skipped.
     let parsed: Value = serde_json::from_str(payload).map_err(|_| ())?;
     Ok(anthropic_chat_chunk(&parsed, fallback_id, state, strict))
 }
@@ -364,13 +416,13 @@ fn sse_event(event: &str, data: &Value) -> String {
 }
 
 fn openai_to_anthropic_messages_stream(
-    event: &str,
+    event: &ParsedEvent,
     fallback_id: &str,
     state: &mut StreamState,
 ) -> Option<String> {
-    let chunk = event.trim();
+    let payload = event.data.as_deref().unwrap_or("").trim();
 
-    if chunk == "data: [DONE]" || chunk == "[DONE]" {
+    if payload == "[DONE]" {
         let mut output = String::new();
         if state.content_block_started {
             output.push_str(&sse_event(
@@ -412,7 +464,6 @@ fn openai_to_anthropic_messages_stream(
         return Some(output);
     }
 
-    let payload = chunk.strip_prefix("data: ").unwrap_or(chunk);
     if payload.is_empty() {
         return None;
     }
@@ -577,19 +628,15 @@ fn openai_to_anthropic_messages_stream(
 
 // ── Anthropic legacy completion SSE → OpenAI completion chunks ───────────────
 
-fn anthropic_complete_stream(event: &str) -> Result<Option<String>, ()> {
-    let chunk = event.trim();
-    if chunk.starts_with("event: ping") {
+fn anthropic_complete_stream(event: &ParsedEvent) -> Result<Option<String>, ()> {
+    if event.name.as_deref() == Some("ping") {
         return Ok(None);
     }
-    let mut payload = chunk;
-    if payload.starts_with("event: completion") {
-        payload = match payload.find('\n') {
-            Some(nl) => payload[nl + 1..].trim_start_matches(['\r', '\n']),
-            None => "",
-        };
+    let payload = event.data.as_deref().unwrap_or("").trim();
+    // No payload → no dispatch, mirroring the chat path.
+    if payload.is_empty() {
+        return Ok(None);
     }
-    let payload = payload.strip_prefix("data: ").unwrap_or(payload).trim();
     if payload == "[DONE]" {
         return Ok(Some("[DONE]".to_string()));
     }
@@ -617,6 +664,72 @@ fn json_str(value: &Value) -> String {
 
 // ── Stream adapter ───────────────────────────────────────────────────────────
 
+/// Incremental SSE tokenizer: splits raw upstream bytes into events at blank
+/// lines. A line terminator is LF, CRLF, or bare CR — a CR-LF pair counts as a
+/// single terminator, tracked across chunk boundaries via `pending_cr`, so a
+/// chunk ending in `\r` never mis-splits. The pending event is one contiguous
+/// byte buffer (lines joined by `\n`), so the cap on its length — the same cap
+/// as the meter's line buffer, and covering the open line as a prefix of it —
+/// bounds actual memory, not just a logical byte count. Exceeding it is
+/// reported as an error (the caller ends the stream as failed).
+#[derive(Default)]
+struct SseEventReader {
+    event_buf: Vec<u8>,
+    // Start offset of the open (unterminated) line within `event_buf`.
+    line_start: usize,
+    pending_cr: bool,
+}
+
+impl SseEventReader {
+    // Feed one upstream chunk; events completed by it are appended to `events`.
+    // `Err(())` means the pending event (hence any single line) ran past the cap.
+    fn push_chunk(&mut self, chunk: &[u8], events: &mut Vec<String>) -> Result<(), ()> {
+        for &byte in chunk {
+            if std::mem::take(&mut self.pending_cr) && byte == b'\n' {
+                continue;
+            }
+            match byte {
+                b'\r' | b'\n' => {
+                    self.pending_cr = byte == b'\r';
+                    self.end_line(events);
+                }
+                _ => self.event_buf.push(byte),
+            }
+            if self.event_buf.len() > MAX_SSE_LINE_BYTES {
+                return Err(());
+            }
+        }
+        Ok(())
+    }
+
+    fn end_line(&mut self, events: &mut Vec<String>) {
+        if self.event_buf.len() == self.line_start {
+            // Blank line: dispatch the pending event, if any. Consecutive blank
+            // lines are empty events and dispatch nothing.
+            if !self.event_buf.is_empty() {
+                events.push(event_string(std::mem::take(&mut self.event_buf)));
+            }
+            self.line_start = 0;
+            return;
+        }
+        self.event_buf.push(b'\n');
+        self.line_start = self.event_buf.len();
+    }
+
+    // Flush the residual at a clean end of stream: an event without a trailing
+    // blank line is still dispatched. The cap already held during accumulation.
+    fn finish(&mut self) -> Option<String> {
+        self.line_start = 0;
+        (!self.event_buf.is_empty()).then(|| event_string(std::mem::take(&mut self.event_buf)))
+    }
+}
+
+// Reuse the event buffer's allocation when it is valid UTF-8 (the
+// overwhelmingly common case); fall back to a lossy copy only on invalid bytes.
+fn event_string(buf: Vec<u8>) -> String {
+    String::from_utf8(buf).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
 /// Splits the provider byte stream into SSE events and applies a stateful
 /// transform to each, emitting client-surface bytes.
 pub struct SseTransformStream {
@@ -624,8 +737,7 @@ pub struct SseTransformStream {
     transform: StreamTransform,
     fallback_id: String,
     state: StreamState,
-    split: &'static [u8],
-    buffer: Vec<u8>,
+    reader: SseEventReader,
     queue: VecDeque<Bytes>,
     inner_done: bool,
 }
@@ -638,8 +750,7 @@ impl SseTransformStream {
             transform,
             fallback_id,
             state: StreamState::default(),
-            split: transform.split_pattern(),
-            buffer: Vec::new(),
+            reader: SseEventReader::default(),
             queue: VecDeque::new(),
             inner_done: false,
         }
@@ -648,14 +759,10 @@ impl SseTransformStream {
     // Returns false if the transform rejected the event (unparseable provider
     // data): the stream must end there, with no terminal marker emitted, so the
     // meter classifies it as failed.
-    fn emit(&mut self, event_bytes: &[u8]) -> bool {
-        if event_bytes.is_empty() {
-            return true;
-        }
-        let event = String::from_utf8_lossy(event_bytes);
+    fn emit(&mut self, event: &str) -> bool {
         match self
             .transform
-            .apply(&event, &self.fallback_id, &mut self.state)
+            .apply(event, &self.fallback_id, &mut self.state)
         {
             Ok(Some(out)) => {
                 self.queue.push_back(Bytes::from(out));
@@ -665,25 +772,6 @@ impl SseTransformStream {
             Err(()) => false,
         }
     }
-
-    // Drain all complete events currently in the buffer into the output queue.
-    fn drain_buffer(&mut self) {
-        while let Some(pos) = find_subslice(&self.buffer, self.split) {
-            let event: Vec<u8> = self.buffer.drain(..pos + self.split.len()).collect();
-            if !self.emit(&event[..pos]) {
-                self.inner_done = true;
-                self.buffer.clear();
-                return;
-            }
-        }
-    }
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
-    }
-    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 impl Stream for SseTransformStream {
@@ -700,16 +788,26 @@ impl Stream for SseTransformStream {
             }
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    this.buffer.extend_from_slice(&bytes);
-                    this.drain_buffer();
+                    let mut events = Vec::new();
+                    // A cap overflow ends the stream, but events completed
+                    // earlier in the same chunk are still emitted first.
+                    let overflowed = this.reader.push_chunk(&bytes, &mut events).is_err();
+                    for event in &events {
+                        if !this.emit(event) {
+                            this.inner_done = true;
+                            break;
+                        }
+                    }
+                    if overflowed {
+                        this.inner_done = true;
+                    }
                     // loop to flush the queue or poll again
                 }
                 Poll::Ready(None) => {
                     this.inner_done = true;
-                    // Flush a non-empty residual event once (no trailing delimiter).
-                    if !this.buffer.is_empty() {
-                        let residual = std::mem::take(&mut this.buffer);
-                        this.emit(&residual);
+                    // Flush a residual event once (no trailing blank line).
+                    if let Some(event) = this.reader.finish() {
+                        this.emit(&event);
                     }
                     // loop to drain any queued output, then return None.
                 }
@@ -718,7 +816,6 @@ impl Stream for SseTransformStream {
                 // terminal marker.
                 Poll::Ready(Some(Err(_))) => {
                     this.inner_done = true;
-                    this.buffer.clear();
                 }
                 Poll::Pending => return Poll::Pending,
             }
@@ -756,6 +853,197 @@ mod tests {
             !text.contains("[DONE]"),
             "stream must not emit a terminal after a malformed event: {text}"
         );
+    }
+
+    // A CRLF-framed upstream must be split per event, not buffered whole: with a
+    // fixed `\n\n` delimiter the events would only surface as one unparseable
+    // residual at end of stream (no [DONE], stream classified failed). The
+    // doubled blank line after the first event is an empty SSE event; it must be
+    // skipped, not surfaced as a lone-`\r` pseudo-event that fails the stream.
+    #[tokio::test]
+    async fn crlf_framed_events_are_split_and_transformed() {
+        let events: Vec<Result<Bytes, ServiceError>> = vec![
+            Ok(Bytes::from(
+                "event: message_start\r\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"c\",\"usage\":{\"input_tokens\":1}}}\r\n\r\n\r\n\r\n",
+            )),
+            Ok(Bytes::from(
+                "event: content_block_delta\r\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"hi\"}}\r\n\r\nevent: message_stop\r\ndata: {\"type\":\"message_stop\"}\r\n\r\n",
+            )),
+        ];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let stream = SseTransformStream::new(inner, StreamTransform::AnthropicToOpenaiChat);
+        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
+        let text: String = collected
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+        assert!(
+            text.contains("\"content\":\"hi\""),
+            "delta transformed: {text}"
+        );
+        assert!(
+            text.contains("[DONE]"),
+            "message_stop mapped to terminal: {text}"
+        );
+    }
+
+    // Comment-only events (proxy heartbeats) and space-less `data:` lines are
+    // valid SSE; neither may end the stream. Both previously hit the
+    // malformed-event path on the Anthropic transforms (no terminal marker, so
+    // a healthy stream was metered as failed).
+    #[tokio::test]
+    async fn comment_and_spaceless_data_events_are_tolerated() {
+        let events: Vec<Result<Bytes, ServiceError>> = vec![
+            Ok(Bytes::from(": PROCESSING\n\n")),
+            Ok(Bytes::from(
+                "event: message_start\ndata:{\"type\":\"message_start\",\"message\":{\"model\":\"c\",\"usage\":{\"input_tokens\":1}}}\n\n",
+            )),
+            Ok(Bytes::from(
+                "event: message_stop\ndata:{\"type\":\"message_stop\"}\n\n",
+            )),
+        ];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let stream = SseTransformStream::new(inner, StreamTransform::AnthropicToOpenaiChat);
+        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
+        let text: String = collected
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+        assert!(text.contains("chat.completion.chunk"), "{text}");
+        assert!(
+            text.contains("[DONE]"),
+            "stream must reach its terminal: {text}"
+        );
+    }
+
+    // Bare-CR line terminators are valid SSE (a `\r\r` blank line ends an
+    // event); a CR-framed stream must split per event, not run into the cap.
+    // The first chunk ends in `\r` to exercise the cross-chunk CR/CRLF
+    // ambiguity: the reader must not mis-split when the next byte arrives.
+    #[tokio::test]
+    async fn cr_framed_events_are_split_and_transformed() {
+        let events: Vec<Result<Bytes, ServiceError>> = vec![
+            Ok(Bytes::from(
+                "event: message_start\rdata: {\"type\":\"message_start\",\"message\":{\"model\":\"c\",\"usage\":{\"input_tokens\":1}}}\r\r",
+            )),
+            Ok(Bytes::from(
+                "event: message_stop\rdata: {\"type\":\"message_stop\"}\r\r",
+            )),
+        ];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let stream = SseTransformStream::new(inner, StreamTransform::AnthropicToOpenaiChat);
+        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
+        let text: String = collected
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+        assert!(text.contains("chat.completion.chunk"), "{text}");
+        assert!(
+            text.contains("[DONE]"),
+            "CR framing reaches terminal: {text}"
+        );
+    }
+
+    // A comment line attached to the head of an event (a heartbeat injected
+    // without its own blank line) and a space-less `event:` field are both
+    // valid SSE; neither may derail the transform.
+    #[test]
+    fn comment_lines_and_spaceless_event_field_are_parsed() {
+        let mut state = StreamState::default();
+        let out = StreamTransform::AnthropicToOpenaiChat
+            .apply(
+                ": heartbeat\nevent:message_stop\ndata:{\"type\":\"message_stop\"}",
+                "fb",
+                &mut state,
+            )
+            .unwrap()
+            .expect("message_stop dispatches its terminal");
+        assert!(out.contains("[DONE]"), "{out}");
+    }
+
+    // Regressions of the field parser against the old prefix-stripping code:
+    // a bare (data:-less) payload must survive an `event:` line or an injected
+    // comment in the same event block; `id:`/`retry:`-only and empty-data
+    // events must dispatch nothing instead of failing the stream; a trailing
+    // space after an event name must not break exact-match dispatch.
+    #[test]
+    fn bare_payloads_and_ignorable_events_are_handled() {
+        let mut state = StreamState::default();
+        let out = StreamTransform::AnthropicCompleteToOpenai
+            .apply(
+                "event: completion\n  {\"completion\":\"hi\"}",
+                "fb",
+                &mut state,
+            )
+            .unwrap()
+            .expect("bare payload after an event line still transforms");
+        assert!(out.contains("\"text\":\"hi\""), "{out}");
+
+        let mut state = StreamState::default();
+        let out = StreamTransform::OpenaiToAnthropicMessages
+            .apply(": keepalive\n[DONE]", "fb", &mut state)
+            .unwrap()
+            .expect("a comment must not swallow the bare terminal");
+        assert!(out.contains("message_stop"), "{out}");
+
+        let mut state = StreamState::default();
+        for ignorable in [
+            "retry: 3000",
+            "id: 7",
+            "x-proxy: heartbeat",
+            "data:",
+            "data: ",
+            "event: heartbeat",
+            "event: heartbeat\ndata:",
+        ] {
+            assert!(
+                matches!(
+                    StreamTransform::AnthropicToOpenaiChat.apply(ignorable, "fb", &mut state),
+                    Ok(None)
+                ),
+                "{ignorable:?} dispatches nothing"
+            );
+        }
+
+        let mut state = StreamState::default();
+        assert!(
+            matches!(
+                StreamTransform::AnthropicToOpenaiChat.apply(
+                    "event: ping \ndata: {}",
+                    "fb",
+                    &mut state
+                ),
+                Ok(None)
+            ),
+            "trailing space after the event name is tolerated"
+        );
+    }
+
+    // `data:[DONE]` without the optional space must terminate the
+    // OpenAI→Anthropic stream, not be skipped as an unparseable event.
+    #[test]
+    fn spaceless_done_terminates_openai_to_anthropic() {
+        let mut state = StreamState::default();
+        let out = StreamTransform::OpenaiToAnthropicMessages
+            .apply("data:[DONE]", "fb", &mut state)
+            .unwrap()
+            .expect("[DONE] emits the terminal events");
+        assert!(out.contains("message_stop"), "{out}");
+    }
+
+    // A body that never yields an event boundary must not accumulate without
+    // bound: past the cap the stream ends with no terminal marker (metered
+    // failed), mirroring the meter's own line cap.
+    #[tokio::test]
+    async fn boundless_body_is_capped() {
+        let events: Vec<Result<Bytes, ServiceError>> = vec![
+            Ok(Bytes::from(vec![b'x'; MAX_SSE_LINE_BYTES + 1])),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let stream = SseTransformStream::new(inner, StreamTransform::OpenaiToAnthropicMessages);
+        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
+        assert!(collected.is_empty(), "capped stream emits nothing further");
     }
 
     // Replay a fixture's input events through the transform (fixed fallback id),


### PR DESCRIPTION
## Summary

Rewrites SSE event splitting and field parsing in the cross-format stream transforms (`stream_transform.rs`), replacing the fixed per-transform delimiter (`\n\n` / `\r\n\r\n`) and ad-hoc prefix stripping with an incremental tokenizer (`SseEventReader`) plus a spec-following field parser (`parse_event`).

### Fixes

- **Framing**: accepts LF, CRLF, and bare-CR line terminators, including a CR-LF pair split across chunk boundaries. Previously a framing mismatch buffered the entire response (user-perceived TTFT degraded to the full response duration) and then misclassified the healthy stream as failed.
- **Heartbeats / ignored fields**: comment-only events (e.g. `: PROCESSING` injected by a proxy hop), `id:`/`retry:`/vendor-extension fields, and empty-payload events are skipped per the SSE spec instead of ending the stream as malformed — a healthy stream is no longer recorded as a 502.
- **Field forms**: `event:`/`data:` with or without the optional space after the colon; multiple `data:` lines joined with `\n`; bare `[DONE]`/JSON payload lines (no `data:` prefix) keep working, including when a comment or `event:` line shares the event block.
- **Bounded memory**: the pending event is one contiguous buffer capped at the same 16 MiB bound as the meter's line buffer, so the cap limits actual memory; a 200-status body that never yields an event boundary now ends as a bounded failure instead of accumulating without limit.

Malformed-event semantics are unchanged: a non-empty unparseable payload still ends the stream with no terminal marker so the meter records the failure.

## Verification

- `cargo test --lib`: 127 passed, including the Node-generated golden fixtures for all three transforms (byte-identical output for LF upstreams) and new regression tests for CRLF/bare-CR framing, split terminators, glued comments, space-less fields, bare payloads, ignorable events, and the buffer cap.
- `cargo clippy --all-targets`: clean. `cargo fmt`: clean.