### PR TITLE
fix(sse): end a broken response stream with an in-protocol error

### DIFF
--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -13,15 +13,16 @@ use crate::aggregator::session::{
 
 use super::claims::{chutes_instance_id, per_instance_session_claims, session_claims_for_event};
 use super::e2ee_crypto::encrypt_e2ee_response_body;
+use super::e2ee_crypto::is_sse_content_type;
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
 };
 use super::streaming::{E2eeSseTransformer, ReceiptFinalizingStream};
 use super::{
-    AciService, ChatCompletionRequest, E2eeResponseInfo, ForwardResult, GatewayRequestContext,
-    ReceiptOwner, ServiceError, StreamingForwardResult, StreamingForwardStream,
-    StreamingUpstreamError, UpstreamVerificationError, UpstreamVerificationRequest,
-    CHANNEL_BINDING_REVERIFY_ATTEMPTS, CHAT_COMPLETIONS_PATH,
+    AciService, ChatCompletionRequest, E2eeError, E2eeResponseInfo, ForwardResult,
+    GatewayRequestContext, ReceiptOwner, ServiceError, StreamingForwardResult,
+    StreamingForwardStream, StreamingUpstreamError, UpstreamVerificationError,
+    UpstreamVerificationRequest, CHANNEL_BINDING_REVERIFY_ATTEMPTS, CHAT_COMPLETIONS_PATH,
 };
 
 /// Outcome of [`AciService::forward_with_binding_reverify`]. The caller maps
@@ -272,6 +273,7 @@ impl AciService {
             req.e2ee.as_ref().is_some(),
         );
         let target_route_id = req.context.target_route_id.clone();
+        let request_id = req.context.request_id.clone();
         let backend_input_body = req.forwarded_body.unwrap_or_else(|| received_body.to_vec());
         let middleware_forwarded_body =
             target_route_id.as_ref().map(|_| backend_input_body.clone());
@@ -369,6 +371,23 @@ impl AciService {
             cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
         Self::append_upstream_verified(&mut builder, recorded_event, recorded)?;
 
+        // This is the streaming entry point, so a response with no declared
+        // media type is taken to be an event stream — the same assumption the
+        // middleware path makes. Only a header that says otherwise turns the
+        // protocol observation off.
+        let is_sse = upstream_response
+            .headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+            .is_none_or(|(_, value)| is_sse_content_type(Some(value)));
+        // E2EE stream encryption only knows how to encrypt SSE event payloads. A
+        // non-SSE body (an upstream that answered `application/json`) cannot be
+        // encrypted, and must not be returned in the clear or signed as if it
+        // were — the middleware path rejects the same combination.
+        if req.e2ee.is_some() && !is_sse {
+            return Err(ServiceError::E2ee(E2eeError::EncryptionFailed));
+        }
+
         let e2ee_response = req.e2ee.as_ref().map(|ctx| E2eeResponseInfo {
             version: ctx.version.clone(),
             algo: ctx.algo.clone(),
@@ -387,6 +406,8 @@ impl AciService {
             endpoint_path.to_string(),
             e2ee_transformer,
             response_modified,
+            Some(request_id),
+            is_sse,
         );
 
         Ok(StreamingForwardResult::Stream(StreamingForwardStream {

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -9,7 +9,7 @@ use super::helpers::{
 };
 use super::streaming::{
     E2eeSseTransformer, MiddlewareProviderResponseDraftingStream,
-    MiddlewareResponseFinalizingStream, SseChatIdParser,
+    MiddlewareResponseFinalizingStream,
 };
 use super::{
     AciService, ChatCompletionRequest, E2eeError, E2eeRequestContext, E2eeResponseInfo,
@@ -23,6 +23,7 @@ use crate::aci::receipt::{ReceiptBuilder, TransparencyEventKind, UpstreamVerifie
 use crate::aci::upstream::{UpstreamError, UpstreamRequest};
 use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
 use crate::aggregator::session::SessionClaims;
+use crate::sse_framing::SseFramingObserver;
 use std::collections::HashMap;
 
 // Provider statuses that make this candidate worth abandoning for the next one.
@@ -494,10 +495,10 @@ impl AciService {
     ) -> Result<MiddlewareReceiptFinalization, ServiceError> {
         let is_sse = is_sse_content_type(content_type);
         if is_sse {
-            let mut parser = SseChatIdParser::default();
+            let mut parser = SseFramingObserver::identifiers_only();
             parser.observe(final_cleartext_body);
-            if parser.chat_id.is_some() {
-                draft.builder.set_chat_id(parser.chat_id);
+            if parser.chat_id().is_some() {
+                draft.builder.set_chat_id(parser.chat_id());
             }
         } else if let Some(chat_id) = extract_chat_id(final_cleartext_body) {
             draft.builder.set_chat_id(Some(chat_id));
@@ -566,6 +567,7 @@ impl AciService {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn finalize_middleware_response_stream(
         &self,
         journal: MiddlewareReceiptJournal,
@@ -574,6 +576,7 @@ impl AciService {
         content_type: Option<&str>,
         requester: Option<ReceiptOwner>,
         e2ee: Option<E2eeRequestContext>,
+        request_id: Option<String>,
     ) -> Result<MiddlewareStreamFinalization, ServiceError> {
         let is_sse = is_sse_content_type(content_type);
         if e2ee.is_some() && !is_sse {
@@ -594,6 +597,8 @@ impl AciService {
             endpoint_path.to_string(),
             e2ee_transformer,
             e2ee_response.is_some(),
+            request_id,
+            is_sse,
         );
         Ok(MiddlewareStreamFinalization {
             body: Box::pin(body),

--- a/src/aggregator/service/streaming.rs
+++ b/src/aggregator/service/streaming.rs
@@ -6,6 +6,9 @@ use bytes::Bytes;
 use futures_util::Stream;
 use sha2::{Digest, Sha256};
 
+use crate::sse_framing::SseFramingObserver;
+use crate::sse_protocol::{stream_error_tail, stream_success_terminator, SseProtocol};
+
 use super::e2ee_crypto::encrypt_e2ee_stream_payload;
 use super::{
     AciService, Clock, E2eeError, E2eeRequestContext, MiddlewareReceiptDraft,
@@ -23,7 +26,7 @@ pub(super) struct MiddlewareProviderResponseDraftingStream {
     provider_response_hasher: Sha256,
     receipt_id: String,
     endpoint_path: String,
-    sse_parser: SseChatIdParser,
+    sse_parser: SseFramingObserver,
     metrics: Arc<ServiceMetrics>,
     upstream_status: u16,
     upstream_ended: bool,
@@ -93,8 +96,8 @@ impl MiddlewareProviderResponseDraftingStream {
             journal,
             provider_response_hasher: Sha256::new(),
             receipt_id,
+            sse_parser: SseFramingObserver::identifiers_only(),
             endpoint_path,
-            sse_parser: SseChatIdParser::default(),
             metrics,
             upstream_status,
             upstream_ended: false,
@@ -107,9 +110,9 @@ impl MiddlewareProviderResponseDraftingStream {
             "sha256:{}",
             hex::encode(self.provider_response_hasher.clone().finalize())
         );
-        let response_model = self.sse_parser.model_id.clone();
+        let response_model = self.sse_parser.model_id();
         let mut builder = self.builder.take().ok_or(ReceiptError::EmptyReceipt)?;
-        builder.set_chat_id(self.sse_parser.chat_id.clone());
+        builder.set_chat_id(self.sse_parser.chat_id());
         builder.set_upstream_verified_model_id(response_model.clone());
         builder.add_response_received_hash(provider_response_hash.clone())?;
         self.journal.set(MiddlewareReceiptDraft {
@@ -145,10 +148,20 @@ struct FinalizerShared {
     clock: Arc<dyn Clock>,
     metrics: Arc<ServiceMetrics>,
     endpoint_path: String,
-    sse_parser: SseChatIdParser,
+    sse_parser: SseFramingObserver,
     e2ee_transformer: Option<E2eeSseTransformer>,
+    request_id: Option<String>,
     upstream_ended: bool,
     finished: bool,
+    /// Set once the clean-EOF check has run, so the tail is considered exactly
+    /// once however many times the terminal branch is polled.
+    error_tail_settled: bool,
+    /// The gateway appended bytes the upstream never sent (a success
+    /// terminator, or a client-visible error).
+    synthesized_tail: bool,
+    /// The stream feeding this finalizer failed, rather than ending. Nothing is
+    /// signed for it, and nothing buffered may be flushed.
+    broken: bool,
 }
 
 impl FinalizerShared {
@@ -157,6 +170,8 @@ impl FinalizerShared {
         requester: Option<ReceiptOwner>,
         endpoint_path: String,
         e2ee_transformer: Option<E2eeSseTransformer>,
+        request_id: Option<String>,
+        is_sse: bool,
     ) -> Self {
         Self {
             cleartext_hasher: Sha256::new(),
@@ -168,12 +183,81 @@ impl FinalizerShared {
             receipt_ttl_seconds: service.config.receipt_ttl_seconds,
             clock: service.clock.clone(),
             metrics: service.metrics.clone(),
+            // A response that is not an event stream has no protocol terminal to
+            // miss, so it is observed for identifiers only.
+            sse_parser: if is_sse {
+                SseFramingObserver::new(&endpoint_path)
+            } else {
+                SseFramingObserver::identifiers_only()
+            },
             endpoint_path,
-            sse_parser: SseChatIdParser::default(),
             e2ee_transformer,
+            request_id,
             upstream_ended: false,
             finished: false,
+            error_tail_settled: false,
+            synthesized_tail: false,
+            broken: false,
         }
+    }
+
+    /// The bytes to append to a stream that ended without its protocol
+    /// terminal, or `None` when nothing may be added.
+    ///
+    /// The kind of ending decides the kind of tail. A clean end of stream is
+    /// the provider closing normally — a completion, never an error. The chat
+    /// surface's `[DONE]` is a fixed stateless marker the gateway supplies when
+    /// the provider omitted it; Anthropic and Responses terminals carry state
+    /// the gateway cannot fabricate, so nothing is appended (the outcome is
+    /// still complete). A transport error is an abnormal interruption, so the
+    /// client is told with the protocol's error.
+    ///
+    /// Built here, inside the finalizer, so the tail is hashed and encrypted
+    /// like any other chunk and the receipt covers exactly what the client
+    /// received.
+    fn take_synthesized_tail(&mut self) -> Option<Vec<u8>> {
+        if std::mem::replace(&mut self.error_tail_settled, true) {
+            return None;
+        }
+        let protocol = self.sse_parser.protocol()?;
+        if self.sse_parser.saw_terminal() || self.sse_parser.saw_error() {
+            return None;
+        }
+        // Nothing may be appended unless the stream stopped cleanly between
+        // events and was observed all the way there.
+        if !self.sse_parser.at_event_boundary() || !self.sse_parser.observation_usable() {
+            return None;
+        }
+
+        // A clean end is a completion, never an error: supply the protocol's
+        // terminator where it is a fixed marker the gateway can emit, and
+        // otherwise append nothing (the outcome is still complete).
+        if !self.broken {
+            return stream_success_terminator(protocol).map(|terminator| {
+                self.synthesized_tail = true;
+                terminator.as_bytes().to_vec()
+            });
+        }
+
+        // A sequence with no successor cannot be continued, so the error would
+        // have to repeat a number the client has already seen. Only the
+        // protocol that numbers its events is affected; the field is recorded
+        // wherever it appears, so gating on its value alone would silence the
+        // others over a number they never use.
+        if protocol == SseProtocol::OpenaiResponses
+            && self.sse_parser.last_sequence_number() == Some(u64::MAX)
+        {
+            return None;
+        }
+        self.synthesized_tail = true;
+        Some(
+            stream_error_tail(
+                protocol,
+                self.request_id.as_deref(),
+                self.sse_parser.last_sequence_number(),
+            )
+            .into_bytes(),
+        )
     }
 
     /// `sha256:` hex digests of the cleartext and wire bytes seen so far.
@@ -224,7 +308,37 @@ fn poll_finalizing_stream<F: FinalizingStream>(
 
     loop {
         if f.shared().upstream_ended {
-            if let Some(mut transformer) = f.shared().e2ee_transformer.take() {
+            // Before the transformer is finished, so the tail passes through it
+            // exactly like an upstream chunk would.
+            if let Some(tail) = f.shared().take_synthesized_tail() {
+                let s = f.shared();
+                s.cleartext_hasher.update(&tail);
+                let wire = match s.e2ee_transformer.as_mut() {
+                    Some(transformer) => match transformer.push_chunk(&tail) {
+                        Ok(wire) => wire,
+                        Err(err) => {
+                            s.metrics
+                                .record_stream_error(&s.endpoint_path, StreamErrorKind::E2ee);
+                            s.finished = true;
+                            return Poll::Ready(Some(Err(ServiceError::E2ee(err))));
+                        }
+                    },
+                    None => tail,
+                };
+                if !wire.is_empty() {
+                    s.wire_hasher.update(&wire);
+                    return Poll::Ready(Some(Ok(Bytes::from(wire))));
+                }
+            }
+            // `finish()` flushes whatever the transformer still holds, which for
+            // a stream cut mid-event means dispatching an event the client
+            // would otherwise discard. Only a stream sitting on an event
+            // boundary is finished; a broken one is never finished at all.
+            let may_finish = !f.shared().broken
+                && f.shared().sse_parser.observation_usable()
+                && f.shared().sse_parser.at_event_boundary();
+            if let Some(mut transformer) = f.shared().e2ee_transformer.take().filter(|_| may_finish)
+            {
                 let wire = match transformer.finish() {
                     Ok(wire) => wire,
                     Err(err) => {
@@ -241,6 +355,11 @@ fn poll_finalizing_stream<F: FinalizingStream>(
                 }
             }
             f.shared().finished = true;
+            // A stream that failed is not signed: the gateway cannot claim the
+            // client received a complete, determinate response.
+            if f.shared().broken {
+                return Poll::Ready(None);
+            }
             return match f.finalize_receipt() {
                 Ok(()) => Poll::Ready(None),
                 Err(err) => {
@@ -279,12 +398,23 @@ fn poll_finalizing_stream<F: FinalizingStream>(
                 s.wire_hasher.update(&chunk);
                 return Poll::Ready(Some(Ok(chunk)));
             }
+            // The stream feeding this finalizer failed. Absorbing it here is
+            // what keeps hyper from aborting the connection, and this is the
+            // last point the underlying error exists, so it is logged. The
+            // terminal branch then decides whether the client can be told —
+            // it holds the protocol state that decision needs.
             Poll::Ready(Some(Err(err))) => {
                 let s = f.shared();
                 s.metrics
                     .record_stream_error(&s.endpoint_path, StreamErrorKind::UpstreamRead);
-                s.finished = true;
-                return Poll::Ready(Some(Err(err)));
+                tracing::warn!(
+                    target: "stream_abort",
+                    request_id = s.request_id.as_deref().unwrap_or_default(),
+                    error = %err,
+                    "response stream failed; ending the body instead of aborting the connection"
+                );
+                s.broken = true;
+                s.upstream_ended = true;
             }
             Poll::Ready(None) => {
                 f.shared().upstream_ended = true;
@@ -326,10 +456,8 @@ impl FinalizingStream for MiddlewareResponseFinalizingStream {
         };
         let (cleartext_hash, wire_hash) = self.shared.hashes();
 
-        if self.shared.sse_parser.chat_id.is_some() {
-            draft
-                .builder
-                .set_chat_id(self.shared.sse_parser.chat_id.clone());
+        if self.shared.sse_parser.chat_id().is_some() {
+            draft.builder.set_chat_id(self.shared.sse_parser.chat_id());
         }
         if draft.provider_response_hash != cleartext_hash || self.response_modified_by_wire {
             draft
@@ -351,6 +479,7 @@ impl FinalizingStream for MiddlewareResponseFinalizingStream {
 }
 
 impl MiddlewareResponseFinalizingStream {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         service: &AciService,
         inner: ServiceResponseStream,
@@ -359,12 +488,21 @@ impl MiddlewareResponseFinalizingStream {
         endpoint_path: String,
         e2ee_transformer: Option<E2eeSseTransformer>,
         response_modified_by_wire: bool,
+        request_id: Option<String>,
+        is_sse: bool,
     ) -> Self {
         Self {
             inner,
             journal,
             response_modified_by_wire,
-            shared: FinalizerShared::new(service, requester, endpoint_path, e2ee_transformer),
+            shared: FinalizerShared::new(
+                service,
+                requester,
+                endpoint_path,
+                e2ee_transformer,
+                request_id,
+                is_sse,
+            ),
         }
     }
 }
@@ -404,9 +542,11 @@ impl FinalizingStream for ReceiptFinalizingStream {
     fn finalize_receipt(&mut self) -> Result<(), ServiceError> {
         let (cleartext_hash, wire_hash) = self.shared.hashes();
         let mut builder = self.builder.take().ok_or(ReceiptError::EmptyReceipt)?;
-        builder.set_chat_id(self.shared.sse_parser.chat_id.clone());
-        builder.set_upstream_verified_model_id(self.shared.sse_parser.model_id.clone());
-        if self.response_modified {
+        builder.set_chat_id(self.shared.sse_parser.chat_id());
+        builder.set_upstream_verified_model_id(self.shared.sse_parser.model_id());
+        // Appending an error tail is a modification of the response, whatever
+        // else did or did not change it.
+        if self.response_modified || self.shared.synthesized_tail {
             builder.add_transparency_event(TransparencyEventKind::ResponseModified)?;
         }
         builder.add_response_returned_hashes(cleartext_hash, wire_hash)?;
@@ -416,12 +556,12 @@ impl FinalizingStream for ReceiptFinalizingStream {
             &self.shared.endpoint_path,
             RequestMode::Streaming,
             200,
-            self.shared.sse_parser.model_id.as_deref(),
+            self.shared.sse_parser.model_id().as_deref(),
         );
         self.shared.metrics.record_receipt_issued(
             &self.shared.endpoint_path,
             RequestMode::Streaming,
-            self.shared.sse_parser.model_id.as_deref(),
+            self.shared.sse_parser.model_id().as_deref(),
         );
 
         Ok(())
@@ -429,6 +569,7 @@ impl FinalizingStream for ReceiptFinalizingStream {
 }
 
 impl ReceiptFinalizingStream {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         service: &AciService,
         inner: UpstreamBodyStream,
@@ -437,12 +578,21 @@ impl ReceiptFinalizingStream {
         endpoint_path: String,
         e2ee_transformer: Option<E2eeSseTransformer>,
         response_modified: bool,
+        request_id: Option<String>,
+        is_sse: bool,
     ) -> Self {
         Self {
             inner,
             builder: Some(builder),
             response_modified,
-            shared: FinalizerShared::new(service, requester, endpoint_path, e2ee_transformer),
+            shared: FinalizerShared::new(
+                service,
+                requester,
+                endpoint_path,
+                e2ee_transformer,
+                request_id,
+                is_sse,
+            ),
         }
     }
 }
@@ -563,77 +713,4 @@ pub(super) fn serialize_original_sse_event(lines: &[Vec<u8>]) -> Vec<u8> {
     }
     out.push(b'\n');
     out
-}
-
-#[derive(Default)]
-pub(super) struct SseChatIdParser {
-    pub(super) line_buffer: Vec<u8>,
-    pub(super) event_data: Vec<u8>,
-    pub(super) chat_id: Option<String>,
-    pub(super) model_id: Option<String>,
-}
-
-impl SseChatIdParser {
-    pub(super) fn observe(&mut self, chunk: &[u8]) {
-        if self.chat_id.is_some() && self.model_id.is_some() {
-            return;
-        }
-        for &byte in chunk {
-            if byte == b'\n' {
-                let mut line = std::mem::take(&mut self.line_buffer);
-                if line.last() == Some(&b'\r') {
-                    line.pop();
-                }
-                self.observe_line(&line);
-                if self.chat_id.is_some() && self.model_id.is_some() {
-                    return;
-                }
-            } else {
-                self.line_buffer.push(byte);
-            }
-        }
-    }
-
-    fn observe_line(&mut self, line: &[u8]) {
-        if line.is_empty() {
-            self.dispatch_event();
-            return;
-        }
-        if line.starts_with(b":") {
-            return;
-        }
-        let Some(rest) = line.strip_prefix(b"data:") else {
-            return;
-        };
-        let data = rest.strip_prefix(b" ").unwrap_or(rest);
-        if !self.event_data.is_empty() {
-            self.event_data.push(b'\n');
-        }
-        self.event_data.extend_from_slice(data);
-    }
-
-    fn dispatch_event(&mut self) {
-        if self.event_data.is_empty() {
-            return;
-        }
-        let data = std::mem::take(&mut self.event_data);
-        if data.as_slice() == b"[DONE]" {
-            return;
-        }
-        let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&data) else {
-            return;
-        };
-        if self.chat_id.is_none() {
-            self.chat_id = parsed
-                .get("id")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-        }
-        if self.model_id.is_none() {
-            self.model_id = parsed
-                .get("model")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-        }
-    }
 }

--- a/src/error_payload.rs
+++ b/src/error_payload.rs
@@ -1,0 +1,76 @@
+//! Client-facing error payloads, shaped per downstream API surface.
+//!
+//! The envelope a surface's SDK parses. HTTP response construction stays in
+//! `middleware::errors`, which re-exports these; the definitions live here
+//! because the service layer builds them too, when it ends a broken response
+//! stream with an in-protocol error.
+
+use serde_json::{json, Value};
+
+/// Downstream API surface that shapes the error envelope and `error.type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Surface {
+    Openai,
+    Anthropic,
+}
+
+/// Map an HTTP status to the surface's `error.type`. Only covers statuses this
+/// gateway actually emits.
+pub fn error_type(surface: Surface, status: u16) -> &'static str {
+    match surface {
+        Surface::Anthropic => match status {
+            400 => "invalid_request_error",
+            401 => "authentication_error",
+            402 => "billing_error",
+            403 => "permission_error",
+            404 => "not_found_error",
+            429 => "rate_limit_error",
+            504 => "timeout_error",
+            s if s >= 500 => "api_error",
+            _ => "invalid_request_error",
+        },
+        Surface::Openai => match status {
+            401 => "authentication_error",
+            402 => "insufficient_quota",
+            403 => "permission_error",
+            404 => "not_found_error",
+            429 => "rate_limit_error",
+            503 => "service_unavailable",
+            504 => "timeout_error",
+            s if s >= 500 => "upstream_error",
+            _ => "invalid_request_error",
+        },
+    }
+}
+
+/// Generic sanitized message for a non-actionable upstream status.
+pub fn upstream_message(upstream_status: u16) -> &'static str {
+    match upstream_status {
+        401..=403 => "The upstream provider is currently unavailable",
+        429 => "Rate limit exceeded. Please retry after some time.",
+        503 => "The model is currently unavailable. Please try again later.",
+        504 => "The upstream provider timed out",
+        _ => "The upstream provider returned an error",
+    }
+}
+
+pub(crate) fn envelope(
+    surface: Surface,
+    error_type: &str,
+    message: &str,
+    request_id: Option<&str>,
+) -> Value {
+    match surface {
+        Surface::Anthropic => {
+            let mut value = json!({
+                "type": "error",
+                "error": { "type": error_type, "message": message },
+            });
+            if let Some(request_id) = request_id {
+                value["request_id"] = json!(request_id);
+            }
+            value
+        }
+        Surface::Openai => json!({ "error": { "message": message, "type": error_type } }),
+    }
+}

--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -70,9 +70,12 @@ pub(super) async fn forward_to_backend(
                 );
                 let status =
                     StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
-                // Same contract as the middleware stream path: a body Err makes
-                // hyper abort the connection with a TCP RST (client-visible as a
-                // silently killed stream); log it and end the body gracefully.
+                // The finalizer already absorbs a failure of the stream it wraps
+                // and tells the client where it safely can. What is left here
+                // is the finalizer's own failure — receipt signing, E2EE
+                // teardown — after headers have gone out: a body `Err` would
+                // make hyper abort the connection with a TCP RST, so it is
+                // logged and the body ended instead.
                 let body = Body::from_stream(forward.body.scan((), move |_, chunk| {
                     std::future::ready(match chunk {
                         Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
@@ -81,7 +84,7 @@ pub(super) async fn forward_to_backend(
                                 target: "stream_abort",
                                 request_id = %request_id,
                                 error = %err,
-                                "response stream error; ending body gracefully instead of aborting the connection"
+                                "response finalization failed; ending the body instead of aborting the connection"
                             );
                             None
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,8 @@
 pub mod aci;
 pub mod aggregator;
 pub mod dstack;
+pub(crate) mod error_payload;
 pub mod http;
 pub mod middleware;
+pub(crate) mod sse_framing;
+pub(crate) mod sse_protocol;

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -682,7 +682,13 @@ pub async fn run(
                     Some(transform) => Box::pin(SseTransformStream::new(forward.body, transform)),
                     None => forward.body,
                 };
-            let metered: ServiceResponseStream = Box::pin(MeterStream::new(transformed, report));
+            let metered: ServiceResponseStream = Box::pin(MeterStream::new(
+                transformed,
+                report,
+                errors::sse_protocol(endpoint_path),
+            ));
+            // A failure anywhere below reaches the finalizer, which holds the
+            // protocol state needed to decide whether the client can be told.
             let kept: ServiceResponseStream = Box::pin(KeepAliveStream::new(metered, keepalive));
 
             let receipt_id = journal.peek_receipt_id();
@@ -693,6 +699,7 @@ pub async fn run(
                 Some(&content_type),
                 requester,
                 e2ee,
+                Some(request_id.clone()),
             ) {
                 Ok(finalized) => {
                     let status =

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -284,6 +284,43 @@ pub fn image_input_error_parts(
     ))
 }
 
+/// Marker substring an upstream uses to signal it has no available capacity or
+/// targets to serve the request. Matched raw against the error body because the
+/// message can sit outside the usual `error`/`error.message` fields.
+const UPSTREAM_CAPACITY_MARKER: &[u8] = b"exhausted all available targets";
+
+/// The client-facing `(status, envelope bytes)` for an upstream capacity signal,
+/// or `None` when the upstream error is not one. An upstream reporting it has no
+/// available capacity/targets is busy, not faulty: surface it as `429`
+/// (rate-limited) rather than a `5xx` outage, so it is treated as load, not an
+/// error. Peer to [`image_input_error_parts`] — both remap a recognized upstream
+/// error body to a specific client status.
+fn capacity_error_parts(
+    surface: Surface,
+    upstream_status: u16,
+    upstream_body: &[u8],
+    request_id: Option<&str>,
+) -> Option<(u16, Vec<u8>)> {
+    if !(500..600).contains(&upstream_status) {
+        return None;
+    }
+    if !upstream_body
+        .windows(UPSTREAM_CAPACITY_MARKER.len())
+        .any(|w| w == UPSTREAM_CAPACITY_MARKER)
+    {
+        return None;
+    }
+    Some((
+        429,
+        envelope_bytes(
+            surface,
+            error_type(surface, 429),
+            upstream_message(429),
+            request_id,
+        ),
+    ))
+}
+
 /// Normalize a non-2xx upstream response into the client-facing status and the
 /// surface-shaped error body bytes. For actionable client errors the provider's
 /// own message is re-wrapped at the original status; everything else gets a
@@ -300,6 +337,10 @@ pub fn normalize_upstream_error_parts(
     if let Some(parts) =
         image_input_error_parts(surface, received_body, upstream_status, body, request_id)
     {
+        return parts;
+    }
+    // A provider signalling it is out of capacity is busy, not broken: 429, not 5xx.
+    if let Some(parts) = capacity_error_parts(surface, upstream_status, body, request_id) {
         return parts;
     }
     if is_actionable_client_error(upstream_status) {
@@ -450,6 +491,34 @@ mod tests {
             body["error"]["message"],
             json!("The upstream provider returned an error")
         );
+    }
+
+    #[tokio::test]
+    async fn capacity_exhaustion_5xx_remaps_to_429() {
+        // An upstream 5xx that reports it has no available capacity/targets is a
+        // busy signal (the message sits under `detail`, outside the usual
+        // `error` field): the client sees 429 (rate-limited), not a 502 outage.
+        let (status, body) = response_json(normalize_upstream_error(
+            Surface::Openai,
+            500,
+            br#"{"detail":"exhausted all available targets to no avail"}"#,
+            b"",
+            None,
+        ))
+        .await;
+        assert_eq!(status, 429);
+        assert_eq!(body["error"]["type"], json!("rate_limit_error"));
+
+        // Regression guard: a plain 500 without the marker still maps to 502.
+        let (status, _) = response_json(normalize_upstream_error(
+            Surface::Openai,
+            500,
+            br#"{"error":{"message":"kaboom"}}"#,
+            b"",
+            None,
+        ))
+        .await;
+        assert_eq!(status, 502);
     }
 
     #[test]

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -16,41 +16,12 @@ use axum::{
 };
 use serde_json::{json, Value};
 
-/// Downstream API surface that shapes the error envelope and `error.type`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Surface {
-    Openai,
-    Anthropic,
-}
+// Re-exported so call sites keep importing client-facing error shapes from one
+// place; the definitions are shared because the service layer builds them too.
+pub use crate::error_payload::{error_type, upstream_message, Surface};
+pub use crate::sse_protocol::{sse_protocol, stream_error_tail, SseProtocol};
 
-/// Map an HTTP status to the surface's `error.type`. Only covers statuses this
-/// gateway actually emits.
-pub fn error_type(surface: Surface, status: u16) -> &'static str {
-    match surface {
-        Surface::Anthropic => match status {
-            400 => "invalid_request_error",
-            401 => "authentication_error",
-            402 => "billing_error",
-            403 => "permission_error",
-            404 => "not_found_error",
-            429 => "rate_limit_error",
-            504 => "timeout_error",
-            s if s >= 500 => "api_error",
-            _ => "invalid_request_error",
-        },
-        Surface::Openai => match status {
-            401 => "authentication_error",
-            402 => "insufficient_quota",
-            403 => "permission_error",
-            404 => "not_found_error",
-            429 => "rate_limit_error",
-            503 => "service_unavailable",
-            504 => "timeout_error",
-            s if s >= 500 => "upstream_error",
-            _ => "invalid_request_error",
-        },
-    }
-}
+use crate::error_payload::envelope;
 
 /// Flatten an upstream status to the client-facing status. The mapping is uniform
 /// across surfaces; only the envelope and `error.type` are surface-aware.
@@ -69,33 +40,6 @@ pub fn map_upstream_status(status: u16) -> u16 {
 /// (always re-wrapped in our envelope, never the raw upstream response).
 pub fn is_actionable_client_error(status: u16) -> bool {
     (400..500).contains(&status) && !matches!(status, 401..=403 | 429)
-}
-
-/// Generic sanitized message for a non-actionable upstream status.
-pub fn upstream_message(upstream_status: u16) -> &'static str {
-    match upstream_status {
-        401..=403 => "The upstream provider is currently unavailable",
-        429 => "Rate limit exceeded. Please retry after some time.",
-        503 => "The model is currently unavailable. Please try again later.",
-        504 => "The upstream provider timed out",
-        _ => "The upstream provider returned an error",
-    }
-}
-
-fn envelope(surface: Surface, error_type: &str, message: &str, request_id: Option<&str>) -> Value {
-    match surface {
-        Surface::Anthropic => {
-            let mut value = json!({
-                "type": "error",
-                "error": { "type": error_type, "message": message },
-            });
-            if let Some(request_id) = request_id {
-                value["request_id"] = json!(request_id);
-            }
-            value
-        }
-        Surface::Openai => json!({ "error": { "message": message, "type": error_type } }),
-    }
 }
 
 /// Serialize the surface error envelope to bytes (for the E2EE generated path).

--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -24,7 +24,9 @@ use futures_util::Stream;
 use serde_json::Value;
 use tokio::time::{sleep, Sleep};
 
+use crate::aci::upstream::UpstreamError;
 use crate::aggregator::service::{ServiceError, ServiceResponseStream};
+use crate::sse_protocol::SseProtocol;
 
 use super::completion::{
     debug_gated_detail, detail_snippet, finish_reasons_anomalous, sanitize_identifier,
@@ -151,8 +153,16 @@ pub struct MeterStream {
     inner_done: bool,
     last_usage: Option<Value>,
     ttft_ms: Option<u64>,
+    /// Diagnostic: any sign the response reached an end, including a per-choice
+    /// `finish_reason`. Feeds the settle log and anomaly detection, not the
+    /// outcome — the outcome comes from `framing`.
     saw_terminal: bool,
     saw_error: bool,
+    /// The client-facing outcome (Completed / Failed) is read from this shared
+    /// observer, byte-accurate about SSE framing, so it agrees with what the
+    /// finalizer does to the body. The line parse below stays for cost, TTFT and
+    /// diagnostics.
+    framing: crate::sse_framing::SseFramingObserver,
     settled: bool,
     // Observation state for the `request_outcome` settle log. Always
     // collected; the distinct-reason list is capped so a pathological stream
@@ -176,7 +186,7 @@ pub struct MeterStream {
 const MAX_REASONS: usize = 8;
 
 impl MeterStream {
-    pub fn new(inner: ServiceResponseStream, report: StreamReport) -> Self {
+    pub fn new(inner: ServiceResponseStream, report: StreamReport, protocol: SseProtocol) -> Self {
         let inject = report.pricing.as_ref().is_some_and(|p| !p.is_null());
         Self {
             inner,
@@ -189,6 +199,7 @@ impl MeterStream {
             ttft_ms: None,
             saw_terminal: false,
             saw_error: false,
+            framing: crate::sse_framing::SseFramingObserver::for_protocol(protocol),
             settled: false,
             data_events: 0,
             finish_reasons: Vec::new(),
@@ -199,6 +210,32 @@ impl MeterStream {
                 target: "request_outcome",
                 tracing::Level::DEBUG
             ),
+        }
+    }
+
+    /// What the stream amounts to, read from the shared framing observer so it
+    /// agrees with what the finalizer does to the body.
+    ///
+    /// A framing terminal settles it as completed regardless of how the body
+    /// ended — a transport error after the terminal does not override a
+    /// delivered response. Without one, a clean end of stream at an event
+    /// boundary is also completed on any surface: a provider that closed
+    /// normally has finished, whether or not it sent the terminator. A transport
+    /// error, or a partial or pending tail, is a failure. An in-band error is
+    /// always a failure.
+    fn protocol_outcome(&self, clean_eof: bool) -> Outcome {
+        let f = &self.framing;
+        // Two complementary error detectors: the meter's own parse catches
+        // error-shaped finish reasons; the framing observer catches framed
+        // errors (in-band `error`, `response.failed`, nested `response.error`).
+        // Either one fails the stream.
+        if self.saw_error || f.saw_error() {
+            Outcome::Failed
+        } else if f.saw_terminal() || (clean_eof && f.at_event_boundary() && f.observation_usable())
+        {
+            Outcome::Completed
+        } else {
+            Outcome::Failed
         }
     }
 
@@ -292,11 +329,21 @@ impl MeterStream {
             .get("response")
             .and_then(|r| r.get("status"))
             .and_then(Value::as_str);
-        if parsed.get("type").and_then(Value::as_str) == Some("message_stop") {
+        // Each terminal counts only on the surface that defines it. A stray
+        // event from another protocol is a diagnostic signal at most; treating
+        // it as end-of-stream would report a stream completed while the
+        // finalizer was appending a client-visible error to it.
+        let event_type = parsed.get("type").and_then(Value::as_str);
+        if event_type == Some("message_stop") {
             self.saw_terminal = true;
             self.terminal_marker.get_or_insert("message_stop");
         }
-        if matches!(response_status, Some("completed") | Some("incomplete")) {
+        let responses_terminal = matches!(response_status, Some("completed") | Some("incomplete"))
+            || matches!(
+                event_type,
+                Some("response.completed" | "response.incomplete" | "response.failed")
+            );
+        if responses_terminal {
             self.saw_terminal = true;
             self.terminal_marker.get_or_insert("response_status");
         }
@@ -390,12 +437,13 @@ impl MeterStream {
     // state for the report and inject cost. Returns `raw` verbatim unless a line
     // was rewritten (only rewritten runs are re-encoded).
     fn transform_lines(&mut self, raw: Vec<u8>) -> Bytes {
+        let text = String::from_utf8_lossy(&raw);
+        let lines: Vec<&str> = text.split('\n').collect();
         let rewritten: Option<String> = {
-            let text = String::from_utf8_lossy(&raw);
             let mut changed = false;
-            let out_lines: Vec<String> = text
-                .split('\n')
-                .map(|line| {
+            let out_lines: Vec<String> = lines
+                .iter()
+                .map(|&line| {
                     // TTFT: the first non-empty, non-comment line marks the first
                     // content delivered. Evaluated on complete lines only, so a
                     // comment (`:`-prefixed) split across chunks can't have its
@@ -481,47 +529,52 @@ impl Stream for MeterStream {
                 return Poll::Ready(None);
             }
             match this.inner.as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok(bytes))) => match this.process(&bytes) {
-                    Fed::Emit(out) => return Poll::Ready(Some(Ok(out))),
-                    // Only a partial line so far: poll again rather than emit a
-                    // fragment.
-                    Fed::NeedMore => {}
-                    // A single line blew past the cap: drop it and end as an
-                    // upstream failure rather than buffer or parse it.
-                    Fed::Overflow => {
-                        this.inner_done = true;
-                        this.buf.clear();
-                        if this.error_detail.is_none() {
-                            this.error_detail = Some("sse line overflow".to_string());
+                Poll::Ready(Some(Ok(bytes))) => {
+                    this.framing.observe(&bytes);
+                    match this.process(&bytes) {
+                        Fed::Emit(out) => return Poll::Ready(Some(Ok(out))),
+                        // Only a partial line so far: poll again rather than emit a
+                        // fragment.
+                        Fed::NeedMore => {}
+                        // A single line blew past the cap: drop it and end as an
+                        // upstream failure rather than buffer or parse it.
+                        Fed::Overflow => {
+                            this.inner_done = true;
+                            this.buf.clear();
+                            if this.error_detail.is_none() {
+                                this.error_detail = Some("sse line overflow".to_string());
+                            }
+                            let outcome = this.protocol_outcome(false);
+                            this.settle(outcome);
+                            return Poll::Ready(Some(Err(ServiceError::Upstream(
+                                UpstreamError::Transport("sse line overflow".to_string()),
+                            ))));
                         }
-                        this.settle(Outcome::Failed);
-                        return Poll::Ready(None);
                     }
-                },
-                // An upstream break ends the client stream cleanly and records a
-                // failure rather than propagating the error downstream. The
-                // truncated residual is dropped, never parsed (a partial line
-                // must not synthesize a spurious terminal marker).
+                }
+                // The truncated residual is dropped, never parsed (a partial
+                // line must not synthesize a spurious terminal marker). The
+                // error is passed on for the wrapper above to turn into a
+                // client-visible one; it never reaches hyper.
                 Poll::Ready(Some(Err(err))) => {
                     this.inner_done = true;
                     this.buf.clear();
                     if this.error_detail.is_none() {
                         this.error_detail = Some(detail_snippet(err.to_string().as_bytes()));
                     }
-                    this.settle(Outcome::Failed);
-                    return Poll::Ready(None);
+                    let outcome = this.protocol_outcome(false);
+                    this.settle(outcome);
+                    return Poll::Ready(Some(Err(err)));
                 }
                 Poll::Ready(None) => {
                     this.inner_done = true;
-                    // Parse the final unterminated line (if any) before settling so
-                    // a usage or terminal marker in it is still counted, then emit
-                    // it so no client-visible bytes are lost.
+                    // Parse the final unterminated line (if any) so a usage
+                    // marker in it is still counted, then emit it so no
+                    // client-visible bytes are lost. A clean end completes only
+                    // where the framing observer says the finalizer can — that
+                    // check lives in `protocol_outcome`.
                     let residual = this.flush();
-                    let outcome = if this.saw_terminal && !this.saw_error {
-                        Outcome::Completed
-                    } else {
-                        Outcome::Failed
-                    };
+                    let outcome = this.protocol_outcome(true);
                     this.settle(outcome);
                     return match residual {
                         Some(out) => Poll::Ready(Some(Ok(out))),
@@ -623,7 +676,157 @@ mod tests {
         assert_eq!(metered_status(Outcome::ClientClosed, 200), 499);
     }
 
+    // A clean end of stream and a transport error are the dividing line, not a
+    // per-choice finish reason. Chat completes on a clean end even without
+    // `[DONE]` (the gateway supplies it); a transport error without `[DONE]` is
+    // a failure whatever content preceded it.
+    #[tokio::test]
+    async fn the_outcome_turns_on_clean_end_versus_transport_error() {
+        // Feed one chunk, then either end cleanly or break; return the outcome.
+        async fn outcome(first: &'static [u8], broken: bool) -> Outcome {
+            let mut meter = test_meter();
+            let mut chunks: Vec<Result<Bytes, ServiceError>> = vec![Ok(Bytes::from_static(first))];
+            if broken {
+                chunks.push(Err(ServiceError::Metrics("dropped".to_string())));
+            }
+            meter.inner = Box::pin(futures_util::stream::iter(chunks));
+            let mut errored = false;
+            while let Some(chunk) = futures_util::StreamExt::next(&mut meter).await {
+                if chunk.is_err() {
+                    errored = true;
+                    break;
+                }
+            }
+            meter.protocol_outcome(!errored)
+        }
+
+        let finish = b"data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n";
+        let content = b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n";
+
+        // Clean end: chat completes with or without a finish reason.
+        assert_eq!(
+            outcome(b"data: [DONE]\n\n", false).await,
+            Outcome::Completed
+        );
+        assert_eq!(outcome(finish, false).await, Outcome::Completed);
+        assert_eq!(
+            outcome(content, false).await,
+            Outcome::Completed,
+            "a chat provider that closed normally has finished"
+        );
+
+        // Transport error: only a delivered `[DONE]` keeps it completed.
+        assert_eq!(outcome(b"data: [DONE]\n\n", true).await, Outcome::Completed);
+        assert_eq!(
+            outcome(finish, true).await,
+            Outcome::Failed,
+            "a finish reason does not rescue a broken connection"
+        );
+        assert_eq!(outcome(content, true).await, Outcome::Failed);
+    }
+
+    // A clean end settles the chat surface as complete only at an event
+    // boundary — the same point the finalizer supplies the missing `[DONE]`. A
+    // partial line or a pending event (a `data:` line not closed by a blank
+    // line) is a truncation and stays Failed.
+    // An error the stream reported is a failure however it is framed — even
+    // alongside the protocol's terminal. A `response.failed` event, or an
+    // error-shaped finish reason followed by `[DONE]`, must not settle Completed.
+    #[tokio::test]
+    async fn a_reported_error_fails_the_outcome_even_with_a_terminal() {
+        async fn drain(meter: &mut MeterStream) -> Outcome {
+            while futures_util::StreamExt::next(meter).await.is_some() {}
+            meter.protocol_outcome(true)
+        }
+
+        let mut responses = test_meter_for(crate::sse_protocol::SseProtocol::OpenaiResponses);
+        responses.inner = Box::pin(futures_util::stream::iter(vec![Ok(Bytes::from_static(
+            b"data: {\"type\":\"response.failed\",\"sequence_number\":1,\"response\":{\"error\":{\"message\":\"x\"}}}\n\n",
+        ))]));
+        assert_eq!(
+            drain(&mut responses).await,
+            Outcome::Failed,
+            "response.failed is not a completed response"
+        );
+
+        // Anthropic→OpenAI transforms an upstream error into an error finish
+        // reason plus `[DONE]`; the terminal must not mask it.
+        let mut chat = test_meter();
+        chat.inner = Box::pin(futures_util::stream::iter(vec![Ok(Bytes::from_static(
+            b"data: {\"choices\":[{\"finish_reason\":\"upstream_error\"}]}\n\ndata: [DONE]\n\n",
+        ))]));
+        assert_eq!(
+            drain(&mut chat).await,
+            Outcome::Failed,
+            "an error finish reason fails even with [DONE]"
+        );
+    }
+
+    // A clean end of stream at an event boundary completes on every surface —
+    // a provider that closed normally has finished, terminator sent or not.
+    #[tokio::test]
+    async fn a_clean_end_completes_on_every_surface() {
+        use crate::sse_protocol::SseProtocol;
+        for (protocol, chunk) in [
+            (
+                SseProtocol::OpenaiChat,
+                &b"data: {\"choices\":[{\"delta\":{}}]}\n\n"[..],
+            ),
+            (
+                SseProtocol::AnthropicMessages,
+                &b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}\n\n"[..],
+            ),
+            (
+                SseProtocol::OpenaiResponses,
+                &b"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1}\n\n"[..],
+            ),
+        ] {
+            let mut meter = test_meter_for(protocol);
+            meter.inner = Box::pin(futures_util::stream::iter(vec![Ok(Bytes::from(chunk))]));
+            while futures_util::StreamExt::next(&mut meter).await.is_some() {}
+            assert_eq!(
+                meter.protocol_outcome(true),
+                Outcome::Completed,
+                "{protocol:?} clean end at a boundary"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn chat_clean_eof_completes_only_at_an_event_boundary() {
+        async fn eof_outcome(chunk: &'static [u8]) -> Outcome {
+            let mut meter = test_meter();
+            meter.inner = Box::pin(futures_util::stream::iter(vec![Ok(Bytes::from_static(
+                chunk,
+            ))]));
+            while futures_util::StreamExt::next(&mut meter).await.is_some() {}
+            // A clean end: whether it completes is decided inside
+            // `protocol_outcome` from the framing observer's boundary state.
+            meter.protocol_outcome(true)
+        }
+
+        assert_eq!(
+            eof_outcome(b"data: {\"choices\":[{\"delta\":{}}]}\n\n").await,
+            Outcome::Completed,
+            "a complete event, cleanly ended, is completable"
+        );
+        assert_eq!(
+            eof_outcome(b"data: {\"choices\":[{\"delta\":{}}]}\n").await,
+            Outcome::Failed,
+            "an event never closed by a blank line is pending, not complete"
+        );
+        assert_eq!(
+            eof_outcome(b"data: {\"choices\":[").await,
+            Outcome::Failed,
+            "a partial line is a truncation"
+        );
+    }
+
     fn test_meter() -> MeterStream {
+        test_meter_for(crate::sse_protocol::SseProtocol::OpenaiChat)
+    }
+
+    fn test_meter_for(protocol: crate::sse_protocol::SseProtocol) -> MeterStream {
         let control = ControlClient::new(&MiddlewareConfig {
             control_url: "http://control.invalid".to_string(),
             control_token: None,
@@ -649,7 +852,7 @@ mod tests {
             settled: Arc::new(AtomicBool::new(false)),
         };
         let inner: ServiceResponseStream = Box::pin(futures_util::stream::empty());
-        MeterStream::new(inner, report)
+        MeterStream::new(inner, report, protocol)
     }
 
     // Observation state: finish reasons are collected distinct and in order,

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -16,6 +16,7 @@ use axum::body::Bytes;
 use futures_util::Stream;
 use serde_json::{json, Value};
 
+use crate::aci::upstream::UpstreamError;
 use crate::aggregator::service::{ServiceError, ServiceResponseStream};
 
 use super::request_transform::Endpoint;
@@ -740,6 +741,11 @@ pub struct SseTransformStream {
     reader: SseEventReader,
     queue: VecDeque<Bytes>,
     inner_done: bool,
+    // Why the stream ended, when it ended badly. Held until the queue drains so
+    // events completed before the failure still reach the client, then yielded
+    // as the final item. Ending on a plain `None` would instead read downstream
+    // as a clean end-of-stream.
+    pending_error: Option<ServiceError>,
 }
 
 impl SseTransformStream {
@@ -753,7 +759,17 @@ impl SseTransformStream {
             reader: SseEventReader::default(),
             queue: VecDeque::new(),
             inner_done: false,
+            pending_error: None,
         }
+    }
+
+    // A transform-side failure is still an upstream failure: the provider sent
+    // bytes this surface cannot represent.
+    fn fail(&mut self, reason: &'static str) {
+        self.inner_done = true;
+        self.pending_error.get_or_insert_with(|| {
+            ServiceError::Upstream(UpstreamError::Transport(reason.to_string()))
+        });
     }
 
     // Returns false if the transform rejected the event (unparseable provider
@@ -784,7 +800,8 @@ impl Stream for SseTransformStream {
                 return Poll::Ready(Some(Ok(bytes)));
             }
             if this.inner_done {
-                return Poll::Ready(None);
+                // The queue is drained; surface why the stream ended, once.
+                return Poll::Ready(this.pending_error.take().map(Err));
             }
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
@@ -794,28 +811,39 @@ impl Stream for SseTransformStream {
                     let overflowed = this.reader.push_chunk(&bytes, &mut events).is_err();
                     for event in &events {
                         if !this.emit(event) {
-                            this.inner_done = true;
+                            this.fail("provider sent an event this surface cannot represent");
                             break;
                         }
                     }
                     if overflowed {
-                        this.inner_done = true;
+                        this.fail("provider SSE event exceeded the size cap");
                     }
                     // loop to flush the queue or poll again
                 }
                 Poll::Ready(None) => {
                     this.inner_done = true;
                     // Flush a residual event once (no trailing blank line).
+                    // Deliberate cross-format framing normalization: a final
+                    // event whose lines are complete but which the upstream
+                    // never closed with a blank line is salvaged and re-framed,
+                    // rather than dropped as WHATWG would at EOF. Delivering a
+                    // valid last event beats losing it; a truncated (unparseable)
+                    // one still fails in `emit`. A byte passthrough cannot do
+                    // this, so the two paths differ for this one malformed shape.
                     if let Some(event) = this.reader.finish() {
-                        this.emit(&event);
+                        if !this.emit(&event) {
+                            this.fail("provider sent an event this surface cannot represent");
+                        }
                     }
-                    // loop to drain any queued output, then return None.
+                    // loop to drain any queued output, then end.
                 }
                 // On an upstream error, end without flushing the (truncated)
                 // residual, so a partial event can't synthesize a spurious
-                // terminal marker.
-                Poll::Ready(Some(Err(_))) => {
+                // terminal marker. The error itself is propagated: swallowing
+                // it would read downstream as a clean end-of-stream.
+                Poll::Ready(Some(Err(err))) => {
                     this.inner_done = true;
+                    this.pending_error.get_or_insert(err);
                 }
                 Poll::Pending => return Poll::Pending,
             }
@@ -843,9 +871,14 @@ mod tests {
         ];
         let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
         let stream = SseTransformStream::new(inner, StreamTransform::AnthropicToOpenaiChat);
-        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
+        let collected: Vec<Result<Bytes, ServiceError>> = stream.collect().await;
+        assert!(
+            collected.last().expect("stream yielded items").is_err(),
+            "a malformed event ends the stream as an error, not a clean EOF"
+        );
         let text: String = collected
             .iter()
+            .filter_map(|r| r.as_ref().ok())
             .map(|b| String::from_utf8_lossy(b).into_owned())
             .collect();
         assert!(text.contains("chat.completion.chunk"));
@@ -1042,8 +1075,9 @@ mod tests {
         ];
         let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
         let stream = SseTransformStream::new(inner, StreamTransform::OpenaiToAnthropicMessages);
-        let collected: Vec<Bytes> = stream.map(|r| r.unwrap()).collect().await;
-        assert!(collected.is_empty(), "capped stream emits nothing further");
+        let collected: Vec<Result<Bytes, ServiceError>> = stream.collect().await;
+        assert_eq!(collected.len(), 1, "no payload, only the failure");
+        assert!(collected[0].is_err(), "and not a clean EOF");
     }
 
     // Replay a fixture's input events through the transform (fixed fallback id),

--- a/src/sse_framing.rs
+++ b/src/sse_framing.rs
@@ -1,0 +1,524 @@
+//! Read-only SSE framing observer, shared by the receipt finalizer and the
+//! metering pass.
+//!
+//! Both need the same answer to "how did this stream end" — did it deliver its
+//! protocol terminal, an in-band error, or stop mid-event — and getting it from
+//! two independent line parsers let them disagree (one counting a `data:` line
+//! the instant it is read, the other only once a blank line dispatches it). One
+//! implementation, byte-accurate about SSE framing, removes that gap.
+//!
+//! It observes; it never rewrites. The finalizer hashes the bytes and the meter
+//! injects cost through their own passes — this only watches.
+
+use serde_json::Value;
+
+use crate::sse_protocol::{sse_protocol, SseProtocol};
+
+/// Cap on the reassembly buffers. Without one, a response that never sends a
+/// line terminator would grow them until the request runs out of memory. A
+/// single SSE event above this is pathological.
+const MAX_OBSERVED_EVENT_BYTES: usize = 16 * 1024 * 1024;
+
+/// Watches an SSE stream as it flows past: the identifiers a receipt records,
+/// and how the stream ended.
+///
+/// "Ended" is decided at the framing level, not the content level. A `[DONE]`,
+/// `message_stop`, or Responses terminal counts only once a blank line has
+/// dispatched the event carrying it; an in-band error likewise. A per-choice
+/// `finish_reason` is not a terminal — whether a terminator-less stream is
+/// complete is decided by its caller from how the body ended.
+pub struct SseFramingObserver {
+    line_buffer: Vec<u8>,
+    event_data: Vec<u8>,
+    /// A `\r` closed the previous line; a `\n` right after it belongs to that
+    /// same CRLF terminator rather than opening an empty line.
+    pending_cr: bool,
+    chat_id: Option<String>,
+    model_id: Option<String>,
+    /// `None` when these bytes are not the client-facing stream, so no terminal
+    /// is meaningful and only the identifiers are collected.
+    protocol: Option<SseProtocol>,
+    saw_terminal: bool,
+    saw_error: bool,
+    /// A non-comment field line has been read but not yet dispatched by a blank
+    /// line: the stream is mid-event. Tracks the WHATWG "event in progress"
+    /// state (any field, not just `data:`), so a pending `event:`/`id:` is not
+    /// mistaken for a boundary where a terminator could be spliced in.
+    mid_event: bool,
+    last_sequence_number: Option<u64>,
+    /// A single line or event ran past the cap. The buffers were dropped, so
+    /// what the stream did afterwards is no longer known.
+    observation_failed: bool,
+}
+
+impl SseFramingObserver {
+    /// Observe the client-facing stream: identifiers and how it ended.
+    pub fn new(endpoint_path: &str) -> Self {
+        Self::with_protocol(Some(sse_protocol(endpoint_path)))
+    }
+
+    /// Observe a client-facing stream whose protocol is already known.
+    pub fn for_protocol(protocol: SseProtocol) -> Self {
+        Self::with_protocol(Some(protocol))
+    }
+
+    /// Observe bytes that are not the client-facing stream — an upstream-format
+    /// draft, or a buffered body. A terminal in some other protocol would mean
+    /// nothing here, so only the identifiers are collected.
+    pub fn identifiers_only() -> Self {
+        Self::with_protocol(None)
+    }
+
+    fn with_protocol(protocol: Option<SseProtocol>) -> Self {
+        Self {
+            line_buffer: Vec::new(),
+            event_data: Vec::new(),
+            pending_cr: false,
+            chat_id: None,
+            model_id: None,
+            protocol,
+            saw_terminal: false,
+            saw_error: false,
+            mid_event: false,
+            last_sequence_number: None,
+            observation_failed: false,
+        }
+    }
+
+    pub fn protocol(&self) -> Option<SseProtocol> {
+        self.protocol
+    }
+
+    /// The stream delivered its protocol's framing terminal.
+    pub fn saw_terminal(&self) -> bool {
+        self.saw_terminal
+    }
+
+    /// The stream delivered an in-band error event; the upstream told the client
+    /// what went wrong, so no gateway error should be appended on top.
+    pub fn saw_error(&self) -> bool {
+        self.saw_error
+    }
+
+    /// The highest `sequence_number` seen, for protocols that number events.
+    pub fn last_sequence_number(&self) -> Option<u64> {
+        self.last_sequence_number
+    }
+
+    pub fn chat_id(&self) -> Option<String> {
+        self.chat_id.clone()
+    }
+
+    pub fn model_id(&self) -> Option<String> {
+        self.model_id.clone()
+    }
+
+    /// The stream is between events: no line is half-written and no event is
+    /// waiting for its blank line. This is where a missing terminator can be
+    /// supplied without splitting an event the client would otherwise discard.
+    pub fn at_event_boundary(&self) -> bool {
+        self.line_buffer.is_empty() && !self.mid_event
+    }
+
+    /// Whether this stream can be judged at all.
+    pub fn observation_usable(&self) -> bool {
+        !self.observation_failed
+    }
+
+    pub fn observe(&mut self, chunk: &[u8]) {
+        if self.done() {
+            return;
+        }
+        for &byte in chunk {
+            // LF, CRLF and a lone CR all terminate a line. Splitting only on
+            // `\n` would leave a CR-framed stream as one endless line, so its
+            // terminal would never be seen and a complete response would look
+            // truncated.
+            let was_pending_cr = std::mem::take(&mut self.pending_cr);
+            if was_pending_cr && byte == b'\n' {
+                continue;
+            }
+            match byte {
+                b'\r' | b'\n' => {
+                    self.pending_cr = byte == b'\r';
+                    let line = std::mem::take(&mut self.line_buffer);
+                    self.observe_line(&line);
+                    if self.done() {
+                        return;
+                    }
+                }
+                _ => self.line_buffer.push(byte),
+            }
+            if self.line_buffer.len() + self.event_data.len() > MAX_OBSERVED_EVENT_BYTES {
+                // Give up rather than keep buffering. The bytes still reach the
+                // client untouched; only the judgement about how the stream
+                // ended is lost, and a lost judgement must not become a guess.
+                self.observation_failed = true;
+                self.line_buffer = Vec::new();
+                self.event_data = Vec::new();
+                return;
+            }
+        }
+    }
+
+    /// Nothing left to learn: the identifiers are known and the stream has
+    /// ended, so no later byte can change the answer.
+    fn done(&self) -> bool {
+        self.observation_failed
+            || (self.chat_id.is_some()
+                && self.model_id.is_some()
+                && (self.protocol.is_none() || self.saw_terminal || self.saw_error))
+    }
+
+    fn observe_line(&mut self, line: &[u8]) {
+        // A blank line ends the event and resets the framing state, whether or
+        // not a message was dispatched.
+        if line.is_empty() {
+            self.dispatch_event();
+            self.mid_event = false;
+            return;
+        }
+        // Comments do not start an event.
+        if line.starts_with(b":") {
+            return;
+        }
+        // Any field line (`data:`, `event:`, `id:`, an unknown field) puts an
+        // event in progress; only `data:` contributes to the payload watched
+        // for identifiers and `[DONE]`.
+        self.mid_event = true;
+        let Some(rest) = line.strip_prefix(b"data:") else {
+            return;
+        };
+        // WHATWG: append the value and a single LF for every `data:` field,
+        // including an empty one. `dispatch` strips one trailing LF. So a lone
+        // empty `data:` before `data: [DONE]` yields the payload "\n[DONE]",
+        // which is not the terminator — as the client's own parser sees it.
+        let data = rest.strip_prefix(b" ").unwrap_or(rest);
+        self.event_data.extend_from_slice(data);
+        self.event_data.push(b'\n');
+    }
+
+    fn dispatch_event(&mut self) {
+        // Empty means no `data:` field was seen (each appends at least an LF).
+        if self.event_data.is_empty() {
+            return;
+        }
+        let mut data = std::mem::take(&mut self.event_data);
+        if data.last() == Some(&b'\n') {
+            data.pop();
+        }
+        if data.as_slice() == b"[DONE]" {
+            self.saw_terminal |= self.protocol == Some(SseProtocol::OpenaiChat);
+            return;
+        }
+        let Ok(parsed) = serde_json::from_slice::<Value>(&data) else {
+            return;
+        };
+        self.observe_terminal(&parsed);
+        if self.chat_id.is_none() {
+            self.chat_id = parsed.get("id").and_then(Value::as_str).map(str::to_string);
+        }
+        if self.model_id.is_none() {
+            self.model_id = parsed
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+    }
+
+    /// Note the protocol's framing terminal or in-band error, and the event
+    /// numbering a Responses error tail continues from.
+    ///
+    /// A per-choice `finish_reason` / `stop_reason` is deliberately not a
+    /// terminal: whether the stream is complete is decided by how it ended
+    /// (a clean end vs a transport error), not by a content-level signal that
+    /// says nothing about the framing around it.
+    fn observe_terminal(&mut self, parsed: &Value) {
+        if let Some(sequence) = parsed.get("sequence_number").and_then(Value::as_u64) {
+            self.last_sequence_number = Some(match self.last_sequence_number {
+                Some(previous) => previous.max(sequence),
+                None => sequence,
+            });
+        }
+        let Some(protocol) = self.protocol else {
+            return;
+        };
+        let event_type = parsed.get("type").and_then(Value::as_str);
+        let terminal = match protocol {
+            SseProtocol::OpenaiChat => false,
+            SseProtocol::AnthropicMessages => event_type == Some("message_stop"),
+            SseProtocol::OpenaiResponses => matches!(
+                event_type,
+                Some("response.completed" | "response.incomplete" | "response.failed")
+            ),
+        };
+        self.saw_terminal |= terminal;
+        // An error is an error however the protocol frames it: a top-level
+        // `error`, an `error`-typed event, a Responses `response.failed`, the
+        // error object nested under `response`, or an error-shaped finish reason
+        // (an upstream error smuggled through `finish_reason` / `stop_reason` —
+        // not a framing terminal, but a failure the finalizer must not stamp a
+        // success terminator over, matching the meter's own detection).
+        let responses_failed = event_type == Some("response.failed");
+        let nested_error = parsed
+            .get("response")
+            .and_then(|r| r.get("error"))
+            .is_some_and(|e| !e.is_null());
+        let is_error_reason = |r: &str| r == "error" || r.ends_with("_error");
+        let choices_error =
+            parsed
+                .get("choices")
+                .and_then(Value::as_array)
+                .is_some_and(|choices| {
+                    choices.iter().any(|choice| {
+                        choice
+                            .get("finish_reason")
+                            .and_then(Value::as_str)
+                            .is_some_and(is_error_reason)
+                    })
+                });
+        let stop_reason_error = parsed
+            .get("delta")
+            .and_then(|d| d.get("stop_reason"))
+            .and_then(Value::as_str)
+            .is_some_and(is_error_reason);
+        self.saw_error |= event_type == Some("error")
+            || parsed.get("error").is_some_and(|e| !e.is_null())
+            || responses_failed
+            || nested_error
+            || choices_error
+            || stop_reason_error;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aggregator::service::{CHAT_COMPLETIONS_PATH, MESSAGES_PATH, RESPONSES_PATH};
+
+    fn observe(path: &str, chunks: &[&str]) -> SseFramingObserver {
+        let mut parser = SseFramingObserver::new(path);
+        for chunk in chunks {
+            parser.observe(chunk.as_bytes());
+        }
+        parser
+    }
+
+    // Every SSE line terminator has to split lines. Splitting only on `\n`
+    // would leave a CR-framed stream as one endless line whose terminal is
+    // never seen — and an unseen terminal makes a complete response look
+    // truncated, the one direction that corrupts good output.
+    #[test]
+    fn every_line_terminator_reveals_the_terminal() {
+        for framing in ["\n\n", "\r\n\r\n", "\r\r"] {
+            let stream =
+                format!("data: {{\"id\":\"a\",\"model\":\"m\"}}{framing}data: [DONE]{framing}");
+            let parser = observe(CHAT_COMPLETIONS_PATH, &[&stream]);
+            assert!(
+                parser.saw_terminal(),
+                "terminal missed with framing {framing:?}"
+            );
+            assert_eq!(parser.chat_id().as_deref(), Some("a"));
+        }
+    }
+
+    // A terminator split across chunks is still one terminator.
+    #[test]
+    fn a_split_crlf_is_not_two_line_endings() {
+        let parser = observe(
+            MESSAGES_PATH,
+            &[
+                "event: message_stop\r",
+                "\ndata: {\"type\":\"message_stop\"}\r\n\r\n",
+            ],
+        );
+        assert!(parser.saw_terminal());
+    }
+
+    // A terminal counts only once a blank line has dispatched the event that
+    // carried it. A `[DONE]` line with no blank line after it is still pending,
+    // and the stream is not at a boundary.
+    #[test]
+    fn a_terminal_counts_only_once_dispatched() {
+        let dispatched = observe(CHAT_COMPLETIONS_PATH, &["data: [DONE]\n\n"]);
+        assert!(dispatched.saw_terminal());
+        assert!(dispatched.at_event_boundary());
+
+        let pending = observe(CHAT_COMPLETIONS_PATH, &["data: [DONE]\n"]);
+        assert!(!pending.saw_terminal(), "no blank line dispatched it");
+        assert!(!pending.at_event_boundary(), "the event is still pending");
+    }
+
+    // The observer tracks only the protocol's framing terminal, each on its own
+    // surface. A per-choice finish reason is not one.
+    #[test]
+    fn only_the_framing_terminal_settles_the_observer() {
+        let chat_finish = observe(
+            CHAT_COMPLETIONS_PATH,
+            &["data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n"],
+        );
+        assert!(
+            !chat_finish.saw_terminal(),
+            "a finish reason is not the terminal"
+        );
+
+        let anthropic_stop_reason = observe(
+            MESSAGES_PATH,
+            &["data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"],
+        );
+        assert!(!anthropic_stop_reason.saw_terminal());
+
+        let anthropic_stop = observe(MESSAGES_PATH, &["data: {\"type\":\"message_stop\"}\n\n"]);
+        assert!(anthropic_stop.saw_terminal());
+
+        // A framing terminal from another protocol does not count.
+        let anthropic_done = observe(MESSAGES_PATH, &["data: [DONE]\n\n"]);
+        assert!(!anthropic_done.saw_terminal());
+
+        let responses_done = observe(
+            RESPONSES_PATH,
+            &["data: {\"type\":\"response.completed\",\"sequence_number\":7}\n\n"],
+        );
+        assert!(responses_done.saw_terminal());
+    }
+
+    // An in-band error is tracked apart from the framing terminal: the finalizer
+    // suppresses its own error on either, but the meter fails the outcome on an
+    // error and completes it on a terminal.
+    #[test]
+    fn an_in_band_error_is_distinct_from_a_terminal() {
+        let parser = observe(
+            CHAT_COMPLETIONS_PATH,
+            &["data: {\"error\":{\"message\":\"boom\"}}\n\n"],
+        );
+        assert!(parser.saw_error());
+        assert!(!parser.saw_terminal());
+    }
+
+    // An error-shaped finish reason (an upstream error smuggled through
+    // `finish_reason`/`stop_reason`) is a failure, though not a framing
+    // terminal — so the finalizer agrees with the meter and stamps no success
+    // terminator over it.
+    #[test]
+    fn an_error_shaped_finish_reason_is_an_error_not_a_terminal() {
+        let chat = observe(
+            CHAT_COMPLETIONS_PATH,
+            &["data: {\"choices\":[{\"finish_reason\":\"upstream_error\"}]}\n\n"],
+        );
+        assert!(chat.saw_error());
+        assert!(!chat.saw_terminal(), "a finish reason is not a terminal");
+
+        let anthropic = observe(
+            MESSAGES_PATH,
+            &["data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"error\"}}\n\n"],
+        );
+        assert!(anthropic.saw_error());
+        assert!(!anthropic.saw_terminal());
+
+        // A normal finish reason is neither.
+        let ok = observe(
+            CHAT_COMPLETIONS_PATH,
+            &["data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n"],
+        );
+        assert!(!ok.saw_error());
+        assert!(!ok.saw_terminal());
+    }
+
+    // The error tail continues the event numbering rather than restarting it.
+    #[test]
+    fn the_last_sequence_number_is_tracked() {
+        let parser = observe(
+            RESPONSES_PATH,
+            &[
+                "data: {\"type\":\"response.output_text.delta\",\"sequence_number\":3}\n\n",
+                "data: {\"type\":\"response.output_text.delta\",\"sequence_number\":9}\n\n",
+            ],
+        );
+        assert!(!parser.saw_terminal(), "truncated before its terminal");
+        assert_eq!(parser.last_sequence_number(), Some(9));
+    }
+
+    // A stream cut mid-line or mid-event is not at a boundary.
+    #[test]
+    fn a_partial_event_is_not_a_boundary() {
+        let complete = observe(CHAT_COMPLETIONS_PATH, &["data: {\"a\":1}\n\n"]);
+        assert!(complete.at_event_boundary());
+
+        let mid_line = observe(CHAT_COMPLETIONS_PATH, &["data: {\"a\":"]);
+        assert!(!mid_line.at_event_boundary());
+
+        let mid_event = observe(CHAT_COMPLETIONS_PATH, &["data: {\"a\":1}\n"]);
+        assert!(!mid_event.at_event_boundary());
+    }
+
+    // A pending `event:` field with no dispatching blank line is not a boundary:
+    // splicing a terminator in would fold it into that event.
+    #[test]
+    fn a_pending_event_field_is_not_a_boundary() {
+        let pending = observe(CHAT_COMPLETIONS_PATH, &["event: custom\n"]);
+        assert!(!pending.at_event_boundary());
+
+        // A blank line resets the event state, dispatched or not.
+        let reset = observe(CHAT_COMPLETIONS_PATH, &["event: custom\n\n"]);
+        assert!(reset.at_event_boundary());
+
+        // A lone comment does not start an event.
+        let comment = observe(CHAT_COMPLETIONS_PATH, &[": keep-alive\n"]);
+        assert!(comment.at_event_boundary());
+    }
+
+    // A Responses failure is an error however it is framed: the `response.failed`
+    // event and the error nested under `response` both count.
+    #[test]
+    fn a_responses_failure_is_an_error() {
+        let failed = observe(
+            RESPONSES_PATH,
+            &["data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"x\"}}}\n\n"],
+        );
+        assert!(
+            failed.saw_error(),
+            "response.failed is a failure, not a success"
+        );
+    }
+
+    // WHATWG appends an LF per `data:` field, so an empty `data:` before
+    // `data: [DONE]` makes the payload "\n[DONE]" — not the terminator, exactly
+    // as the client's own parser would decode it.
+    #[test]
+    fn an_empty_data_line_is_not_folded_away() {
+        let terminal = observe(CHAT_COMPLETIONS_PATH, &["data: [DONE]\n\n"]);
+        assert!(terminal.saw_terminal());
+
+        let not_terminal = observe(CHAT_COMPLETIONS_PATH, &["data:\ndata: [DONE]\n\n"]);
+        assert!(
+            !not_terminal.saw_terminal(),
+            "payload is \\n[DONE], not the [DONE] sentinel"
+        );
+
+        // Multi-line data joins with LF (each line its own `data:` field),
+        // forming one JSON payload — matching the client's decode.
+        let multi = observe(
+            CHAT_COMPLETIONS_PATH,
+            &["data: {\"id\":\"a\",\ndata: \"model\":\"m\"}\n\n"],
+        );
+        assert_eq!(multi.chat_id().as_deref(), Some("a"));
+    }
+
+    // Past the cap the stream is no longer judged at all; a lost judgement must
+    // not become a guess.
+    #[test]
+    fn an_unbounded_line_ends_observation_rather_than_memory() {
+        let mut parser = SseFramingObserver::new(CHAT_COMPLETIONS_PATH);
+        parser.observe(&vec![b'x'; MAX_OBSERVED_EVENT_BYTES + 1]);
+        assert!(!parser.observation_usable());
+    }
+
+    // Bytes that are not the client-facing stream carry no meaningful terminal.
+    #[test]
+    fn identifier_only_parsing_tracks_no_terminal() {
+        let mut parser = SseFramingObserver::identifiers_only();
+        parser.observe(b"data: {\"id\":\"a\",\"model\":\"m\"}\n\ndata: [DONE]\n\n");
+        assert_eq!(parser.chat_id().as_deref(), Some("a"));
+        assert!(!parser.saw_terminal());
+    }
+}

--- a/src/sse_protocol.rs
+++ b/src/sse_protocol.rs
@@ -1,0 +1,112 @@
+//! Streaming protocol of a downstream endpoint, and the in-stream error it
+//! carries.
+//!
+//! Which protocol an endpoint speaks decides the event that ends a stream and
+//! the shape an error takes inside one. The receipt finalizer uses this to end
+//! a stream that stopped without its terminal, choosing by how it ended: supply
+//! the protocol's success terminator where it is a fixed marker, append the
+//! protocol's error on a transport failure, or leave the stream as-is when a
+//! clean end has no terminator the gateway may fabricate.
+
+use serde_json::{json, Value};
+
+use crate::aggregator::service::{MESSAGES_PATH, RESPONSES_PATH};
+use crate::error_payload::{envelope, error_type, upstream_message, Surface};
+
+/// Streaming protocol of a downstream endpoint. Narrower than [`Surface`],
+/// which groups all OpenAI-compatible endpoints together: the chat/completions
+/// and responses streams carry errors and terminate differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SseProtocol {
+    OpenaiChat,
+    OpenaiResponses,
+    AnthropicMessages,
+}
+
+/// The streaming protocol an endpoint speaks.
+pub fn sse_protocol(endpoint_path: &str) -> SseProtocol {
+    match endpoint_path {
+        MESSAGES_PATH => SseProtocol::AnthropicMessages,
+        RESPONSES_PATH => SseProtocol::OpenaiResponses,
+        _ => SseProtocol::OpenaiChat,
+    }
+}
+
+/// SSE bytes that complete the framing of a clean but terminator-less stream,
+/// or `None` if the protocol's terminal carries state the gateway cannot
+/// fabricate. A clean end is a success either way; this only decides whether a
+/// missing terminator can be filled in for the client.
+pub fn stream_success_terminator(protocol: SseProtocol) -> Option<&'static str> {
+    match protocol {
+        // `[DONE]` is a fixed marker carrying no state, so a chat provider that
+        // closed normally without it has still finished; the gateway completes
+        // the framing.
+        SseProtocol::OpenaiChat => Some("data: [DONE]\n\n"),
+        // The gateway does not fabricate a terminator for the other surfaces:
+        // supplying an event the upstream never sent would assert state it did
+        // not (a `message_stop` with no preceding `stop_reason`, or a
+        // `response.completed` with no usage). A clean end is still recorded
+        // complete; the client simply receives what the upstream sent.
+        SseProtocol::AnthropicMessages | SseProtocol::OpenaiResponses => None,
+    }
+}
+
+/// SSE bytes that end a broken response stream visibly to the client.
+///
+/// A broken stream is ended gracefully rather than failed — a body `Err` would
+/// make hyper abort the connection — but a graceful end alone reads as a
+/// complete response. These events say it failed, in the shape the protocol
+/// defines. Only the chat stream has a `[DONE]` sentinel to follow with; on the
+/// other two the error event is itself terminal.
+///
+/// The message is the generic 502 text; the underlying error is only logged.
+pub fn stream_error_tail(
+    protocol: SseProtocol,
+    request_id: Option<&str>,
+    last_sequence_number: Option<u64>,
+) -> String {
+    let message = upstream_message(502);
+    // The leading blank line dispatches an event written but not yet dispatched
+    // (a `data:` line with no blank line after it), so these start their own
+    // event instead of folding into it as extra `data:` lines. Two newlines,
+    // not one: after a `\r` a single `\n` completes a CRLF, which is one line
+    // terminator, and the next `data:` line would join the same event. Against
+    // an already dispatched stream the extra blank lines are ignored.
+    match protocol {
+        SseProtocol::AnthropicMessages => {
+            let body = envelope(
+                Surface::Anthropic,
+                error_type(Surface::Anthropic, 502),
+                message,
+                request_id,
+            );
+            format!("\n\nevent: error\ndata: {}\n\n", json_str(&body))
+        }
+        SseProtocol::OpenaiResponses => {
+            // The protocol numbers its events, so the error continues the
+            // sequence rather than restarting it. A caller with no view of the
+            // stream has none to continue from.
+            let body = json!({
+                "type": "error",
+                "code": Value::Null,
+                "message": message,
+                "param": Value::Null,
+                "sequence_number": last_sequence_number.map_or(0, |last| last.saturating_add(1)),
+            });
+            format!("\n\nevent: error\ndata: {}\n\n", json_str(&body))
+        }
+        SseProtocol::OpenaiChat => {
+            let body = envelope(
+                Surface::Openai,
+                error_type(Surface::Openai, 502),
+                message,
+                request_id,
+            );
+            format!("\n\ndata: {}\n\ndata: [DONE]\n\n", json_str(&body))
+        }
+    }
+}
+
+fn json_str(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -122,6 +122,9 @@ struct RecordingUpstream {
     stream_status: u16,
     stream_headers: HashMap<String, String>,
     stream_chunks: Vec<Bytes>,
+    /// When set, the body yields the chunks and then this transport error,
+    /// standing in for a connection that dropped mid-stream.
+    stream_error: Option<String>,
 }
 
 impl Default for RecordingUpstream {
@@ -138,6 +141,7 @@ impl Default for RecordingUpstream {
                 Bytes::from_static(b"data: {\"id\":\"chat-stream-1\",\"delta\":\"lo\"}\n\n"),
                 Bytes::from_static(b"data: [DONE]\n\n"),
             ],
+            stream_error: None,
         }
     }
 }
@@ -159,6 +163,25 @@ impl RecordingUpstream {
             stream_chunks,
             ..Self::default()
         }
+    }
+
+    fn with_stream_chunks_then_error(stream_chunks: Vec<Bytes>) -> Self {
+        Self {
+            stream_chunks,
+            stream_error: Some("connection reset".to_string()),
+            ..Self::default()
+        }
+    }
+
+    fn without_content_type(mut self) -> Self {
+        self.stream_headers.remove("content-type");
+        self
+    }
+
+    fn with_content_type(mut self, content_type: &str) -> Self {
+        self.stream_headers
+            .insert("content-type".to_string(), content_type.to_string());
+        self
     }
 }
 
@@ -192,7 +215,14 @@ impl UpstreamBackend for RecordingUpstream {
         Ok(UpstreamStreamResponse {
             status_code: self.stream_status,
             headers: self.stream_headers.clone(),
-            body: Box::pin(stream::iter(self.stream_chunks.clone().into_iter().map(Ok))),
+            body: {
+                let ok = self.stream_chunks.clone().into_iter().map(Ok);
+                let tail = self
+                    .stream_error
+                    .clone()
+                    .map(|message| Err(UpstreamError::Transport(message)));
+                Box::pin(stream::iter(ok.chain(tail)))
+            },
             served_instance_id: None,
         })
     }
@@ -286,6 +316,7 @@ fn harness_with_streaming_upstream_error() -> Harness {
             stream_chunks: vec![Bytes::from_static(
                 br#"{"error":{"message":"Invalid request parameters","type":"invalid_request_error","code":400}}"#,
             )],
+            stream_error: None,
         },
     )
 }
@@ -1229,6 +1260,346 @@ async fn streaming_chat_completion_hashes_complete_ordered_stream() {
     assert_eq!(
         receipt_event(&receipt, "response.returned")["wire_hash"],
         sha256_hex(&resp.body)
+    );
+}
+
+// An OpenAI chat upstream that closes normally without ever sending `[DONE]`
+// has finished, not truncated: `[DONE]` is a fixed marker the gateway can
+// supply. It completes the framing rather than injecting an error, and because
+// that happens inside the finalizer the receipt commits to exactly the bytes
+// the client received — appended terminator included.
+#[tokio::test]
+async fn a_chat_stream_missing_done_is_completed_inside_the_receipt() {
+    let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![
+        Bytes::from_static(b"data: {\"id\":\"chat-stream-1\",\"delta\":\"hel\"}\n\n"),
+        Bytes::from_static(b"data: {\"id\":\"chat-stream-1\",\"delta\":\"lo\"}\n\n"),
+    ]));
+    let resp = h
+        .requester
+        .post(
+            "/v1/chat/completions",
+            br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hello"}]}"#,
+            &[],
+        )
+        .await;
+
+    assert_eq!(resp.status, StatusCode::OK);
+    let body = String::from_utf8(resp.body.clone()).unwrap();
+    assert!(
+        !body.contains("\"error\""),
+        "a clean close is not an error: {body}"
+    );
+    assert!(
+        body.ends_with("data: [DONE]\n\n"),
+        "the missing terminator is supplied: {body}"
+    );
+
+    // The receipt covers the appended terminator, not just what the upstream
+    // sent, and a clean stream is signed.
+    let receipt_id = header(&resp.headers, "x-receipt-id");
+    let receipt = h.service.get_receipt_by_receipt_id(receipt_id).unwrap();
+    assert_eq!(
+        receipt_event(&receipt, "response.returned")["wire_hash"],
+        sha256_hex(&resp.body)
+    );
+    assert!(
+        receipt
+            .event_log
+            .iter()
+            .any(|event| event.event_type == "transparency.response_modified"),
+        "the gateway added the terminator the upstream never sent"
+    );
+}
+
+// An Anthropic stream that closes cleanly without `message_stop` has finished,
+// so it is completed and signed — but the gateway appends nothing: fabricating
+// a `message_stop` would assert an end the upstream never sent. The client gets
+// exactly what the upstream sent, then EOF, as litellm's Anthropic passthrough
+// also does.
+#[tokio::test]
+async fn an_anthropic_stream_missing_message_stop_is_completed_without_a_tail() {
+    let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![
+        Bytes::from_static(
+            b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}\n\n",
+        ),
+    ]));
+    let resp = h
+        .requester
+        .post(
+            "/v1/messages",
+            br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+            &[],
+        )
+        .await;
+
+    let body = String::from_utf8(resp.body.clone()).unwrap();
+    assert!(
+        !body.contains("event: error"),
+        "a clean close is not an error: {body}"
+    );
+    assert!(
+        !body.contains("message_stop"),
+        "no terminal is fabricated: {body}"
+    );
+    assert!(
+        body.ends_with("data: {\"type\":\"content_block_delta\"}\n\n"),
+        "nothing appended: {body}"
+    );
+    let receipt_id = header(&resp.headers, "x-receipt-id");
+    let receipt = h.service.get_receipt_by_receipt_id(receipt_id).unwrap();
+    assert_eq!(
+        receipt_event(&receipt, "response.returned")["wire_hash"],
+        sha256_hex(&resp.body)
+    );
+}
+
+// A Responses stream that closes without `response.completed` also completes,
+// but its terminal carries the final response object and cannot be fabricated,
+// so nothing is appended — no error, and the receipt covers the bytes as sent.
+#[tokio::test]
+async fn a_responses_stream_missing_its_terminal_is_completed_without_a_tail() {
+    let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![
+        Bytes::from_static(
+            b"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"delta\":\"hi\"}\n\n",
+        ),
+    ]));
+    let resp = h
+        .requester
+        .post(
+            "/v1/responses",
+            br#"{"model":"aci-model","stream":true,"input":"hi"}"#,
+            &[],
+        )
+        .await;
+
+    let body = String::from_utf8(resp.body.clone()).unwrap();
+    assert!(
+        !body.contains("\"error\""),
+        "a clean close is not an error: {body}"
+    );
+    assert!(
+        body.ends_with("\"delta\":\"hi\"}\n\n"),
+        "nothing appended (the terminal cannot be fabricated): {body}"
+    );
+    let receipt_id = header(&resp.headers, "x-receipt-id");
+    assert!(
+        h.service.get_receipt_by_receipt_id(receipt_id).is_some(),
+        "a clean end is signed"
+    );
+}
+
+// An error-shaped finish reason without `[DONE]`, then a clean end, must not be
+// stamped with a success terminator: the finalizer detects the error (as the
+// meter does) and appends nothing, so a signed receipt never frames an upstream
+// error as a completed response.
+#[tokio::test]
+async fn an_error_finish_reason_is_not_completed_with_done() {
+    let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![
+        Bytes::from_static(b"data: {\"choices\":[{\"finish_reason\":\"upstream_error\"}]}\n\n"),
+    ]));
+    let resp = h
+        .requester
+        .post(
+            "/v1/chat/completions",
+            br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+            &[],
+        )
+        .await;
+
+    let body = String::from_utf8(resp.body.clone()).unwrap();
+    assert!(
+        !body.contains("[DONE]"),
+        "no success terminator over an error: {body}"
+    );
+    assert!(
+        body.ends_with("\"finish_reason\":\"upstream_error\"}]}\n\n"),
+        "nothing appended: {body}"
+    );
+}
+
+// A stream that ended mid-event is left alone: supplying the delimiter the
+// upstream never sent would dispatch a fragment the client would otherwise
+// discard, and it would fail on that instead of reading the error.
+// A transport failure reaches the finalizer, which holds the protocol state
+// that decides whether the client can still be told. It appends the error only
+// when the stream stopped on a complete event without its terminal; a stream
+// that already ended, or stopped mid-event, is left as it is.
+#[tokio::test]
+async fn a_transport_failure_is_told_to_the_client_only_when_it_is_safe() {
+    struct Case {
+        name: &'static str,
+        path: &'static str,
+        request: &'static [u8],
+        chunks: Vec<Bytes>,
+        expect_error: bool,
+        /// Substring the appended error must contain, when one is expected.
+        expect_in_error: &'static str,
+    }
+    let chat =
+        br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hi"}]}"#;
+    let responses = br#"{"model":"aci-model","stream":true,"input":"hi"}"#;
+    let cases = vec![
+        Case {
+            name: "already terminated, then the connection drops",
+            path: "/v1/chat/completions",
+            request: chat,
+            chunks: vec![
+                Bytes::from_static(b"data: {\"id\":\"c\",\"delta\":\"hi\"}\n\n"),
+                Bytes::from_static(b"data: [DONE]\n\n"),
+            ],
+            expect_error: false,
+            expect_in_error: "",
+        },
+        Case {
+            name: "content with no completion reason, then the connection drops",
+            path: "/v1/chat/completions",
+            request: chat,
+            chunks: vec![Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+            )],
+            expect_error: true,
+            expect_in_error: "data: [DONE]",
+        },
+        Case {
+            // A finish reason does not rescue a broken connection: the transport
+            // failed, so the client is told, whatever content-level signal came
+            // before it.
+            name: "a finish reason, then the connection drops",
+            path: "/v1/chat/completions",
+            request: chat,
+            chunks: vec![Bytes::from_static(
+                b"data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n",
+            )],
+            expect_error: true,
+            expect_in_error: "data: [DONE]",
+        },
+        Case {
+            name: "mid-event, then the connection drops",
+            path: "/v1/chat/completions",
+            request: chat,
+            chunks: vec![Bytes::from_static(b"data: {\"id\":\"c\",")],
+            expect_error: false,
+            expect_in_error: "",
+        },
+        Case {
+            // The error continues the event numbering rather than restarting
+            // it, which is why the finalizer builds it: only there is the last
+            // sequence known.
+            name: "responses stream drops after sequence 4",
+            path: "/v1/responses",
+            request: responses,
+            chunks: vec![Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":4}\n\n",
+            )],
+            expect_error: true,
+            expect_in_error: "\"sequence_number\":5",
+        },
+    ];
+    for case in cases {
+        let h = harness_with_upstream(RecordingUpstream::with_stream_chunks_then_error(
+            case.chunks.clone(),
+        ));
+        let resp = h.requester.post(case.path, case.request, &[]).await;
+        let body = String::from_utf8(resp.body.clone()).unwrap();
+        assert_eq!(
+            body.contains("\"error\""),
+            case.expect_error,
+            "{}: {body:?}",
+            case.name
+        );
+        assert!(
+            body.contains(case.expect_in_error),
+            "{}: expected {:?} in {body:?}",
+            case.name,
+            case.expect_in_error
+        );
+        // A failed stream is never signed, however it ended: the reserved id
+        // is on the header, but no receipt is stored under it.
+        let receipt_id = header(&resp.headers, "x-receipt-id");
+        assert!(
+            h.service.get_receipt_by_receipt_id(receipt_id).is_none(),
+            "{}: a broken stream must not be bound to a receipt",
+            case.name
+        );
+    }
+}
+
+// The streaming entry point treats a response with no declared media type as an
+// event stream, so the missing chat terminator is still supplied on a clean end.
+#[tokio::test]
+async fn a_stream_without_a_content_type_is_still_observed() {
+    let h = harness_with_upstream(
+        RecordingUpstream::with_stream_chunks(vec![Bytes::from_static(
+            b"data: {\"id\":\"chat-stream-1\",\"delta\":\"hi\"}\n\n",
+        )])
+        .without_content_type(),
+    );
+    let resp = h
+        .requester
+        .post(
+            "/v1/chat/completions",
+            br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+            &[],
+        )
+        .await;
+    let body = String::from_utf8(resp.body.clone()).unwrap();
+    assert!(!body.contains("\"error\""), "{body}");
+    assert!(
+        body.ends_with("data: [DONE]\n\n"),
+        "the terminator is supplied: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_stream_cut_mid_event_is_not_given_an_error() {
+    let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![
+        Bytes::from_static(b"data: {\"id\":\"chat-stream-1\",\"delta\":\"hel\"}\n\n"),
+        Bytes::from_static(b"data: {\"id\":\"chat-stream-1\","),
+    ]));
+    let resp = h
+        .requester
+        .post(
+            "/v1/chat/completions",
+            br#"{"model":"aci-model","stream":true,"messages":[{"role":"user","content":"hello"}]}"#,
+            &[],
+        )
+        .await;
+
+    assert_eq!(
+        resp.body,
+        b"data: {\"id\":\"chat-stream-1\",\"delta\":\"hel\"}\n\ndata: {\"id\":\"chat-stream-1\","
+    );
+}
+
+// E2EE stream encryption only knows how to encrypt SSE event payloads. An
+// upstream that answered `application/json` on a streaming request cannot be
+// encrypted, so the request is rejected rather than returned in the clear or
+// bound to a receipt — the same rule the middleware path enforces.
+#[tokio::test]
+async fn e2ee_streaming_rejects_a_non_sse_upstream_without_a_receipt() {
+    let h = harness_with_e2ee(
+        RecordingUpstream::with_stream_chunks(vec![Bytes::from_static(
+            br#"{"id":"chat-1","choices":[{"message":{"content":"hi"}}]}"#,
+        )])
+        .with_content_type("application/json"),
+    );
+    let client_secret = k256::SecretKey::from_slice(&[0x5b; 32]).unwrap();
+    let nonce = hex_nonce("nonce-json");
+    let (encrypted_body, headers) = e2ee_stream_request(&h, &client_secret, nonce.as_str());
+
+    let resp = h
+        .requester
+        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::OK,
+        "the combination must be rejected"
+    );
+    assert!(
+        resp.headers.get("x-receipt-id").is_none(),
+        "a rejected E2EE response is not bound to a receipt"
     );
 }
 

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -25,7 +25,7 @@ use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::middleware::control::ControlClient;
-use private_ai_gateway::middleware::errors::Surface;
+use private_ai_gateway::middleware::errors::{SseProtocol, Surface};
 use private_ai_gateway::middleware::request_transform::Endpoint;
 use private_ai_gateway::middleware::sse::{MeterStream, StreamReport};
 use private_ai_gateway::middleware::{CompletionInput, Middleware, MiddlewareConfig};
@@ -432,7 +432,7 @@ async fn meter_stream_injects_cost_classifies_completed_and_reports() {
         Ok(Bytes::from("data: [DONE]\n\n")),
     ];
     let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
-    let metered = MeterStream::new(inner, report);
+    let metered = MeterStream::new(inner, report, SseProtocol::OpenaiChat);
     let collected: Vec<Bytes> = metered.map(|r| r.unwrap()).collect().await;
     let text: String = collected
         .iter()
@@ -708,7 +708,7 @@ async fn downstream_abort_before_settle_reports_gateway_failure_not_client_close
         ))];
     let inner: ServiceResponseStream =
         Box::pin(futures_util::stream::iter(events).chain(futures_util::stream::pending()));
-    let mut metered = MeterStream::new(inner, report);
+    let mut metered = MeterStream::new(inner, report, SseProtocol::OpenaiChat);
     let first = metered.next().await;
     assert!(first.is_some(), "meter must have started streaming");
 
@@ -765,7 +765,7 @@ async fn downstream_abort_after_settle_does_not_double_report() {
             "data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
         ))];
     let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
-    let mut metered = MeterStream::new(inner, report);
+    let mut metered = MeterStream::new(inner, report, SseProtocol::OpenaiChat);
     while metered.next().await.is_some() {}
     assert!(
         settled.load(std::sync::atomic::Ordering::Relaxed),


### PR DESCRIPTION
## Problem

A streaming response that fails **after** the 200 status has gone out used to end silently — the body just stopped, no error, no terminal. Clients kept the partial content as a complete answer, and the underlying error survived only in a debug-gated log field.

## Behavior

How the stream ended decides what it gets:

| Ending | Behavior |
| --- | --- |
| Transport error | Told with the protocol's error (chat `{error}`+`[DONE]`, Anthropic `event: error`, Responses error event w/ next `sequence_number`); **not signed** |
| Clean end at an event boundary | A completion, never an error; **signed**. Chat's fixed stateless `[DONE]` is supplied when the provider omitted it; Anthropic/Responses carry state the gateway cannot fabricate, so **nothing is appended** — client gets what the upstream sent, then EOF |
| Cut mid-line / mid-event | Left as-is (appending would splice a fragment the client discards) |
| In-band error / `response.failed` / error finish reason | No gateway error on top; outcome is a failure |

A body `Err` reaching hyper would abort the connection with a TCP RST (killed stream + poisoned keep-alive pool); the error is absorbed and the body ended cleanly, so the connection stays reusable.

## Structure

- **Synthesis happens inside the shared receipt finalizer** (both routing modes go through it, inside the hash boundary), so appended bytes are hashed and encrypted like upstream ones and the receipt commits to exactly what the client received.
- **One `SseFramingObserver`** answers the framing questions (terminal delivered, event boundary, sequence number, in-band error), byte-accurate per WHATWG (LF/CRLF/lone-CR splitting, per-field data buffering, pending event-field tracking, size cap). The finalizer and the meter share it, so **what the client receives and what the report records agree**. The meter keeps its own line parse for cost/TTFT/diagnostics.
- The direct streaming path now also **rejects an E2EE request whose upstream answered a non-SSE body** (the stream encrypter only handles SSE payloads); the middleware path already did.

## Notes

Client-facing behavior tracks litellm — inject an error mid-stream, treat a clean end as complete, pass a missing structured-surface terminal through untouched rather than fabricate it. The per-protocol error shapes and the receipt coverage go beyond it. A leading BOM is not stripped (deliberate non-conformance for trusted upstreams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)