### PR TITLE
Request outcome observation + connection-level failure fixes

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -61,6 +61,27 @@ out-of-process hop. When the section is omitted the gateway serves directly.
 | `middleware.control_post_timeout_ms` | `10000` | Timeout for the fire-and-forget post-request usage report. |
 | `middleware.sse_keepalive_ms` | `10000` | Idle keep-alive interval for streaming responses; `0` disables the heartbeat. |
 
+Request outcome observation is always on and needs no configuration: every
+failed request that reaches the middleware completion path (consult denials,
+routing/shaping failures, upstream errors, stream failures, client
+disconnects; final 429s excepted, they are recorded per-attempt in the usage
+pipeline) emits a `request_outcome` tracing line carrying the client-facing
+and upstream status, route, attempt chain length, TTFT/duration, finish
+reasons, and terminal marker. Requests rejected before that path — malformed
+JSON, oversized bodies, E2EE setup failures — do not produce lines, so
+complete request accounting still needs the usage pipeline. A request emits
+at most one primary line; a late receipt/E2EE finalization failure appends
+one supplemental `phase=finalize_error` line for the same `request_id`
+(aggregate by unique request id, letting `finalize_error` supersede).
+Completed
+responses are logged only when their finish reasons fall outside the standard
+OpenAI/Anthropic set (`anomalous_finish=true`) — the "error smuggled through a
+success" class. The `detail` field (a 240-char snippet of the upstream error
+body, which may quote request fragments) is emitted only when the
+`request_outcome` target is enabled at `debug`; at the default level it is
+blank. Silence or re-route the target via `RUST_LOG` (the subscriber uses
+`EnvFilter`).
+
 ```json
 {
   "middleware": {

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -13,7 +13,7 @@ use super::streaming::{
 };
 use super::{
     AciService, ChatCompletionRequest, E2eeError, E2eeRequestContext, E2eeResponseInfo,
-    ForwardCandidate, MiddlewareForwardResult, MiddlewareForwarded,
+    ForwardCandidate, MiddlewareAllFailed, MiddlewareForwardResult, MiddlewareForwarded,
     MiddlewareGeneratedFinalization, MiddlewareReceiptDraft, MiddlewareReceiptFinalization,
     MiddlewareReceiptJournal, MiddlewareStreamFinalization, MiddlewareStreamingForwarded,
     MiddlewareUpstreamError, ReceiptOwner, ServiceError, ServiceResponseStream,
@@ -463,14 +463,22 @@ impl AciService {
             )));
         }
 
-        // No candidate succeeded. Return the highest-priority failure, with
-        // the attempted route ids for context.
-        Err(aggregated_err.map(|(_, err)| err).unwrap_or_else(|| {
+        // No candidate succeeded. Return the highest-priority failure together
+        // with every attempt's outcome — the caller reports the attempts (they
+        // are unrecoverable from the error alone) and derives the client
+        // status from the failure mix.
+        let error = aggregated_err.map(|(_, err)| err).unwrap_or_else(|| {
             ServiceError::Upstream(UpstreamError::Routing(format!(
                 "all upstream routes failed (attempted: {})",
                 candidate_route_ids.join(", ")
             )))
-        }))
+        });
+        Ok(MiddlewareForwardResult::AllFailed(Box::new(
+            MiddlewareAllFailed {
+                failed_attempts,
+                error,
+            },
+        )))
     }
 
     /// Start a streaming chat completion. The response stream hashes

--- a/src/aggregator/service/mod.rs
+++ b/src/aggregator/service/mod.rs
@@ -54,7 +54,7 @@ pub use receipt_store::{InMemoryReceiptStore, ReceiptStore};
 pub use wire::{
     ChatCompletionRequest, E2eePreparedRequest, E2eeRequestContext, E2eeRequestParts,
     E2eeResponseInfo, ForwardCandidate, ForwardResult, GatewayRequestContext,
-    LegacySignatureResult, MiddlewareForwardResult, MiddlewareForwarded,
+    LegacySignatureResult, MiddlewareAllFailed, MiddlewareForwardResult, MiddlewareForwarded,
     MiddlewareGeneratedFinalization, MiddlewareReceiptDraft, MiddlewareReceiptFinalization,
     MiddlewareReceiptJournal, MiddlewareStreamFinalization, MiddlewareStreamingForwarded,
     MiddlewareUpstreamError, ServiceResponseStream, StreamingForwardResult, StreamingForwardStream,

--- a/src/aggregator/service/wire.rs
+++ b/src/aggregator/service/wire.rs
@@ -71,6 +71,27 @@ pub enum MiddlewareForwardResult {
     Forwarded(Box<MiddlewareForwarded>),
     Stream(Box<MiddlewareStreamingForwarded>),
     UpstreamError(Box<MiddlewareUpstreamError>),
+    /// Every candidate was attempted and failed without an HTTP response to
+    /// relay. Carries the per-attempt outcomes so the caller can report each
+    /// attempt (they are otherwise unrecoverable from the aggregated error)
+    /// and derive an honest client status from the failure mix.
+    AllFailed(Box<MiddlewareAllFailed>),
+}
+
+pub struct MiddlewareAllFailed {
+    /// Every candidate attempted, as (route_id, status), in the order tried.
+    /// Non-HTTP failures (prepare/verification/transport) record 502; HTTP
+    /// failures record the upstream status (e.g. 429).
+    ///
+    /// Usage-report consumers: the caller reports these as attempt rows
+    /// 0..N-1, and MAY additionally report one request-level summary row at
+    /// attempt index N (currently only for 5xx aggregate errors) with an
+    /// empty route and a gateway/upstream error source. A row with no route
+    /// and a non-empty error source is a request-level summary, not an
+    /// attempt; attempt counting must only consider rows that carry a route.
+    pub failed_attempts: Vec<(String, u16)>,
+    /// The highest-priority underlying failure across the attempts.
+    pub error: ServiceError,
 }
 
 pub struct MiddlewareForwarded {

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -39,6 +39,7 @@ pub(super) async fn forward_to_backend(
     input: BackendForwardInput,
 ) -> Response {
     if input.stream {
+        let request_id = input.context.request_id.clone();
         let result = service
             .forward_chat_completion_stream_request(ChatCompletionRequest {
                 context: input.context,
@@ -69,11 +70,23 @@ pub(super) async fn forward_to_backend(
                 );
                 let status =
                     StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
-                let body = Body::from_stream(
-                    forward
-                        .body
-                        .map(|chunk| chunk.map_err(|e| std::io::Error::other(e.to_string()))),
-                );
+                // Same contract as the middleware stream path: a body Err makes
+                // hyper abort the connection with a TCP RST (client-visible as a
+                // silently killed stream); log it and end the body gracefully.
+                let body = Body::from_stream(forward.body.scan((), move |_, chunk| {
+                    std::future::ready(match chunk {
+                        Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "stream_abort",
+                                request_id = %request_id,
+                                error = %err,
+                                "response stream error; ending body gracefully instead of aborting the connection"
+                            );
+                            None
+                        }
+                    })
+                }));
                 (status, resp_headers, body).into_response()
             }
             Ok(StreamingForwardResult::UpstreamError(forward)) => {

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -72,7 +72,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Request, State},
+    extract::{DefaultBodyLimit, Request, State},
     http::{HeaderName, HeaderValue},
     middleware::{self, Next},
     response::Response,
@@ -80,6 +80,13 @@ use axum::{
     Router,
 };
 use tower_http::cors::CorsLayer;
+
+/// Request-body cap for the inference surface. Multimodal chat payloads with
+/// base64 image parts routinely run 5–20 MB; axum's 2 MB default rejected them
+/// with an extractor-level 413 that reached clients as a connection reset.
+/// Bodies are buffered in memory, so the cap stays bounded rather than
+/// unlimited.
+const MAX_REQUEST_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 use crate::aggregator::service::AciService;
 use crate::aggregator::upstream_config::UpstreamConfigManager;
@@ -182,6 +189,13 @@ fn build_router_inner(
         // Outermost layer: it answers preflight OPTIONS before routing, which
         // otherwise 405s since the routes only declare GET/POST/PUT.
         .layer(CorsLayer::permissive())
+        // Multimodal chat payloads (base64 image parts) routinely exceed
+        // axum's 2 MB default body limit. The default-limit 413 is rejected in
+        // the extractor with the client's upload left unread, which hyper
+        // turns into a TCP RST — clients see a connection error instead of a
+        // 413, and the request never reaches request logging. Raise the cap so
+        // legitimate payloads fit.
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         .with_state(state)
 }
 

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -386,11 +386,27 @@ pub async fn run(
                         HeaderName::from_static("cache-control"),
                         HeaderValue::from_static("no-cache"),
                     );
-                    let body = Body::from_stream(
-                        finalized
-                            .body
-                            .map(|chunk| chunk.map_err(|e| std::io::Error::other(e.to_string()))),
-                    );
+                    // A response-stream error must not become a body Err: hyper
+                    // aborts the connection (TCP RST toward the proxy), which
+                    // clients experience as a silently killed stream and a
+                    // poisoned keep-alive pool, invisible to application logs.
+                    // Log the error (this is its only surface) and end the body
+                    // instead, so the connection closes with a normal FIN.
+                    let stream_request_id = request_id.clone();
+                    let body = Body::from_stream(finalized.body.scan((), move |_, chunk| {
+                        std::future::ready(match chunk {
+                            Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
+                            Err(err) => {
+                                tracing::warn!(
+                                    target: "stream_abort",
+                                    request_id = %stream_request_id,
+                                    error = %err,
+                                    "response stream error; ending body gracefully instead of aborting the connection"
+                                );
+                                None
+                            }
+                        })
+                    }));
                     (status, headers, body).into_response()
                 }
                 Err(err) => {

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -434,10 +434,38 @@ pub async fn run(
             );
             finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
         }
-        // All candidates failed. Record an upstream-attributed failure so the
-        // request is visible to billing/health (per-attempt rows are not
-        // recoverable from the typed error). Client-attributable errors (E2EE/4xx)
-        // are not recorded. The E2EE context is still available to encrypt the body.
+        // Every candidate was attempted and failed without an HTTP response to
+        // relay (a chain that ends in an upstream HTTP status — including an
+        // all-429 chain — exits via the UpstreamError arm above, which relays
+        // that status). Report each attempt so deployment health and triage
+        // see the full chain, then a summary row placed after them carrying
+        // the aggregated error message.
+        Ok(MiddlewareForwardResult::AllFailed(forward)) => {
+            let status = forward_error_status(&forward.error);
+            meter.failed_attempts(&forward.failed_attempts, stream);
+            if status >= 500 {
+                meter.gateway_failure_at(
+                    forward.failed_attempts.len() as u32,
+                    status,
+                    ErrorSource::Upstream,
+                    &forward.error.to_string(),
+                    stream,
+                );
+            }
+            service_error_response(
+                surface,
+                endpoint_path,
+                service,
+                &request_id,
+                forward.error,
+                e2ee,
+            )
+        }
+        // Failures where no attempt chain is available (pre-forward errors,
+        // plus the forwarder's rare mid-walk internal-error abort): record an
+        // upstream-attributed failure so the request is visible to
+        // billing/health. Client-attributable errors (E2EE/4xx) are not
+        // recorded. The E2EE context is still available to encrypt the body.
         Err(err) => {
             let status = forward_error_status(&err);
             if status >= 500 {
@@ -528,9 +556,25 @@ impl Meter<'_> {
     }
 
     fn gateway_failure(&self, status: u16, source: ErrorSource, message: &str, is_streaming: bool) {
+        self.gateway_failure_at(0, status, source, message, is_streaming);
+    }
+
+    // Like `gateway_failure`, but placed at an explicit attempt index. Control
+    // dedupes reports by (request_id, attempt, status), so a summary row that
+    // follows per-attempt rows must sit after them or it collides with (and
+    // silently drops) the first attempt's row.
+    fn gateway_failure_at(
+        &self,
+        attempt_index: u32,
+        status: u16,
+        source: ErrorSource,
+        message: &str,
+        is_streaming: bool,
+    ) {
         self.spawn(PostReport {
             status,
             is_streaming: Some(is_streaming),
+            attempt_index: Some(attempt_index),
             error_source: Some(source),
             error_message: Some(truncate(message, 500)),
             ..self.base()

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -6,6 +6,8 @@
 //! response, inject cost, post the usage report, and finalize through the
 //! existing receipt/E2EE finalizers.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::{
@@ -51,6 +53,170 @@ pub struct CompletionInput {
     pub stream: bool,
 }
 
+/// Cap on the error-detail snippet in `request_outcome` lines. Long enough to
+/// carry a provider's error envelope, short enough to bound log growth and to
+/// avoid replaying large bodies into the log.
+const MAX_DETAIL_CHARS: usize = 240;
+
+/// Whether a terminal failure with this client-facing status gets a
+/// `request_outcome` line. Always-on for every model; the only exclusion is
+/// final 429s — the highest-volume, lowest-information class, already recorded
+/// per-attempt in the usage pipeline. Every other failure (4xx/5xx, client
+/// disconnects, stream failures) is logged with content-free structured
+/// fields (statuses, route, phase, finish reasons, timings); the raw error
+/// detail appears only with `request_outcome=debug`. Silence the target via
+/// `RUST_LOG` if ever needed — there is deliberately no config knob.
+pub(super) fn should_log_failure(status: u16) -> bool {
+    status != 429
+}
+
+/// Finish/stop reasons that mark a genuinely clean completion on the OpenAI
+/// and Anthropic surfaces. A completed stream whose collected reasons include
+/// anything outside this set is logged as an anomaly: an upstream signalling
+/// an error through a nonstandard finish reason would otherwise be recorded
+/// as a plain success.
+///
+/// This is a heuristic: a miss on a newly introduced legitimate value costs
+/// only an info-level false positive and a one-line addition here. Keep it a
+/// flat list — no provider-specific registries or runtime configuration.
+pub(super) const STANDARD_FINISH_REASONS: &[&str] = &[
+    "stop",
+    "length",
+    "tool_calls",
+    "function_call",
+    "content_filter",
+    "end_turn",
+    "max_tokens",
+    "stop_sequence",
+    "tool_use",
+    "pause_turn",
+    "refusal",
+    "model_context_window_exceeded",
+];
+
+pub(super) fn finish_reasons_anomalous<'a, I: IntoIterator<Item = &'a str>>(reasons: I) -> bool {
+    reasons
+        .into_iter()
+        .any(|r| !STANDARD_FINISH_REASONS.contains(&r))
+}
+
+/// Per-reason length cap for logged finish reasons. Long enough for every
+/// standard value and any plausible provider-specific token, short enough
+/// that a provider-controlled string cannot become a content channel in the
+/// always-on log.
+const MAX_REASON_CHARS: usize = 32;
+
+/// Log-safe form of a client-controlled identifier (the requested model
+/// name): single-line, control characters replaced, length-capped. The
+/// request body allows megabytes, so an unbounded identifier in an always-on
+/// info log would be a log-injection and disk-amplification vector.
+pub(super) fn sanitize_identifier(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(128)
+        .collect()
+}
+
+/// Log-safe form of a single provider-controlled finish reason:
+/// length-capped, with every control character (newlines, ANSI escapes)
+/// replaced — a JSON string can embed them after parsing, enabling forged
+/// log records or terminal-escape injection.
+pub(super) fn sanitize_reason(reason: &str) -> String {
+    reason
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(MAX_REASON_CHARS)
+        .collect()
+}
+
+/// Emission form of collected finish reasons: count-capped, each value
+/// sanitized. Anomaly *detection* runs on the raw values; only what gets
+/// stored or logged is bounded.
+pub(super) fn sanitized_reasons<'a, I: IntoIterator<Item = &'a str>>(reasons: I) -> String {
+    reasons
+        .into_iter()
+        .take(8)
+        .map(sanitize_reason)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Whether raw error detail may be included in `request_outcome` lines.
+/// Upstream error bodies can echo request content (validation errors quoting
+/// input, signed URLs), and this gateway's confidentiality model treats logs
+/// as operator-visible — so raw detail is opt-in via the tracing filter
+/// (`RUST_LOG=request_outcome=debug`); at the default level the structured
+/// fields (statuses, route, phase, finish reasons, timings) still identify
+/// the failure class.
+pub(super) fn debug_gated_detail(detail: &str) -> &str {
+    if tracing::enabled!(target: "request_outcome", tracing::Level::DEBUG) {
+        detail
+    } else {
+        ""
+    }
+}
+
+/// Single-line, length-capped snippet of an error body/message for the
+/// `request_outcome` `detail` field (char-boundary safe). The input is
+/// byte-capped before the lossy conversion so a large non-UTF-8 body is never
+/// copied whole; a char split at the cap degrades to a replacement character,
+/// which is fine for a log snippet.
+pub(super) fn detail_snippet(raw: &[u8]) -> String {
+    let capped = &raw[..raw.len().min(4 * MAX_DETAIL_CHARS)];
+    String::from_utf8_lossy(capped)
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(MAX_DETAIL_CHARS)
+        .collect()
+}
+
+/// `request_outcome` line for a terminal path that never settles a stream or a
+/// buffered 2xx: consult denials, routing/shaping failures, upstream error
+/// responses, and forward errors. Together with the stream-settle and
+/// buffered-2xx lines this makes observation exhaustive. Contract: a request
+/// emits at most one primary line, and a late finalization failure may append
+/// one supplemental `phase=finalize_error` line for the same request_id —
+/// aggregate by unique request_id, with `finalize_error` superseding the
+/// earlier record.
+/// Identity fields threaded into response finalization so a late failure
+/// there (E2EE encryption of a generated body) can record the actual
+/// client-facing terminal as `phase=finalize_error`.
+#[derive(Clone, Copy)]
+struct OutcomeCtx<'a> {
+    request_id: &'a str,
+    model: &'a str,
+    started: Instant,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_generated_outcome(
+    request_id: &str,
+    model: &str,
+    phase: &'static str,
+    status: u16,
+    upstream_status: u16,
+    route: &str,
+    attempt: u32,
+    started: Instant,
+    detail: &str,
+) {
+    tracing::info!(
+        target: "request_outcome",
+        request_id = %request_id,
+        model = %sanitize_identifier(model),
+        route = %route,
+        attempt,
+        upstream_status,
+        status,
+        outcome = "Generated",
+        phase = %phase,
+        duration_ms = started.elapsed().as_millis() as u64,
+        detail = %debug_gated_detail(detail),
+        "generated response"
+    );
+}
+
 /// Run the completion flow and produce the client response.
 pub async fn run(
     control: &ControlClient,
@@ -75,6 +241,11 @@ pub async fn run(
 
     let started = Instant::now();
     let model = params.get("model").and_then(Value::as_str);
+    let outcome_ctx = OutcomeCtx {
+        request_id: &request_id,
+        model: model.unwrap_or(""),
+        started,
+    };
     // Forward the routing block verbatim; the control plane validates it. Parsing
     // it here would silently drop a caller's restrictions on a malformed field.
     let provider = params.get("provider");
@@ -99,6 +270,19 @@ pub async fn run(
     if !consult.allow {
         let status = consult.status.unwrap_or(403);
         let message = consult.message.as_deref().unwrap_or("forbidden");
+        if should_log_failure(status) {
+            log_generated_outcome(
+                &request_id,
+                model.unwrap_or(""),
+                "consult_deny",
+                status,
+                0,
+                "",
+                0,
+                started,
+                &detail_snippet(message.as_bytes()),
+            );
+        }
         // Record 5xx and 429 denials as gateway failures; other user denials
         // (401/402/404) are caller-attributable and left unrecorded. Tagging
         // these ErrorSource::Control keeps them out of upstream-health signals.
@@ -117,6 +301,7 @@ pub async fn run(
                     body,
                     &extra,
                     e2ee,
+                    outcome_ctx,
                 );
             }
         }
@@ -126,14 +311,45 @@ pub async fn run(
             message,
             Some(&request_id),
         );
-        return finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee);
+        return finalize_generated(
+            surface,
+            service,
+            endpoint_path,
+            status,
+            body,
+            &[],
+            e2ee,
+            outcome_ctx,
+        );
     }
 
     let candidates = consult.candidates.clone().unwrap_or_default();
     if candidates.is_empty() {
         let message = format!("no route available for model {}", model.unwrap_or("(none)"));
+        if should_log_failure(400) {
+            log_generated_outcome(
+                &request_id,
+                model.unwrap_or(""),
+                "no_route",
+                400,
+                0,
+                "",
+                0,
+                started,
+                "",
+            );
+        }
         let body = errors::envelope_bytes(surface, "model_not_found", &message, Some(&request_id));
-        return finalize_generated(surface, service, endpoint_path, 400, body, &[], e2ee);
+        return finalize_generated(
+            surface,
+            service,
+            endpoint_path,
+            400,
+            body,
+            &[],
+            e2ee,
+            outcome_ctx,
+        );
     }
 
     // Shape one body per candidate (typed per-route contract).
@@ -141,6 +357,19 @@ pub async fn run(
         Ok(shaped) => shaped,
         Err(err) => {
             let message = format!("failed to shape provider request: {err}");
+            if should_log_failure(500) {
+                log_generated_outcome(
+                    &request_id,
+                    model.unwrap_or(""),
+                    "shape_error",
+                    500,
+                    0,
+                    "",
+                    0,
+                    started,
+                    &detail_snippet(message.as_bytes()),
+                );
+            }
             meter.gateway_failure(500, ErrorSource::Gateway, &message, stream);
             let body = errors::envelope_bytes(
                 surface,
@@ -148,7 +377,16 @@ pub async fn run(
                 &message,
                 Some(&request_id),
             );
-            return finalize_generated(surface, service, endpoint_path, 500, body, &[], e2ee);
+            return finalize_generated(
+                surface,
+                service,
+                endpoint_path,
+                500,
+                body,
+                &[],
+                e2ee,
+                outcome_ctx,
+            );
         }
     };
     let forward_candidates: Vec<ForwardCandidate> = shaped
@@ -160,7 +398,7 @@ pub async fn run(
         .collect();
 
     let context = GatewayRequestContext {
-        request_id,
+        request_id: request_id.clone(),
         user_model,
         target_route_id: None,
         user_tier: consult.user_tier.clone(),
@@ -169,7 +407,6 @@ pub async fn run(
     // The receipt-draft journal is only consumed by the streaming finalizer; the
     // buffered result carries its draft inline.
     let journal = MiddlewareReceiptJournal::default();
-    let request_id = context.request_id.clone();
     let result = service
         .forward_chat_completion_for_middleware(
             ChatCompletionRequest {
@@ -218,6 +455,19 @@ pub async fn run(
                         // success. Attribute it to the upstream (it sent an
                         // unparseable success body) and return 502.
                         let message = "upstream returned a malformed success body";
+                        if should_log_failure(502) {
+                            log_generated_outcome(
+                                &request_id,
+                                model.unwrap_or(""),
+                                "malformed_body",
+                                502,
+                                upstream_status,
+                                &forward.selected_route,
+                                attempt_index,
+                                started,
+                                message,
+                            );
+                        }
                         meter.gateway_failure(502, ErrorSource::Upstream, message, false);
                         let body = errors::envelope_bytes(
                             surface,
@@ -233,6 +483,7 @@ pub async fn run(
                             body,
                             &[],
                             e2ee,
+                            outcome_ctx,
                         );
                     }
                 };
@@ -245,6 +496,45 @@ pub async fn run(
                 // Raw usage (pre-cost) goes to the report; cost is injected only
                 // into the client body's top-level usage.
                 let raw_usage = transformed.get("usage").cloned();
+                // A buffered 2xx is only observable when its finish reasons are
+                // nonstandard — an upstream error smuggled through a "success".
+                // Covers both response shapes: OpenAI `choices[].finish_reason`
+                // and Anthropic top-level `stop_reason`.
+                let mut finish_reasons: Vec<&str> = transformed
+                    .get("choices")
+                    .and_then(Value::as_array)
+                    .map(|choices| {
+                        choices
+                            .iter()
+                            .filter_map(|c| c.get("finish_reason").and_then(Value::as_str))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if let Some(stop_reason) = transformed.get("stop_reason").and_then(Value::as_str) {
+                    finish_reasons.push(stop_reason);
+                }
+                if finish_reasons_anomalous(finish_reasons.iter().copied()) {
+                    let out_tokens = raw_usage.as_ref().and_then(|u| {
+                        u.get("completion_tokens")
+                            .or_else(|| u.get("output_tokens"))
+                            .and_then(Value::as_u64)
+                    });
+                    tracing::info!(
+                        target: "request_outcome",
+                        request_id = %request_id,
+                        model = %sanitize_identifier(model.unwrap_or("")),
+                        route = %forward.selected_route,
+                        attempt = attempt_index,
+                        upstream_status,
+                        status = upstream_status,
+                        outcome = "Buffered",
+                        anomalous_finish = true,
+                        duration_ms = started.elapsed().as_millis() as u64,
+                        out_tokens,
+                        finish_reasons = %sanitized_reasons(finish_reasons.iter().copied()),
+                        "buffered response with nonstandard finish reason"
+                    );
+                }
                 meter.success(
                     upstream_status,
                     attempt_index,
@@ -275,6 +565,19 @@ pub async fn run(
                     &received_body,
                     Some(&request_id),
                 );
+                if should_log_failure(mapped) {
+                    log_generated_outcome(
+                        &request_id,
+                        model.unwrap_or(""),
+                        "upstream_error_buffered",
+                        mapped,
+                        upstream_status,
+                        &forward.selected_route,
+                        attempt_index,
+                        started,
+                        &detail_snippet(&forward.upstream_body),
+                    );
+                }
                 meter.success(
                     reported_status(mapped, upstream_status),
                     attempt_index,
@@ -304,7 +607,24 @@ pub async fn run(
                 // The receipt finalizer consumed the E2EE context, so a generated
                 // error here is necessarily cleartext.
                 Err(err) => {
-                    service_error_response(surface, endpoint_path, service, &request_id, err, None)
+                    // Any earlier outcome line for this request described the
+                    // upstream outcome; the client actually receives this
+                    // finalization error, so record the real terminal too.
+                    let status = forward_error_status(&err);
+                    if should_log_failure(status) {
+                        log_generated_outcome(
+                            &request_id,
+                            model.unwrap_or(""),
+                            "finalize_error",
+                            status,
+                            upstream_status,
+                            &forward.selected_route,
+                            attempt_index,
+                            started,
+                            &detail_snippet(err.to_string().as_bytes()),
+                        );
+                    }
+                    service_error_response(surface, endpoint_path, service, outcome_ctx, err, None)
                 }
             }
         }
@@ -318,6 +638,11 @@ pub async fn run(
             let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
 
+            // Set when the downstream finalizer (receipt drafting / E2EE)
+            // errors while the body is being consumed: the meter's drop must
+            // then record an internal failure, not a client disconnect.
+            let downstream_abort = Arc::new(AtomicBool::new(false));
+            let meter_settled = Arc::new(AtomicBool::new(false));
             let report = StreamReport {
                 control: control.clone(),
                 request_id: request_id.clone(),
@@ -331,6 +656,8 @@ pub async fn run(
                 attempt_index,
                 upstream_status,
                 started,
+                downstream_abort: downstream_abort.clone(),
+                settled: meter_settled.clone(),
             };
             // 0 (or unset → default) disables the heartbeat.
             let keepalive = match sse_keepalive_ms.unwrap_or(10_000) {
@@ -391,18 +718,43 @@ pub async fn run(
                     // clients experience as a silently killed stream and a
                     // poisoned keep-alive pool, invisible to application logs.
                     // Log the error (this is its only surface) and end the body
-                    // instead, so the connection closes with a normal FIN.
+                    // instead — a clean HTTP body termination (h1 terminal
+                    // chunk, h2 END_STREAM), leaving the connection reusable.
                     let stream_request_id = request_id.clone();
+                    let stream_model = model.unwrap_or("").to_string();
+                    let stream_route = forward.selected_route.clone();
                     let body = Body::from_stream(finalized.body.scan((), move |_, chunk| {
                         std::future::ready(match chunk {
                             Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
                             Err(err) => {
+                                // Mark before the chain drops so the meter's
+                                // drop settles this as an internal failure
+                                // rather than misreading it as a client
+                                // disconnect.
+                                downstream_abort.store(true, Ordering::Relaxed);
                                 tracing::warn!(
                                     target: "stream_abort",
                                     request_id = %stream_request_id,
                                     error = %err,
                                     "response stream error; ending body gracefully instead of aborting the connection"
                                 );
+                                // A finalizer error after a clean end-of-stream
+                                // (receipt store / E2EE finish): the meter has
+                                // already settled Completed and will not emit,
+                                // so record the client-visible failure here.
+                                if meter_settled.load(Ordering::Relaxed) {
+                                    log_generated_outcome(
+                                        &stream_request_id,
+                                        &stream_model,
+                                        "finalize_error",
+                                        502,
+                                        upstream_status,
+                                        &stream_route,
+                                        attempt_index,
+                                        started,
+                                        &detail_snippet(err.to_string().as_bytes()),
+                                    );
+                                }
                                 None
                             }
                         })
@@ -410,7 +762,24 @@ pub async fn run(
                     (status, headers, body).into_response()
                 }
                 Err(err) => {
-                    service_error_response(surface, endpoint_path, service, &request_id, err, None)
+                    // Synchronous finalizer failure: the stream never started,
+                    // so the meter never settles — this is the request's only
+                    // outcome line.
+                    let status = forward_error_status(&err);
+                    if should_log_failure(status) {
+                        log_generated_outcome(
+                            &request_id,
+                            model.unwrap_or(""),
+                            "finalize_error",
+                            status,
+                            upstream_status,
+                            &forward.selected_route,
+                            attempt_index,
+                            started,
+                            &detail_snippet(err.to_string().as_bytes()),
+                        );
+                    }
+                    service_error_response(surface, endpoint_path, service, outcome_ctx, err, None)
                 }
             }
         }
@@ -426,13 +795,35 @@ pub async fn run(
                 Some(&request_id),
             );
             let attempt_index = forward.failed_attempts.len() as u32;
+            if should_log_failure(status) {
+                log_generated_outcome(
+                    &request_id,
+                    model.unwrap_or(""),
+                    "upstream_error_stream",
+                    status,
+                    forward.error.upstream_status,
+                    &forward.selected_route,
+                    attempt_index,
+                    started,
+                    &detail_snippet(&forward.error.upstream_body),
+                );
+            }
             meter.failed_attempts(&forward.failed_attempts, true);
             meter.upstream_error(
                 reported_status(status, forward.error.upstream_status),
                 attempt_index,
                 &forward.selected_route,
             );
-            finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
+            finalize_generated(
+                surface,
+                service,
+                endpoint_path,
+                status,
+                body,
+                &[],
+                e2ee,
+                outcome_ctx,
+            )
         }
         // Every candidate was attempted and failed without an HTTP response to
         // relay (a chain that ends in an upstream HTTP status — including an
@@ -443,6 +834,19 @@ pub async fn run(
         Ok(MiddlewareForwardResult::AllFailed(forward)) => {
             let status = forward_error_status(&forward.error);
             meter.failed_attempts(&forward.failed_attempts, stream);
+            if should_log_failure(status) {
+                log_generated_outcome(
+                    &request_id,
+                    model.unwrap_or(""),
+                    "all_candidates_failed",
+                    status,
+                    0,
+                    "",
+                    forward.failed_attempts.len() as u32,
+                    started,
+                    &detail_snippet(forward.error.to_string().as_bytes()),
+                );
+            }
             if status >= 500 {
                 meter.gateway_failure_at(
                     forward.failed_attempts.len() as u32,
@@ -456,7 +860,7 @@ pub async fn run(
                 surface,
                 endpoint_path,
                 service,
-                &request_id,
+                outcome_ctx,
                 forward.error,
                 e2ee,
             )
@@ -468,10 +872,23 @@ pub async fn run(
         // recorded. The E2EE context is still available to encrypt the body.
         Err(err) => {
             let status = forward_error_status(&err);
+            if should_log_failure(status) {
+                log_generated_outcome(
+                    &request_id,
+                    model.unwrap_or(""),
+                    "forward_failed",
+                    status,
+                    0,
+                    "",
+                    0,
+                    started,
+                    &detail_snippet(err.to_string().as_bytes()),
+                );
+            }
             if status >= 500 {
                 meter.gateway_failure(status, ErrorSource::Upstream, &err.to_string(), stream);
             }
-            service_error_response(surface, endpoint_path, service, &request_id, err, e2ee)
+            service_error_response(surface, endpoint_path, service, outcome_ctx, err, e2ee)
         }
     }
 }
@@ -622,10 +1039,11 @@ fn service_error_response(
     surface: Surface,
     endpoint_path: &str,
     service: &AciService,
-    request_id: &str,
+    outcome: OutcomeCtx<'_>,
     err: ServiceError,
     e2ee: Option<E2eeRequestContext>,
 ) -> Response {
+    let request_id = outcome.request_id;
     let status = forward_error_status(&err);
     let e2ee = match &err {
         ServiceError::E2ee(_) => None,
@@ -637,12 +1055,22 @@ fn service_error_response(
         &err.to_string(),
         Some(request_id),
     );
-    finalize_generated(surface, service, endpoint_path, status, body, &[], e2ee)
+    finalize_generated(
+        surface,
+        service,
+        endpoint_path,
+        status,
+        body,
+        &[],
+        e2ee,
+        outcome,
+    )
 }
 
 // Build a generated (no-receipt) response, E2EE-encrypting the body when a
 // request context is present. If encryption fails it is fail-closed: a generic
 // error is returned rather than the cleartext body.
+#[allow(clippy::too_many_arguments)]
 fn finalize_generated(
     surface: Surface,
     service: &AciService,
@@ -651,6 +1079,7 @@ fn finalize_generated(
     body: Vec<u8>,
     extra_headers: &[(&'static str, String)],
     e2ee: Option<E2eeRequestContext>,
+    outcome: OutcomeCtx<'_>,
 ) -> Response {
     let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
     let mut headers = HeaderMap::new();
@@ -674,6 +1103,19 @@ fn finalize_generated(
         // Fail-closed: never return the cleartext body when E2EE was requested.
         Err(err) => {
             tracing::error!(error = %err, "E2EE generated-response finalization failed");
+            // Any earlier outcome line recorded the pre-finalization status;
+            // the client actually receives this 500.
+            log_generated_outcome(
+                outcome.request_id,
+                outcome.model,
+                "finalize_error",
+                500,
+                0,
+                "",
+                0,
+                outcome.started,
+                &detail_snippet(err.to_string().as_bytes()),
+            );
             errors::error_response(
                 surface,
                 500,
@@ -770,5 +1212,45 @@ fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) {
         HeaderValue::from_str(value),
     ) {
         headers.insert(name, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observed_failure_policy() {
+        // Every client-visible failure class is logged...
+        for status in [400u16, 401, 402, 404, 499, 500, 502, 503, 504] {
+            assert!(should_log_failure(status), "{status} must be observable");
+        }
+        // ...except final 429s, which are recorded in the usage pipeline.
+        assert!(!should_log_failure(429));
+    }
+
+    #[test]
+    fn client_controlled_identifier_is_bounded_and_single_line() {
+        let hostile = format!("bad\u{1b}[2Jmodel\n{}", "m".repeat(4096));
+        let cleaned = sanitize_identifier(&hostile);
+        assert!(cleaned.chars().count() <= 128);
+        assert!(!cleaned.contains('\n') && !cleaned.contains('\u{1b}'));
+        assert_eq!(sanitize_identifier("z-ai/glm-5.2"), "z-ai/glm-5.2");
+    }
+
+    #[test]
+    fn finish_reason_anomaly_detection() {
+        assert!(!finish_reasons_anomalous(["stop"]));
+        assert!(!finish_reasons_anomalous(["length", "tool_calls"]));
+        assert!(!finish_reasons_anomalous(["end_turn", "max_tokens"]));
+        // A legitimate context-window truncation is a successful response.
+        assert!(!finish_reasons_anomalous(["model_context_window_exceeded"]));
+        // Empty is not anomalous: truncation without a terminal is already a
+        // Failed outcome, and some surfaces terminate without finish reasons.
+        assert!(!finish_reasons_anomalous([]));
+        // Nonstandard values — the "error smuggled through a success"
+        // class — must trip the anomaly.
+        assert!(finish_reasons_anomalous(["upstream_error"]));
+        assert!(finish_reasons_anomalous(["stop", "weird_provider_reason"]));
     }
 }

--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -14,6 +14,8 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -24,9 +26,13 @@ use tokio::time::{sleep, Sleep};
 
 use crate::aggregator::service::{ServiceError, ServiceResponseStream};
 
+use super::completion::{
+    debug_gated_detail, detail_snippet, finish_reasons_anomalous, sanitize_identifier,
+    sanitize_reason, should_log_failure,
+};
 use super::control::ControlClient;
 use super::pricing;
-use super::types::{PostReport, SpendMode};
+use super::types::{ErrorSource, PostReport, SpendMode};
 
 /// Cap on the partial-line reassembly buffer. An upstream that streams bytes
 /// without ever sending a `\n` would otherwise grow it without bound until the
@@ -68,10 +74,26 @@ pub struct StreamReport {
     pub attempt_index: u32,
     pub upstream_status: u16,
     pub started: Instant,
+    /// Set by the response-body wrapper when the downstream finalizer
+    /// (receipt drafting / E2EE) errors mid-consumption. The meter's drop then
+    /// settles the stream as an internal failure instead of misattributing the
+    /// teardown to the client.
+    pub downstream_abort: Arc<AtomicBool>,
+    /// Set once this report has settled. Lets the response-body wrapper tell
+    /// whether a finalizer error arrived after a clean end-of-stream (the
+    /// meter has already settled Completed and will not emit again) so it can
+    /// record the failure itself.
+    pub settled: Arc<AtomicBool>,
 }
 
 impl StreamReport {
     fn settle(&self, outcome: Outcome, usage: Option<Value>, ttft_ms: Option<u64>) {
+        self.settled.store(true, Ordering::Relaxed);
+        // A Failed settle caused by the downstream finalizer is a gateway
+        // failure, not the upstream's: attribute it so health scoring does not
+        // count it against the serving route.
+        let downstream =
+            matches!(outcome, Outcome::Failed) && self.downstream_abort.load(Ordering::Relaxed);
         let report = PostReport {
             request_id: self.request_id.clone(),
             endpoint: self.endpoint.clone(),
@@ -87,8 +109,9 @@ impl StreamReport {
             spend_mode: self.spend_mode,
             user_id: self.user_id,
             virtual_key_id: self.virtual_key_id,
-            error_source: None,
-            error_message: None,
+            error_source: downstream.then_some(ErrorSource::Gateway),
+            error_message: downstream
+                .then(|| "downstream finalizer aborted the response".to_string()),
         };
         let control = self.control.clone();
         // Fire-and-forget. Guard against being called from a drop that runs
@@ -131,7 +154,26 @@ pub struct MeterStream {
     saw_terminal: bool,
     saw_error: bool,
     settled: bool,
+    // Observation state for the `request_outcome` settle log. Always
+    // collected; the distinct-reason list is capped so a pathological stream
+    // cannot grow it without bound.
+    data_events: u64,
+    // Sanitized at collection: length-capped, single-line. Raw values are
+    // judged for anomaly once and never retained (a provider-controlled
+    // reason near the SSE line cap must not be held per stream).
+    finish_reasons: Vec<String>,
+    anomalous_finish: bool,
+    terminal_marker: Option<&'static str>,
+    error_detail: Option<String>,
+    // Whether raw error detail may be collected at all, resolved once per
+    // stream from the `request_outcome` target's debug level: the 240-char
+    // output bound must also bound the transient memory producing it, so at
+    // the default level in-band error values are never serialized.
+    detail_enabled: bool,
 }
+
+/// Cap on distinct finish reasons retained for the observation log.
+const MAX_REASONS: usize = 8;
 
 impl MeterStream {
     pub fn new(inner: ServiceResponseStream, report: StreamReport) -> Self {
@@ -148,6 +190,15 @@ impl MeterStream {
             saw_terminal: false,
             saw_error: false,
             settled: false,
+            data_events: 0,
+            finish_reasons: Vec::new(),
+            anomalous_finish: false,
+            terminal_marker: None,
+            error_detail: None,
+            detail_enabled: tracing::enabled!(
+                target: "request_outcome",
+                tracing::Level::DEBUG
+            ),
         }
     }
 
@@ -156,30 +207,98 @@ impl MeterStream {
             return;
         }
         self.settled = true;
+        let status = metered_status(outcome, self.report.upstream_status);
+        // Failures are always logged; a Completed stream is logged only when
+        // its finish reasons are nonstandard (an upstream error smuggled
+        // through a "success").
+        let anomalous_finish = self.anomalous_finish;
+        if (outcome != Outcome::Completed && should_log_failure(status)) || anomalous_finish {
+            let out_tokens = self.last_usage.as_ref().and_then(|u| {
+                u.get("completion_tokens")
+                    .or_else(|| u.get("output_tokens"))
+                    .and_then(Value::as_u64)
+            });
+            tracing::info!(
+                target: "request_outcome",
+                request_id = %self.report.request_id,
+                model = %sanitize_identifier(&self.report.request_model),
+                route = %self.report.selected_route_id.as_deref().unwrap_or(""),
+                attempt = self.report.attempt_index,
+                upstream_status = self.report.upstream_status,
+                status,
+                outcome = ?outcome,
+                anomalous_finish,
+                ttft_ms = self.ttft_ms,
+                duration_ms = self.report.started.elapsed().as_millis() as u64,
+                data_events = self.data_events,
+                out_tokens,
+                finish_reasons = %self.finish_reasons.join(","),
+                terminal = %self.terminal_marker.unwrap_or("none"),
+                saw_error = self.saw_error,
+                downstream_abort = self.report.downstream_abort.load(Ordering::Relaxed),
+                detail = %debug_gated_detail(self.error_detail.as_deref().unwrap_or("")),
+                "stream settled"
+            );
+        }
         self.report
             .settle(outcome, self.last_usage.take(), self.ttft_ms);
+    }
+
+    // Judge the raw reason once, then retain only a sanitized copy for the
+    // observation log: distinct values, in arrival order, capped.
+    fn record_reason(&mut self, reason: &str) {
+        if finish_reasons_anomalous([reason]) {
+            self.anomalous_finish = true;
+        }
+        let sanitized = sanitize_reason(reason);
+        if self.finish_reasons.len() >= MAX_REASONS || self.finish_reasons.contains(&sanitized) {
+            return;
+        }
+        self.finish_reasons.push(sanitized);
     }
 
     // Detect in-band terminal/error signals, surface-agnostic (works on either
     // the OpenAI or Anthropic shape).
     fn detect_outcome(&mut self, parsed: &Value) {
-        if parsed.get("error").is_some_and(|e| !e.is_null())
-            || parsed.get("type").and_then(Value::as_str) == Some("error")
-            || parsed
-                .get("response")
-                .and_then(|r| r.get("error"))
-                .is_some_and(|e| !e.is_null())
-        {
+        let error_value = parsed
+            .get("error")
+            .filter(|e| !e.is_null())
+            .or_else(|| {
+                (parsed.get("type").and_then(Value::as_str) == Some("error")).then_some(parsed)
+            })
+            .or_else(|| {
+                parsed
+                    .get("response")
+                    .and_then(|r| r.get("error"))
+                    .filter(|e| !e.is_null())
+            });
+        if let Some(error_value) = error_value {
             self.saw_error = true;
+            // Collect detail only when it can actually be emitted
+            // (request_outcome=debug), and prefer the error's message field
+            // over serializing the whole value — an in-band error event can
+            // approach the 16 MiB SSE line cap, and the 240-char output bound
+            // must also bound the transient memory spent producing it.
+            if self.error_detail.is_none() && self.detail_enabled {
+                let message = error_value
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .or_else(|| error_value.as_str())
+                    .unwrap_or("in-band stream error");
+                self.error_detail = Some(detail_snippet(message.as_bytes()));
+            }
         }
         let response_status = parsed
             .get("response")
             .and_then(|r| r.get("status"))
             .and_then(Value::as_str);
-        if parsed.get("type").and_then(Value::as_str) == Some("message_stop")
-            || matches!(response_status, Some("completed") | Some("incomplete"))
-        {
+        if parsed.get("type").and_then(Value::as_str) == Some("message_stop") {
             self.saw_terminal = true;
+            self.terminal_marker.get_or_insert("message_stop");
+        }
+        if matches!(response_status, Some("completed") | Some("incomplete")) {
+            self.saw_terminal = true;
+            self.terminal_marker.get_or_insert("response_status");
         }
         let mut reasons: Vec<&str> = parsed
             .get("choices")
@@ -201,8 +320,14 @@ impl MeterStream {
         for reason in reasons {
             if !reason.is_empty() {
                 self.saw_terminal = true;
+                self.terminal_marker.get_or_insert("finish_reason");
+                self.record_reason(reason);
                 if reason == "error" || reason.ends_with("_error") {
                     self.saw_error = true;
+                    if self.error_detail.is_none() {
+                        self.error_detail =
+                            Some(format!("finish_reason={}", sanitize_reason(reason)));
+                    }
                 }
             }
         }
@@ -287,8 +412,10 @@ impl MeterStream {
                         return line.to_string();
                     };
                     let data = data.trim();
+                    self.data_events += 1;
                     if data == "[DONE]" {
                         self.saw_terminal = true;
+                        self.terminal_marker.get_or_insert("done");
                         return line.to_string();
                     }
                     let Ok(parsed) = serde_json::from_str::<Value>(data) else {
@@ -364,6 +491,9 @@ impl Stream for MeterStream {
                     Fed::Overflow => {
                         this.inner_done = true;
                         this.buf.clear();
+                        if this.error_detail.is_none() {
+                            this.error_detail = Some("sse line overflow".to_string());
+                        }
                         this.settle(Outcome::Failed);
                         return Poll::Ready(None);
                     }
@@ -372,9 +502,12 @@ impl Stream for MeterStream {
                 // failure rather than propagating the error downstream. The
                 // truncated residual is dropped, never parsed (a partial line
                 // must not synthesize a spurious terminal marker).
-                Poll::Ready(Some(Err(_))) => {
+                Poll::Ready(Some(Err(err))) => {
                     this.inner_done = true;
                     this.buf.clear();
+                    if this.error_detail.is_none() {
+                        this.error_detail = Some(detail_snippet(err.to_string().as_bytes()));
+                    }
                     this.settle(Outcome::Failed);
                     return Poll::Ready(None);
                 }
@@ -407,7 +540,14 @@ impl Drop for MeterStream {
         // downstream consumer went away. A drop before the first poll (the stream
         // was never consumed, e.g. the finalizer errored) is not a client cancel.
         if self.started {
-            self.settle(Outcome::ClientClosed);
+            if self.report.downstream_abort.load(Ordering::Relaxed) {
+                // The finalizer aborted mid-consumption: an internal failure,
+                // not a client disconnect (the settle line carries the
+                // `downstream_abort` flag).
+                self.settle(Outcome::Failed);
+            } else {
+                self.settle(Outcome::ClientClosed);
+            }
         }
     }
 }
@@ -505,9 +645,128 @@ mod tests {
             attempt_index: 0,
             upstream_status: 200,
             started: Instant::now(),
+            downstream_abort: Arc::new(AtomicBool::new(false)),
+            settled: Arc::new(AtomicBool::new(false)),
         };
         let inner: ServiceResponseStream = Box::pin(futures_util::stream::empty());
         MeterStream::new(inner, report)
+    }
+
+    // Observation state: finish reasons are collected distinct and in order,
+    // the terminal marker records how the stream ended, and data events are
+    // counted — the raw material for the `request_outcome` settle log.
+    #[test]
+    fn observation_state_collects_reasons_and_terminal() {
+        let mut meter = test_meter();
+        let chunk = Bytes::from(concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"x\"},\"finish_reason\":null}]}\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n",
+            "data: [DONE]\n",
+        ));
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+
+        assert_eq!(meter.data_events, 5, "every data line is counted");
+        assert_eq!(
+            meter.finish_reasons,
+            vec!["tool_calls".to_string(), "stop".to_string()],
+            "reasons dedupe and keep arrival order"
+        );
+        assert_eq!(
+            meter.terminal_marker,
+            Some("finish_reason"),
+            "first terminal signal wins"
+        );
+        assert!(!meter.saw_error);
+    }
+
+    // An in-band error event is captured (truncated) as the `detail` for the
+    // settle log, and only the first error is retained. Detail collection is
+    // gated on the target's debug level, resolved once per stream.
+    #[test]
+    fn observation_captures_in_band_error_detail() {
+        let mut meter = test_meter();
+        meter.detail_enabled = true;
+        let chunk = Bytes::from(concat!(
+            "data: {\"error\":{\"message\":\"upstream exploded\",\"code\":500}}\n",
+            "data: {\"error\":{\"message\":\"second error ignored\"}}\n",
+        ));
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+        assert!(meter.saw_error);
+        let detail = meter.error_detail.as_deref().expect("detail captured");
+        assert!(
+            detail.contains("upstream exploded"),
+            "first error message retained: {detail}"
+        );
+        assert!(!detail.contains("second error"), "first error wins");
+    }
+
+    // Without request_outcome=debug the in-band error value is never
+    // serialized into detail state — the output bound must also bound the
+    // transient memory producing it.
+    #[test]
+    fn in_band_error_detail_not_collected_at_default_level() {
+        let mut meter = test_meter();
+        meter.detail_enabled = false;
+        let chunk =
+            Bytes::from("data: {\"error\":{\"message\":\"upstream exploded\",\"code\":500}}\n");
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+        assert!(meter.saw_error, "classification is unaffected");
+        assert!(
+            meter.error_detail.is_none(),
+            "no detail state at info level"
+        );
+    }
+
+    // A hostile finish reason (multi-line, near the SSE line cap) must be
+    // judged on the raw value but stored only in sanitized, bounded form —
+    // never retained raw (memory amplification) nor logged with newlines
+    // (log-record forgery).
+    #[test]
+    fn hostile_finish_reason_is_bounded_and_single_line_at_collection() {
+        let mut meter = test_meter();
+        let hostile = format!("evil\nFORGED LOG LINE\n{}", "x".repeat(1024));
+        let chunk = Bytes::from(format!(
+            "data: {{\"choices\":[{{\"delta\":{{}},\"finish_reason\":{}}}]}}\n",
+            serde_json::to_string(&hostile).unwrap()
+        ));
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+        assert!(meter.anomalous_finish, "raw value judged anomalous");
+        assert_eq!(meter.finish_reasons.len(), 1);
+        let stored = &meter.finish_reasons[0];
+        assert!(stored.chars().count() <= 32, "length-capped: {stored:?}");
+        assert!(
+            !stored.contains('\n') && !stored.contains('\r'),
+            "single-line"
+        );
+    }
+
+    // An error-ish finish_reason (no error object) still yields a detail.
+    #[test]
+    fn observation_captures_error_finish_reason_detail() {
+        let mut meter = test_meter();
+        let chunk = Bytes::from(
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"upstream_error\"}]}\n",
+        );
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+        assert!(meter.saw_error);
+        assert_eq!(
+            meter.error_detail.as_deref(),
+            Some("finish_reason=upstream_error")
+        );
+    }
+
+    // Observation state is always collected — there is no off switch — so a
+    // settle can decide on failure/anomaly logging for any request.
+    #[test]
+    fn observation_always_collects() {
+        let mut meter = test_meter();
+        let chunk =
+            Bytes::from("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n");
+        assert!(matches!(meter.process(&chunk), Fed::Emit(_)));
+        assert_eq!(meter.finish_reasons, vec!["stop".to_string()]);
+        assert!(meter.saw_terminal, "classification is unaffected");
     }
 
     // A usage-bearing SSE event split across two upstream chunks must still be

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -127,6 +127,13 @@ pub struct PostReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempt_index: Option<u32>,
     /// `<provider>:<model>` from the backend's selected route, or `null`.
+    ///
+    /// Wire contract for consumers: a request may emit multiple per-attempt
+    /// reports — aggregate by `request_id`. A report with
+    /// `selected_route_id == null` and a non-empty `error_source` is a
+    /// request-level summary (e.g. the aggregate error after every candidate
+    /// failed), not an attempt; attempt counting must only consider reports
+    /// that carry a route.
     pub selected_route_id: Option<String>,
     pub request_model: String,
     /// Raw upstream usage before any cost injection, or `null`.

--- a/tests/forward_binding_reverify.rs
+++ b/tests/forward_binding_reverify.rs
@@ -20,7 +20,7 @@ use private_ai_gateway::aci::upstream::{
 };
 use private_ai_gateway::aggregator::service::{
     AciService, AciServiceConfig, ChatCompletionRequest, FixedClock, ForwardCandidate,
-    GatewayRequestContext, InMemoryReceiptStore, MiddlewareReceiptJournal,
+    GatewayRequestContext, InMemoryReceiptStore, MiddlewareForwardResult, MiddlewareReceiptJournal,
     UpstreamVerificationRequest, UpstreamVerifier,
 };
 
@@ -329,10 +329,17 @@ async fn middleware_single_candidate_caller_supplied_always_mismatch_flushes() {
         )
         .await;
 
-    assert!(
-        result.is_err(),
-        "single candidate that always mismatches must be exhausted into an error"
-    );
+    match result {
+        Ok(MiddlewareForwardResult::AllFailed(all_failed)) => {
+            assert_eq!(
+                all_failed.failed_attempts,
+                vec![("route-a".to_string(), 502)],
+                "the exhausted candidate is reported as a per-attempt failure"
+            );
+        }
+        Ok(_) => panic!("single candidate that always mismatches must not commit"),
+        Err(err) => panic!("exhausted candidates now surface AllFailed, not Err: {err}"),
+    }
     assert!(
         verifier.invalidate_calls() >= 1,
         "middleware path must flush a possibly-stale binding even for a caller-supplied event"

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -419,6 +419,8 @@ async fn meter_stream_injects_cost_classifies_completed_and_reports() {
         attempt_index: 0,
         upstream_status: 200,
         started: std::time::Instant::now(),
+        downstream_abort: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        settled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let events: Vec<Result<Bytes, _>> = vec![
         Ok(Bytes::from(
@@ -662,4 +664,127 @@ async fn empty_candidates_returns_model_not_found() {
         .as_str()
         .unwrap()
         .contains("no route available"));
+}
+
+// Behavior contract for finalizer failures relative to meter settle timing.
+//
+// Pre-settle: a downstream finalizer error during body consumption (the
+// response wrapper sets `downstream_abort` before the chain drops) must
+// settle as an internal gateway failure — 502 with error_source=gateway —
+// not as a client disconnect (499), and must not charge the serving route.
+#[tokio::test]
+async fn downstream_abort_before_settle_reports_gateway_failure_not_client_close() {
+    let (control_url, posts) = spawn_control_capturing(200, json!({})).await;
+    let control = ControlClient::new(&MiddlewareConfig {
+        control_url,
+        control_token: None,
+        control_timeout_ms: Some(2_000),
+        control_post_timeout_ms: Some(2_000),
+        sse_keepalive_ms: None,
+    })
+    .unwrap();
+    let downstream_abort = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let report = StreamReport {
+        control,
+        request_id: "r-abort".to_string(),
+        endpoint: "/v1/chat/completions".to_string(),
+        request_model: "gpt".to_string(),
+        pricing: None,
+        spend_mode: None,
+        user_id: None,
+        virtual_key_id: None,
+        selected_route_id: Some("openai:gpt".to_string()),
+        attempt_index: 0,
+        upstream_status: 200,
+        started: std::time::Instant::now(),
+        downstream_abort: downstream_abort.clone(),
+        settled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    // One chunk, then the stream stays open: the meter starts but never
+    // reaches a terminal marker.
+    let events: Vec<Result<Bytes, private_ai_gateway::aggregator::service::ServiceError>> =
+        vec![Ok(Bytes::from(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+        ))];
+    let inner: ServiceResponseStream =
+        Box::pin(futures_util::stream::iter(events).chain(futures_util::stream::pending()));
+    let mut metered = MeterStream::new(inner, report);
+    let first = metered.next().await;
+    assert!(first.is_some(), "meter must have started streaming");
+
+    // The downstream finalizer errors; the wrapper marks it, then the chain
+    // is dropped.
+    downstream_abort.store(true, std::sync::atomic::Ordering::Relaxed);
+    drop(metered);
+
+    let report = wait_for_post(&posts, |r| r["requestId"] == json!("r-abort")).await;
+    assert_eq!(report["status"], json!(502), "internal failure, not 499");
+    assert_eq!(report["errorSource"], json!("gateway"));
+    assert_eq!(
+        report["selectedRouteId"],
+        json!("openai:gpt"),
+        "route still recorded for traceability"
+    );
+}
+
+// Post-settle: once the meter settled Completed at a clean end-of-stream, a
+// later finalizer error (flag set just before the drop) must not emit a
+// second, conflicting usage report — the supplemental request_outcome line is
+// the response wrapper's job, not the meter's.
+#[tokio::test]
+async fn downstream_abort_after_settle_does_not_double_report() {
+    let (control_url, posts) = spawn_control_capturing(200, json!({})).await;
+    let control = ControlClient::new(&MiddlewareConfig {
+        control_url,
+        control_token: None,
+        control_timeout_ms: Some(2_000),
+        control_post_timeout_ms: Some(2_000),
+        sse_keepalive_ms: None,
+    })
+    .unwrap();
+    let downstream_abort = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let settled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let report = StreamReport {
+        control,
+        request_id: "r-late".to_string(),
+        endpoint: "/v1/chat/completions".to_string(),
+        request_model: "gpt".to_string(),
+        pricing: None,
+        spend_mode: None,
+        user_id: None,
+        virtual_key_id: None,
+        selected_route_id: Some("openai:gpt".to_string()),
+        attempt_index: 0,
+        upstream_status: 200,
+        started: std::time::Instant::now(),
+        downstream_abort: downstream_abort.clone(),
+        settled: settled.clone(),
+    };
+    let events: Vec<Result<Bytes, private_ai_gateway::aggregator::service::ServiceError>> =
+        vec![Ok(Bytes::from(
+            "data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
+        ))];
+    let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+    let mut metered = MeterStream::new(inner, report);
+    while metered.next().await.is_some() {}
+    assert!(
+        settled.load(std::sync::atomic::Ordering::Relaxed),
+        "clean EOF settles the meter"
+    );
+
+    // Receipt/E2EE finalization now fails; the wrapper marks the abort and
+    // the chain is dropped afterwards.
+    downstream_abort.store(true, std::sync::atomic::Ordering::Relaxed);
+    drop(metered);
+
+    let first = wait_for_post(&posts, |r| r["requestId"] == json!("r-late")).await;
+    assert_eq!(first["status"], json!(200), "the settled outcome stands");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let count = posts
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|r| r["requestId"] == json!("r-late"))
+        .count();
+    assert_eq!(count, 1, "no second, conflicting report after settle");
 }


### PR DESCRIPTION
Fixes three connection-level defects that were invisible to application logging, then adds per-request outcome observability to the middleware.

## Fixes

- **End response bodies gracefully on stream error** (`3ea864e`). A body-stream `Err` reaching hyper aborts the connection with an RST, which clients experience as a silently killed stream and a poisoned keep-alive pool. Log the error (`stream_abort` target — its only surface) and end the body cleanly instead — an ordinary HTTP body termination (h1 terminal chunk, h2 END_STREAM) that leaves the connection reusable — on both the middleware and direct paths.
- **Raise request body limit to 32 MB** (`d1f341d`). axum's 2 MB default rejects multimodal payloads (base64 image parts) with an extractor-level 413 while the client is still uploading; hyper turns the unread remainder into a TCP RST, so clients see a connection reset instead of a 413, and the request never reaches any application-level logging. 32 MB matches the widest documented first-party API request cap.
- **Surface per-attempt outcomes when every candidate fails** (`be468e3`). The forwarder returned one aggregated error and discarded which routes were tried and how each failed; `MiddlewareForwardResult::AllFailed` now carries the (route, status) chain, reported per-attempt. A request-level summary row (empty route, error source set, index N) MAY follow for 5xx aggregates; the wire contract on `PostReport` documents that routeless rows are summaries, not attempts, and that consumers aggregate by `request_id`.

## Observation

`b06396e`: every failed request that reaches the completion path — consult denials, routing/shaping failures, upstream error responses, stream failures, client disconnects — emits one `request_outcome` tracing line with client-facing + upstream status, route, phase, TTFT/duration, data-event count, finish reasons, and terminal marker. Final 429s are excluded (highest volume, already recorded per-attempt by the usage pipeline). Completed responses are logged only when their finish reasons fall outside the standard OpenAI/Anthropic set (`anomalous_finish=true`).

**Line contract**: at most one primary line per request, plus at most one supplemental `phase=finalize_error` line when receipt/E2EE finalization fails late — aggregate by unique `request_id`, letting `finalize_error` supersede.

Review-driven hardening:
- **Confidentiality & robustness**: logs are operator-visible and finish reasons are provider-controlled — raw values are judged for anomaly once, and only sanitized copies (length-capped, single-line; a JSON string can embed newlines and forge log records) are retained or emitted, bounding per-stream memory. The error-detail snippet is blank unless the target is enabled at `debug` via `RUST_LOG`.
- **Terminal accuracy**: synchronous finalization failures log `phase=finalize_error` with the actual client-facing status (generated, buffered, stream-construction, and — via a shared settled flag — finalizer errors after a clean end-of-stream). A finalizer error during body consumption surfaces as the meter's settle with `outcome=Failed, downstream_abort=true`, reported with `error_source=gateway` so health scoring does not charge the serving route. Both timings are covered by behavior tests.
- **Scope honesty**: requests rejected before the completion path (malformed JSON, oversized bodies, E2EE setup failures) produce no lines; documented, with the usage pipeline as the complete accounting source.

## Verification

- 365 tests pass, `cargo fmt --check` and clippy clean; every commit in the series builds and passes tests standalone.
- Behavior tests cover: pre-settle downstream aborts (502 + gateway attribution, not 499), post-settle aborts (no conflicting second report), hostile finish reasons (bounded, single-line, anomaly still detected), failover exhaustion, denials, in-band stream errors, split SSE frames, oversized lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


