### PR TITLE
fix(catalog): relay the query string on the embeddings catalog too

### DIFF
--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -121,7 +121,10 @@ pub(super) async fn models_subpath(
 
 // Embedding model catalog. Only meaningful in the control-plane middleware
 // topology.
-pub(super) async fn embeddings_models(State(state): State<AppState>) -> Response {
+pub(super) async fn embeddings_models(
+    State(state): State<AppState>,
+    RawQuery(query): RawQuery,
+) -> Response {
     let Some(middleware) = state.middleware.clone() else {
         return error_response(
             StatusCode::NOT_FOUND,
@@ -129,7 +132,9 @@ pub(super) async fn embeddings_models(State(state): State<AppState>) -> Response
             "embedding model catalog is not available in direct-upstream mode",
         );
     };
-    middleware.handle_catalog("/v1/embeddings/models").await
+    middleware
+        .handle_catalog(&catalog_path("/v1/embeddings/models", query))
+        .await
 }
 
 pub(super) async fn metrics(State(state): State<AppState>) -> Response {

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -92,7 +92,9 @@ async fn spawn_stub_control() -> String {
         )
         .route(
             "/embeddings/models",
-            get(|| async { Json(json!({ "data": ["e1"], "source": "control-embeddings" })) }),
+            get(|RawQuery(q): RawQuery| async move {
+                Json(json!({ "data": ["e1"], "source": "control-embeddings", "query": q }))
+            }),
         );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -173,6 +175,12 @@ async fn relays_catalog_query_string_to_control() {
     // Sub-catalogs relay it too, alongside the path.
     let (_, body) = get_json(app.clone(), "/v1/models/my-namespace?zdr=true").await;
     assert_eq!(body["source"], "control-sub");
+    assert_eq!(body["query"], "zdr=true");
+
+    // Every catalog route relays it — embeddings included. Missing one would
+    // serve an unfiltered catalog to a client that asked to filter.
+    let (_, body) = get_json(app.clone(), "/v1/embeddings/models?zdr=true").await;
+    assert_eq!(body["source"], "control-embeddings");
     assert_eq!(body["query"], "zdr=true");
 
     // No query string means no trailing `?` is invented.


### PR DESCRIPTION
Follow-up to #95.

That change wired the raw query into `/v1/models` and its sub-catalogs but left
`/v1/embeddings/models` building a hardcoded relay path, so its query string was
still dropped. The control plane filters that catalog, which means a client
sending `?zdr=true` there got the full unfiltered list with a 200 — the exact
silent failure #95 set out to fix, left behind on one route.

Caught while verifying #95 on a live gateway: the models catalog filtered
correctly while the embeddings catalog returned its full list.

`relays_catalog_query_string_to_control` now asserts the embeddings route too,
so a catalog route cannot be added without relaying the query.

CI set run locally: `cargo fmt --check`, `cargo clippy --all-targets -D
warnings`, `cargo test --test middleware_catalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)