### PR TITLE
fix(aci): name the requested model when a session pin cannot be met

### DIFF
--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -82,6 +82,16 @@ pub(super) fn attested_route_eligible(is_tee: Option<bool>) -> bool {
     is_tee == Some(true)
 }
 
+/// A request's `provider.aci_session_ids` allowlist, carried with the model id
+/// to name if it cannot be satisfied. The label travels with the ids so every
+/// path reports the model the caller asked for, including the reverify path,
+/// which has only the prepared (upstream-renamed) request to hand.
+#[derive(Clone, Copy)]
+pub(super) struct AciSessionPin<'a> {
+    pub ids: &'a [String],
+    pub requested_model: &'a str,
+}
+
 impl AciService {
     pub async fn forward_chat_completion(
         &self,
@@ -141,6 +151,10 @@ impl AciService {
         let caller_supplied_upstream_event = req.upstream_verification_event.is_some();
         let upstream_required =
             self.upstream_required_for_prepared(&prepared, req.upstream_required, aci_required);
+        let pin = AciSessionPin {
+            ids: &req.aci_session_ids,
+            requested_model: req.context.user_model.as_deref().unwrap_or_default(),
+        };
         let mut recorded_event = self
             .recorded_upstream_event(
                 &prepared,
@@ -148,11 +162,7 @@ impl AciService {
                 req.upstream_verification_event,
             )
             .await?;
-        self.apply_aci_session_constraint(
-            &mut recorded_event,
-            &req.aci_session_ids,
-            &prepared.model_id,
-        )?;
+        self.apply_aci_session_constraint(&mut recorded_event, pin)?;
 
         let upstream_response = match self
             .forward_with_binding_reverify(
@@ -160,7 +170,7 @@ impl AciService {
                 &mut recorded_event,
                 upstream_required,
                 caller_supplied_upstream_event,
-                &req.aci_session_ids,
+                pin,
                 // Single forward: only flush the cache for an event we own.
                 false,
                 |prepared, event| async move {
@@ -326,6 +336,10 @@ impl AciService {
         let caller_supplied_upstream_event = req.upstream_verification_event.is_some();
         let upstream_required =
             self.upstream_required_for_prepared(&prepared, req.upstream_required, aci_required);
+        let pin = AciSessionPin {
+            ids: &req.aci_session_ids,
+            requested_model: req.context.user_model.as_deref().unwrap_or_default(),
+        };
         let mut recorded_event = self
             .recorded_upstream_event(
                 &prepared,
@@ -333,11 +347,7 @@ impl AciService {
                 req.upstream_verification_event,
             )
             .await?;
-        self.apply_aci_session_constraint(
-            &mut recorded_event,
-            &req.aci_session_ids,
-            &prepared.model_id,
-        )?;
+        self.apply_aci_session_constraint(&mut recorded_event, pin)?;
 
         let upstream_response = match self
             .forward_with_binding_reverify(
@@ -345,7 +355,7 @@ impl AciService {
                 &mut recorded_event,
                 upstream_required,
                 caller_supplied_upstream_event,
-                &req.aci_session_ids,
+                pin,
                 // Single forward: only flush the cache for an event we own.
                 false,
                 |prepared, event| async move {
@@ -543,7 +553,7 @@ impl AciService {
         recorded_event: &mut UpstreamVerifiedEvent,
         upstream_required: Option<bool>,
         caller_supplied_event: bool,
-        aci_session_ids: &[String],
+        pin: AciSessionPin<'_>,
         always_invalidate_on_mismatch: bool,
         mut forward: Fwd,
     ) -> ReverifyOutcome<R>
@@ -568,11 +578,7 @@ impl AciService {
                         .await
                     {
                         Ok(mut event) => {
-                            if let Err(err) = self.apply_aci_session_constraint(
-                                &mut event,
-                                aci_session_ids,
-                                &prepared.model_id,
-                            ) {
+                            if let Err(err) = self.apply_aci_session_constraint(&mut event, pin) {
                                 return ReverifyOutcome::RefreshFailed(err);
                             }
                             *recorded_event = event;
@@ -729,15 +735,14 @@ impl AciService {
     pub(super) fn apply_aci_session_constraint(
         &self,
         event: &mut UpstreamVerifiedEvent,
-        allowed_ids: &[String],
-        model_id: &str,
+        pin: AciSessionPin<'_>,
     ) -> Result<(), ServiceError> {
-        if allowed_ids.is_empty() {
+        if pin.ids.is_empty() {
             return Ok(());
         }
 
         let sealed = self.record_attested_upstream_session(event)?;
-        let allowed_ids: HashSet<&str> = allowed_ids.iter().map(String::as_str).collect();
+        let allowed_ids: HashSet<&str> = pin.ids.iter().map(String::as_str).collect();
         let allowed_bindings: Vec<ChannelBinding> = event
             .channel_bindings
             .iter()
@@ -752,7 +757,9 @@ impl AciService {
 
         if allowed_bindings.is_empty() {
             return Err(ServiceError::UpstreamVerification(
-                UpstreamVerificationError::NoEligibleAttestedSession(model_id.to_string()),
+                UpstreamVerificationError::NoEligibleAttestedSession(
+                    pin.requested_model.to_string(),
+                ),
             ));
         }
         event.channel_bindings = allowed_bindings;

--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -3,7 +3,9 @@
 //!
 
 use super::e2ee_crypto::{encrypt_e2ee_final_response, is_sse_content_type};
-use super::forward::{attested_route_eligible, cite_served_session, ReverifyOutcome};
+use super::forward::{
+    attested_route_eligible, cite_served_session, AciSessionPin, ReverifyOutcome,
+};
 use super::helpers::{
     accepted_response_model, collect_upstream_body, extract_chat_id, generate_receipt_id,
 };
@@ -295,6 +297,13 @@ impl AciService {
         // failures (prepare/verification/transport) record 502.
         let mut failed_attempts: Vec<(String, u16)> = Vec::new();
 
+        // The session allowlist, labelled with the model the caller asked for so
+        // a pin miss names that rather than the upstream's own model id.
+        let pin = AciSessionPin {
+            ids: &req.aci_session_ids,
+            requested_model: user_model.as_deref().unwrap_or_default(),
+        };
+
         // The most recent candidate that actually answered, held back in case
         // nothing better follows. See [`RetainedResponse`].
         let mut retained: Option<RetainedResponse> = None;
@@ -366,11 +375,7 @@ impl AciService {
                 Err(err) => return Err(err),
             };
 
-            if let Err(err) = self.apply_aci_session_constraint(
-                &mut recorded_event,
-                &req.aci_session_ids,
-                &prepared.model_id,
-            ) {
+            if let Err(err) = self.apply_aci_session_constraint(&mut recorded_event, pin) {
                 if matches!(
                     err,
                     ServiceError::UpstreamVerification(
@@ -392,7 +397,7 @@ impl AciService {
                         &mut recorded_event,
                         candidate_required,
                         caller_supplied_upstream_event,
-                        &req.aci_session_ids,
+                        pin,
                         // Failover path: flush a possibly-stale binding on any
                         // terminal mismatch so the next candidate/request re-verifies.
                         true,
@@ -524,7 +529,7 @@ impl AciService {
                     &mut recorded_event,
                     candidate_required,
                     caller_supplied_upstream_event,
-                    &req.aci_session_ids,
+                    pin,
                     // Failover path: flush a possibly-stale binding on any
                     // terminal mismatch so the next candidate/request re-verifies.
                     true,

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -96,7 +96,9 @@ impl UpstreamBackend for TeeAwareUpstream {
         Ok(PreparedUpstreamRequest {
             upstream_name: self.name().to_string(),
             url_origin: self.url_origin().map(str::to_string),
-            model_id: "gpt-test".to_string(),
+            // Renamed like a real router does, so a test can tell the
+            // requested model from the upstream's own name.
+            model_id: "upstream-model".to_string(),
             is_tee: Some(route_id.starts_with("tee-")),
             route_id: Some(route_id),
             request: req,
@@ -908,11 +910,14 @@ async fn aci_session_ids_are_a_preforward_hard_allowlist() {
         )
         .await;
     match result {
+        // The model named is the one the caller asked for. The upstream renames
+        // it (here to "upstream-model"), and reporting that name instead would
+        // hand the caller an id they never sent and cannot look up.
         Ok(MiddlewareForwardResult::AllFailed(failure)) => assert!(matches!(
-            failure.error,
+            &failure.error,
             ServiceError::UpstreamVerification(
-                UpstreamVerificationError::NoEligibleAttestedSession(_)
-            )
+                UpstreamVerificationError::NoEligibleAttestedSession(model)
+            ) if model == "gpt-test"
         )),
         _ => panic!("an unavailable session must fail closed"),
     }


### PR DESCRIPTION
A pin miss reported `prepared.model_id`, the upstream's own name for the model,
while the sibling no-eligible-route error reports the model the caller asked
for. Same `provider` block, two different identifiers.

Observed in production after the feature shipped. A request for
`google/gemma-3-27b-it` fails with:

```
none of the requested attested sessions is available for model google/gemma-4-31B-it
```

`google/gemma-4-31B-it` is what the near-ai upstream calls that model. The
caller never sent that id and cannot look it up in the catalog, so the error
points away from the request that produced it.

## Change

The allowlist and the label to report travel together as `AciSessionPin`. That
also carries the label into `forward_with_binding_reverify`, which has only the
prepared (upstream-renamed) request to hand and so could not otherwise report
the requested model. Bundling avoids adding a sixth parameter to a signature
that already carries `#[allow(clippy::too_many_arguments)]`.

Behaviour change is limited to the message string. The constraint itself, its
status code, and its attribution are unchanged.

## Why the tests missed it

The existing allowlist test built a stub whose `prepare` returned
`model_id: "gpt-test"`, the same string as the requested model, so both labels
were identical and indistinguishable. The stub now renames the model the way a
real router does, and the assertion pins which name is reported. Reverting the
fix fails that assertion.

CI set run locally: `cargo fmt --check`, `cargo clippy --all-targets -D
warnings`, `cargo test` (413 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
