### PR TITLE
feat: add fail-closed 0G response verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ container.
 | Downstream ACI E2EE and legacy vLLM E2EE | Implemented for chat/completions/embeddings; streaming E2EE for chat/completions |
 | Runtime upstream config file and admin API | Implemented |
 | Gateway-owned Prometheus metrics | Implemented |
-| Provider adapters | Implemented for Tinfoil, NEAR AI, Chutes, PhalaDirect, ACI service, and generic OpenAI-compatible upstreams |
+| Provider adapters | Implemented for Tinfoil, NEAR AI, Chutes, PhalaDirect, ACI service, 0G buffered response verification, and generic OpenAI-compatible upstreams |
 | Attested-session audit records | Implemented for upstream sessions; downstream sessions pending TLS/domain work |
 | Middleware framework | Implemented over HTTP on Unix domain sockets |
 | Receipt store | In-memory; receipt TTL is configurable. The gateway never stores request bodies (receipts hold hashes, not content). |
@@ -331,14 +331,16 @@ Supported `provider` values:
 | `near-ai` | NEAR AI gateway adapter with TLS binding from the provider report. |
 | `chutes` | Chutes adapter with provider E2EE key verification and encrypted `/e2e/invoke` transport. |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint (one per model) with TLS SPKI binding from the version-2 attestation report. See [docs/providers/phala-direct/verification.md](docs/providers/phala-direct/verification.md). |
+| `0g` | 0G router adapter with provider-reported per-response verification. Buffered requests force `verify_tee=true`; streaming is rejected as unsupported. See [docs/providers/0g/verification.md](docs/providers/0g/verification.md). |
 
 ACI service verification policy is set on the upstream entry with
 `accepted_workload_ids`, `accepted_image_digests`,
 `accepted_dstack_kms_root_public_keys`, and `pccs_url`.
 
 Tinfoil, NEAR AI, Chutes, and PhalaDirect use the vendored provider verifier
-bridge. Set `PRIVATE_AI_VERIFIER_DIR` only when you need to override the
-vendored verifier package with an external checkout.
+bridge. 0G uses first-party Rust response-marker enforcement and does not claim
+cryptographic TEE signature validation. Set `PRIVATE_AI_VERIFIER_DIR` only when
+you need to override the vendored verifier package with an external checkout.
 
 For one-command Compose deployments, set `upstream_config_seed_path` in the
 static gateway config to a read-only seed file. The gateway validates and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -219,7 +219,9 @@ Example seed:
 ```
 
 Supported provider values are `openai-compatible`, `aci-service`, `tinfoil`,
-`near-ai`, `chutes`, and `phala-direct`.
+`near-ai`, `chutes`, `phala-direct`, and `0g`. The `0g` adapter enforces
+provider-reported buffered response verification only; streaming is rejected as
+unsupported.
 
 For `aci-service`, `base_url` is the HTTPS origin used for both model traffic and
 `/v1/attestation/report`. The router fetches the report through normal TLS,

--- a/deploy/upstreams.example.json
+++ b/deploy/upstreams.example.json
@@ -28,6 +28,15 @@
     "bearer_token": "<near-ai-api-key>"
   },
   {
+    "name": "zero-g",
+    "provider": "0g",
+    "base_url": "https://router-api.0g.ai",
+    "models": {
+      "zero-g-model": "<0g-provider-model-id>"
+    },
+    "bearer_token": "<0g-api-key>"
+  },
+  {
     "name": "chutes-glm51",
     "provider": "chutes",
     "base_url": "https://api.chutes.ai",

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -160,6 +160,7 @@ Supported `provider` values:
 | `near-ai` | NEAR AI provider adapter. |
 | `chutes` | Chutes provider adapter. |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint. |
+| `0g` | 0G router adapter. Forces `verify_tee=true` and fail-closes successful buffered responses unless 0G reports `tee_verified=true`; streaming is unsupported. |
 
 Provider verification policy belongs on the upstream entry. For ACI service
 routes, configure accepted workload ids, image digests, or dstack KMS root

--- a/docs/providers/0g/verification.md
+++ b/docs/providers/0g/verification.md
@@ -1,0 +1,95 @@
+# 0G — provider-reported per-response verification
+
+- **TEE:** provider-reported by 0G per response.
+- **Session binding:** none enforced by this gateway in the first adapter.
+- **Verifier:** first-party Rust adapter (`provider: "0g"`).
+- **Status:** fail-closed for buffered responses only; streaming is intentionally
+  unsupported until response verification can be bound before bytes are released.
+
+## What Is Enforced
+
+For every routed request, the gateway rewrites the OpenAI-compatible JSON body
+after model aliasing and forces the top-level field:
+
+```json
+{
+  "verify_tee": true
+}
+```
+
+The receipt's `request.forwarded.body_hash` covers these exact routed bytes, so
+a caller can see that the request sent upstream asked 0G for TEE verification.
+
+For buffered inference responses, the gateway accepts only `2xx` responses with
+both provider-reported markers present:
+
+- `ZG-Res-Key` exists and is non-empty.
+- The JSON response body contains `x_0g_trace.tee_verified` as the JSON boolean
+  `true`.
+
+Other statuses and invalid successful responses are rejected before the gateway
+returns the body or issues a receipt.
+
+## Receipt Evidence
+
+On an accepted buffered response, the signed `upstream.verified` event records
+compact request-specific evidence under
+`provider_claims.response_evidence.0g_response_verification`:
+
+- `verification_type: "provider_reported_per_response"`
+- `tee_verified: true`
+- `zg_res_key_present: true`
+- `zg_res_key_sha256`
+- `x_0g_trace_sha256`
+- `forwarded_body_hash`
+- `response_body_hash`
+- `cryptographic_binding: "pending_0g_clarification"`
+
+The gateway stores hashes of the response key and trace rather than claiming it has
+verified a cryptographic TEE signature. The `upstream.verified.verifier_id` is
+`0g/provider-reported-response/v1` to make that scope explicit.
+
+## What Is Not Claimed
+
+This adapter does **not** claim that the gateway cryptographically validates a
+TEE quote, a provider TEE signature, or a binding between `ZG-Res-Key`,
+`x_0g_trace`, the forwarded request bytes, and the returned response bytes.
+
+0G's public router API points clients to `ZG-Res-Key` and SDK-level verification
+for independent proof. The exact cryptographic binding expected at the gateway
+layer is pending clarification from 0G, so this first adapter records only
+provider-reported per-response verification.
+
+## Streaming Limitation
+
+Streaming 0G requests fail closed with an upstream-verification error:
+
+```text
+0G response verification for streaming responses is unsupported
+```
+
+The gateway does this before opening the upstream stream. Releasing SSE chunks
+before the final `ZG-Res-Key` / `x_0g_trace` response verification would expose
+unverifiable bytes, so streaming stays disabled for `provider: "0g"` until the
+0G contract provides a verification scheme suitable for incremental responses.
+
+## Configuration
+
+```json
+[
+  {
+    "name": "zero-g-router",
+    "provider": "0g",
+    "base_url": "https://router-api.0g.ai",
+    "models": {
+      "0g-model": "<0g-provider-model-id>"
+    },
+    "bearer_token": "<0g-api-key>"
+  }
+]
+```
+
+`base_url` is the origin. The gateway appends `/v1/chat/completions` for chat
+requests unless a route-specific `path` is configured. Production 0G origins
+must use HTTPS, and the adapter rejects redirects so evidence stays tied to the
+configured origin.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -15,6 +15,7 @@ One directory per upstream provider. Each holds up to two documents:
 | Tinfoil | AMD SEV-SNP (or TDX) + NVIDIA CC | `tls_spki_sha256` | [verification](tinfoil/verification.md) | [review](tinfoil/review.md) |
 | AciService (first-party) | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](aci-service/verification.md) | — (first-party) |
 | PhalaDirect | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](phala-direct/verification.md) | [review](phala-direct/review.md) |
+| 0G | Provider-reported per response | response markers (`ZG-Res-Key`, `x_0g_trace`) | [verification](0g/verification.md) | — (first-party adapter) |
 | SecretAI | AMD SEV-SNP + NVIDIA CC | — (adapter deferred) | — | [review](secret-ai/review.md) |
 
 The two columns are different document *types* — `verification.md` tracks the running
@@ -62,13 +63,21 @@ The two binding types:
   backend encrypts the request body to that key, so only the attested enclave can
   decrypt.
 
-### Invariant: verified ⟹ enforceable binding
+### Invariant: session-verified ⟹ enforceable binding
 
 A "verified" result that carries no enforceable channel binding is rejected
 (`src/aci/verifier.rs`). Forwarding fails closed if the selected backend cannot enforce
 the accepted binding
 (`tests/upstream_verifier.rs::service_fails_if_selected_backend_cannot_enforce_channel_binding`).
-A provider can never be "verified but unpinned."
+For session-bound providers, a provider can never be "verified but unpinned."
+
+The initial 0G adapter is a documented exception because the current 0G router
+contract is response-scoped: the gateway forces `verify_tee=true` and accepts a
+successful buffered response only when 0G reports `x_0g_trace.tee_verified=true`
+with a non-empty `ZG-Res-Key`. The receipt records this as
+`provider_reported_per_response` and does not attach an attested session or
+claim cryptographic TEE signature validation. Streaming 0G responses are
+rejected before upstream bytes are released.
 
 ### The attested session record
 

--- a/src/aci/upstream/chutes/mod.rs
+++ b/src/aci/upstream/chutes/mod.rs
@@ -407,6 +407,7 @@ impl UpstreamBackend for ChutesProviderBackend {
                 body,
                 headers,
                 served_instance_id,
+                provider_response_claims: None,
             });
         }
         let body = decrypt_chutes_response(&body, &invoke.response_sk)?;
@@ -415,6 +416,7 @@ impl UpstreamBackend for ChutesProviderBackend {
             body,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
             served_instance_id,
+            provider_response_claims: None,
         })
     }
 

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -24,6 +24,7 @@ use std::pin::Pin;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{stream, Stream};
+use serde_json::Value;
 
 use crate::aci::receipt::UpstreamVerifiedEvent;
 
@@ -31,12 +32,14 @@ mod chutes;
 mod openai;
 mod router;
 mod tls;
+mod zero_g;
 
 pub use chutes::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
 };
 pub use openai::OpenAICompatibleBackend;
 pub use router::{ModelRoute, ModelRouterBackend};
+pub use zero_g::ZeroGProviderBackend;
 
 use openai::request_model_id;
 
@@ -77,6 +80,11 @@ pub struct UpstreamResponse {
     /// several (Chutes: the serving instance id). Lets the receipt cite that
     /// instance's attested session; `None` for single-channel backends.
     pub served_instance_id: Option<String>,
+    /// Compact provider-authored claims learned from this specific response,
+    /// signed into the receipt's `upstream.verified` event before bytes are
+    /// released to the caller. Used by providers whose current contract reports
+    /// per-response verification rather than a pre-forward channel binding.
+    pub provider_response_claims: Option<Value>,
 }
 
 pub type UpstreamBodyStream = Pin<Box<dyn Stream<Item = Result<Bytes, UpstreamError>> + Send>>;
@@ -97,6 +105,10 @@ pub enum UpstreamError {
     Transport(String),
     #[error("upstream channel binding mismatch: {0}")]
     ChannelBindingMismatch(String),
+    #[error("upstream response verification failed: {0}")]
+    ResponseVerificationFailed(String),
+    #[error("upstream response verification unsupported: {0}")]
+    ResponseVerificationUnsupported(String),
     #[error("upstream rejected request with status {status}: {body}")]
     Upstream { status: u16, body: String },
 }

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -115,6 +115,18 @@ impl OpenAICompatibleBackend {
         self
     }
 
+    /// Provider evidence must come from the configured origin. Disabling HTTP
+    /// redirects prevents evidence from another origin being accepted under it.
+    pub(crate) fn without_redirects(mut self) -> Result<Self, UpstreamError> {
+        self.client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(self.connect_timeout_seconds))
+            .read_timeout(Duration::from_secs(self.read_timeout_seconds))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| UpstreamError::Transport(e.to_string()))?;
+        Ok(self)
+    }
+
     fn apply_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.auth {
             Some(UpstreamAuth::Bearer(token)) => {
@@ -192,6 +204,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             body,
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 
@@ -246,6 +259,7 @@ impl UpstreamBackend for OpenAICompatibleBackend {
             body,
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 
@@ -356,6 +370,7 @@ impl OpenAICompatibleBackend {
             body,
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -196,11 +196,12 @@ impl UpstreamBackend for ModelRouterBackend {
                     .unwrap_or_else(|| "/v1/chat/completions".to_string()),
             );
         }
+        let provider_prepared = route.upstream.prepare(request)?;
         Ok(PreparedUpstreamRequest {
-            request,
-            upstream_name: route.upstream.name().to_string(),
-            url_origin: route.upstream.url_origin().map(str::to_string),
-            model_id: route.upstream_model_id.clone(),
+            request: provider_prepared.request,
+            upstream_name: provider_prepared.upstream_name,
+            url_origin: provider_prepared.url_origin,
+            model_id: provider_prepared.model_id,
             route_id: Some(route.route_id.clone()),
             is_tee: route.is_tee,
         })
@@ -280,6 +281,7 @@ impl UpstreamBackend for ModelRouterBackend {
             body,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 

--- a/src/aci/upstream/tls.rs
+++ b/src/aci/upstream/tls.rs
@@ -17,7 +17,13 @@ pub(super) fn response_headers(resp: &reqwest::Response) -> HashMap<String, Stri
     let mut headers = HashMap::new();
     for (k, v) in resp.headers().iter() {
         if let Ok(value) = v.to_str() {
-            headers.insert(k.to_string(), value.to_string());
+            headers
+                .entry(k.to_string())
+                .and_modify(|existing: &mut String| {
+                    existing.push(',');
+                    existing.push_str(value);
+                })
+                .or_insert_with(|| value.to_string());
         }
     }
     headers

--- a/src/aci/upstream/zero_g.rs
+++ b/src/aci/upstream/zero_g.rs
@@ -1,0 +1,213 @@
+//! 0G OpenAI-compatible backend with provider-reported response verification.
+//!
+//! The current 0G router contract reports TEE execution per response using
+//! `ZG-Res-Key` and `x_0g_trace.tee_verified`. This adapter deliberately does
+//! not claim cryptographic TEE signature validation; it only enforces that the
+//! provider reported per-response TEE verification before the gateway releases
+//! successful buffered response bytes.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use super::{
+    OpenAICompatibleBackend, PreparedUpstreamRequest, UpstreamBackend, UpstreamError,
+    UpstreamRequest, UpstreamResponse, UpstreamStreamResponse,
+};
+use crate::aci::canonical::sha256_hex;
+use crate::aci::receipt::UpstreamVerifiedEvent;
+
+const ZG_RES_KEY_HEADER: &str = "zg-res-key";
+
+const STREAMING_UNSUPPORTED: &str =
+    "0G response verification for streaming responses is unsupported";
+
+pub struct ZeroGProviderBackend {
+    inner: OpenAICompatibleBackend,
+}
+
+impl ZeroGProviderBackend {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, UpstreamError> {
+        Ok(Self {
+            inner: OpenAICompatibleBackend::new(base_url)?.without_redirects()?,
+        })
+    }
+
+    pub fn new_with_timeouts(
+        base_url: impl Into<String>,
+        connect_timeout_seconds: u64,
+        read_timeout_seconds: u64,
+    ) -> Result<Self, UpstreamError> {
+        Ok(Self {
+            inner: OpenAICompatibleBackend::new_with_timeouts(
+                base_url,
+                connect_timeout_seconds,
+                read_timeout_seconds,
+            )?
+            .without_redirects()?,
+        })
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.inner = self.inner.with_name(name);
+        self
+    }
+
+    pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.inner = self.inner.with_bearer_token(token);
+        self
+    }
+
+    pub fn with_basic_auth(mut self, enabled: bool) -> Self {
+        self.inner = self.inner.with_basic_auth(enabled);
+        self
+    }
+
+    fn force_verify_tee(body: &[u8]) -> Result<Vec<u8>, UpstreamError> {
+        let mut parsed: Value = serde_json::from_slice(body)
+            .map_err(|e| UpstreamError::Routing(format!("invalid JSON request body: {e}")))?;
+        let Some(obj) = parsed.as_object_mut() else {
+            return Err(UpstreamError::Routing(
+                "request body must be a JSON object".to_string(),
+            ));
+        };
+        obj.insert("verify_tee".to_string(), Value::Bool(true));
+        serde_json::to_vec(&parsed).map_err(|e| UpstreamError::Routing(e.to_string()))
+    }
+
+    fn verify_buffered_response(
+        forwarded_body: &[u8],
+        response: &mut UpstreamResponse,
+    ) -> Result<(), UpstreamError> {
+        if !(200..300).contains(&response.status_code) {
+            return Err(UpstreamError::ResponseVerificationFailed(format!(
+                "0G response verification applies only to successful inference responses; upstream returned {}",
+                response.status_code
+            )));
+        }
+
+        let zg_res_key = header(&response.headers, ZG_RES_KEY_HEADER)
+            .filter(|value| !value.trim().is_empty() && !value.contains(','))
+            .ok_or_else(|| {
+                UpstreamError::ResponseVerificationFailed(
+                    "0G response verification failed: expected exactly one non-empty ZG-Res-Key"
+                        .to_string(),
+                )
+            })?;
+        let response_json: Value = serde_json::from_slice(&response.body).map_err(|e| {
+            UpstreamError::ResponseVerificationFailed(format!(
+                "0G response verification failed: response body must be JSON: {e}"
+            ))
+        })?;
+        let trace = response_json.get("x_0g_trace").ok_or_else(|| {
+            UpstreamError::ResponseVerificationFailed(
+                "0G response verification failed: missing response x_0g_trace object".to_string(),
+            )
+        })?;
+        if trace.get("tee_verified") != Some(&Value::Bool(true)) {
+            return Err(UpstreamError::ResponseVerificationFailed(
+                "0G response verification failed: x_0g_trace.tee_verified must be JSON boolean true"
+                    .to_string(),
+            ));
+        }
+
+        response.provider_response_claims = Some(json!({
+            "0g_response_verification": {
+                "verification_type": "provider_reported_per_response",
+                "tee_verified": true,
+                "zg_res_key_present": true,
+                "zg_res_key_sha256": sha256_hex(zg_res_key.as_bytes()),
+                "x_0g_trace_sha256": sha256_hex(
+                    serde_json::to_vec(trace)
+                        .expect("parsed 0G trace must serialize")
+                        .as_slice()
+                ),
+                "forwarded_body_hash": sha256_hex(forwarded_body),
+                "response_body_hash": sha256_hex(&response.body),
+                "cryptographic_binding": "pending_0g_clarification"
+            }
+        }));
+        Ok(())
+    }
+
+    fn streaming_unsupported() -> UpstreamError {
+        UpstreamError::ResponseVerificationUnsupported(STREAMING_UNSUPPORTED.to_string())
+    }
+}
+
+fn header<'a>(headers: &'a HashMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+#[async_trait]
+impl UpstreamBackend for ZeroGProviderBackend {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn url_origin(&self) -> Option<&str> {
+        self.inner.url_origin()
+    }
+
+    fn prepare(&self, req: UpstreamRequest) -> Result<PreparedUpstreamRequest, UpstreamError> {
+        let mut req = req;
+        req.body = Self::force_verify_tee(&req.body)?;
+        self.inner.prepare(req)
+    }
+
+    async fn forward(&self, req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        let prepared = self.prepare(req)?;
+        self.forward_prepared(prepared).await
+    }
+
+    async fn forward_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        let forwarded_body = req.request.body.clone();
+        let mut response = self.inner.forward_prepared(req).await?;
+        Self::verify_buffered_response(&forwarded_body, &mut response)?;
+        Ok(response)
+    }
+
+    async fn forward_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        let forwarded_body = req.request.body.clone();
+        let mut response = self.inner.forward_verified_prepared(req, event).await?;
+        Self::verify_buffered_response(&forwarded_body, &mut response)?;
+        Ok(response)
+    }
+
+    async fn forward_stream(
+        &self,
+        _req: UpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(Self::streaming_unsupported())
+    }
+
+    async fn forward_stream_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(Self::streaming_unsupported())
+    }
+
+    async fn forward_stream_verified_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+        _event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(Self::streaming_unsupported())
+    }
+
+    async fn models(&self) -> Result<UpstreamResponse, UpstreamError> {
+        self.inner.models().await
+    }
+}

--- a/src/aci/verifier/mod.rs
+++ b/src/aci/verifier/mod.rs
@@ -45,7 +45,7 @@ pub use aci_service::{
 pub use external::ProviderVerifierConfigError;
 pub use providers::{
     ChutesProviderVerifier, NearAiProviderVerifier, PhalaDirectProviderVerifier,
-    RoutingUpstreamVerifier, TinfoilProviderVerifier,
+    RoutingUpstreamVerifier, TinfoilProviderVerifier, ZeroGProviderVerifier,
 };
 pub use report::{validate_aci_report_binding, AciReportValidationError, ValidatedAciReport};
 pub use simple::{PreverifiedUpstreamVerifier, StaticUpstreamVerifier};

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -314,6 +314,46 @@ impl UpstreamVerifier for PhalaDirectProviderVerifier {
     }
 }
 
+/// 0G's current public contract is per-response provider reporting:
+/// the gateway requests `verify_tee=true`, then accepts successful buffered
+/// response bytes only when 0G returns a non-empty `ZG-Res-Key` and the JSON
+/// response body contains `x_0g_trace.tee_verified: true`.
+///
+/// This verifier event intentionally does **not** claim a cryptographically
+/// verified TEE quote or channel binding. The backend performs the response
+/// gate and adds request-specific response evidence to `provider_claims` before
+/// the receipt is signed.
+#[derive(Debug, Clone, Default)]
+pub struct ZeroGProviderVerifier;
+
+impl ZeroGProviderVerifier {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl UpstreamVerifier for ZeroGProviderVerifier {
+    async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        UpstreamVerifiedEvent {
+            upstream_name: request.upstream_name,
+            provider_type: Some("0g".to_string()),
+            model_id: request.model_id,
+            url_origin: request.url_origin,
+            verifier_id: "0g/provider-reported-response/v1".to_string(),
+            result: VerificationResult::Verified,
+            required: request.required,
+            provider_claims: Some(serde_json::json!({
+                "trust_boundary": "0g-router-provider-report",
+                "evidence_scope": "per_response",
+                "verification_type": "provider_reported_per_response",
+                "cryptographic_binding": "pending_0g_clarification"
+            })),
+            ..Default::default()
+        }
+    }
+}
+
 pub struct RoutingUpstreamVerifier {
     by_origin: HashMap<String, Arc<dyn UpstreamVerifier>>,
     by_name: HashMap<String, Arc<dyn UpstreamVerifier>>,

--- a/src/aggregator/service/errors.rs
+++ b/src/aggregator/service/errors.rs
@@ -49,6 +49,24 @@ pub enum UpstreamVerificationError {
     NoVerifierResult,
     #[error("upstream verifier reported failed: {0}")]
     VerifierFailed(String),
+    #[error("provider response verification failed: {0}")]
+    ProviderResponseInvalid(String),
+    #[error("provider response verification unsupported: {0}")]
+    ProviderResponseVerificationUnsupported(String),
+}
+
+pub(super) fn forwarding_error(err: UpstreamError) -> ServiceError {
+    match err {
+        UpstreamError::ResponseVerificationFailed(reason) => ServiceError::UpstreamVerification(
+            UpstreamVerificationError::ProviderResponseInvalid(reason),
+        ),
+        UpstreamError::ResponseVerificationUnsupported(reason) => {
+            ServiceError::UpstreamVerification(
+                UpstreamVerificationError::ProviderResponseVerificationUnsupported(reason),
+            )
+        }
+        other => ServiceError::Upstream(other),
+    }
 }
 
 #[derive(Debug, thiserror::Error, Clone)]

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::aci::receipt::{
     ChannelBinding, ReceiptBuilder, ReceiptError, TransparencyEventKind, UpstreamVerifiedEvent,
@@ -13,6 +13,7 @@ use crate::aggregator::session::{
 
 use super::claims::{chutes_instance_id, per_instance_session_claims, session_claims_for_event};
 use super::e2ee_crypto::encrypt_e2ee_response_body;
+use super::errors::forwarding_error;
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
 };
@@ -123,7 +124,7 @@ impl AciService {
             )
             .await?;
 
-        let upstream_response = match self
+        let mut upstream_response = match self
             .forward_with_binding_reverify(
                 &prepared,
                 &mut recorded_event,
@@ -141,8 +142,12 @@ impl AciService {
         {
             ReverifyOutcome::Forwarded(response) => response,
             ReverifyOutcome::RefreshFailed(err) => return Err(err),
-            ReverifyOutcome::Failed(err) => return Err(err.into()),
+            ReverifyOutcome::Failed(err) => return Err(forwarding_error(err)),
         };
+        Self::attach_provider_response_claims(
+            &mut recorded_event,
+            upstream_response.provider_response_claims.take(),
+        );
         let response_model =
             accepted_response_model(upstream_response.status_code, &upstream_response.body);
         self.metrics.record_upstream_response(
@@ -311,7 +316,7 @@ impl AciService {
         {
             ReverifyOutcome::Forwarded(response) => response,
             ReverifyOutcome::RefreshFailed(err) => return Err(err),
-            ReverifyOutcome::Failed(err) => return Err(err.into()),
+            ReverifyOutcome::Failed(err) => return Err(forwarding_error(err)),
         };
         // Match dstack-vllm-proxy compatibility behavior: streaming
         // requests whose upstream response is not exactly HTTP 200
@@ -338,7 +343,6 @@ impl AciService {
                 },
             ));
         }
-
         let receipt_id = generate_receipt_id();
         let served_at = self.clock.now_secs();
         let mut builder = ReceiptBuilder::new(
@@ -729,6 +733,18 @@ impl AciService {
             }
             None => builder.add_upstream_verified(event),
         }
+    }
+
+    pub(super) fn attach_provider_response_claims(
+        event: &mut UpstreamVerifiedEvent,
+        claims: Option<Value>,
+    ) {
+        let Some(claims) = claims else {
+            return;
+        };
+        event.provider_claims = Some(json!({
+            "response_evidence": claims
+        }));
     }
 
     pub(super) fn store_receipt(&self, receipt: Receipt, requester: Option<ReceiptOwner>) {

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -3,6 +3,7 @@
 //!
 
 use super::e2ee_crypto::{encrypt_e2ee_final_response, is_sse_content_type};
+use super::errors::forwarding_error;
 use super::forward::{cite_served_session, ReverifyOutcome};
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
@@ -265,7 +266,16 @@ impl AciService {
                         // Terminal binding mismatch and transport errors
                         // intentionally share failover priority 2 (a failed
                         // reverify outranks them at 3).
-                        upgrade_err(&mut aggregated_err, 2, err.into());
+                        let priority = if matches!(
+                            err,
+                            UpstreamError::ResponseVerificationFailed(_)
+                                | UpstreamError::ResponseVerificationUnsupported(_)
+                        ) {
+                            3
+                        } else {
+                            2
+                        };
+                        upgrade_err(&mut aggregated_err, priority, forwarding_error(err));
                         None
                     }
                 };
@@ -308,7 +318,6 @@ impl AciService {
                         },
                     )));
                 }
-
                 // Commit this candidate.
                 let upstream_headers = upstream_response.headers;
                 let receipt_id = generate_receipt_id();
@@ -384,14 +393,32 @@ impl AciService {
                     None
                 }
                 ReverifyOutcome::Failed(err) => {
+                    if candidate_required == Some(true)
+                        && matches!(
+                            err,
+                            UpstreamError::ResponseVerificationFailed(_)
+                                | UpstreamError::ResponseVerificationUnsupported(_)
+                        )
+                    {
+                        return Err(forwarding_error(err));
+                    }
                     // Terminal binding mismatch and transport errors
                     // intentionally share failover priority 2 (a failed
                     // reverify outranks them at 3).
-                    upgrade_err(&mut aggregated_err, 2, err.into());
+                    let priority = if matches!(
+                        err,
+                        UpstreamError::ResponseVerificationFailed(_)
+                            | UpstreamError::ResponseVerificationUnsupported(_)
+                    ) {
+                        3
+                    } else {
+                        2
+                    };
+                    upgrade_err(&mut aggregated_err, priority, forwarding_error(err));
                     None
                 }
             };
-            let Some(upstream_response) = upstream_response else {
+            let Some(mut upstream_response) = upstream_response else {
                 failed_attempts.push((route_id.clone(), 502));
                 continue;
             };
@@ -407,6 +434,10 @@ impl AciService {
                 failed_attempts.push((route_id.clone(), status));
                 continue;
             }
+            Self::attach_provider_response_claims(
+                &mut recorded_event,
+                upstream_response.provider_response_claims.take(),
+            );
 
             // Commit this candidate.
             let response_model = accepted_response_model(status, &upstream_response.body);

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -11,12 +11,12 @@ use super::{
 use crate::aci::canonical;
 use crate::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ModelRoute, ModelRouterBackend,
-    OpenAICompatibleBackend, UpstreamBackend,
+    OpenAICompatibleBackend, UpstreamBackend, ZeroGProviderBackend,
 };
 use crate::aci::verifier::{
     AciServiceUpstreamVerifier, AciServiceVerifierPolicy, ChutesProviderVerifier,
     NearAiProviderVerifier, PhalaDirectProviderVerifier, PreverifiedUpstreamVerifier,
-    RoutingUpstreamVerifier, TinfoilProviderVerifier,
+    RoutingUpstreamVerifier, TinfoilProviderVerifier, ZeroGProviderVerifier,
 };
 use crate::aggregator::service::UpstreamVerifier;
 
@@ -78,7 +78,8 @@ fn provider_is_tee(provider: UpstreamProvider) -> bool {
         | UpstreamProvider::Chutes
         | UpstreamProvider::Tinfoil
         | UpstreamProvider::NearAi
-        | UpstreamProvider::PhalaDirect => true,
+        | UpstreamProvider::PhalaDirect
+        | UpstreamProvider::ZeroG => true,
     }
 }
 
@@ -106,6 +107,20 @@ fn build_provider_backend(
                 options,
                 session_store,
             )?))
+        }
+        UpstreamProvider::ZeroG => {
+            let mut backend = ZeroGProviderBackend::new_with_timeouts(
+                cfg.base_url.clone(),
+                connect_timeout_seconds,
+                read_timeout_seconds,
+            )
+            .map_err(|e| UpstreamConfigError::InvalidConfig(e.to_string()))?
+            .with_name(cfg.name.clone());
+            if let Some(token) = &cfg.bearer_token {
+                backend = backend.with_bearer_token(token.clone());
+            }
+            backend = backend.with_basic_auth(cfg.basic_auth);
+            Ok(Arc::new(backend))
         }
         UpstreamProvider::OpenAiCompatible
         | UpstreamProvider::Anthropic
@@ -263,6 +278,7 @@ fn build_provider_verifier(
                 }
                 Some(Arc::new(verifier))
             }
+            UpstreamProvider::ZeroG => Some(Arc::new(ZeroGProviderVerifier::new())),
         };
         if let Some(verifier) = verifier {
             router = router

--- a/src/aggregator/upstream_config/dynamic.rs
+++ b/src/aggregator/upstream_config/dynamic.rs
@@ -54,6 +54,7 @@ impl UpstreamBackend for EmptyUpstreamBackend {
                 .map_err(|e| UpstreamError::Routing(e.to_string()))?,
             headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 }

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -165,6 +165,8 @@ pub enum UpstreamProvider {
     Tinfoil,
     NearAi,
     PhalaDirect,
+    #[serde(rename = "0g")]
+    ZeroG,
 }
 
 impl UpstreamProvider {
@@ -175,6 +177,7 @@ impl UpstreamProvider {
             UpstreamProvider::NearAi | UpstreamProvider::Tinfoil => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
             UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
+            UpstreamProvider::ZeroG => AttestationScope::PerModel,
             // Plain cloud APIs (OpenAI-compatible, Anthropic) have no verifier
             // and ACI service uses its own, so for all of these this only tunes
             // prewarm probe granularity. Per-model is the safe default — it

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -69,6 +69,22 @@ fn router_provider_verifies_once_per_channel() {
 }
 
 #[test]
+fn zero_g_response_scoped_verification_is_not_prewarmed() {
+    let zero_g = test_upstream_config("zero-g", UpstreamProvider::ZeroG, "pub-a", "up-a");
+    assert!(super::validation::verification_targets(&[zero_g]).is_empty());
+}
+
+#[test]
+fn zero_g_requires_https_except_for_loopback_fixtures() {
+    let insecure = r#"[{"name":"zero-g","provider":"0g","base_url":"http://0g.example","models":{"public-model":"provider-model"}}]"#;
+    let err = parse_config_text(insecure).unwrap_err();
+    assert!(err.to_string().contains("0g base_url must use HTTPS"));
+
+    let loopback = r#"[{"name":"zero-g","provider":"0g","base_url":"http://127.0.0.1:8080","models":{"public-model":"provider-model"}}]"#;
+    assert!(parse_config_text(loopback).is_ok());
+}
+
+#[test]
 fn provider_attestation_scopes() {
     // NEAR AI (gateway TD) and Tinfoil (confidential-model-router) front many
     // models behind one verified channel, so they are per-router. Phala-direct
@@ -79,6 +95,7 @@ fn provider_attestation_scopes() {
     assert_eq!(UpstreamProvider::Tinfoil.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::PhalaDirect.attestation_scope(), PerModel);
     assert_eq!(UpstreamProvider::Chutes.attestation_scope(), PerInstance);
+    assert_eq!(UpstreamProvider::ZeroG.attestation_scope(), PerModel);
     assert_eq!(
         UpstreamProvider::OpenAiCompatible.attestation_scope(),
         PerModel
@@ -150,6 +167,26 @@ fn parse_config_rejects_preverified_provider() {
     .expect_err("preverified must not be accepted as upstream config");
 
     assert!(err.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn parse_config_accepts_zero_g_provider() {
+    let config = parse_config_text(
+        r#"
+            [
+              {
+                "name": "zero-g",
+                "provider": "0g",
+                "base_url": "https://router-api.0g.ai",
+                "models": {"public-model": "provider-model"}
+              }
+            ]
+            "#,
+    )
+    .expect("0G provider config should parse");
+
+    let public = serde_json::to_value(config[0].redacted()).unwrap();
+    assert_eq!(public["provider"], "0g");
 }
 
 #[test]

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -41,6 +41,11 @@ fn verification_targets_for_configs<'a>(
     let mut seen = HashSet::new();
     let mut targets = Vec::new();
     for cfg in configs {
+        if cfg.provider == UpstreamProvider::ZeroG {
+            // 0G evidence is learned from each inference response. There is no
+            // channel/session fact to prewarm or refresh before a request.
+            continue;
+        }
         let url_origin = Some(cfg.base_url.trim_end_matches('/').to_string());
         // A router's attestation is of the gateway/enclave channel itself, which
         // is identical for every model it fronts — every model resolves to the
@@ -161,6 +166,24 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
                 upstream.name
             )));
         }
+        if upstream.provider == UpstreamProvider::ZeroG {
+            let url = reqwest::Url::parse(&upstream.base_url).map_err(|e| {
+                UpstreamConfigError::InvalidConfig(format!(
+                    "upstream {:?} 0g base_url is invalid: {e}",
+                    upstream.name
+                ))
+            })?;
+            let loopback = url
+                .host_str()
+                .and_then(|host| host.parse::<std::net::IpAddr>().ok())
+                .is_some_and(|ip| ip.is_loopback());
+            if url.scheme() != "https" && !loopback {
+                return Err(UpstreamConfigError::InvalidConfig(format!(
+                    "upstream {:?} 0g base_url must use HTTPS",
+                    upstream.name
+                )));
+            }
+        }
         if upstream.models.is_empty() {
             return Err(UpstreamConfigError::InvalidConfig(format!(
                 "upstream {:?} must route at least one public model",
@@ -176,10 +199,12 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
             }
             if !matches!(
                 upstream.provider,
-                UpstreamProvider::OpenAiCompatible | UpstreamProvider::Chutes
+                UpstreamProvider::OpenAiCompatible
+                    | UpstreamProvider::Chutes
+                    | UpstreamProvider::ZeroG
             ) {
                 return Err(UpstreamConfigError::InvalidConfig(format!(
-                    "upstream {:?} basic_auth is supported only for openai-compatible or chutes providers",
+                    "upstream {:?} basic_auth is supported only for openai-compatible, chutes, or 0g providers",
                     upstream.name
                 )));
             }

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -181,6 +181,7 @@ impl UpstreamBackend for RecordingUpstream {
             body: self.response_body.clone(),
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 

--- a/tests/aggregator_scenarios.rs
+++ b/tests/aggregator_scenarios.rs
@@ -89,6 +89,7 @@ impl MockUpstream {
                     body: body.to_vec(),
                     headers,
                     served_instance_id: None,
+                    provider_response_claims: None,
                 }),
                 models_response: Mutex::new(UpstreamResponse {
                     status_code: 200,
@@ -98,6 +99,7 @@ impl MockUpstream {
                         "application/json".to_string(),
                     )]),
                     served_instance_id: None,
+                    provider_response_claims: None,
                 }),
                 calls: calls.clone(),
             },

--- a/tests/auth_and_retention.rs
+++ b/tests/auth_and_retention.rs
@@ -45,6 +45,7 @@ impl UpstreamBackend for StubUpstream {
             body: CHAT_RESPONSE.to_vec(),
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 }

--- a/tests/dstack_live.rs
+++ b/tests/dstack_live.rs
@@ -81,6 +81,7 @@ impl UpstreamBackend for LiveStubUpstream {
             body: CHAT_RESPONSE.to_vec(),
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 }

--- a/tests/forward_binding_reverify.rs
+++ b/tests/forward_binding_reverify.rs
@@ -121,6 +121,7 @@ impl MismatchingBackend {
             body: br#"{"id":"chat-ok","object":"chat.completion","model":"model-a","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}"#.to_vec(),
             headers: std::collections::HashMap::new(),
             served_instance_id: None,
+            provider_response_claims: None,
         }
     }
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -73,6 +73,7 @@ impl UpstreamBackend for StubUpstream {
             body: self.body.clone(),
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 
@@ -449,6 +450,7 @@ async fn direct_messages_image_fetch_5xx_returns_anthropic_400() {
                 body: br#"{"error":{"message":"403, message='Forbidden', url='https://img.example/x.jpg'","type":"InternalServerError"}}"#.to_vec(),
                 headers,
                 served_instance_id: None,
+                provider_response_claims: None,
             })
         }
         async fn forward_verified_prepared(

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -56,6 +56,7 @@ impl UpstreamBackend for MockUpstream {
             body: self.body.clone(),
             headers,
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
     async fn models(&self) -> Result<UpstreamResponse, UpstreamError> {
@@ -64,6 +65,7 @@ impl UpstreamBackend for MockUpstream {
             body: b"{}".to_vec(),
             headers: HashMap::new(),
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 }

--- a/tests/provider_e2e.rs
+++ b/tests/provider_e2e.rs
@@ -46,8 +46,8 @@ use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
 };
 use private_ai_gateway::aggregator::upstream_config::{
-    UpstreamConfig, UpstreamConfigManager, UpstreamProvider, UpstreamRuntimeOptions,
-    UpstreamVerifierMode,
+    parse_config_text, UpstreamConfig, UpstreamConfigManager, UpstreamProvider,
+    UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::http::build_router;
 use rand::RngCore;
@@ -68,6 +68,11 @@ const EMBEDDINGS_RESPONSE: &[u8] =
     br#"{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2,0.3]}],"model":"provider-embed-model","usage":{"prompt_tokens":5,"total_tokens":5}}"#;
 const STREAM_CHAT_REQUEST: &[u8] =
     br#"{"model":"provider-model","stream":true,"messages":[{"role":"user","content":"hello"}]}"#;
+const ZERO_G_CHAT_REQUEST_VERIFY_FALSE: &[u8] =
+    br#"{"model":"public-model","verify_tee":false,"messages":[{"role":"user","content":"hello"}]}"#;
+const ZERO_G_STREAM_CHAT_REQUEST: &[u8] =
+    br#"{"model":"public-model","stream":true,"messages":[{"role":"user","content":"hello"}]}"#;
+
 const STREAM_CHAT_RESPONSE_EVENT: &[u8] =
     br#"data: {"id":"chat-provider-1","object":"chat.completion.chunk","model":"provider-model","choices":[{"index":0,"delta":{"role":"assistant","content":"world"},"finish_reason":null}]}"#;
 const CHUTES_CHUTE_ID: &str = "2ff25e81-4586-5ec8-b892-3a6f342693d7";
@@ -192,6 +197,126 @@ async fn serve_openai_provider_fixture() -> (String, Arc<Mutex<Vec<ProviderCall>
         .route("/v1/models", get(models_handler))
         .with_state(ProviderState {
             calls: calls.clone(),
+        });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), calls)
+}
+
+#[derive(Clone)]
+struct ZeroGProviderState {
+    calls: Arc<Mutex<Vec<ProviderCall>>>,
+    response: Arc<Mutex<ZeroGFixtureResponse>>,
+}
+
+#[derive(Clone)]
+struct ZeroGFixtureResponse {
+    status: StatusCode,
+    zg_res_key: Option<String>,
+    body: Vec<u8>,
+}
+
+impl ZeroGFixtureResponse {
+    fn verified() -> Self {
+        Self {
+            status: StatusCode::OK,
+            zg_res_key: Some("zg-response-key-a".to_string()),
+            body: serde_json::to_vec(&json!({
+                "id": "chatcmpl-provider",
+                "object": "chat.completion",
+                "model": "provider-model",
+                "choices": [],
+                "x_0g_trace": {
+                    "request_id": "0g-request-a",
+                    "provider": "0x0000000000000000000000000000000000000001",
+                    "tee_verified": true
+                }
+            }))
+            .unwrap(),
+        }
+    }
+
+    fn without_zg_res_key() -> Self {
+        Self {
+            zg_res_key: None,
+            ..Self::verified()
+        }
+    }
+
+    fn with_unverified_trace() -> Self {
+        Self {
+            body: serde_json::to_vec(&json!({
+                "id": "chatcmpl-provider",
+                "object": "chat.completion",
+                "model": "provider-model",
+                "choices": [],
+                "x_0g_trace": {
+                    "request_id": "0g-request-a",
+                    "provider": "0x0000000000000000000000000000000000000001",
+                    "tee_verified": false
+                }
+            }))
+            .unwrap(),
+            ..Self::verified()
+        }
+    }
+}
+
+async fn zero_g_chat_handler(
+    State(state): State<ZeroGProviderState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    state.calls.lock().unwrap().push(ProviderCall {
+        path: "/v1/chat/completions".to_string(),
+        authorization: headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        accept: headers
+            .get("accept")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        content_type: headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        x_chute_id: None,
+        x_instance_id: None,
+        x_e2e_nonce: None,
+        x_e2e_stream: None,
+        x_e2e_path: None,
+        body: body.to_vec(),
+        decrypted_body: None,
+    });
+    let response = state.response.lock().unwrap().clone();
+    let mut out = (response.status, response.body).into_response();
+    out.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    if let Some(zg_res_key) = response.zg_res_key {
+        out.headers_mut().insert(
+            axum::http::HeaderName::from_static("zg-res-key"),
+            axum::http::HeaderValue::from_str(&zg_res_key).unwrap(),
+        );
+    }
+    out
+}
+
+async fn serve_zero_g_provider_fixture_with_response(
+    response: ZeroGFixtureResponse,
+) -> (String, Arc<Mutex<Vec<ProviderCall>>>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/v1/chat/completions", post(zero_g_chat_handler))
+        .route("/v1/models", get(models_handler))
+        .with_state(ZeroGProviderState {
+            calls: calls.clone(),
+            response: Arc::new(Mutex::new(response)),
         });
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -486,6 +611,31 @@ fn service_for_manager(manager: Arc<UpstreamConfigManager>) -> Arc<AciService> {
         )
         .unwrap(),
     )
+}
+
+fn zero_g_manager(base_url: &str) -> Arc<UpstreamConfigManager> {
+    let path = temp_config_path();
+    let manager = Arc::new(
+        UpstreamConfigManager::load(&path, runtime_options(UpstreamVerifierMode::None)).unwrap(),
+    );
+    let config = parse_config_text(
+        &json!([{
+            "name": "zero-g-provider",
+            "provider": "0g",
+            "base_url": base_url,
+            "models": {
+                "public-model": "provider-model"
+            },
+            "bearer_token": "zero-g-secret"
+        }])
+        .to_string(),
+    )
+    .expect("0G upstream config should parse");
+    manager
+        .replace(config)
+        .expect("0G upstream config should be accepted");
+    let _ = std::fs::remove_file(path);
+    manager
 }
 
 fn receipt_event<'a>(
@@ -846,6 +996,158 @@ async fn openai_compatible_provider_routes_embeddings_via_runtime_config() {
     assert_eq!(upstream_verified["result"], "verified");
 
     let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn zero_g_provider_forces_verify_tee_and_records_response_evidence() {
+    let (base_url, provider_calls) =
+        serve_zero_g_provider_fixture_with_response(ZeroGFixtureResponse::verified()).await;
+    let service = service_for_manager(zero_g_manager(&base_url));
+    let app = build_router(service.clone());
+
+    let (status, headers, body) = call(
+        app,
+        "POST",
+        "/v1/chat/completions",
+        ZERO_G_CHAT_REQUEST_VERIFY_FALSE,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let response: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response["x_0g_trace"]["tee_verified"], true);
+    let receipt_id = headers
+        .get("x-receipt-id")
+        .and_then(|value| value.to_str().ok())
+        .expect("successful 0G response must include x-receipt-id");
+
+    let calls = provider_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    let call = &calls[0];
+    assert_eq!(call.authorization.as_deref(), Some("Bearer zero-g-secret"));
+    let forwarded: Value = serde_json::from_slice(&call.body).unwrap();
+    assert_eq!(forwarded["model"], "provider-model");
+    assert_eq!(forwarded["verify_tee"], true);
+    assert_ne!(
+        call.body, ZERO_G_CHAT_REQUEST_VERIFY_FALSE,
+        "receipt must hash the exact routed bytes after forcing verify_tee=true"
+    );
+
+    let receipt = service
+        .get_receipt_by_receipt_id(receipt_id)
+        .expect("verified 0G response must persist a receipt");
+    assert_eq!(
+        receipt_event(&receipt, EVENT_REQUEST_FORWARDED)["body_hash"],
+        sha256_hex(&call.body)
+    );
+    let upstream_verified = receipt_event(&receipt, EVENT_UPSTREAM_VERIFIED);
+    assert_eq!(upstream_verified["upstream_name"], "zero-g-provider");
+    assert_eq!(upstream_verified["provider_type"], "0g");
+    assert_eq!(upstream_verified["model_id"], "provider-model");
+    assert_eq!(upstream_verified["url_origin"], base_url);
+    assert_eq!(
+        upstream_verified["verifier_id"],
+        "0g/provider-reported-response/v1"
+    );
+    assert_eq!(upstream_verified["result"], "verified");
+
+    let evidence =
+        &upstream_verified["provider_claims"]["response_evidence"]["0g_response_verification"];
+    assert_eq!(
+        evidence["verification_type"],
+        "provider_reported_per_response"
+    );
+    assert_eq!(evidence["tee_verified"], true);
+    assert_eq!(evidence["zg_res_key_present"], true);
+    assert_eq!(
+        evidence["zg_res_key_sha256"],
+        sha256_hex(b"zg-response-key-a")
+    );
+    assert_eq!(
+        evidence["x_0g_trace_sha256"],
+        sha256_hex(
+            serde_json::to_vec(&json!({
+                "request_id": "0g-request-a",
+                "provider": "0x0000000000000000000000000000000000000001",
+                "tee_verified": true
+            }))
+            .unwrap()
+            .as_slice()
+        )
+    );
+    assert_eq!(evidence["forwarded_body_hash"], sha256_hex(&call.body));
+    assert_eq!(
+        evidence["cryptographic_binding"],
+        "pending_0g_clarification"
+    );
+}
+
+#[tokio::test]
+async fn zero_g_provider_rejects_success_without_non_empty_zg_res_key() {
+    let (base_url, provider_calls) =
+        serve_zero_g_provider_fixture_with_response(ZeroGFixtureResponse::without_zg_res_key())
+            .await;
+    let app = build_router(service_for_manager(zero_g_manager(&base_url)));
+
+    let (status, headers, body) = call(app, "POST", "/v1/chat/completions", CHAT_REQUEST).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(headers.get("x-receipt-id").is_none());
+    let error: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(error["error"]["type"], "upstream_verification_failed");
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("expected exactly one non-empty ZG-Res-Key"));
+    assert_eq!(
+        provider_calls.lock().unwrap().len(),
+        1,
+        "0G buffered verification happens after the provider response but before release"
+    );
+}
+
+#[tokio::test]
+async fn zero_g_provider_rejects_success_without_tee_verified_true() {
+    let (base_url, provider_calls) =
+        serve_zero_g_provider_fixture_with_response(ZeroGFixtureResponse::with_unverified_trace())
+            .await;
+    let app = build_router(service_for_manager(zero_g_manager(&base_url)));
+
+    let (status, headers, body) = call(app, "POST", "/v1/chat/completions", CHAT_REQUEST).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(headers.get("x-receipt-id").is_none());
+    let error: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(error["error"]["type"], "upstream_verification_failed");
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("x_0g_trace.tee_verified must be JSON boolean true"));
+    assert_eq!(provider_calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn zero_g_provider_rejects_streaming_as_unverifiable() {
+    let (base_url, provider_calls) =
+        serve_zero_g_provider_fixture_with_response(ZeroGFixtureResponse::verified()).await;
+    let app = build_router(service_for_manager(zero_g_manager(&base_url)));
+
+    let (status, headers, body) = call(
+        app,
+        "POST",
+        "/v1/chat/completions",
+        ZERO_G_STREAM_CHAT_REQUEST,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(headers.get("x-receipt-id").is_none());
+    let error: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(error["error"]["type"], "upstream_verification_failed");
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("0G response verification for streaming responses is unsupported"));
+    assert!(
+        provider_calls.lock().unwrap().is_empty(),
+        "streaming 0G requests must fail before unverifiable upstream bytes exist"
+    );
 }
 
 #[tokio::test]

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -77,6 +77,7 @@ impl UpstreamBackend for StubUpstream {
             body: self.body.clone(),
             headers: Default::default(),
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 

--- a/tests/upstream_verifier.rs
+++ b/tests/upstream_verifier.rs
@@ -33,6 +33,7 @@ impl UpstreamBackend for NoopUpstream {
             body: b"{}".to_vec(),
             headers: HashMap::new(),
             served_instance_id: None,
+            provider_response_claims: None,
         })
     }
 }


### PR DESCRIPTION
## Summary
- add a first-party `provider: "0g"` adapter
- force `verify_tee: true` in the exact forwarded request bytes
- accept buffered inference responses only when `ZG-Res-Key` is present and `x_0g_trace.tee_verified` is JSON boolean `true`
- bind compact provider-reported evidence into the signed receipt and fail closed before releasing response bytes
- require HTTPS origins, reject redirects, skip response-scoped prewarm, and reject streaming until incremental verification is defined

## Trust scope
This adapter records **provider-reported per-response verification**. It does not claim cryptographic validation of a TEE quote, provider signature, channel binding, or request/response binding. Those fields remain explicitly pending clarification from 0G.

## Tests
- `cargo test zero_g -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
