### PR TITLE
feat(catalog): relay the query string to the control plane

### DIFF
--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     body::Bytes,
-    extract::{Path, Query, State},
+    extract::{Path, Query, RawQuery, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
@@ -76,9 +76,21 @@ pub(super) async fn root(State(state): State<AppState>) -> Json<Value> {
     }))
 }
 
-pub(super) async fn models(State(state): State<AppState>) -> Response {
+// Catalog filters (e.g. `?zdr=true`) are the control plane's to interpret, so
+// the query string is relayed verbatim rather than parsed here. Without this the
+// gateway would silently drop it and serve an unfiltered catalog.
+fn catalog_path(base: &str, query: Option<String>) -> String {
+    match query.as_deref().filter(|q| !q.is_empty()) {
+        Some(q) => format!("{base}?{q}"),
+        None => base.to_string(),
+    }
+}
+
+pub(super) async fn models(State(state): State<AppState>, RawQuery(query): RawQuery) -> Response {
     if let Some(middleware) = state.middleware.clone() {
-        return middleware.handle_catalog("/v1/models").await;
+        return middleware
+            .handle_catalog(&catalog_path("/v1/models", query))
+            .await;
     }
     match state.service.upstream().models().await {
         Ok(upstream) => upstream_direct_response(upstream, "application/json"),
@@ -93,6 +105,7 @@ pub(super) async fn models(State(state): State<AppState>) -> Response {
 pub(super) async fn models_subpath(
     State(state): State<AppState>,
     Path(rest): Path<String>,
+    RawQuery(query): RawQuery,
 ) -> Response {
     let Some(middleware) = state.middleware.clone() else {
         return error_response(
@@ -102,7 +115,7 @@ pub(super) async fn models_subpath(
         );
     };
     middleware
-        .handle_catalog(&format!("/v1/models/{rest}"))
+        .handle_catalog(&catalog_path(&format!("/v1/models/{rest}"), query))
         .await
 }
 

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -10,6 +10,7 @@ mod common;
 
 use axum::{
     body::{to_bytes, Body},
+    extract::RawQuery,
     http::{Request, StatusCode},
     routing::get,
     Json, Router,
@@ -72,17 +73,22 @@ fn build_service() -> (Arc<AciService>, Arc<UpstreamConfigManager>) {
 }
 
 // Spawn a stub control plane that labels each catalog so the test can prove the
-// relay reached the right path. The control plane serves catalogs without the
-// `/v1` prefix.
+// relay reached the right path, and echoes the query string it received so the
+// test can prove catalog filters (e.g. `?zdr=true`) survive the relay. The
+// control plane serves catalogs without the `/v1` prefix.
 async fn spawn_stub_control() -> String {
     let app = Router::new()
         .route(
             "/models",
-            get(|| async { Json(json!({ "data": ["m1"], "source": "control-models" })) }),
+            get(|RawQuery(q): RawQuery| async move {
+                Json(json!({ "data": ["m1"], "source": "control-models", "query": q }))
+            }),
         )
         .route(
             "/models/*rest",
-            get(|| async { Json(json!({ "data": ["ns"], "source": "control-sub" })) }),
+            get(|RawQuery(q): RawQuery| async move {
+                Json(json!({ "data": ["ns"], "source": "control-sub", "query": q }))
+            }),
         )
         .route(
             "/embeddings/models",
@@ -134,6 +140,44 @@ async fn relays_catalogs_from_control() {
     let (status, body) = get_json(app, "/v1/embeddings/models").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["source"], "control-embeddings");
+}
+
+// Catalog filters live in the control plane (`?zdr=true` restricts the catalog
+// to zero-data-retention providers). The gateway must relay the query string
+// verbatim — dropping it would silently serve an unfiltered catalog to a client
+// that asked to filter.
+#[tokio::test]
+async fn relays_catalog_query_string_to_control() {
+    let control_url = spawn_stub_control().await;
+    let middleware = Arc::new(
+        Middleware::new(&MiddlewareConfig {
+            control_url,
+            control_token: None,
+            control_timeout_ms: Some(2_000),
+            control_post_timeout_ms: Some(2_000),
+            sse_keepalive_ms: None,
+        })
+        .unwrap(),
+    );
+    let (service, manager) = build_service();
+    let app = build_router_with_admin_and_middleware(service, manager, None, middleware);
+
+    let (status, body) = get_json(app.clone(), "/v1/models?zdr=true").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["query"], "zdr=true");
+
+    // Multiple params survive intact; the gateway does not parse or reorder them.
+    let (_, body) = get_json(app.clone(), "/v1/models?zdr=true&foo=bar").await;
+    assert_eq!(body["query"], "zdr=true&foo=bar");
+
+    // Sub-catalogs relay it too, alongside the path.
+    let (_, body) = get_json(app.clone(), "/v1/models/my-namespace?zdr=true").await;
+    assert_eq!(body["source"], "control-sub");
+    assert_eq!(body["query"], "zdr=true");
+
+    // No query string means no trailing `?` is invented.
+    let (_, body) = get_json(app, "/v1/models").await;
+    assert_eq!(body["query"], Value::Null);
 }
 
 #[tokio::test]


### PR DESCRIPTION
The `/v1/models` handlers built their relay path from a hardcoded string, so any
query string on a catalog request was dropped before it reached the control
plane. A client asking the catalog to filter would silently receive the full
unfiltered list with a 200 — the worst failure mode for a filter, since nothing
signals that it was ignored.

Relay the raw query verbatim instead. Catalog filtering is the control plane's
concern, so the gateway should not need a change per filter — it passes the
query through and returns the response body as-is, exactly as it already does
for the path and body.

## Scope

Confined to the handlers. `handle_catalog` (`src/middleware/mod.rs`) and
`catalog_get` (`src/middleware/control.rs`) already forward the path unmodified,
and `ControlClient::url` is plain string concatenation, so a path carrying a
query needs no plumbing changes.

Direct-upstream mode is unaffected: `models()` only consults the middleware when
one is configured, and that branch is untouched.

## Test

`relays_catalog_query_string_to_control` in `tests/middleware_catalog.rs`. The
stub control plane now echoes the query string it received, so the test asserts
end to end that it survives the relay:

- a single param arrives intact
- multiple params keep their order and are not reparsed
- sub-catalogs (`/v1/models/<sub>`) relay it alongside the path
- no query string does not invent a trailing `?`

Full CI set run locally: `cargo fmt --check`, `cargo clippy --all-targets -D
warnings`, `cargo test --all-targets` (30 suites), `python3 -m compileall
scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)