### PR TITLE
feat(middleware): add tee_only_domains for TEE-only hosts

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -60,6 +60,7 @@ out-of-process hop. When the section is omitted the gateway serves directly.
 | `middleware.control_timeout_ms` | `60000` | Timeout for the pre-request consult and catalog fetches. A failed or timed-out consult fails closed. |
 | `middleware.control_post_timeout_ms` | `10000` | Timeout for the fire-and-forget post-request usage report. |
 | `middleware.sse_keepalive_ms` | `10000` | Idle keep-alive interval for streaming responses; `0` disables the heartbeat. |
+| `middleware.tee_only_domains` | `[]` | Hosts (matched against the request `Host` header, case-insensitive) that serve TEE models only. On these hosts the model catalog is forced to `?tee=true`, a non-TEE model is refused with `404` at the pre-consult (before any forward), and serving is forced to attested (`aci_verified`) upstreams — a client cannot opt out via `provider.aci_verified:false` or `X-Upstream-Verification: none`. Two predicates apply by design: the catalog/consult gate uses the model's `is_tee` capability flag, while serving is enforced against the deployment's attestation, so a listed `is_tee` model with no live attested deployment still fails closed (`503`). Empty (the default) leaves every host unrestricted. |
 
 Request outcome observation is always on and needs no configuration: every
 failed request that reaches the middleware completion path (consult denials,

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -38,12 +38,13 @@ use super::error_responses::{
     unknown_downstream_host_response, unsupported_e2ee_response, upstream_config_error_response,
 };
 use super::util::{
-    enforce_admin, enforce_owner, extract_bearer, has_e2ee_headers, header_str, request_host_domain,
+    enforce_admin, enforce_owner, extract_bearer, force_tee_true, has_e2ee_headers, header_str,
+    request_host_domain,
 };
 use super::AppState;
 use crate::middleware::errors::Surface;
 use crate::middleware::request_transform::Endpoint;
-use crate::middleware::{hash_api_key, CompletionInput};
+use crate::middleware::{hash_api_key, CompletionInput, Middleware};
 
 #[derive(Deserialize)]
 pub(super) struct AttestationQuery {
@@ -88,8 +89,13 @@ fn catalog_path(base: &str, query: Option<String>) -> String {
     }
 }
 
-pub(super) async fn models(State(state): State<AppState>, RawQuery(query): RawQuery) -> Response {
+pub(super) async fn models(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    RawQuery(query): RawQuery,
+) -> Response {
     if let Some(middleware) = state.middleware.clone() {
+        let query = tee_only_catalog_query(&middleware, &headers, query);
         return middleware
             .handle_catalog(&catalog_path("/v1/models", query))
             .await;
@@ -100,12 +106,26 @@ pub(super) async fn models(State(state): State<AppState>, RawQuery(query): RawQu
     }
 }
 
+/// On a TEE-only host, rewrite the relayed catalog query to force `?tee=true`
+/// (see `force_tee_true`); otherwise pass the client's query through unchanged.
+fn tee_only_catalog_query(
+    middleware: &Middleware,
+    headers: &HeaderMap,
+    query: Option<String>,
+) -> Option<String> {
+    match request_host_domain(headers) {
+        Some(host) if middleware.is_tee_only_domain(&host) => Some(force_tee_true(query)),
+        _ => query,
+    }
+}
+
 // Relay every /v1/models/<sub> sub-catalog to the middleware, which owns the
 // real routing (namespace, providers, ...). matchit 0.7.3 forbids a param and
 // a static sibling at the same position, so we relay the whole subtree rather
 // than enumerate routes here. Only meaningful in the middleware topology.
 pub(super) async fn models_subpath(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(rest): Path<String>,
     RawQuery(query): RawQuery,
 ) -> Response {
@@ -116,6 +136,7 @@ pub(super) async fn models_subpath(
             "model sub-catalogs are not available in direct-upstream mode",
         );
     };
+    let query = tee_only_catalog_query(&middleware, &headers, query);
     middleware
         .handle_catalog(&catalog_path(&format!("/v1/models/{rest}"), query))
         .await
@@ -125,6 +146,7 @@ pub(super) async fn models_subpath(
 // topology.
 pub(super) async fn embeddings_models(
     State(state): State<AppState>,
+    headers: HeaderMap,
     RawQuery(query): RawQuery,
 ) -> Response {
     let Some(middleware) = state.middleware.clone() else {
@@ -134,6 +156,7 @@ pub(super) async fn embeddings_models(
             "embedding model catalog is not available in direct-upstream mode",
         );
     };
+    let query = tee_only_catalog_query(&middleware, &headers, query);
     middleware
         .handle_catalog(&catalog_path("/v1/embeddings/models", query))
         .await
@@ -726,6 +749,16 @@ pub(super) async fn openai_completion_endpoint(
             Surface::Openai
         };
         let api_key_hash = extract_bearer(&headers).as_deref().map(hash_api_key);
+        // TEE-only host: force attested serving and refuse to be opted out of it.
+        // `aci_required` makes verification non-waivable at serve time, and forcing
+        // `upstream_required` closes the `X-Upstream-Verification: none` escape; the
+        // `tee_only` flag is carried to the control plane so a non-TEE model is a
+        // 404 before any forward. Client `provider.aci_verified:false` is ignored.
+        let tee_only = request_host_domain(&headers)
+            .as_deref()
+            .map_or(false, |host| middleware.is_tee_only_domain(host));
+        let upstream_required = upstream_required || tee_only;
+        let aci_required = aci.required || tee_only;
         let input = CompletionInput {
             endpoint,
             endpoint_path,
@@ -736,11 +769,12 @@ pub(super) async fn openai_completion_endpoint(
             requester,
             e2ee,
             upstream_required,
-            aci_required: aci.required,
+            aci_required,
             aci_session_ids: aci.session_ids,
             request_id: context.request_id,
             user_model: context.user_model,
             stream,
+            tee_only,
         };
         return middleware.handle_completion(&state.service, input).await;
     }

--- a/src/http/app/handlers.rs
+++ b/src/http/app/handlers.rs
@@ -756,7 +756,7 @@ pub(super) async fn openai_completion_endpoint(
         // 404 before any forward. Client `provider.aci_verified:false` is ignored.
         let tee_only = request_host_domain(&headers)
             .as_deref()
-            .map_or(false, |host| middleware.is_tee_only_domain(host));
+            .is_some_and(|host| middleware.is_tee_only_domain(host));
         let upstream_required = upstream_required || tee_only;
         let aci_required = aci.required || tee_only;
         let input = CompletionInput {

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -54,6 +54,24 @@ pub(super) fn normalize_host_domain(raw: &str) -> Option<String> {
     Some(domain)
 }
 
+/// Force `tee=true` onto a relayed catalog query string, dropping any
+/// client-supplied `tee` value and preserving every other param (e.g. `zdr`).
+/// Forcing rather than appending is deliberate: on a TEE-only host a client
+/// must not be able to widen the catalog back to the full set via `?tee=false`
+/// (nor trip the control plane's strict-`true` 400 on `?tee=anything-else`).
+pub(super) fn force_tee_true(query: Option<String>) -> String {
+    let mut params: Vec<String> = query
+        .as_deref()
+        .unwrap_or("")
+        .split('&')
+        .filter(|p| !p.is_empty())
+        .filter(|p| *p != "tee" && !p.starts_with("tee="))
+        .map(str::to_string)
+        .collect();
+    params.push("tee=true".to_string());
+    params.join("&")
+}
+
 pub(super) fn has_e2ee_headers(headers: &HeaderMap) -> bool {
     [
         "x-signing-algo",
@@ -91,6 +109,31 @@ pub(super) fn enforce_owner(
             "redaction_required",
             "the presented credential does not match the receipt owner",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::force_tee_true;
+
+    #[test]
+    fn force_tee_true_forces_and_dedupes() {
+        // No query at all -> just the forced param.
+        assert_eq!(force_tee_true(None), "tee=true");
+        assert_eq!(force_tee_true(Some(String::new())), "tee=true");
+        // A client `tee` value (including `false`) is dropped, never widening
+        // the catalog back to the full set.
+        assert_eq!(force_tee_true(Some("tee=false".to_string())), "tee=true");
+        assert_eq!(force_tee_true(Some("tee".to_string())), "tee=true");
+        // Other params survive, and only the client `tee` is stripped.
+        assert_eq!(
+            force_tee_true(Some("zdr=true&tee=false".to_string())),
+            "zdr=true&tee=true"
+        );
+        assert_eq!(
+            force_tee_true(Some("zdr=true".to_string())),
+            "zdr=true&tee=true"
+        );
     }
 }
 

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -112,6 +112,28 @@ pub(super) fn enforce_owner(
     }
 }
 
+pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+    let Some(expected) = state.admin_token.as_deref() else {
+        return Some(admin_not_found_response());
+    };
+    let Some(token) = extract_bearer(headers) else {
+        return Some(error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "admin bearer token required",
+        ));
+    };
+    if token == expected {
+        None
+    } else {
+        Some(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "invalid admin bearer token",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::force_tee_true;
@@ -134,27 +156,5 @@ mod tests {
             force_tee_true(Some("zdr=true".to_string())),
             "zdr=true&tee=true"
         );
-    }
-}
-
-pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Response> {
-    let Some(expected) = state.admin_token.as_deref() else {
-        return Some(admin_not_found_response());
-    };
-    let Some(token) = extract_bearer(headers) else {
-        return Some(error_response(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "admin bearer token required",
-        ));
-    };
-    if token == expected {
-        None
-    } else {
-        Some(error_response(
-            StatusCode::FORBIDDEN,
-            "forbidden",
-            "invalid admin bearer token",
-        ))
     }
 }

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -55,6 +55,10 @@ pub struct CompletionInput {
     pub request_id: String,
     pub user_model: Option<String>,
     pub stream: bool,
+    /// Request arrived on a TEE-only host: the pre-consult carries `tee: true`
+    /// so the control plane 404s a non-TEE model before any forward. Attested
+    /// serving itself is enforced via `aci_required` (forced true alongside this).
+    pub tee_only: bool,
 }
 
 /// Cap on the error-detail snippet in `request_outcome` lines. Long enough to
@@ -243,6 +247,7 @@ pub async fn run(
         request_id,
         user_model,
         stream,
+        tee_only,
     } = input;
 
     let started = Instant::now();
@@ -257,7 +262,7 @@ pub async fn run(
     let provider = params.get("provider");
 
     let consult = control
-        .consult_pre(model, api_key_hash.as_deref(), provider)
+        .consult_pre(model, api_key_hash.as_deref(), provider, tee_only)
         .await;
 
     let meter = Meter {

--- a/src/middleware/config.rs
+++ b/src/middleware/config.rs
@@ -29,4 +29,11 @@ pub struct MiddlewareConfig {
     /// `0` disables the heartbeat.
     #[serde(default)]
     pub sse_keepalive_ms: Option<u64>,
+    /// Hosts (matched against the request `Host` header) that serve TEE models
+    /// only. On these hosts the model catalog is forced to `?tee=true`,
+    /// non-TEE models are refused (404) at consult, and serving is forced to
+    /// attested (`aci_verified`) upstreams — a client cannot opt out. Empty
+    /// (the default) leaves every host unrestricted.
+    #[serde(default)]
+    pub tee_only_domains: Vec<String>,
 }

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -137,6 +137,7 @@ impl ControlClient {
         model: Option<&str>,
         api_key_hash: Option<&str>,
         provider: Option<&Value>,
+        tee_only: bool,
     ) -> PreConsult {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -149,12 +150,17 @@ impl ControlClient {
             // block must not silently drop the caller's routing restrictions).
             #[serde(skip_serializing_if = "Option::is_none")]
             provider: Option<&'a Value>,
+            // TEE-only host: the control plane 404s a non-TEE model. Only sent
+            // when set so the metadata-minimal payload is unchanged off these hosts.
+            #[serde(skip_serializing_if = "std::ops::Not::not")]
+            tee: bool,
         }
 
         let body = Body {
             api_key_hash,
             model,
             provider,
+            tee: tee_only,
         };
         let build = || {
             self.authorize(self.client.post(self.url("/consult/pre")))
@@ -265,6 +271,7 @@ mod tests {
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         }
     }
 
@@ -291,7 +298,7 @@ mod tests {
         // Port 1 is unroutable in practice; the request fails fast within the
         // configured timeout and must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
-        let consult = client.consult_pre(Some("m"), None, None).await;
+        let consult = client.consult_pre(Some("m"), None, None, false).await;
         assert!(!consult.allow);
         assert_eq!(consult.status, Some(503));
         assert_eq!(

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -168,13 +168,13 @@ mod tests {
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
-            tee_only_domains: vec!["Tee.Redpill.ai".to_string(), "  ".to_string()],
+            tee_only_domains: vec!["Tee.Example.com".to_string(), "  ".to_string()],
         })
         .unwrap();
         // Config entries are lowercased on load; the lookup key is an
         // already-normalized host from `request_host_domain`.
-        assert!(middleware.is_tee_only_domain("tee.redpill.ai"));
-        assert!(!middleware.is_tee_only_domain("api.redpill.ai"));
+        assert!(middleware.is_tee_only_domain("tee.example.com"));
+        assert!(!middleware.is_tee_only_domain("api.example.com"));
         // Blank entries are dropped, so an empty host never matches.
         assert!(!middleware.is_tee_only_domain(""));
     }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -16,6 +16,8 @@ pub mod sse;
 pub mod stream_transform;
 pub mod types;
 
+use std::collections::HashSet;
+
 use axum::{
     http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -32,6 +34,8 @@ use errors::Surface;
 pub struct Middleware {
     control: ControlClient,
     sse_keepalive_ms: Option<u64>,
+    /// Normalized (lowercased) TEE-only host set; see `MiddlewareConfig::tee_only_domains`.
+    tee_only_domains: HashSet<String>,
 }
 
 impl Middleware {
@@ -39,7 +43,20 @@ impl Middleware {
         Ok(Self {
             control: ControlClient::new(config)?,
             sse_keepalive_ms: config.sse_keepalive_ms,
+            tee_only_domains: config
+                .tee_only_domains
+                .iter()
+                .map(|d| d.trim().to_ascii_lowercase())
+                .filter(|d| !d.is_empty())
+                .collect(),
         })
+    }
+
+    /// Whether `host` (an already-normalized `Host` domain from
+    /// `request_host_domain`) is a TEE-only host. On these hosts the catalog is
+    /// forced to `?tee=true` and completions are forced to attested serving.
+    pub fn is_tee_only_domain(&self, host: &str) -> bool {
+        self.tee_only_domains.contains(host)
     }
 
     /// Relay a `/v1/...` catalog request to the control plane, which serves
@@ -109,6 +126,7 @@ mod tests {
             control_timeout_ms: Some(2_000),
             control_post_timeout_ms: Some(2_000),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         })
         .unwrap();
 
@@ -134,10 +152,30 @@ mod tests {
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         })
         .unwrap();
 
         let response = middleware.handle_catalog("/v1/models").await;
         assert_eq!(response.status().as_u16(), 502);
+    }
+
+    #[test]
+    fn is_tee_only_domain_matches_normalized_hosts() {
+        let middleware = Middleware::new(&MiddlewareConfig {
+            control_url: "http://control.invalid".to_string(),
+            control_token: None,
+            control_timeout_ms: Some(200),
+            control_post_timeout_ms: Some(200),
+            sse_keepalive_ms: None,
+            tee_only_domains: vec!["Tee.Redpill.ai".to_string(), "  ".to_string()],
+        })
+        .unwrap();
+        // Config entries are lowercased on load; the lookup key is an
+        // already-normalized host from `request_host_domain`.
+        assert!(middleware.is_tee_only_domain("tee.redpill.ai"));
+        assert!(!middleware.is_tee_only_domain("api.redpill.ai"));
+        // Blank entries are dropped, so an empty host never matches.
+        assert!(!middleware.is_tee_only_domain(""));
     }
 }

--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -833,6 +833,7 @@ mod tests {
             control_timeout_ms: Some(200),
             control_post_timeout_ms: Some(200),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         })
         .unwrap();
         let report = StreamReport {

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -125,6 +125,7 @@ async fn relays_catalogs_from_control() {
             control_timeout_ms: Some(2_000),
             control_post_timeout_ms: Some(2_000),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         })
         .unwrap(),
     );
@@ -158,6 +159,7 @@ async fn relays_catalog_query_string_to_control() {
             control_timeout_ms: Some(2_000),
             control_post_timeout_ms: Some(2_000),
             sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
         })
         .unwrap(),
     );

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -364,6 +364,7 @@ fn middleware(control_url: String) -> Middleware {
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        tee_only_domains: Vec::new(),
     })
     .unwrap()
 }
@@ -385,6 +386,7 @@ fn chat_input() -> CompletionInput {
         request_id: "req-1".to_string(),
         user_model: Some("gpt-test".to_string()),
         stream: false,
+        tee_only: false,
     }
 }
 
@@ -533,6 +535,7 @@ async fn meter_stream_injects_cost_classifies_completed_and_reports() {
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        tee_only_domains: Vec::new(),
     })
     .unwrap();
     let report = StreamReport {
@@ -1177,6 +1180,7 @@ async fn downstream_abort_before_settle_reports_gateway_failure_not_client_close
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        tee_only_domains: Vec::new(),
     })
     .unwrap();
     let downstream_abort = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -1236,6 +1240,7 @@ async fn downstream_abort_after_settle_does_not_double_report() {
         control_timeout_ms: Some(2_000),
         control_post_timeout_ms: Some(2_000),
         sse_keepalive_ms: None,
+        tee_only_domains: Vec::new(),
     })
     .unwrap();
     let downstream_abort = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));


### PR DESCRIPTION
## What

Adds an optional `middleware.tee_only_domains` list (matched against the request `Host` header, case-insensitive). On a listed host the gateway restricts traffic to TEE models:

- **Catalog** — `/v1/models*` relays are forced to `?tee=true`, dropping any client-supplied `tee` value (so `?tee=false` cannot widen the catalog back to the full set).
- **Completions** — `aci_required` and `upstream_required` are forced true, so serving is pinned to attested (`aci_verified`) upstreams and a client cannot opt out via `provider.aci_verified:false` or `X-Upstream-Verification: none`.
- **Pre-consult** — the request carries `tee: true`, so the control plane can refuse a non-TEE model with a `404` before any forward.

## Behavior on a TEE-only host

| Request | Result |
|---|---|
| `is_tee` model, attested deployment available | `200`, served attested |
| non-`is_tee` model (exists) | `404` (control consult gate, pre-forward) |
| model does not exist | `404` (normal model-not-found) |
| `is_tee` model, no live attested deployment | `503` (`NoEligibleAttestedRoute` at serve time) |
| client sets `aci_verified:false` / `X-Upstream-Verification:none` | ignored — attestation still enforced |

Two predicates apply by design: `is_tee` (model capability) gates admission; `aci_verified` (attested serving) gates reachability.

## Notes

- The field is `#[serde(default)]`, so existing configs parse unchanged and every host stays unrestricted unless listed. Safe to merge independently.
- The private control-plane 404 gate and the deploy config (`tee_only_domains` value + `REPO_COMMIT` bump) land in separate PRs. Because `MiddlewareConfig` is `deny_unknown_fields`, the compose change that sets `tee_only_domains` must not deploy until this is merged and pinned.

## Tests

- `force_tee_true` unit test (drops `tee=false`, preserves `zdr`, forces `tee=true`).
- `is_tee_only_domain` unit test (case-insensitive host match, blanks dropped).
- Completion-input test updated for the new `tee_only` field.
- `cargo check --tests` and the touched unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)