### PR TITLE
Expose measured app compose in ACI attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Use this checklist before treating a deployment as private inference.
 
 | Check | Evidence |
 | --- | --- |
-| Gateway identity is real | `GET /v1/attestation/report?nonce=<fresh nonce>` proves the TEE quote, workload id, and keyset. When source provenance is present, it must match the reviewed deployment. |
+| Gateway identity is real | `GET /v1/aci/attestation?nonce=<fresh nonce>` proves the TEE quote, workload id, and keyset. For dstack, verify `evidence.app_compose` against the RTMR3-bound `compose-hash`. Image and source-code acceptance remain verifier-policy TODOs. |
 | Keys are bound to the workload | The keyset in the report lists identity, receipt-signing, E2EE, and optional TLS SPKI keys endorsed by the workload identity. |
 | Client session is bound | For direct TLS, verify the server certificate SPKI matches the attested keyset. For ACI E2EE, verify the E2EE public key from the keyset. |
 | Upstream is verified | Receipt event `upstream.verified` must be `verified` for the provider and canonical model id. |
@@ -376,9 +376,15 @@ The recommended dstack deployment path uses `git-launcher`:
 
 Source provenance in attestation reports is derived from the git-launcher pin,
 not from gateway JSON. If the launcher config is absent, the report omits
-source provenance and the value is unknown. In production, compare the report's
-source provenance with `REPO_URL` and `COMMIT_SHA` in the attested launcher
-config.
+source provenance and the value is unknown. The current native verifier does not
+yet bind the reported commit or image digest to reviewed source; that policy is
+an explicit TODO.
+
+The canonical report publishes the exact measured `app_compose` preimage so an
+independent verifier can check it against the RTMR3-bound `compose-hash`. Keep
+plaintext secrets out of the Compose file. Supply values through Phala encrypted
+environment variables; the measured Compose contains the variable references,
+not their values.
 
 The launcher stays generic. Build, install, and run logic belongs to this repo.
 For production, prefer a Rust-capable gateway image so the toolchain is covered

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,20 +30,20 @@ Prepare an audited gateway commit, then run:
 
 ```bash
 cd deploy
-PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha> \
-PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token> \
-phala-h4xuser deploy -n private-ai-gateway -c compose.yaml
+phala deploy -n private-ai-gateway -c compose.yaml \
+  -e PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha> \
+  -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
 ```
 
 For local/dev deploys, you can also copy
-[`gateway.env.example`](./gateway.env.example), export those values from your
-shell, and run the same `phala-h4xuser deploy` command. For production, pass
-secrets such as admin tokens through the deployment secret mechanism rather
-than keeping them in a plaintext env file.
+[`gateway.env.example`](./gateway.env.example), fill in its values, and pass it
+as `-e gateway.env`. For production, pass variables with repeated `-e KEY=VALUE`
+arguments so secrets such as admin tokens do not remain in a plaintext env file.
 
 `compose.yaml` inlines the launcher config, the static gateway config, and the
-initial upstream config. dstack therefore measures the whole launch policy into
-`compose_hash`.
+initial upstream config. dstack measures the raw manifest into `compose_hash`,
+and the published `app_compose` contains variable references rather than their
+values.
 After deployment, the gateway listens on port `8086`.
 
 The gateway consumes two JSON files:
@@ -191,16 +191,18 @@ Changing `gateway-upstreams` in a later compose revision does not overwrite an
 existing active config volume. Use the admin API to replace the config, or
 delete the `gateway-state` volume intentionally before redeploying.
 
-The static gateway config, seed, and bootstrap env are part of the attested
-compose. API keys in the seed and secrets interpolated into the static config
-are therefore part of the deployment input and must be handled as secrets by
-the deployment environment. For production, pass secrets through dstack
-encrypted secrets, KMS, or mounted secret files rather than inline compose
-values.
+The static gateway config, seed, and bootstrap environment references are part
+of the attested Compose. The canonical attestation endpoint publishes that raw
+Compose preimage for independent verification. Do not place plaintext secrets
+in it. Pass secrets through dstack encrypted environment variables, KMS, or
+mounted secret files. Keep only variable references in Compose.
 
 Source provenance is not set in the gateway config. The gateway reports the
-`REPO_URL` and `COMMIT_SHA` from the git-launcher config, which is also covered
-by the attested compose.
+`REPO_URL` and `COMMIT_SHA` observed by git-launcher. The canonical report also
+returns the raw measured `app_compose`, so a verifier can hash it and match the
+RTMR3-bound `compose-hash`. The checked-in manifest measures the commit variable
+name, not its encrypted value. Binding the reported commit and accepted image
+digests to reviewed source is intentionally left as a verifier-policy TODO.
 
 Example seed:
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -2,9 +2,9 @@
 #
 # Deploy from this directory after setting the variables below, for example:
 #
-#   PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha> \
-#   PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-token> \
-#   phala-h4xuser deploy -n private-ai-gateway -c compose.yaml
+#   phala deploy -n private-ai-gateway -c compose.yaml \
+#     -e PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha> \
+#     -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-token>
 #
 # The compose inlines the launcher pin, static gateway config, and initial
 # upstream config so dstack's compose_hash covers the complete launch policy.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -107,9 +107,16 @@ WORK_DIR=/var/lib/git-launcher/private-ai-gateway
 
 When the launcher config is absent, source provenance is unknown and the
 gateway omits `source_provenance` from attestation reports. Production
-deployments should use `git-launcher`; relying parties should compare reported
-source provenance, when present, with the `REPO_URL` and `COMMIT_SHA` covered by
-the attested dstack compose.
+deployments should use `git-launcher`. The native ACI-service verifier checks
+that `attestation.evidence.app_compose` hashes to the `compose-hash` event bound
+into RTMR3. Binding the reported repository commit or image digest to reviewed
+source remains a verifier-policy TODO.
+
+The canonical attestation endpoint publishes the raw measured `app_compose`.
+Never place plaintext tokens, API keys, or passwords in Compose. Use Phala
+encrypted environment variables and leave only variable references in the
+measured file. Their encrypted values are not published or bound by
+`app_compose`.
 
 If the launcher config exists, `COMMIT_SHA` must be a full 40- or 64-character
 hexadecimal commit hash. Branch names, tags, and short hashes are rejected at

--- a/docs/providers/aci-service/verification.md
+++ b/docs/providers/aci-service/verification.md
@@ -4,6 +4,8 @@
 - **Session binding:** `tls_spki_sha256`
 - **Verifier:** native Rust — `AciServiceUpstreamVerifier` (`src/aci/verifier.rs`). No
   bridge / Python; this is the path for the gateway's own ACI-compatible workers.
+- **Versions:** ACI report wire format `aci/1`; verifier implementation
+  `aci-service/v2`.
 - **Status:** sound (designed with the keyset-digest binding from the start;
   covered by `tests/upstream_verifier.rs`).
 - **Audit:** none — first-party path; [`audit-criteria.md`](../audit-criteria.md) targets
@@ -24,10 +26,25 @@ canonical ACI report) from the worker and verifies it natively:
    - The keyset endorsement signature (identity key over the keyset digest) verifies.
    - Freshness: `fetched_at <= now < stale_after`.
 2. **DCAP quote** — `dcap_qvl` verifies the TDX quote against fetched collateral.
-3. **dstack event log + app-id** — replay the RTMR event log and extract/accept the
-   dstack app-id.
-4. **dstack KMS identity custody** — verify the secp256k1 KMS signature chain against
+3. **dstack event log, app-id, and Compose:** verify RTMR3, extract and accept
+   the measured app-id, and verify the Compose preimage as described below.
+4. **dstack KMS identity custody:** verify the secp256k1 KMS signature chain against
    the accepted KMS root key.
+
+## How the measured Compose is verified
+
+The ACI-service verifier connects `attestation.evidence.app_compose` to the
+verified TDX quote as follows:
+
+1. Verify the TDX quote and its nonce-bound `report_data`.
+2. Recompute the dstack runtime-event digests, replay the boot event log, and
+   require the result to equal RTMR3 in the verified quote.
+3. Read the pre-`system-ready` `compose-hash` event and require
+   `SHA256(UTF8(app_compose))` to equal that measured value.
+
+These checks prove integrity and measurement binding. They do not prove that an
+image, launcher, source revision, compiler, dependency, or OS build is
+acceptable. Those trust-policy checks remain separate.
 
 ## What binds the session
 
@@ -76,9 +93,11 @@ connection before forwarding.
 Tracking criteria 13–14 of [audit-criteria.md](../audit-criteria.md) (AciService has no
 separate `review.md`):
 
-- **Software provenance** (worker code → reviewed source): via the
-  `accepted_workload_ids` / `accepted_image_digests` policy plus `app_compose`.
-  **TODO:** populate and pin the reviewed allowlist (kept minimal today).
+- **Software provenance** (worker code → reviewed source): via the RTMR3-bound
+  `app_compose`, followed by launcher/image and source-provenance policy. The
+  native verifier proves the Compose preimage is measured. **TODO:** parse and
+  enforce the reviewed launcher/image/source allowlist rather than accepting a
+  workload id alone.
 - **Platform/OS provenance** (dstack guest OS / firmware → reviewed reproducible build):
   the dstack event-log RTMR replay and KMS-root custody are verified, but the reviewed
   dstack OS image digest is **TODO** to pin.

--- a/scripts/phala_multi_upstream_smoke.sh
+++ b/scripts/phala_multi_upstream_smoke.sh
@@ -10,7 +10,7 @@ Phala Cloud, deploys one router with a mounted upstream config file, and
 asserts the routing/receipt/metrics invariants.
 
 Environment:
-  PHALA_CLI              Phala CLI binary. Default: phala-h4xuser
+  PHALA_CLI              Phala CLI binary. Default: phala
   WORK_DIR               Artifact directory. Default: /tmp/private-ai-gateway-smoke-router
   NAME_PREFIX            CVM name prefix. Default: aci-route-smoke
   PHALA_GATEWAY_DOMAIN   Gateway domain. Default: dstack-pha-prod5.phala.network
@@ -20,7 +20,7 @@ Environment:
   HTTP_READY_ATTEMPTS    Attempts for endpoint readiness. Default: 60
 
 Requirements:
-  docker buildx, phala-h4xuser, curl, jq, cargo, sha256sum, awk
+  docker buildx, phala, curl, jq, cargo, sha256sum, awk
 
 Artifacts:
   The script writes compose files, reports, receipts, metrics, and deploy
@@ -36,7 +36,7 @@ fi
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-PHALA_CLI="${PHALA_CLI:-phala-h4xuser}"
+PHALA_CLI="${PHALA_CLI:-phala}"
 WORK_DIR="${WORK_DIR:-/tmp/private-ai-gateway-smoke-router}"
 NAME_PREFIX="${NAME_PREFIX:-aci-route-smoke}"
 PHALA_GATEWAY_DOMAIN="${PHALA_GATEWAY_DOMAIN:-dstack-pha-prod5.phala.network}"

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -520,7 +520,9 @@ Field rules:
   by proving that an attested, provenance-checked launcher fetched and ran a
   pinned commit. A report without acceptable provenance MUST be rejected by
   the verifier (the wire field may be absent on non-conformant or development
-  deployments).
+  deployments). The provenance claim alone is not evidence. A verifier MUST
+  connect it to a measurement in `attestation.evidence` and reject a claim that
+  does not match the measured deployment artifact.
 - **Freshness**: recency comes from the **nonce** — a client that checks its
   fresh `nonce` is bound into `report_data` knows the quote postdates the
   challenge. `fetched_at` / `stale_after` are the service's declared validity
@@ -546,8 +548,9 @@ publishes:
 {
   "quote": "<hex TDX quote>",
   "quote_report_data": "<hex report-data bytes bound by the quote>",
-  "event_log": [ "...boot / RTMR event log..." ],
-  "vm_config": { "...VM and TCB configuration..." },
+  "event_log": "<JSON-encoded boot / RTMR event-log array>",
+  "vm_config": "<JSON-encoded VM and TCB configuration>",
+  "app_compose": "<exact raw app-compose JSON>",
   "key_custody": { "provider": "dstack-kms", "keys": [ "...KMS signature chains..." ] },
   "downstream_tls_binding": { "domain": "<host>", "spki_sha256": "<hex>" }
 }

--- a/src/aci/keys.rs
+++ b/src/aci/keys.rs
@@ -66,6 +66,8 @@ pub struct Quote {
     /// VM / TCB configuration metadata. Serialised verbatim into the
     /// attestation envelope `evidence.vm_config`.
     pub vm_config: serde_json::Value,
+    /// Exact deployment-manifest preimage measured by dstack, when available.
+    pub app_compose: Option<String>,
 }
 
 /// Produces a TEE quote binding caller-supplied report-data.

--- a/src/aci/verifier/aci_service.rs
+++ b/src/aci/verifier/aci_service.rs
@@ -131,6 +131,12 @@ pub(super) enum AciServiceVerificationError {
     EventLogRtmrMismatch,
     #[error("dstack app-id event missing from verified event log")]
     MissingAppId,
+    #[error("dstack compose-hash event missing from verified event log")]
+    MissingComposeHash,
+    #[error("missing dstack app_compose evidence")]
+    MissingAppCompose,
+    #[error("dstack app_compose preimage does not match the RTMR3-bound compose hash")]
+    AppComposeHashMismatch,
     #[error("missing dstack KMS key custody evidence")]
     MissingKeyCustody,
     #[error("unsupported key custody provider: {0}")]
@@ -387,7 +393,7 @@ impl AciServiceUpstreamVerifier {
             cache_ttl_seconds,
             request_timeout_seconds,
             cache: RwLock::new(None),
-            verifier_id: "aci-service/v1".to_string(),
+            verifier_id: "aci-service/v2".to_string(),
         })
     }
 

--- a/src/aci/verifier/dstack.rs
+++ b/src/aci/verifier/dstack.rs
@@ -1,24 +1,18 @@
 //! dstack-specific verification helpers: event-log/app-id checks, RTMR replay,
 //! KMS identity custody, and secp256k1 key recovery.
 
+use dstack_sdk::dstack_client::EventLog as DstackEventLog;
 use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256VerifyingKey};
 use k256::EncodedPoint;
-use serde::Deserialize;
 use serde_json::Value;
-use sha2::{Digest, Sha384};
+use sha2::{Digest, Sha256, Sha384};
 use sha3::Keccak256;
 
 use super::aci_service::{dcap_rtmr3, AciServiceVerificationError, AciServiceVerifierPolicy};
 use super::decode_hex;
 use crate::aci::types::AttestationReport;
 
-#[derive(Debug, Deserialize)]
-struct DstackEventLog {
-    imr: u32,
-    digest: String,
-    event: String,
-    event_payload: String,
-}
+const DSTACK_RUNTIME_EVENT_TYPE: u32 = 0x08000001;
 
 pub(super) fn verify_dstack_event_log_and_app_id(
     evidence: &Value,
@@ -39,12 +33,64 @@ pub(super) fn verify_dstack_event_log_and_app_id(
     if rtmr3.as_slice() != quote_rtmr3 {
         return Err(AciServiceVerificationError::EventLogRtmrMismatch);
     }
-    let app_id = events
-        .iter()
-        .take_while(|event| !(event.imr == 3 && event.event == "system-ready"))
-        .find(|event| event.imr == 3 && event.event == "app-id")
+    let app_id = runtime_event_before_system_ready(&events, "app-id")?
         .ok_or(AciServiceVerificationError::MissingAppId)?;
-    decode_hex(&app_id.event_payload).map_err(AciServiceVerificationError::InvalidEventLog)
+    let app_id =
+        decode_hex(&app_id.event_payload).map_err(AciServiceVerificationError::InvalidEventLog)?;
+    let compose_hash = runtime_event_before_system_ready(&events, "compose-hash")?
+        .ok_or(AciServiceVerificationError::MissingComposeHash)?;
+    let compose_hash = decode_hex(&compose_hash.event_payload)
+        .map_err(AciServiceVerificationError::InvalidEventLog)?;
+    let compose_hash: [u8; 32] = compose_hash.as_slice().try_into().map_err(|_| {
+        AciServiceVerificationError::InvalidEventLog(format!(
+            "compose-hash event must contain 32 bytes, got {}",
+            compose_hash.len()
+        ))
+    })?;
+    verify_dstack_app_compose(evidence, &compose_hash)?;
+    Ok(app_id)
+}
+
+fn runtime_event_before_system_ready<'a>(
+    events: &'a [DstackEventLog],
+    event_name: &str,
+) -> Result<Option<&'a DstackEventLog>, AciServiceVerificationError> {
+    let mut matches = events
+        .iter()
+        .take_while(|event| {
+            !(event.imr == 3
+                && event.event_type == DSTACK_RUNTIME_EVENT_TYPE
+                && event.event == "system-ready")
+        })
+        .filter(|event| {
+            event.imr == 3
+                && event.event_type == DSTACK_RUNTIME_EVENT_TYPE
+                && event.event == event_name
+        });
+    let event = matches.next();
+    if matches.next().is_some() {
+        return Err(AciServiceVerificationError::InvalidEventLog(format!(
+            "multiple pre-system-ready {event_name} events"
+        )));
+    }
+    Ok(event)
+}
+
+/// Verify that `app_compose` is the preimage of the compose measurement bound
+/// into RTMR3 by the verified event log.
+pub(super) fn verify_dstack_app_compose(
+    evidence: &Value,
+    measured_compose_hash: &[u8; 32],
+) -> Result<(), AciServiceVerificationError> {
+    let app_compose = evidence
+        .get("app_compose")
+        .and_then(Value::as_str)
+        .ok_or(AciServiceVerificationError::MissingAppCompose)?;
+    let actual_compose_hash: [u8; 32] = Sha256::digest(app_compose.as_bytes()).into();
+    if &actual_compose_hash != measured_compose_hash {
+        return Err(AciServiceVerificationError::AppComposeHashMismatch);
+    }
+    Ok(())
 }
 
 fn replay_dstack_rtmr(
@@ -53,8 +99,7 @@ fn replay_dstack_rtmr(
 ) -> Result<[u8; 48], AciServiceVerificationError> {
     let mut mr = vec![0u8; 48];
     for event in events.iter().filter(|event| event.imr == imr) {
-        let mut digest =
-            decode_hex(&event.digest).map_err(AciServiceVerificationError::InvalidEventLog)?;
+        let mut digest = dstack_event_digest(event)?;
         if digest.len() < 48 {
             digest.resize(48, 0);
         }
@@ -64,6 +109,22 @@ fn replay_dstack_rtmr(
     mr.as_slice().try_into().map_err(|_| {
         AciServiceVerificationError::InvalidEventLog("replayed RTMR is not 48 bytes".to_string())
     })
+}
+
+fn dstack_event_digest(event: &DstackEventLog) -> Result<Vec<u8>, AciServiceVerificationError> {
+    if event.event_type != DSTACK_RUNTIME_EVENT_TYPE {
+        return decode_hex(&event.digest).map_err(AciServiceVerificationError::InvalidEventLog);
+    }
+
+    let payload =
+        decode_hex(&event.event_payload).map_err(AciServiceVerificationError::InvalidEventLog)?;
+    let mut hasher = Sha384::new();
+    hasher.update(event.event_type.to_ne_bytes());
+    hasher.update(b":");
+    hasher.update(event.event.as_bytes());
+    hasher.update(b":");
+    hasher.update(payload);
+    Ok(hasher.finalize().to_vec())
 }
 
 pub(super) fn verify_dstack_kms_identity_custody(
@@ -206,4 +267,66 @@ pub(super) fn compressed_k256_public_key_hex(public_key_hex: &str) -> Result<Str
     let key = K256VerifyingKey::from_encoded_point(&point)
         .map_err(|e| format!("invalid secp256k1 public key: {e}"))?;
     Ok(hex::encode(key.to_sec1_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime_event(event: &str, payload: &[u8]) -> DstackEventLog {
+        let mut event = DstackEventLog {
+            imr: 3,
+            event_type: DSTACK_RUNTIME_EVENT_TYPE,
+            digest: String::new(),
+            event: event.to_string(),
+            event_payload: hex::encode(payload),
+        };
+        event.digest = hex::encode(dstack_event_digest(&event).unwrap());
+        event
+    }
+
+    #[test]
+    fn replay_recomputes_runtime_event_digest_from_semantic_fields() {
+        let measured = runtime_event("app-id", &[0x11; 20]);
+        let expected_rtmr = replay_dstack_rtmr(std::slice::from_ref(&measured), 3).unwrap();
+
+        let mut tampered = runtime_event("compose-hash", &[0x22; 32]);
+        tampered.digest = measured.digest;
+        let tampered_rtmr = replay_dstack_rtmr(&[tampered], 3).unwrap();
+
+        assert_ne!(tampered_rtmr, expected_rtmr);
+    }
+
+    #[test]
+    fn semantic_events_must_be_dstack_runtime_events() {
+        let disguised_firmware_event = DstackEventLog {
+            imr: 3,
+            event_type: 0,
+            digest: hex::encode([0x33; 48]),
+            event: "compose-hash".to_string(),
+            event_payload: hex::encode([0x44; 32]),
+        };
+
+        assert!(
+            runtime_event_before_system_ready(&[disguised_firmware_event], "compose-hash")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_semantic_events() {
+        let compose_hash = runtime_event("compose-hash", &[0x44; 32]);
+        let err = runtime_event_before_system_ready(
+            &[compose_hash.clone(), compose_hash],
+            "compose-hash",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(
+            err,
+            "invalid dstack event_log evidence: multiple pre-system-ready compose-hash events"
+        );
+    }
 }

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use sha3::{Digest, Keccak256};
 
 use super::aci_service::{aci_report_tls_channel_bindings, CachedAciServiceVerification};
-use super::dstack::verify_dstack_kms_identity_custody;
+use super::dstack::{verify_dstack_app_compose, verify_dstack_kms_identity_custody};
 use super::external::ExternalProviderVerifier;
 use super::*;
 use crate::aci::keys::ALGO_ECDSA_SECP256K1;
@@ -1016,5 +1016,31 @@ fn rejects_dstack_kms_identity_key_custody_under_unaccepted_root() {
     assert_eq!(
         err,
         "dstack KMS root public key is not accepted by verifier policy"
+    );
+}
+
+#[test]
+fn verifies_dstack_app_compose_preimage_against_measured_hash() {
+    let app_compose = r#"{"manifest_version":"2","name":"gateway"}"#;
+    let compose_hash: [u8; 32] = sha2::Sha256::digest(app_compose.as_bytes()).into();
+    let evidence = json!({ "app_compose": app_compose });
+
+    verify_dstack_app_compose(&evidence, &compose_hash).unwrap();
+}
+
+#[test]
+fn rejects_dstack_app_compose_that_is_not_the_measured_preimage() {
+    let measured_app_compose = r#"{"manifest_version":"2","name":"gateway"}"#;
+    let compose_hash: [u8; 32] = sha2::Sha256::digest(measured_app_compose.as_bytes()).into();
+    let evidence = json!({
+        "app_compose": r#"{"manifest_version":"2","name":"other"}"#,
+    });
+
+    let err = verify_dstack_app_compose(&evidence, &compose_hash)
+        .unwrap_err()
+        .to_string();
+    assert_eq!(
+        err,
+        "dstack app_compose preimage does not match the RTMR3-bound compose hash"
     );
 }

--- a/src/aggregator/service/e2ee.rs
+++ b/src/aggregator/service/e2ee.rs
@@ -195,6 +195,9 @@ impl AciService {
             "event_log": quote.event_log,
             "vm_config": quote.vm_config,
         });
+        if let Some(app_compose) = quote.app_compose {
+            evidence["app_compose"] = Value::String(app_compose);
+        }
         let key_custody = self.keys.key_custody_evidence();
         if !key_custody.is_null() {
             evidence["key_custody"] = key_custody;

--- a/src/dstack.rs
+++ b/src/dstack.rs
@@ -348,6 +348,7 @@ impl DstackAciProvider {
             report_data: returned_report_data,
             event_log: serde_json::Value::String(event_log),
             vm_config: serde_json::Value::String(response.vm_config),
+            app_compose: Some(info.tcb_info.app_compose),
         })
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -306,6 +306,7 @@ impl StubQuoter {
             report_data,
             event_log: serde_json::Value::Null,
             vm_config: serde_json::json!({ "stub": true }),
+            app_compose: Some(r#"{"stub":true}"#.to_string()),
         }
     }
 }

--- a/tests/dstack_live.rs
+++ b/tests/dstack_live.rs
@@ -223,6 +223,7 @@ async fn dstack_live_provider_loads_kms_keys_and_quote() {
     assert!(quote.raw_quote.len() > 1024);
     assert!(quote.event_log.as_str().is_some_and(|s| !s.is_empty()));
     assert!(quote.vm_config.as_str().is_some_and(|s| !s.is_empty()));
+    assert!(quote.app_compose.as_deref().is_some_and(|s| !s.is_empty()));
 }
 
 #[tokio::test]
@@ -289,6 +290,9 @@ async fn dstack_live_aci_report_and_receipt_chain_verify() {
     assert_eq!(report.attestation.vendor, "phala");
     assert_eq!(report.attestation.tee_type, "tdx");
     assert_ne!(report.attestation.evidence["vm_config"]["stub"], true);
+    assert!(report.attestation.evidence["app_compose"]
+        .as_str()
+        .is_some_and(|s| !s.is_empty()));
 
     let endorsement_payload =
         identity::keyset_endorsement_payload(&report.attestation.workload_keyset).unwrap();
@@ -439,7 +443,7 @@ async fn dstack_live_aci_service_upstream_verifier_accepts_real_aci_service() {
         "{:?}",
         event.reason
     );
-    assert_eq!(event.verifier_id, "aci-service/v1");
+    assert_eq!(event.verifier_id, "aci-service/v2");
     assert!(event.evidence.is_some());
     assert_eq!(
         event.channel_bindings,

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -187,6 +187,10 @@ async fn attestation_report_endpoint_shape() {
         .get("value")
         .unwrap()
         .is_string());
+    assert_eq!(
+        body["attestation"]["evidence"]["app_compose"],
+        serde_json::json!(r#"{"stub":true}"#)
+    );
     // The capability advertisement is empty by default; no E2EE
     // version is wired.
     assert_eq!(


### PR DESCRIPTION
## Summary

- expose dstack's measured `app_compose` preimage in `GET /v1/aci/attestation`
- use the existing dstack SDK event-log type, recompute runtime-event digests from semantic fields, replay RTMR3, and bind `SHA256(app_compose)` to the measured `compose-hash` event
- keep the ACI wire format at `aci/1` while bumping the stricter native verifier identity to `aci-service/v2`
- document encrypted deployment variables accurately and leave image/source-code acceptance as an explicit verifier-policy TODO

## Why

The attestation endpoint returned the quote and event log but not the deployment-manifest preimage needed for independent Compose verification. The previous RTMR replay also trusted each event's supplied digest, so event names and payloads were not authenticated before being interpreted as `app-id` or `compose-hash`.

This adds the missing preimage and implements dstack's runtime-event digest algorithm without adding or vendoring another crate.

## Impact

The report change is additive, so the endpoint and `api_version: "aci/1"` remain unchanged. The native ACI-service verifier now requires valid `app_compose` evidence and reports `verifier_id: "aci-service/v2"`; producers should expose the new evidence before consumers switch to the stricter verifier.

Encrypted environment values remain outside the published Compose preimage. Binding accepted image digests or repository commits to reviewed source is intentionally deferred.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- private-identifier scan

Four live-dstack tests remain ignored unless a forwarded dstack socket and live PCCS access are configured.