### PR TITLE
Add measured Privatemode sidecar upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dstack-sdk"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3264,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "dcap-qvl",
+ "dotenvy",
  "dstack-sdk",
  "ed25519-dalek",
  "flate2",
@@ -3278,6 +3285,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3 0.10.9",
+ "subtle",
  "thiserror 1.0.69",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,14 @@ rust_decimal = "1"
 # Cryptography.
 sha2 = "0.10"
 sha3 = "0.10"
+subtle = "2"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic", "ecdh"] }
 curve25519-dalek = "4"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 aes-gcm = "0.10"
 base64 = "0.22"
+dotenvy = "0.15.7"
 chacha20poly1305 = "0.10"
 flate2 = "1"
 hkdf = "0.12"

--- a/README.md
+++ b/README.md
@@ -268,7 +268,10 @@ Use the helper script when the gateway is reachable:
 uv run python scripts/live_e2e/user_verify.py \
   --base-url http://127.0.0.1:8086 \
   --chat-id "$RECEIPT_ID" \
-  --nonce "$NONCE"
+  --bearer-token "$INFERENCE_TOKEN" \
+  --nonce "$NONCE" \
+  --request-body request.json \
+  --response-body response.json
 ```
 
 The script's `--chat-id` argument accepts either a chat id or a receipt id. To
@@ -278,8 +281,18 @@ verify already captured artifacts, run the Rust verifier directly:
 cargo run --quiet --example verify_aci_artifacts -- \
   --report report.json \
   --receipt receipt.json \
-  --nonce "$NONCE"
+  --nonce "$NONCE" \
+  --request-body request.json \
+  --response-body response.json
 ```
+
+These commands verify cryptographic consistency. They surface the
+`upstream.verified` events but do not decide which gateway commit, measured
+Compose, provider image digest, or credential digest your policy
+accepts. Compare the attested `app_compose` and signed channel bindings against
+separately reviewed values; the
+[Privatemode deployment runbook](deploy/README.md#verify-a-privatemode-deployment)
+shows concrete assertions.
 
 ## Configure Upstreams
 
@@ -331,6 +344,7 @@ Supported `provider` values:
 | `near-ai` | NEAR AI gateway adapter with TLS binding from the provider report. |
 | `chutes` | Chutes adapter with provider E2EE key verification and encrypted `/e2e/invoke` transport. |
 | `secret-ai` | Direct SecretAI SecretVM adapter with CPU/GPU verification, measured production workload reporting, optional workload pinning, and enforced inference TLS SPKI. See [docs/providers/secret-ai/verification.md](docs/providers/secret-ai/verification.md). |
+| `privatemode` | Privatemode adapter using an official proxy image in the same measured dstack Compose, with dynamic Contrast manifest observation. See [docs/providers/privatemode/verification.md](docs/providers/privatemode/verification.md). |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint (one per model) with TLS SPKI binding from the version-2 attestation report. See [docs/providers/phala-direct/verification.md](docs/providers/phala-direct/verification.md). |
 
 ACI service verification policy is set on the upstream entry with
@@ -340,6 +354,12 @@ ACI service verification policy is set on the upstream entry with
 Tinfoil, NEAR AI, Chutes, SecretAI, and PhalaDirect use the Python provider
 verifier bridge. Set `PRIVATE_AI_VERIFIER_DIR` only when you need to override
 the bridge's vendored `confidential_verifier` package with an external checkout.
+Privatemode verification is delegated to the official proxy co-deployed with
+the gateway. The measured Compose binds the proxy image and topology; the Rust
+adapter validates the credential, enforces the pinned origin and encrypted
+handler set, and reports the proxy's latest fetched manifest digest as
+informational metadata. A relying party must verify that the attested
+`app_compose` contains the reviewed proxy image digest.
 
 For one-command Compose deployments, set `upstream_config_seed_path` in the
 static gateway config to a read-only seed file. The gateway validates and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,13 @@ This directory contains the one-file dstack compose path for launching
 Private AI Gateway through
 [`git-launcher`](https://github.com/Dstack-TEE/dstack-examples/tree/main/git-launcher).
 
+Two complete deployment files are provided:
+
+| File | Services |
+| --- | --- |
+| `compose.yaml` | Gateway only. |
+| `compose.privatemode.yaml` | Gateway plus the official digest-pinned Privatemode proxy in the same measured workload. |
+
 The launcher fetches a pinned `private-ai-gateway` commit, verifies `HEAD`,
 scrubs the checkout, preserves the container environment, and runs the gateway
 repo's own [`../entrypoint.sh`](../entrypoint.sh). The launcher remains
@@ -35,6 +42,58 @@ phala deploy -n private-ai-gateway -c compose.yaml \
   -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
 ```
 
+For Privatemode, use the co-deployed variant.
+[`privatemode.env.example`](./privatemode.env.example) lists all inputs.
+
+```bash
+cd deploy
+phala status
+docker compose version
+command -v jq
+command -v cargo
+command -v python3
+command -v sha256sum
+
+export PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
+export PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN=<long-random-client-token>
+export PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256="$(printf %s "$PRIVATE_AI_GATEWAY_INFERENCE_TOKEN" | sha256sum | cut -d' ' -f1)"
+export PRIVATEMODE_API_KEY=<privatemode-api-key>
+
+./render-privatemode-compose.sh /tmp/private-ai-gateway-privatemode.json
+phala deploy -n private-ai-gateway \
+  -c /tmp/private-ai-gateway-privatemode.json \
+  -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN="$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -e PRIVATEMODE_API_KEY="$PRIVATEMODE_API_KEY" \
+  --wait
+```
+
+Render before deployment so the credential digest, admin-token digest,
+downstream inference-token digest, image digest, and git commit are part of the
+measured Compose. The admin token
+itself is deliberately absent from the rendered file and is passed through
+Phala's encrypted environment instead. The downstream inference token remains
+client-side and is not passed to the deployment; callers send it as the Bearer
+credential on inference requests. The
+Privatemode API key follows the same path into one Compose-managed secret
+mounted into both services. The proxy reads it through its official
+`--apiKey @<file>` interface; the gateway reads it only at startup to verify the
+renderer-derived measured digest. `PrivatemodeProxyDeployment` neither retains
+the credential nor forwards it over the internal hop.
+
+That compose pins
+`ghcr.io/edgelesssys/privatemode/privatemode-proxy` at OCI digest
+`sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307`,
+runs the proxy in dynamic manifest mode, shares its public manifest history
+read-only with the gateway, mounts the credential secret into both services,
+and does not publish the proxy port. Add only the mutable model route through
+the admin API after boot; `bearer_token` is forbidden for Privatemode. The
+official proxy loads one credential at startup, so rotating it requires
+rerendering with the new `PRIVATEMODE_API_KEY` and redeploying the gateway and
+proxy together. A gateway-only restart with a secret that does not match
+measured policy fails closed.
+
 For local/dev deploys, you can also copy
 [`gateway.env.example`](./gateway.env.example), fill in its values, and pass it
 as `-e gateway.env`. For production, pass variables with repeated `-e KEY=VALUE`
@@ -44,7 +103,161 @@ arguments so secrets such as admin tokens do not remain in a plaintext env file.
 initial upstream config. dstack measures the raw manifest into `compose_hash`,
 and the published `app_compose` contains variable references rather than their
 values.
-After deployment, the gateway listens on port `8086`.
+After deployment, the gateway listens on port `8086`. The Privatemode variant
+rejects inference requests unless `Authorization: Bearer
+$PRIVATE_AI_GATEWAY_INFERENCE_TOKEN` hashes to the digest measured in its
+static config. Health, attestation, transparency, and model-catalog endpoints
+remain public. The admin API uses its separate admin token, and receipts owned
+by an authenticated inference request require that same inference bearer.
+
+### Verify a Privatemode deployment
+
+Resolve the public gateway URL, wait for the gateway to become ready, install
+the mutable model route, and exercise real attested inference:
+
+```bash
+set -euo pipefail
+CVM_NAME=private-ai-gateway
+APP_ID="$(
+  phala cvms list --search "$CVM_NAME" --json |
+    jq -er --arg name "$CVM_NAME" '
+      [.items[] | select(.cvmName == $name) | .appId] as $matches |
+      if ($matches | length) == 1
+      then $matches[0]
+      else error("expected exactly one exact CVM name match")
+      end
+    '
+)"
+GATEWAY_DOMAIN="$(
+  phala runtime-config "$APP_ID" --json | jq -er '.default_gateway_domain'
+)"
+GATEWAY_URL="https://${APP_ID}-8086.${GATEWAY_DOMAIN}"
+
+health_deadline=$((SECONDS + 600))
+until health_json="$(
+  curl -fsS --connect-timeout 5 --max-time 10 "$GATEWAY_URL/health"
+)" && jq -e '.status == "ok"' <<<"$health_json" >/dev/null; do
+  if (( SECONDS >= health_deadline )); then
+    echo "Gateway did not become ready within 10 minutes" >&2
+    phala ps "$APP_ID" || true
+    phala logs private-ai-gateway --cvm-id "$APP_ID" --stderr -n 200 || true
+    phala logs privatemode-proxy --cvm-id "$APP_ID" --stderr -n 200 || true
+    exit 1
+  fi
+  sleep 5
+done
+printf '%s\n' "$health_json" | jq .
+
+curl -fsS -X PUT "$GATEWAY_URL/v1/admin/upstreams" \
+  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary '[{
+    "name":"privatemode-gpt-oss",
+    "provider":"privatemode",
+    "base_url":"http://privatemode-proxy:8080",
+    "models":{"gpt-oss-120b-private":"gpt-oss-120b"}
+  }]' |
+  jq -e '.upstreams[] | select(.name == "privatemode-gpt-oss")'
+
+artifact_dir="$(mktemp -d)"
+jq -n '{
+  model: "gpt-oss-120b-private",
+  messages: [{role: "user", content: "Reply with exactly: private-ok"}],
+  provider: {aci_verified: true}
+}' >"$artifact_dir/request.json"
+curl -fsS -D "$artifact_dir/inference.headers" \
+  -o "$artifact_dir/inference.json" \
+  -X POST "$GATEWAY_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_INFERENCE_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @"$artifact_dir/request.json"
+receipt_id="$(
+  awk 'BEGIN{IGNORECASE=1} /^x-receipt-id:/{gsub("\r",""); print $2}' \
+    "$artifact_dir/inference.headers"
+)"
+test -n "$receipt_id"
+curl -fsS "$GATEWAY_URL/v1/aci/receipts/$receipt_id" \
+  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_INFERENCE_TOKEN" \
+  -o "$artifact_dir/receipt.json"
+
+nonce="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+curl -fsS "$GATEWAY_URL/v1/attestation/report?nonce=$nonce" \
+  -o "$artifact_dir/report.json"
+cargo run --quiet --manifest-path ../Cargo.toml \
+  --example verify_aci_artifacts -- \
+  --report "$artifact_dir/report.json" \
+  --receipt "$artifact_dir/receipt.json" \
+  --nonce "$nonce" \
+  --request-body "$artifact_dir/request.json" \
+  --response-body "$artifact_dir/inference.json"
+
+credential_sha256="$(
+  printf %s "$PRIVATEMODE_API_KEY" | sha256sum | cut -d' ' -f1
+)"
+proxy_image="ghcr.io/edgelesssys/privatemode/privatemode-proxy@sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+
+# Treat the locally reviewed render as policy. Structural JSON equality checks
+# every service image, command, environment value, mount, config, secret wiring,
+# port, and restart policy in one operation.
+jq -e \
+  --slurpfile expected /tmp/private-ai-gateway-privatemode.json '
+    (.attestation.evidence.app_compose | fromjson |
+      .docker_compose_file | fromjson) == $expected[0]
+  ' "$artifact_dir/report.json"
+
+# Independently require the signed receipt to cite the measured Privatemode
+# deployment that handled this request.
+jq -e \
+  --arg credential "$credential_sha256" \
+  --arg image_digest "${proxy_image##*@}" '
+    any(.event_log[];
+      .type == "upstream.verified" and
+      .required == true and
+      .result == "verified" and
+      .provider_type == "privatemode" and
+      any(.channel_bindings[];
+        .type == "proxy_image_sha256" and
+        .credential_sha256 == $credential and
+        .proxy_image_digest == $image_digest) and
+      .provider_claims.manifest_mode == "dynamic" and
+      .provider_claims.manifest_observation == "latest-proxy-fetch-log" and
+      .provider_claims.manifest_bound_to_active_secret == false and
+      (.provider_claims.observed_manifest_sha256 |
+        test("^[0-9a-f]{64}$")))
+  ' "$artifact_dir/receipt.json"
+```
+
+Every command above must exit zero. The inference must return HTTP 2xx and a
+non-empty `x-receipt-id`. The Rust verifier checks report binding, the attested
+keyset, receipt signature, and exact request/response hashes. The first `jq`
+assertion requires the complete attested Compose to equal the locally reviewed
+render; workload-owned labels are not treated as proof. The second independently
+applies local policy to the signed proxy binding and confirms that the receipt
+labels its manifest digest as an unbound observation. Do not treat that digest
+as the manifest used by this request's inference secret. See
+[Verify A Response](../README.md#verify-a-response) for the verification model.
+The first Rust verifier run may compile dependencies locally.
+
+Credential, image, or gateway-source rotation is a measured deployment update,
+not a container restart. Update the inputs, rerender, and reconcile both
+services. The proxy handles manifest updates dynamically:
+
+```bash
+./render-privatemode-compose.sh /tmp/private-ai-gateway-privatemode.json
+phala deploy --cvm-id "$APP_ID" \
+  -c /tmp/private-ai-gateway-privatemode.json \
+  -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN="$PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -e PRIVATEMODE_API_KEY="$PRIVATEMODE_API_KEY" \
+  --wait
+```
+
+For diagnostics:
+
+```bash
+phala ps "$APP_ID"
+phala logs private-ai-gateway --cvm-id "$APP_ID" --stderr -n 200
+phala logs privatemode-proxy --cvm-id "$APP_ID" --stderr -n 200
+```
 
 The gateway consumes two JSON files:
 
@@ -63,7 +276,8 @@ For a real deployment, replace the `gateway-upstreams` `content:` block in
 `compose.yaml` with the provider routes you want to boot with, or keep it
 empty and set the config after boot through `PUT /v1/admin/upstreams`.
 [`upstreams.example.json`](./upstreams.example.json) shows the current
-three-provider shape.
+generic provider shape. Privatemode routes require
+`compose.privatemode.yaml`; use the route in the verification sequence above.
 
 ## Ownership boundary
 
@@ -220,8 +434,9 @@ Example seed:
 ]
 ```
 
-Supported provider values are `openai-compatible`, `aci-service`, `tinfoil`,
-`near-ai`, `chutes`, `secret-ai`, and `phala-direct`.
+Supported provider values are `openai-compatible`, `anthropic`, `aci-service`,
+`tinfoil`, `near-ai`, `chutes`, `secret-ai`, `privatemode`, and
+`phala-direct`.
 
 For `aci-service`, `base_url` is the HTTPS origin used for both model traffic and
 `/v1/attestation/report`. The router fetches the report through normal TLS,
@@ -264,9 +479,10 @@ config is part of the trust surface.
 
 ## Toolchain Posture
 
-The current `entrypoint.sh` can bootstrap Rust with apt + rustup inside the
-TEE. That keeps the first deploy path simple, but it is a development-grade
-trust surface.
+The current `entrypoint.sh` can bootstrap a missing native compiler/linker
+with apt + build-essential and Rust with apt + rustup inside the TEE. That
+keeps the first deploy path simple, but it is a development-grade trust
+surface.
 
 The production target is a gateway-owned image that already contains the
 Rust toolchain, or eventually the prebuilt gateway binary. The launcher still

--- a/deploy/compose.privatemode.yaml
+++ b/deploy/compose.privatemode.yaml
@@ -1,0 +1,100 @@
+# dstack deployment with the official Privatemode proxy in the same measured
+# Compose workload as Private AI Gateway. Only the gateway port is published.
+
+services:
+  private-ai-gateway:
+    image: docker.io/dstacktee/git-launcher@sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b
+    command: ["/etc/git-launcher/gateway.conf"]
+    # Compose identifies mounted configs by source name, so also bind their
+    # immutable content pins into the service definition. A pin change then
+    # recreates the container instead of restarting it with stale config bytes.
+    labels:
+      ai.private-gateway.source-commit: ${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
+      ai.private-gateway.admin-token-sha256: ${PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256}
+      ai.private-gateway.inference-token-sha256: ${PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256}
+      ai.private-gateway.privatemode-credential-sha256: ${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}
+    ports:
+      - "8086:8086"
+    configs:
+      - source: gateway-pin
+        target: /etc/git-launcher/gateway.conf
+      - source: gateway-config
+        target: /etc/private-ai-gateway/gateway.config.json
+      - source: gateway-upstreams
+        target: /etc/private-ai-gateway/upstreams.seed.json
+    secrets:
+      - source: privatemode-api-key
+        target: privatemode-api-key
+    environment:
+      PRIVATE_AI_GATEWAY_CONFIG_PATH: /etc/private-ai-gateway/gateway.config.json
+      PRIVATE_AI_GATEWAY_CACHE_DIR: /var/lib/private-ai-gateway/cache
+      PRIVATE_AI_GATEWAY_ENV_FILE: /run/secrets/dstack-encrypted-env
+    volumes:
+      - gateway-checkout:/var/lib/git-launcher
+      - gateway-state:/var/lib/private-ai-gateway
+      - privatemode-manifests:/run/privatemode-manifests:ro
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - /dstack/.host-shared/.decrypted-env:/run/secrets/dstack-encrypted-env:ro
+    depends_on:
+      - privatemode-proxy
+    restart: unless-stopped
+
+  privatemode-proxy:
+    image: ghcr.io/edgelesssys/privatemode/privatemode-proxy@sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307
+    labels:
+      ai.private-gateway.privatemode-credential-sha256: ${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}
+    command:
+      - --workspace
+      - /var/lib/privatemode
+      - --port
+      - "8080"
+      - --apiKey
+      - "@/run/secrets/privatemode-api-key"
+      - --nvidiaOCSPAllowUnknown=false
+      - --nvidiaOCSPRevokedGracePeriod=0
+    tmpfs:
+      - /var/lib/privatemode:mode=0700
+    volumes:
+      - privatemode-manifests:/var/lib/privatemode/manifests
+    secrets:
+      - source: privatemode-api-key
+        target: privatemode-api-key
+    restart: unless-stopped
+
+configs:
+  gateway-pin:
+    content: |
+      REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+      COMMIT_SHA=${PRIVATE_AI_GATEWAY_REPO_COMMIT:?set PRIVATE_AI_GATEWAY_REPO_COMMIT to the audited full commit SHA}
+      WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+
+  gateway-config:
+    content: |
+      {
+        "bind": "0.0.0.0:8086",
+        "state_dir": "/var/lib/private-ai-gateway",
+        "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+        "admin_token_sha256": "${PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256}",
+        "inference_token_sha256": "${PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?set measured PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256}",
+        "dstack_endpoint": "unix:/var/run/dstack.sock",
+        "privatemode_proxy": {
+          "base_url": "http://privatemode-proxy:8080",
+          "manifest_log_path": "/run/privatemode-manifests/log.txt",
+          "credential_path": "/run/secrets/privatemode-api-key",
+          "credential_sha256": "${PRIVATEMODE_CREDENTIAL_SHA256:?set PRIVATEMODE_CREDENTIAL_SHA256 to the API credential digest}",
+          "proxy_image_digest": "sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
+        }
+      }
+
+  gateway-upstreams:
+    content: |
+      []
+
+volumes:
+  gateway-checkout:
+  gateway-state:
+  privatemode-manifests:
+
+secrets:
+  privatemode-api-key:
+    environment: PRIVATEMODE_API_KEY

--- a/deploy/gateway.config.example.json
+++ b/deploy/gateway.config.example.json
@@ -3,9 +3,13 @@
   "state_dir": "/var/lib/private-ai-gateway",
   "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
   "admin_token": "<long-random-admin-token>",
+  "inference_token_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
   "dstack_endpoint": "unix:/var/run/dstack.sock",
-  "middleware": {
-    "control_url": "https://control.example",
-    "control_token": "<control-plane-bearer-token>"
+  "privatemode_proxy": {
+    "base_url": "http://privatemode-proxy:8080",
+    "manifest_log_path": "/run/privatemode-manifests/log.txt",
+    "credential_path": "/run/secrets/privatemode-api-key",
+    "credential_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "proxy_image_digest": "sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307"
   }
 }

--- a/deploy/privatemode.env.example
+++ b/deploy/privatemode.env.example
@@ -1,0 +1,6 @@
+PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha>
+PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
+PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256=<sha256-of-admin-token>
+PRIVATE_AI_GATEWAY_INFERENCE_TOKEN=<long-random-client-token-not-passed-to-deployment>
+PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256=<sha256-of-inference-token>
+PRIVATEMODE_API_KEY=<privatemode-api-key-passed-only-as-encrypted-env>

--- a/deploy/render-privatemode-compose.sh
+++ b/deploy/render-privatemode-compose.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Render a self-contained measured Compose document.
+
+set -euo pipefail
+
+PROG=render-privatemode-compose.sh
+die() { printf '[%s] error: %s\n' "$PROG" "$*" >&2; exit 1; }
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "required tool not found in PATH: $1"
+}
+
+[[ $# -eq 1 ]] || die "usage: $PROG OUTPUT.json"
+output=$1
+[[ -n $output ]] || die "output path must not be empty"
+
+for name in \
+  PRIVATE_AI_GATEWAY_REPO_COMMIT \
+  PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256 \
+  PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256 \
+  PRIVATEMODE_API_KEY
+do
+  [[ -n ${!name:-} ]] || die "$name must be set"
+done
+
+require_tool docker
+require_tool sha256sum
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd)
+PRIVATEMODE_CREDENTIAL_SHA256=$(
+  printf '%s' "$PRIVATEMODE_API_KEY" | sha256sum | cut -d' ' -f1
+)
+export PRIVATEMODE_CREDENTIAL_SHA256
+
+mkdir -p -- "$(dirname -- "$output")"
+tmp=$(mktemp "${output}.tmp.XXXXXX")
+trap 'rm -f -- "$tmp"' EXIT
+
+docker compose -f "$script_dir/compose.privatemode.yaml" config --format json \
+  >"$tmp"
+
+for secret_name in \
+  PRIVATE_AI_GATEWAY_ADMIN_TOKEN \
+  PRIVATE_AI_GATEWAY_INFERENCE_TOKEN \
+  PRIVATEMODE_API_KEY
+do
+  secret_value=${!secret_name:-}
+  if [[ -n $secret_value ]] && grep -Fq -- "$secret_value" "$tmp"; then
+    die "$secret_name was embedded in the rendered Compose"
+  fi
+done
+
+docker compose -f "$tmp" config --quiet
+mv -- "$tmp" "$output"
+trap - EXIT
+
+printf '[%s] wrote %s\n' "$PROG" "$output" >&2

--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -187,16 +187,17 @@ auditor sees the full provider scope. The event carries a stable `provider_type`
 (distinct from the operator's per-endpoint config `name`) that selects the
 mapping. A `failed` result asserts nothing.
 
-| Claim | tinfoil | near-ai | chutes | phala-direct | secret-ai⁴ | generic |
-| --- | --- | --- | --- | --- | --- | --- |
-| `tee_attested` | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ verifier-derived |
-| `tcb_up_to_date` | tri-state¹ | tri-state¹ | tri-state¹ | tri-state¹ | TDX ✅ / SEV unknown | unknown |
-| `serving_software_known_good` | ✅ Sigstore² | unknown | unknown | unknown | optional pin | unknown |
-| `os_known_good` | unknown | unknown | unknown | unknown | ✅ registry | unknown |
-| `gpu_attested` | unknown | unknown | ✅³ | ✅³ | ✅ required | unknown |
-| `model_weights_provenance` | unknown | unknown | unknown | unknown | unknown | unknown |
+| Claim | tinfoil | near-ai | chutes | phala-direct | secret-ai⁴ | privatemode⁵ | generic |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `tee_attested` | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ hardware | ✅ verifier-derived | ✅ verifier-derived |
+| `tcb_up_to_date` | tri-state¹ | tri-state¹ | tri-state¹ | tri-state¹ | TDX ✅ / SEV unknown | unknown | unknown |
+| `serving_software_known_good` | ✅ Sigstore² | unknown | unknown | unknown | optional pin | unknown⁵ | unknown |
+| `os_known_good` | unknown | unknown | unknown | unknown | ✅ registry | unknown⁵ | unknown |
+| `gpu_attested` | unknown | unknown | ✅³ | ✅³ | ✅ required | unknown⁵ | unknown |
+| `model_weights_provenance` | unknown | unknown | unknown | unknown | unknown | unknown⁵ | unknown |
 
-- For the five real provider verifiers `tee_attested` is `HardwareProven`: a
+- For Tinfoil, NEAR AI, Chutes, PhalaDirect, and SecretAI, `tee_attested` is
+  `HardwareProven`: a
   genuine TEE quote was verified and the request channel bound to it. For NEAR AI
   this is the **gateway** TD — a router that fronts many models behind one TEE,
   so its attested session is the gateway *channel*: one session per router, not
@@ -209,6 +210,20 @@ mapping. A `failed` result asserts nothing.
   roadmap item is finer: binding the exact backend instance to a specific request
   (a per-instance, request-bound model attestation on the receipt — see
   [roadmap.md](roadmap.md)).
+- ⁵ Privatemode delegates Contrast verification and E2EE-secret ownership to the
+  official proxy co-deployed inside the gateway's measured dstack Compose. The
+  gateway pins the internal origin, shared credential digest, and proxy OCI
+  image digest, then requires an internal model-list readiness probe. The
+  unencrypted probe corroborates proxy startup and liveness but does not inspect
+  its current inference secret. Each encrypted inference performs the proxy's
+  fail-closed secret lookup. The proxy applies its static credential outbound;
+  the gateway sends no internal Bearer. The gateway also reports the proxy's
+  latest fetched manifest digest and fetch time.
+  Privatemode v1.48 writes that log before Coordinator verification and secret
+  exchange complete, so the observation is not bound to the active inference
+  secret. Manifest-specific GPU, OS, serving-software, model-weight, and TCB
+  claims therefore remain unknown. `tee_attested` is `VerifierDerived` from the
+  measured proxy's successful initial Contrast secret establishment.
 - ¹ `tcb_up_to_date` is an honest tri-state from the verifier's reported
   `tcb_status` (`HardwareProven`): `UpToDate` asserts, any other reported status
   **refutes** (the quote proves a stale TCB — the gateway records the bad claim

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -42,8 +42,24 @@ This is the smallest practical container config.
 | `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
+| `admin_token_sha256` | unset | Optional SHA-256 policy for the admin token supplied by config or `PRIVATE_AI_GATEWAY_ADMIN_TOKEN`. Startup fails on a missing or mismatched token. |
+| `inference_token_sha256` | unset | SHA-256 of the downstream bearer accepted by direct-mode inference POST endpoints; required when `privatemode_proxy` is configured without middleware and forbidden when middleware is enabled. The high-entropy bearer remains client-side. Missing or mismatched credentials are rejected before request parsing or forwarding. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
 | `middleware` | unset | Optional middleware section. When present, the gateway consults a control plane to route and authorize each request and applies request/response transforms; when unset it serves directly. See [Middleware](#middleware). |
+| `privatemode_proxy` | unset | Static policy for an official Privatemode proxy co-deployed in the same measured dstack Compose. The proxy uses dynamic manifests. Required before a `privatemode` route can load. |
+
+### Privatemode proxy
+
+`privatemode_proxy` belongs in static deployment config, not the mutable
+upstream database. All fields are required when the section is present.
+
+| Field | Meaning |
+| --- | --- |
+| `privatemode_proxy.base_url` | Internal HTTP(S) origin of the co-deployed proxy. Paths, credentials, queries, and fragments are rejected. |
+| `privatemode_proxy.manifest_log_path` | Absolute path to the proxy's read-only manifest-history log as mounted into the gateway. The latest entry is reported as unbound observation metadata. |
+| `privatemode_proxy.credential_path` | Absolute path to the Compose secret source mounted into both gateway and proxy. The gateway validates it but does not retain it in deployment state; the proxy owns its use. |
+| `privatemode_proxy.credential_sha256` | SHA-256 of that mounted API credential. The renderer derives it from `PRIVATEMODE_API_KEY`; a mismatch in the live shared secret fails startup. |
+| `privatemode_proxy.proxy_image_digest` | OCI digest of the proxy image pinned in the same Compose, in `sha256:<64-hex>` form. |
 
 ## Middleware
 
@@ -51,7 +67,10 @@ The optional `middleware` section runs the middleware in the request
 path. When present, the gateway consults a control plane at `control_url` to
 authorize and route each request, shapes the provider request, injects response
 cost, and reports usage back to the control plane — all in-process, with no
-out-of-process hop. When the section is omitted the gateway serves directly.
+out-of-process hop. The gateway hashes each client's original bearer as
+`apiKeyHash` for control-plane authorization, attribution, and billing; it does
+not replace distinct client credentials with the direct-mode inference token.
+When the section is omitted the gateway serves directly.
 
 | Field | Default | Use |
 | --- | --- | --- |
@@ -189,6 +208,7 @@ Supported `provider` values:
 | `near-ai` | NEAR AI provider adapter. |
 | `chutes` | Chutes provider adapter. |
 | `secret-ai` | Direct SecretAI SecretVM origin with optional workload pinning; see [SecretAI verification](providers/secret-ai/verification.md). |
+| `privatemode` | Official Privatemode proxy co-deployed in the measured Compose. Forbids `bearer_token` and `path`, and requires a `base_url` exactly matching static `privatemode_proxy.base_url`. |
 | `phala-direct` | Direct Phala dstack-vllm-proxy endpoint. |
 
 Provider verification policy belongs on the upstream entry. For ACI service
@@ -213,6 +233,15 @@ For `aci-service`, `base_url` is the HTTPS origin used for both model traffic an
 derives the attested TLS SPKI binding from that report, then pins that SPKI for
 the actual upstream model request.
 
+For `privatemode`, dstack Compose owns the proxy process, image pin, shared
+manifest-history volume, restart policy, and private network. Mutable routes must match the static
+origin and cannot set `bearer_token` or `path`; all share the measured Compose
+credential. The gateway validates the credential digest, requires a bounded
+model-list readiness probe, reports the latest fetched manifest as explicitly
+unbound metadata, and forwards only to the encrypted v1.48 handlers. Separate
+credentials require separate measured deployments.
+See [Privatemode verification](providers/privatemode/verification.md).
+
 ## Environment Variables
 
 The gateway runtime reads only these environment variables. Provider verifier
@@ -222,6 +251,8 @@ bridges may consume provider-specific environment variables such as
 | Variable | Use |
 | --- | --- |
 | `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Selects the static gateway config file. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Optional runtime secret overriding static `admin_token`. |
+| `PRIVATE_AI_GATEWAY_ENV_FILE` | Optional dotenv file consulted for `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` when that variable is absent. The Privatemode Compose points it at dstack's decrypted, TEE-internal deployment environment. |
 | `RUST_LOG` | Tracing filter consumed by `tracing_subscriber`. |
 
 Deployment tooling also uses these variables:
@@ -233,4 +264,7 @@ Deployment tooling also uses these variables:
 | `RUSTUP_HOME` | Optional override for Rustup state. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
 | `CARGO_TARGET_DIR` | Optional override for Cargo build output. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
 | `PRIVATE_AI_GATEWAY_REPO_COMMIT` | Used by `deploy/compose.yaml` interpolation for the git-launcher `COMMIT_SHA` pin. |
-| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Used by `deploy/compose.yaml` interpolation for the static config's `admin_token`. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | `deploy/compose.yaml` interpolates this legacy input; `compose.privatemode.yaml` instead reads it from dstack's TEE-internal decrypted environment file. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256` | Non-secret digest rendered into `compose.privatemode.yaml`; binds the encrypted admin token to measured static policy. |
+| `PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256` | Non-secret digest rendered into `compose.privatemode.yaml`; binds the client-held bearer required by paid inference endpoints. |
+| `PRIVATEMODE_API_KEY` | Encrypted deployment input mounted as one Compose secret into both services. The renderer derives `PRIVATEMODE_CREDENTIAL_SHA256` for measured static policy; the gateway verifies the live mounted bytes before serving. |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -13,6 +13,7 @@ One directory per upstream provider. Each holds up to two documents:
 | Chutes | Intel TDX + NVIDIA CC | `e2ee_public_key_sha256` | [configuration](chutes/configuration.md), [verification](chutes/verification.md) | [review](chutes/review.md) |
 | NEAR AI | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](near-ai/verification.md) | [review](near-ai/review.md) |
 | Tinfoil | AMD SEV-SNP (or TDX) + NVIDIA CC | `tls_spki_sha256` | [verification](tinfoil/verification.md) | [review](tinfoil/review.md) |
+| Privatemode | AMD SEV-SNP or Intel TDX + NVIDIA CC | `proxy_image_sha256` plus unbound manifest observation | [verification](privatemode/verification.md) | [review](privatemode/review.md) |
 | AciService (first-party) | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](aci-service/verification.md) | — (first-party) |
 | PhalaDirect | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](phala-direct/verification.md) | [review](phala-direct/review.md) |
 | SecretAI | AMD SEV-SNP or Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](secret-ai/verification.md) | [review](secret-ai/review.md) |
@@ -49,18 +50,24 @@ partition from Redpill tenant identity.
 
 ## The shared verification model
 
-**A session binding is only trustworthy if it is bound into a verified attestation.**
-Every provider produces exactly one kind of binding, and in every case the bound value
-lives inside (or is digested into) the quote/report whose signature is verified. Each
-`verification.md` states plainly *what is bound* and *what a tamper rejects*.
+**A session binding is only trustworthy if it is bound into a verified attestation or
+an attestation-gated key-release protocol.** Every provider produces exactly one kind
+of binding. The bound value either lives inside the signed quote/report or identifies
+the attested policy that gates the provider's encryption secret. Each `verification.md`
+states plainly *what is bound* and *what a tamper rejects*.
 
-The two binding types:
+The binding types:
 
 - **`tls_spki_sha256`** — SHA-256 fingerprint of the upstream's TLS public key; the
   backend enforces it against the actual upstream HTTPS connection before forwarding.
 - **`e2ee_public_key_sha256`** — SHA-256 of the upstream's end-to-end public key; the
   backend encrypts the request body to that key, so only the attested enclave can
   decrypt.
+- **`proxy_image_sha256`** — SHA-256 of an official proxy OCI image plus its
+  shared credential digest. dstack launches the proxy beside the gateway from
+  the same measured Compose, and the gateway accepts only the statically pinned
+  internal service origin. Provider manifest metadata remains separate evidence
+  until the proxy binds it to the E2EE secret used for a request.
 
 ### Invariant: verified ⟹ enforceable binding
 

--- a/docs/providers/privatemode/review.md
+++ b/docs/providers/privatemode/review.md
@@ -1,0 +1,125 @@
+# Privatemode provider review
+
+Audit date: 2026-05-26 UTC. Provider behavior was rechecked against
+Privatemode v1.48 and the live manifest on 2026-07-09. The gateway adapter was
+changed to the measured co-deployment boundary on 2026-07-13 and to dynamic
+manifest mode on 2026-07-31.
+
+Provider: [Privatemode](https://www.privatemode.ai/) by Edgeless Systems.
+TCB source: [`edgelesssys/privatemode-public`](https://github.com/edgelesssys/privatemode-public).
+Attestation framework: [`edgelesssys/contrast`](https://github.com/edgelesssys/contrast).
+
+## Verdict
+
+**Acceptable with conditions.** Privatemode has one of the strongest engineering
+postures in the surveyed provider set. Its full encryption lifecycle was
+reproduced against production: the client proxy verified the Coordinator,
+obtained the attested Mesh CA, exchanged an inference secret, encrypted a live
+chat request, decrypted the response, and streamed successfully. The public API
+rejected a plaintext request.
+
+Deployment conditions:
+
+- Pin the official proxy OCI image by digest in the same measured dstack
+  Compose as the gateway.
+- Require every mutable Privatemode route to use the statically pinned internal
+  service origin.
+- Disable HTTP redirects for proxy readiness and forwarding requests.
+- Bind the accepted credential digest in measured static policy and require a
+  coordinated gateway/proxy redeploy to change it, matching the proxy's
+  startup credential ownership semantics.
+- Expose only the gateway listener from the workload network. Version 1.48 of
+  the official proxy has no listen-address flag and opens its configured port on
+  the network namespace's wildcard address.
+- Override the proxy's availability-oriented NVIDIA OCSP defaults: reject
+  unknown status and use no revoked-certificate grace period.
+- Use the proxy's dynamic manifest mode so provider updates do not require a
+  gateway redeployment.
+- Surface the latest fetched manifest digest as explicitly unbound metadata.
+  Do not derive manifest-specific claims until the proxy exposes the manifest
+  bound to the active inference secret.
+- Treat the proxy as part of the TCB. The gateway does not possess the provider
+  E2EE secret.
+
+## Verified trust chain
+
+The observed chain was:
+
+```text
+SEV-SNP or TDX hardware evidence
+  -> Contrast reference values in the dynamically fetched manifest
+    -> Coordinator policy admitted
+      -> attested Coordinator supplies Mesh CA
+        -> Secret Service authenticates under that Mesh CA
+          -> inference secret released only to admitted workers
+            -> official proxy encrypts request bodies to those workers
+```
+
+The manifest pins workload policies and hardware reference values. During the
+original audit it included strict SNP guest policy and chip allowlists, TDX
+measurements/platform identities, minimum TCB versions, and separate policies
+for the Coordinator, Secret Service, and model workloads. The 2026-07-09 live
+manifest still contained exactly one Coordinator policy, SNP and TDX reference
+profiles, and one seed-share owner key.
+
+Privatemode's model workers place decryption in an inference-proxy sidecar
+inside the confidential VM. Plaintext is then passed locally to the model
+server. The public edge sees encrypted bodies and routes them to workers.
+
+## Criteria status
+
+Passed:
+
+- Workload identity is measured and admitted under Contrast policy.
+- The inference secret is released through an attested Mesh-CA chain.
+- CPU-TEE and GPU confidential-computing checks gate worker activation.
+- Model workloads and deployment images are published in the TCB source.
+- Builds are reproducible and releases are versioned.
+- The public endpoint rejects unencrypted inference traffic.
+- OpenAI-compatible chat, streaming, embeddings, models, and other documented
+  surfaces are mediated by the official proxy.
+
+Open or conditional:
+
+- The manifest publication channel has no detached signature. Dynamic mode
+  fetches through CDN TLS, then verifies that the Coordinator attestation
+  matches the exact fetched manifest before accepting its Mesh CA.
+- The observed manifest has one RSA seed-share owner key. Public ownership,
+  recovery procedure, rotation policy, and quorum expectations should be
+  documented.
+- Privatemode does not expose a per-worker TLS SPKI or public E2EE key for the
+  gateway to pin directly. Its binding is transitive through the manifest,
+  attested Coordinator/Mesh CA, and secret-release protocol.
+- Version 1.48 does not expose which manifest produced the active inference
+  secret. Its manifest history is written before attestation and secret
+  exchange complete. The gateway therefore reports the latest fetched digest
+  but does not use it for manifest-specific claims.
+- The exact served worker is not named in a per-request signed receipt. ACI
+  records the selected model and measured proxy session.
+
+## Validation evidence
+
+The original audit reproduced initial attestation, secret exchange, buffered
+chat, and SSE streaming against production; a direct plaintext request to the
+public API was rejected. The co-deployed v1.48 boundary was then exercised on
+Phala Cloud on 2026-07-13 with a real `gpt-oss-120b` response and a signed
+receipt.
+
+A later source trace showed that the proxy replaces inbound authorization with
+its startup credential. The current adapter therefore sends no internal Bearer,
+validates the shared Compose credential digest itself, and records that digest
+in the enforced binding. Tests cover the proxy-image and credential pins,
+dynamic manifest observation, bounded readiness probe, redirect refusal,
+encrypted-handler allowlist, buffered and streaming paths, and receipt binding.
+See [verification.md](verification.md) for the current contract and its
+freshness limits.
+
+## Adapter decision
+
+The gateway does not reimplement Contrast or copy only its quote checks. dstack
+owns the official proxy lifecycle as a separate service in the same measured
+Compose. The gateway verifier and forwarding backend share immutable static
+policy for that service. Receipts bind the shared credential digest, official
+proxy image digest, and internal origin that carried the request. They expose
+the latest manifest-log entry as unbound evidence. See
+[verification.md](verification.md) for the enforced contract.

--- a/docs/providers/privatemode/verification.md
+++ b/docs/providers/privatemode/verification.md
@@ -1,0 +1,146 @@
+# Privatemode co-deployed proxy verification
+
+- **TEE:** AMD SEV-SNP or Intel TDX with NVIDIA Confidential Computing
+- **Session binding:** `proxy_image_sha256`
+- **Verifier:** official `privatemode-proxy` co-deployed in the gateway's
+  measured dstack Compose
+- **Transport:** private Compose HTTP to the proxy, then Privatemode full-body
+  E2EE to model workers
+- **Manifest mode:** dynamic
+- **Audit:** see [review.md](review.md)
+
+## Trust boundary
+
+The official proxy verifies the Contrast Coordinator, obtains the Mesh CA,
+exchanges an inference secret, and encrypts inference bodies with that secret.
+The gateway delegates the complete protocol to the proxy instead of
+reimplementing individual quote checks.
+
+dstack launches the gateway and proxy as separate services in one measured
+Compose workload. The measurement binds the proxy image, command, credential
+digest, private network topology, and shared manifest-history volume. The proxy
+port is not published. Mutable upstream configuration cannot change the proxy
+origin, supply another credential, or select a proxy path.
+
+The proxy uses dynamic manifest mode. It fetches the current manifest when it
+needs a Mesh CA and verifies the Coordinator against those exact bytes before
+using the CA. It calls `LatestSecret` before each encrypted inference attempt.
+An expired secret that cannot be refreshed fails the request.
+
+## What the manifest observation proves
+
+Privatemode v1.48 writes every fetched manifest to
+`<workspace>/manifests/log.txt`. The gateway reads the latest version from the
+shared read-only manifest-history volume and reports:
+
+- `observed_manifest_sha256`
+- `manifest_observed_at`
+- `manifest_observation: "latest-proxy-fetch-log"`
+- `manifest_bound_to_active_secret: false`
+
+This is useful update visibility, but it is not a channel binding. The proxy
+writes the history entry before Coordinator verification and before secret
+exchange completes. The v1.48 API does not expose the manifest associated with
+the secret used for a request. A receipt therefore must not use the observation
+to assert manifest-specific GPU, OS, serving-software, or model-weight claims.
+
+The observation may also be older than the request by the route's
+`verifier_cache_seconds` lease. Its timestamp states when the proxy fetched the
+manifest, not when the gateway emitted the receipt.
+
+## Verification and forwarding
+
+At startup, the gateway validates the mounted API credential against its
+measured SHA-256 digest. It retains no credential bytes in deployment state.
+The measured proxy image is pinned by OCI digest.
+
+For route verification, the gateway:
+
+1. Sends an unauthenticated `GET /v1/models` to the pinned internal proxy
+   origin.
+2. Rejects redirects, ambient HTTP proxies, non-success status, non-JSON
+   responses, and bodies larger than 1 MiB.
+3. Reads and validates the latest manifest-history entry.
+4. Emits the measured proxy binding and the explicitly unbound manifest
+   observation.
+
+The model-list probe corroborates proxy startup and liveness. It does not use or
+identify the current inference secret.
+
+For inference, the gateway permits only the encrypted v1.48 handlers:
+
+- `/v1/chat/completions`
+- `/v1/completions`
+- `/v1/embeddings`
+- `/v1/messages`
+
+The gateway sends no internal Bearer token. The proxy applies its measured
+startup credential outbound. The forwarding client rejects redirects and
+ignores HTTP proxy environment variables.
+
+Plain HTTP is intentional on the internal hop. Both services and the private
+network are inside the same attested dstack workload. Privatemode E2EE protects
+the request after it leaves that workload.
+
+## Session binding and claims
+
+The verified event contains:
+
+```json
+{
+  "type": "proxy_image_sha256",
+  "provider": "privatemode",
+  "proxy_image_digest": "sha256:...",
+  "credential_sha256": "..."
+}
+```
+
+The event's `url_origin` is the measured internal origin. Its verifier ID is
+`privatemode-proxy/co-deployed-contrast/v1`.
+
+The session asserts `tee_attested` as `VerifierDerived`: the measured proxy must
+establish a Contrast-attested E2EE secret before it starts serving. These claims
+remain `Unknown` until the proxy exposes a request-bound active manifest:
+
+- `gpu_attested`
+- `tcb_up_to_date`
+- `os_known_good`
+- `serving_software_known_good`
+- `model_weights_provenance`
+
+The full observed manifest is retained as session evidence with
+`bound_to_active_secret: false`.
+
+## Failure behavior
+
+The route fails closed when:
+
+- static proxy policy is absent or its origin does not match the route;
+- the credential is missing, malformed, or has the wrong digest;
+- the proxy image digest is malformed;
+- mutable configuration supplies a Bearer token or path;
+- the model-list probe fails;
+- the manifest log is malformed or its latest file is missing or unreadable;
+- forwarding targets a handler outside the encrypted allowlist; or
+- the verified proxy-image binding differs from the active deployment.
+
+There is no fallback to the public Privatemode API, another proxy, an HTTP
+redirect, or an ambient HTTP proxy.
+
+## Configuration and updates
+
+Use the [deployment runbook](../../../deploy/README.md#verify-a-privatemode-deployment)
+and [configuration reference](../../configuration-reference.md#privatemode-proxy).
+
+The official proxy refreshes the manifest when secret refresh needs a new Mesh
+CA. A proxy-image or credential change requires a measured redeployment. A
+manifest update does not require a redeployment, but relying parties should
+review the new observed digest before assigning manifest-specific transitive
+claims outside the gateway.
+
+## Sources
+
+- [Privatemode attestation overview](https://docs.privatemode.ai/architecture/attestation/overview/)
+- [Privatemode proxy configuration](https://docs.privatemode.ai/api/proxy-configuration/)
+- [Privatemode TCB source](https://github.com/edgelesssys/privatemode-public)
+- [Contrast source](https://github.com/edgelesssys/contrast)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,7 +59,9 @@ An attested session is a verified secure channel, and we never create more than
 one session per channel. The channel boundary a provider attests is a first-class
 property, `UpstreamProvider::attestation_scope()` → `AttestationScope`: per E2EE
 instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
-(NEAR AI) or model router (Tinfoil), where one channel fronts many models. The
+(NEAR AI), model router (Tinfoil), or manifest-bound encryption proxy
+(Privatemode's measured co-deployed proxy), where one channel fronts
+many models. The
 scope is the single source of truth: it drives channel-keyed verification (the
 model is dropped from the verifier cache key for routers, so every model resolves
 to one verified channel and one attested session) and is enforced fail-closed at

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,10 @@
 #   toolchain is our concern, not the launcher's.
 #
 # What it does
-#   1. If `cargo` is not on PATH, this aggregator chooses to bootstrap a
-#      Rust toolchain via apt + rustup. That choice is internal to the
-#      aggregator (see "Aggregator-owned trust surface" below) and would
-#      become dead code under a Rust-capable aggregator image.
+#   1. Installs any missing native build toolchain, and if `cargo` is not on
+#      PATH bootstraps Rust via apt + rustup. Those choices are internal to
+#      the aggregator (see "Aggregator-owned trust surface" below) and would
+#      become dead code under a build-capable aggregator image.
 #   2. Builds in release mode with --locked so Cargo.lock is authoritative
 #      (a rebuild that would require resolver-level changes is a hard
 #      failure, not silent dependency drift).
@@ -35,21 +35,22 @@
 #     hard exit.
 #
 # Aggregator-owned trust surface in this slice
-#   This slice chooses runtime apt + rustup bootstrap so the aggregator
+#   This slice chooses runtime apt + build-essential + rustup bootstrap so the aggregator
 #   can run on top of the stock launcher image unchanged. That choice
-#   brings three things into this aggregator's trust surface that a
-#   pre-built Rust-capable aggregator image would not:
+#   brings four things into this aggregator's trust surface that a
+#   pre-built build-capable aggregator image would not:
 #
 #     * the Ubuntu archive index that apt-get fetches at deploy time;
+#     * the native compiler and linker shipped by build-essential;
 #     * the rustup CDN / signature key shipped by the rustup package;
 #     * whichever rustc the upstream stable channel resolved to at build
 #       time.
 #
-#   The production fix is a Rust-capable aggregator image - owned by
-#   this repo, not by the launcher - that pre-installs rustc/cargo and
+#   The production fix is a build-capable aggregator image - owned by
+#   this repo, not by the launcher - that pre-installs cc/rustc/cargo and
 #   pre-populates the crate cache. When that image exists, the
-#   `if ! command -v cargo` block becomes dead code; everything else in
-#   this script is unchanged. See deploy/README.md for the recipe.
+#   bootstrap below becomes dead code; everything else in this script is
+#   unchanged. See deploy/README.md for the recipe.
 
 set -euo pipefail
 
@@ -79,16 +80,24 @@ export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-$PRIVATE_AI_GATEWAY_CACHE_DIR/target
 mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$CARGO_TARGET_DIR"
 export PATH="$CARGO_HOME/bin:$PATH"
 
-# Aggregator-internal bootstrap: if no Rust toolchain is present in the
-# image we are running on, this aggregator installs one. The launcher is
-# build-system agnostic and does not care what language we are written
-# in; supplying our own toolchain is our responsibility.
-if ! command -v cargo >/dev/null 2>&1; then
-  log "cargo not on PATH; aggregator bootstrapping a Rust toolchain via apt + rustup."
+# Aggregator-internal bootstrap: install the native build toolchain and/or
+# Rust toolchain when the launcher image does not provide them. Cargo alone is
+# insufficient: Rust build scripts and the final link require `cc`.
+need_cc=0
+need_rust=0
+command -v cc >/dev/null 2>&1 || need_cc=1
+command -v cargo >/dev/null 2>&1 || need_rust=1
+
+if ((need_cc || need_rust)); then
+  apt_packages=(ca-certificates)
+  ((need_cc)) && apt_packages+=(build-essential)
+  ((need_rust)) && apt_packages+=(rustup)
+
+  log "installing missing build prerequisites via apt: ${apt_packages[*]}"
   log "WARNING: dev-grade trust path. The Ubuntu archive index, the rustup"
-  log "package, and the upstream Rust stable channel are part of this"
+  log "package, native compiler, and upstream Rust stable channel are part of this"
   log "aggregator's trust surface in this build-in-TEE configuration."
-  log "Production should publish a Rust-capable aggregator image so the"
+  log "Production should publish a build-capable aggregator image so the"
   log "toolchain is covered by an aggregator-owned image digest instead."
   log "See deploy/README.md."
 
@@ -102,8 +111,10 @@ if ! command -v cargo >/dev/null 2>&1; then
   # 24.04 docker base enables main+restricted+universe+multiverse by default,
   # so this just works. If the deploy customised sources.list and removed
   # universe, the apt-get below fails loud and we exit before building.
-  apt-get install -y --no-install-recommends ca-certificates rustup
+  apt-get install -y --no-install-recommends "${apt_packages[@]}"
+fi
 
+if ((need_rust)); then
   # Install a current stable. --no-self-update so rustup does not silently
   # upgrade itself at runtime; --profile minimal keeps the install to
   # rustc + cargo + std.

--- a/scripts/live_e2e/bfcl_v4.py
+++ b/scripts/live_e2e/bfcl_v4.py
@@ -403,62 +403,67 @@ def run_provider_bfcl(
         env=merged_env(),
         artifact_dir=artifact_dir,
     ) as aggregator:
-        (bfcl_project / ".env").write_text(
+        bfcl_env_path = bfcl_project / ".env"
+        bfcl_env_path.write_text(
             "\n".join(
                 [
                     f"OPENAI_BASE_URL={aggregator.base_url.rstrip('/')}/v1",
-                    "OPENAI_API_KEY=aci-local",
+                    f"OPENAI_API_KEY={aggregator.inference_token}",
                     "",
                 ]
             ),
             encoding="utf-8",
         )
+        bfcl_env_path.chmod(0o600)
         env = {
             **os.environ,
             "BFCL_PROJECT_ROOT": str(bfcl_project),
             "OPENAI_BASE_URL": f"{aggregator.base_url.rstrip('/')}/v1",
-            "OPENAI_API_KEY": "aci-local",
+            "OPENAI_API_KEY": aggregator.inference_token,
             "TOKENIZERS_PARALLELISM": "false",
         }
-        generate = run_bfcl(
-            bfcl_dir,
-            [
-                "generate",
-                "--model",
-                bfcl_public_model,
-                "--run-ids",
-                "--allow-overwrite",
-                "--num-threads",
-                str(num_threads),
-                "--result-dir",
-                "result",
-            ],
-            cwd=bfcl_dir,
-            env=env,
-            stdout_path=artifact_dir / "bfcl.generate.stdout",
-            stderr_path=artifact_dir / "bfcl.generate.stderr",
-            timeout_seconds=timeout_seconds,
-        )
-        evaluate = run_bfcl(
-            bfcl_dir,
-            [
-                "evaluate",
-                "--model",
-                bfcl_public_model,
-                "--test-category",
-                ",".join(sampled_categories),
-                "--partial-eval",
-                "--result-dir",
-                "result",
-                "--score-dir",
-                "score",
-            ],
-            cwd=bfcl_dir,
-            env=env,
-            stdout_path=artifact_dir / "bfcl.evaluate.stdout",
-            stderr_path=artifact_dir / "bfcl.evaluate.stderr",
-            timeout_seconds=timeout_seconds,
-        )
+        try:
+            generate = run_bfcl(
+                bfcl_dir,
+                [
+                    "generate",
+                    "--model",
+                    bfcl_public_model,
+                    "--run-ids",
+                    "--allow-overwrite",
+                    "--num-threads",
+                    str(num_threads),
+                    "--result-dir",
+                    "result",
+                ],
+                cwd=bfcl_dir,
+                env=env,
+                stdout_path=artifact_dir / "bfcl.generate.stdout",
+                stderr_path=artifact_dir / "bfcl.generate.stderr",
+                timeout_seconds=timeout_seconds,
+            )
+            evaluate = run_bfcl(
+                bfcl_dir,
+                [
+                    "evaluate",
+                    "--model",
+                    bfcl_public_model,
+                    "--test-category",
+                    ",".join(sampled_categories),
+                    "--partial-eval",
+                    "--result-dir",
+                    "result",
+                    "--score-dir",
+                    "score",
+                ],
+                cwd=bfcl_dir,
+                env=env,
+                stdout_path=artifact_dir / "bfcl.evaluate.stdout",
+                stderr_path=artifact_dir / "bfcl.evaluate.stderr",
+                timeout_seconds=timeout_seconds,
+            )
+        finally:
+            bfcl_env_path.unlink(missing_ok=True)
 
     score = collect_scores(bfcl_project, bfcl_public_model)
     result = {

--- a/scripts/live_e2e/cases/embeddings.py
+++ b/scripts/live_e2e/cases/embeddings.py
@@ -8,7 +8,6 @@ from ..common import Provider, json_bytes, request_json, run_cmd_json, write_byt
 from .attested_sessions import assert_upstream_attested_sessions
 
 
-REQUESTER_TOKEN = "live-e2e-requester"
 PROBE_INPUT = "Reply with exactly one short sentence confirming ACI embeddings lifecycle."
 
 
@@ -17,6 +16,7 @@ def run_embeddings_case(
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     provider_dir = artifact_dir / provider.name / "embeddings"
     body = {
@@ -30,7 +30,7 @@ def run_embeddings_case(
         "POST",
         f"{base_url}/v1/embeddings",
         headers={
-            "Authorization": f"Bearer {REQUESTER_TOKEN}",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,
@@ -67,7 +67,7 @@ def run_embeddings_case(
     receipt_status, _, receipt_body, receipt_json = request_json(
         "GET",
         f"{base_url}/v1/signature/{receipt_id}",
-        headers={"Authorization": f"Bearer {REQUESTER_TOKEN}"},
+        headers={"Authorization": f"Bearer {inference_token}"},
         timeout=120,
     )
     receipt_path = provider_dir / "receipt.json"

--- a/scripts/live_e2e/cases/fidelity_structured_outputs.py
+++ b/scripts/live_e2e/cases/fidelity_structured_outputs.py
@@ -21,6 +21,7 @@ def run_structured_outputs_case(
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     if not provider.has_capability("structured_outputs"):
         return {"provider": provider.name, "status": "skipped", "reason": "capability_absent"}
@@ -71,7 +72,7 @@ def run_structured_outputs_case(
         "POST",
         f"{base_url}/v1/chat/completions",
         headers={
-            "Authorization": "Bearer live-e2e-structured",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,

--- a/scripts/live_e2e/cases/lifecycle.py
+++ b/scripts/live_e2e/cases/lifecycle.py
@@ -8,14 +8,12 @@ from ..common import Provider, json_bytes, request_json, run_cmd_json, write_byt
 from .attested_sessions import assert_upstream_attested_sessions
 
 
-REQUESTER_TOKEN = "live-e2e-requester"
-
-
 def run_lifecycle_case(
     *,
     base_url: str,
     provider: Provider,
     artifact_dir: Path,
+    inference_token: str,
 ) -> dict[str, Any]:
     provider_dir = artifact_dir / provider.name / "lifecycle"
     body = {
@@ -36,7 +34,7 @@ def run_lifecycle_case(
         "POST",
         f"{base_url}/v1/chat/completions",
         headers={
-            "Authorization": f"Bearer {REQUESTER_TOKEN}",
+            "Authorization": f"Bearer {inference_token}",
             "Content-Type": "application/json",
         },
         body=request_body,
@@ -72,7 +70,7 @@ def run_lifecycle_case(
     receipt_status, _, receipt_body, receipt_json = request_json(
         "GET",
         f"{base_url}/v1/signature/{chat_id}",
-        headers={"Authorization": f"Bearer {REQUESTER_TOKEN}"},
+        headers={"Authorization": f"Bearer {inference_token}"},
         timeout=120,
     )
     receipt_path = provider_dir / "receipt.json"

--- a/scripts/live_e2e/common.py
+++ b/scripts/live_e2e/common.py
@@ -40,6 +40,8 @@ class Provider:
     chutes_chute_ids: dict[str, str]
     chutes_e2ee_discovery_rounds: int | None
     chutes_e2ee_discovery_interval_seconds: int | None
+    privatemode_manifest_log_path: str | None
+    privatemode_proxy_image_digest: str | None
 
     @classmethod
     def from_json(cls, value: dict[str, Any]) -> "Provider":
@@ -65,6 +67,12 @@ class Provider:
             ),
             chutes_e2ee_discovery_interval_seconds=optional_int(
                 value, "chutes_e2ee_discovery_interval_seconds"
+            ),
+            privatemode_manifest_log_path=optional_str(
+                value, "privatemode_manifest_log_path"
+            ),
+            privatemode_proxy_image_digest=optional_str(
+                value, "privatemode_proxy_image_digest"
             ),
         )
 

--- a/scripts/live_e2e/launch_aggregator.py
+++ b/scripts/live_e2e/launch_aggregator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import os
+import secrets
 import signal
 import subprocess
 import tempfile
@@ -29,6 +31,7 @@ class AggregatorProcess:
         dstack_endpoint: str = DEFAULT_DSTACK_ENDPOINT,
         env: dict[str, str] | None = None,
         artifact_dir: Path | None = None,
+        inference_token: str | None = None,
     ) -> None:
         self.providers = providers
         self.port = port
@@ -36,6 +39,13 @@ class AggregatorProcess:
         self.dstack_endpoint = dstack_endpoint
         self.env = {**os.environ, **(env or {})}
         self.artifact_dir = artifact_dir
+        if inference_token is None:
+            inference_token = secrets.token_urlsafe(32)
+        if not inference_token or inference_token != inference_token.strip():
+            raise ValueError(
+                "inference_token must be non-empty and have no surrounding whitespace"
+            )
+        self.inference_token = inference_token
         self._tmp: tempfile.TemporaryDirectory[str] | None = None
         self._process: subprocess.Popen[bytes] | None = None
         self.gateway_config_path: Path | None = None
@@ -57,16 +67,30 @@ class AggregatorProcess:
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         config = build_upstream_config(self.providers, self.env)
         write_json(self.upstream_seed_path, config, mode=0o600)
-        write_json(
-            self.gateway_config_path,
-            {
-                "bind": f"127.0.0.1:{self.port}",
-                "state_dir": str(self.state_dir),
-                "upstream_config_seed_path": str(self.upstream_seed_path),
-                "dstack_endpoint": self.dstack_endpoint,
-            },
-            mode=0o600,
+        privatemode_credential_path = None
+        privatemode = [
+            provider for provider in self.providers if provider.provider == "privatemode"
+        ]
+        if privatemode:
+            credential = self.env.get(privatemode[0].api_key_env)
+            if not credential:
+                raise RuntimeError(
+                    f"missing API key env var {privatemode[0].api_key_env}"
+                )
+            privatemode_credential_path = tmp_dir / "privatemode-api-key"
+            privatemode_credential_path.write_text(credential, encoding="utf-8")
+            privatemode_credential_path.chmod(0o600)
+        gateway_config = build_gateway_config(
+            self.providers,
+            self.env,
+            port=self.port,
+            state_dir=self.state_dir,
+            upstream_seed_path=self.upstream_seed_path,
+            dstack_endpoint=self.dstack_endpoint,
+            inference_token=self.inference_token,
+            privatemode_credential_path=privatemode_credential_path,
         )
+        write_json(self.gateway_config_path, gateway_config, mode=0o600)
         if self.artifact_dir:
             write_json(
                 self.artifact_dir / "aggregator-upstreams.redacted.json",
@@ -141,6 +165,75 @@ class AggregatorProcess:
         raise TimeoutError(f"aggregator did not become ready: {last_error}; log: {self.log_path}")
 
 
+def build_gateway_config(
+    providers: list[Provider],
+    env: dict[str, str],
+    *,
+    port: int,
+    state_dir: Path,
+    upstream_seed_path: Path,
+    dstack_endpoint: str,
+    inference_token: str,
+    privatemode_credential_path: Path | None,
+) -> dict[str, Any]:
+    gateway_config: dict[str, Any] = {
+        "bind": f"127.0.0.1:{port}",
+        "state_dir": str(state_dir),
+        "upstream_config_seed_path": str(upstream_seed_path),
+        "dstack_endpoint": dstack_endpoint,
+    }
+    privatemode = [
+        provider for provider in providers if provider.provider == "privatemode"
+    ]
+    if not privatemode:
+        return gateway_config
+
+    first = privatemode[0]
+    credential = env.get(first.api_key_env)
+    if not credential:
+        raise RuntimeError(f"missing API key env var {first.api_key_env}")
+    required = {
+        "manifest_log_path": first.privatemode_manifest_log_path,
+        "credential_path": str(privatemode_credential_path)
+        if privatemode_credential_path is not None
+        else None,
+        "credential_sha256": hashlib.sha256(
+            credential.encode("utf-8")
+        ).hexdigest(),
+        "proxy_image_digest": first.privatemode_proxy_image_digest,
+    }
+    missing = [name for name, value in required.items() if value is None]
+    if missing:
+        raise RuntimeError(
+            f"Privatemode live E2E is missing static fields: {', '.join(missing)}"
+        )
+    expected = (
+        first.base_url,
+        first.privatemode_manifest_log_path,
+        first.privatemode_proxy_image_digest,
+    )
+    if any(
+        (
+            provider.base_url,
+            provider.privatemode_manifest_log_path,
+            provider.privatemode_proxy_image_digest,
+        )
+        != expected
+        for provider in privatemode[1:]
+    ):
+        raise RuntimeError(
+            "all Privatemode routes must share one static proxy deployment"
+        )
+    gateway_config["inference_token_sha256"] = hashlib.sha256(
+        inference_token.encode("utf-8")
+    ).hexdigest()
+    gateway_config["privatemode_proxy"] = {
+        "base_url": first.base_url,
+        **required,
+    }
+    return gateway_config
+
+
 def build_upstream_config(
     providers: list[Provider],
     env: dict[str, str],
@@ -155,13 +248,14 @@ def build_upstream_config(
             "provider": provider.provider,
             "base_url": provider.base_url,
             "models": {provider.public_model: provider.upstream_model},
-            "bearer_token": token,
             "connect_timeout_seconds": 10,
             "read_timeout_seconds": 600,
             "verifier_request_timeout_seconds": 600
             if provider.provider == "chutes"
             else 120,
         }
+        if provider.provider != "privatemode":
+            item["bearer_token"] = token
         for field in (
             "verification_refresh_seconds",
             "session_refresh_seconds",
@@ -181,6 +275,7 @@ def redact_upstream_config(config: list[dict[str, Any]]) -> list[dict[str, Any]]
     out = []
     for item in config:
         redacted = dict(item)
-        redacted["bearer_token"] = "<redacted>"
+        if "bearer_token" in redacted:
+            redacted["bearer_token"] = "<redacted>"
         out.append(redacted)
     return out

--- a/scripts/live_e2e/provider_verify.py
+++ b/scripts/live_e2e/provider_verify.py
@@ -25,6 +25,24 @@ def verify_provider(
     timeout: int = 300,
     artifact_dir: Path | None = None,
 ) -> dict[str, Any]:
+    if provider.provider == "privatemode":
+        # Privatemode verification is inseparable from the official proxy
+        # co-deployed with the gateway. A standalone Python probe would not bind
+        # that service to the measured deployment and must not compete with it.
+        output = {
+            "status": "deferred_to_gateway",
+            "verifier_id": "privatemode-proxy/co-deployed-contrast/v1",
+            "reason": (
+                "verification occurs when the gateway probes the measured proxy; "
+                "the lifecycle phase exercises that binding with real inference"
+            ),
+        }
+        if artifact_dir:
+            write_json(
+                artifact_dir / provider.name / "provider-verifier-output.json",
+                output,
+            )
+        return output
     # The bridge runs from the gateway project (cwd=ROOT) so it uses the gateway's
     # own uv env and the vendored confidential_verifier package. An external verifier
     # checkout is selected only when PRIVATE_AI_VERIFIER_DIR is set in the environment.

--- a/scripts/live_e2e/run.py
+++ b/scripts/live_e2e/run.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 from pathlib import Path
@@ -101,6 +100,7 @@ def main() -> None:
                         base_url=aggregator.base_url,
                         provider=provider,
                         artifact_dir=artifact_dir,
+                        inference_token=aggregator.inference_token,
                     )
                 )
             summary["phases"]["lifecycle"] = lifecycle
@@ -114,6 +114,7 @@ def main() -> None:
                         base_url=aggregator.base_url,
                         provider=provider,
                         artifact_dir=artifact_dir,
+                        inference_token=aggregator.inference_token,
                     )
                 )
             summary["phases"]["embeddings"] = embeddings
@@ -126,6 +127,7 @@ def main() -> None:
                             base_url=aggregator.base_url,
                             provider=provider,
                             artifact_dir=artifact_dir,
+                            inference_token=aggregator.inference_token,
                         )
                     )
                 summary["phases"]["structured_outputs"] = structured

--- a/scripts/live_e2e/streaming_smoke.py
+++ b/scripts/live_e2e/streaming_smoke.py
@@ -50,7 +50,11 @@ def main() -> int:
         }
         print(f"POST {base}/v1/chat/completions  (stream=true, model={provider.public_model})")
         resp = requests.post(
-            f"{base}/v1/chat/completions", json=body, stream=True, timeout=180
+            f"{base}/v1/chat/completions",
+            json=body,
+            headers={"Authorization": f"Bearer {agg.inference_token}"},
+            stream=True,
+            timeout=180,
         )
         raw = bytearray()
         for chunk in resp.iter_content(chunk_size=None):
@@ -72,7 +76,11 @@ def main() -> int:
             print("  FAIL: no x-receipt-id header")
             return 1
 
-        r2 = requests.get(f"{base}/v1/aci/receipts/{receipt_id}", timeout=30)
+        r2 = requests.get(
+            f"{base}/v1/aci/receipts/{receipt_id}",
+            headers={"Authorization": f"Bearer {agg.inference_token}"},
+            timeout=30,
+        )
         if r2.status_code != 200:
             print(f"  FAIL: receipt fetch {r2.status_code}: {r2.text[:300]}")
             return 1

--- a/scripts/live_e2e/tests/__init__.py
+++ b/scripts/live_e2e/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for live E2E orchestration helpers."""

--- a/scripts/live_e2e/tests/test_launch_aggregator.py
+++ b/scripts/live_e2e/tests/test_launch_aggregator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from live_e2e.common import Provider  # noqa: E402
+from live_e2e.launch_aggregator import (  # noqa: E402
+    AggregatorProcess,
+    build_gateway_config,
+    build_upstream_config,
+    redact_upstream_config,
+)
+
+
+def privatemode_provider() -> Provider:
+    return Provider.from_json(
+        {
+            "name": "privatemode-test",
+            "provider": "privatemode",
+            "base_url": "http://privatemode-proxy:8080",
+            "public_model": "private-model",
+            "upstream_model": "upstream-model",
+            "api_key_env": "PRIVATEMODE_API_KEY",
+            "binding": "proxy_image_sha256",
+            "privatemode_manifest_log_path": "/run/privatemode-manifests/log.txt",
+            "privatemode_proxy_image_digest": f"sha256:{'b' * 64}",
+        }
+    )
+
+
+class LaunchAggregatorTests(unittest.TestCase):
+    def test_privatemode_config_binds_generated_client_auth_digest(self) -> None:
+        token = "per-run-client-token"
+        config = build_gateway_config(
+            [privatemode_provider()],
+            {"PRIVATEMODE_API_KEY": "provider-credential"},
+            port=18086,
+            state_dir=Path("/tmp/state"),
+            upstream_seed_path=Path("/tmp/upstreams.json"),
+            dstack_endpoint="unix:/tmp/dstack.sock",
+            inference_token=token,
+            privatemode_credential_path=Path("/run/secrets/privatemode-api-key"),
+        )
+
+        self.assertEqual(
+            config["inference_token_sha256"],
+            hashlib.sha256(token.encode("utf-8")).hexdigest(),
+        )
+        self.assertNotIn(token, json.dumps(config, sort_keys=True))
+        self.assertEqual(
+            config["privatemode_proxy"]["credential_sha256"],
+            hashlib.sha256(b"provider-credential").hexdigest(),
+        )
+        self.assertEqual(
+            config["privatemode_proxy"]["credential_path"],
+            "/run/secrets/privatemode-api-key",
+        )
+        upstream = build_upstream_config(
+            [privatemode_provider()],
+            {"PRIVATEMODE_API_KEY": "provider-credential"},
+        )
+        self.assertNotIn("bearer_token", upstream[0])
+        self.assertNotIn("bearer_token", redact_upstream_config(upstream)[0])
+
+    def test_process_generates_a_distinct_high_entropy_token_per_run(self) -> None:
+        first = AggregatorProcess([], port=18086, env={})
+        second = AggregatorProcess([], port=18087, env={})
+
+        self.assertNotEqual(first.inference_token, second.inference_token)
+        self.assertGreaterEqual(len(first.inference_token), 32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/aci.md
+++ b/spec/aci.md
@@ -75,7 +75,8 @@ surface**, not its routing policy:
 
 - Before forwarding a prompt constrained by §6.1, the aggregator MUST verify
   the selected upstream and obtain an enforceable channel binding (a TLS key
-  pin or an upstream E2EE key), or fail closed.
+  pin, an upstream E2EE key, or an attested manifest that gates an E2EE secret
+  owned by a provider proxy inside the aggregator workload), or fail closed.
 - Each receipt records the verification outcome in an `upstream.verified`
   event (§8.4).
 - Each successful verification is captured as an immutable, content-addressed
@@ -881,7 +882,7 @@ appear):
   "upstream_name": "<service-chosen upstream label>",
   "provider_type": "<verifier adapter type or null>",
   "model_id": "<upstream model served>",
-  "url_origin": "<https-origin-or-null>",
+  "url_origin": "<origin-or-null>",
   "verifier_id": "<verifier implementation id>",
   "result": "verified" | "failed",
   "required": true | false,
@@ -906,7 +907,27 @@ upstream. Defined shapes:
 ```json
 { "type": "tls_spki_sha256",        "origin": "<https-origin>", "spki_sha256": "<hex>" }
 { "type": "e2ee_public_key_sha256", "provider": "<label>", "key_id": "<optional>", "algorithm": "<algo>", "public_key_sha256": "<hex>" }
+{ "type": "proxy_image_sha256",      "provider": "<label>", "proxy_image_digest": "sha256:<hex>", "credential_sha256": "<hex>" }
 ```
+
+`proxy_image_sha256` is enforceable only when the provider proxy is inside the
+aggregator's attested workload. The measured deployment MUST launch the exact
+`proxy_image_digest` with the shared credential secret, keep the proxy endpoint
+private to that workload, pin that endpoint in static measured policy, and
+route every forward through it. The aggregator MUST validate the live shared
+secret against `credential_sha256` without forwarding that credential on the
+internal hop. It MUST also pin forwarding to handlers that the measured proxy
+version encrypts. A mutable path override or an unencrypted catalog or health
+handler cannot carry inference data.
+
+Provider manifest metadata is informational unless the proxy binds it to the
+E2EE secret used for the request. A fetched-manifest log, CDN response, or
+readiness probe does not establish that binding.
+
+External upstream origins MUST use HTTPS. A plaintext HTTP `url_origin` is
+valid only for a service inside the same measured workload when its binding
+type (such as `proxy_image_sha256`) explicitly binds that deployment and the
+client disables redirects and ambient HTTP proxies.
 
 To a generic verifier this event proves only that the attested aggregator
 *asserted* the outcome; deep audit (§10.3) upgrades it to independently
@@ -1281,7 +1302,7 @@ these sets requires a published extension document.
 | Signature algorithms | `ed25519` (RECOMMENDED), `ecdsa-secp256k1` | Reject |
 | E2EE suites | `x25519-aes-256-gcm-hkdf-sha256` (RECOMMENDED; HKDF info `aci.e2ee.v2.x25519`), `secp256k1-aes-256-gcm-hkdf-sha256` (HKDF info `aci.e2ee.v2.secp256k1`) | Reject; other keyset entries with unknown `algo` are ignored for E2EE |
 | Receipt event types | `request.received`, `request.forwarded`, `response.returned`, `response.received`, `upstream.verified`, `transparency.request_modified`, `transparency.response_modified` | Ignore; preserve for signature recomputation (§3.2) |
-| Channel binding types | `tls_spki_sha256`, `e2ee_public_key_sha256` | Treat as not enforceable |
+| Channel binding types | `tls_spki_sha256`, `e2ee_public_key_sha256`, `proxy_image_sha256` | Treat as not enforceable |
 | Claim names | `tee_attested`, `gpu_attested`, `tcb_up_to_date`, `os_known_good`, `serving_software_known_good`, `model_weights_provenance` | Extra facts live in `claims.extra`; unknown entries are informational |
 | Claim statuses / sources | `asserted`, `refuted`, `unknown` / `hardware_proven`, `verifier_derived`, `provider_asserted`, `operator_asserted` | Treat the claim as `unknown` |
 | TEE types | `tdx`, `sev_snp` | Requires a published verifier extension (§5.2) |

--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -55,7 +55,7 @@ pub struct UpstreamVerifiedEvent {
     /// "tinfoil-glm51") — a label chosen by whoever wrote the config.
     pub upstream_name: String,
     /// The verifier adapter *type* the verification logic keys on (e.g.
-    /// "tinfoil", "near-ai", "chutes", "phala-direct"). Many `upstream_name`
+    /// "tinfoil", "near-ai", "chutes", "privatemode", "phala-direct"). Many `upstream_name`
     /// entries can share one `provider_type` (two configs both pointing at
     /// Tinfoil). Used to map provider evidence onto typed session claims;
     /// `None` for generic/static verifiers that have no provider type.
@@ -109,6 +109,15 @@ pub enum ChannelBinding {
         key_id: Option<String>,
         algorithm: String,
         public_key_sha256: String,
+    },
+    /// Digests binding a provider proxy co-deployed in the gateway's measured
+    /// dstack Compose. The proxy verifies the provider's attestation chain.
+    ProxyImageSha256 {
+        provider: String,
+        proxy_image_digest: String,
+        /// Digest of the exact Compose secret mounted into both the measured
+        /// gateway and proxy.
+        credential_sha256: String,
     },
 }
 

--- a/src/aci/upstream/mod.rs
+++ b/src/aci/upstream/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! The aggregator forwards a chat-completion request to an upstream
 //! after ACI-side hashing. Different upstream providers (Chutes,
-//! Tinfoil, NEAR AI, Phala dstack-vllm-proxy, raw OpenAI-compatible
+//! Tinfoil, NEAR AI, Privatemode, Phala dstack-vllm-proxy, raw OpenAI-compatible
 //! endpoints) speak slightly different dialects on top of the OpenAI
 //! base. We isolate that with the small trait defined here so:
 //!
@@ -29,6 +29,7 @@ use crate::aci::receipt::UpstreamVerifiedEvent;
 
 mod chutes;
 mod openai;
+mod privatemode;
 mod router;
 mod tls;
 
@@ -36,6 +37,9 @@ pub use chutes::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
 };
 pub use openai::OpenAICompatibleBackend;
+pub use privatemode::{
+    PrivatemodeDeploymentConfigError, PrivatemodeProviderBackend, PrivatemodeProxyDeployment,
+};
 pub use router::{ModelRoute, ModelRouterBackend};
 
 use openai::request_model_id;
@@ -106,6 +110,15 @@ pub trait UpstreamBackend: Send + Sync {
 
     /// Origin (scheme + host + port) recorded in receipts.
     fn url_origin(&self) -> Option<&str>;
+
+    /// Whether chat-shaped downstream endpoints keep their native paths.
+    ///
+    /// Most OpenAI-compatible backends map both chat surfaces to one configured
+    /// path. Multi-protocol backends such as Privatemode serve
+    /// `/v1/chat/completions` and `/v1/messages` as distinct handlers.
+    fn preserves_chat_surface_path(&self) -> bool {
+        false
+    }
 
     /// Prepare an upstream request before verification and receipt
     /// hashing. Routers use this phase to select the concrete upstream

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -154,6 +154,11 @@ impl OpenAICompatibleBackend {
         self
     }
 
+    pub(super) fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
+    }
+
     fn apply_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.auth {
             Some(UpstreamAuth::Bearer(token)) => {
@@ -342,6 +347,12 @@ impl OpenAICompatibleBackend {
                 } => {
                     return Err(UpstreamError::Transport(format!(
                         "backend {} cannot enforce {provider} E2EE binding {algorithm:?}",
+                        self.name
+                    )));
+                }
+                ChannelBinding::ProxyImageSha256 { provider, .. } => {
+                    return Err(UpstreamError::Transport(format!(
+                        "backend {} cannot enforce {provider} proxy-image binding",
                         self.name
                     )));
                 }

--- a/src/aci/upstream/privatemode.rs
+++ b/src/aci/upstream/privatemode.rs
@@ -1,0 +1,432 @@
+//! Privatemode transport through an official proxy co-deployed with the gateway.
+//!
+//! The dstack Compose measurement binds the proxy image and its internal
+//! network endpoint. The gateway independently verifies the shared credential
+//! bytes at startup, records the measured proxy image in receipts, and sends
+//! plaintext only to that statically configured service. The official proxy
+//! owns dynamic manifest verification, credential use, secret exchange, and
+//! Privatemode body encryption.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::{
+    OpenAICompatibleBackend, PreparedUpstreamRequest, UpstreamBackend, UpstreamError,
+    UpstreamRequest, UpstreamResponse, UpstreamStreamResponse,
+};
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
+
+const PROVIDER: &str = "privatemode";
+const DEFAULT_ENCRYPTED_PATH: &str = "/v1/chat/completions";
+const ENCRYPTED_PATHS: &[&str] = &[
+    DEFAULT_ENCRYPTED_PATH,
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/messages",
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivatemodeDeploymentConfigError {
+    #[error("Privatemode proxy base URL must be an HTTP(S) origin: {0}")]
+    InvalidBaseUrl(String),
+    #[error("Privatemode manifest log path must be absolute")]
+    RelativeManifestLogPath,
+    #[error("failed to read Privatemode manifest log {path}: {source}")]
+    ReadManifestLog {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("invalid Privatemode manifest log: {0}")]
+    InvalidManifestLog(String),
+    #[error("failed to read observed Privatemode manifest {path}: {source}")]
+    ReadObservedManifest {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("Privatemode credential path must be absolute")]
+    RelativeCredentialPath,
+    #[error("failed to read Privatemode credential {path}: {source}")]
+    ReadCredential {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("Privatemode credential must be non-empty UTF-8 without surrounding whitespace")]
+    InvalidCredential,
+    #[error("invalid Privatemode credential SHA-256 digest: {0}")]
+    InvalidCredentialDigest(String),
+    #[error("Privatemode credential digest {actual} does not match configured digest {expected}")]
+    CredentialDigestMismatch { actual: String, expected: String },
+    #[error("invalid Privatemode proxy OCI image digest: {0}")]
+    InvalidImageDigest(String),
+}
+
+/// Static, measured deployment policy for one co-deployed Privatemode proxy.
+#[derive(Debug)]
+pub struct PrivatemodeProxyDeployment {
+    base_url: String,
+    manifest_log_path: PathBuf,
+    credential_sha256: String,
+    proxy_image_digest: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct ObservedPrivatemodeManifest {
+    bytes: Vec<u8>,
+    pub(crate) sha256: String,
+    pub(crate) observed_at: String,
+}
+
+impl PrivatemodeProxyDeployment {
+    pub fn new(
+        base_url: impl Into<String>,
+        manifest_log_path: impl AsRef<Path>,
+        credential_path: impl AsRef<Path>,
+        accepted_credential_sha256: impl AsRef<str>,
+        proxy_image_digest: impl AsRef<str>,
+    ) -> Result<Self, PrivatemodeDeploymentConfigError> {
+        let base_url = normalize_origin(&base_url.into())?;
+
+        let manifest_log_path = manifest_log_path.as_ref();
+        if !manifest_log_path.is_absolute() {
+            return Err(PrivatemodeDeploymentConfigError::RelativeManifestLogPath);
+        }
+
+        let credential_path = credential_path.as_ref();
+        if !credential_path.is_absolute() {
+            return Err(PrivatemodeDeploymentConfigError::RelativeCredentialPath);
+        }
+        let credential = std::fs::read(credential_path).map_err(|source| {
+            PrivatemodeDeploymentConfigError::ReadCredential {
+                path: credential_path.display().to_string(),
+                source,
+            }
+        })?;
+        let credential_text = std::str::from_utf8(&credential)
+            .map_err(|_| PrivatemodeDeploymentConfigError::InvalidCredential)?;
+        if credential_text.is_empty() || credential_text.trim() != credential_text {
+            return Err(PrivatemodeDeploymentConfigError::InvalidCredential);
+        }
+        let credential_sha256 = normalize_sha256_hex(accepted_credential_sha256.as_ref())
+            .map_err(PrivatemodeDeploymentConfigError::InvalidCredentialDigest)?;
+        let actual_credential_sha256 = sha256_hex(&credential);
+        if actual_credential_sha256 != credential_sha256 {
+            return Err(PrivatemodeDeploymentConfigError::CredentialDigestMismatch {
+                actual: actual_credential_sha256,
+                expected: credential_sha256,
+            });
+        }
+        let proxy_image_digest = format!(
+            "sha256:{}",
+            normalize_sha256_hex(proxy_image_digest.as_ref())
+                .map_err(PrivatemodeDeploymentConfigError::InvalidImageDigest)?
+        );
+
+        Ok(Self {
+            base_url,
+            manifest_log_path: manifest_log_path.to_path_buf(),
+            credential_sha256,
+            proxy_image_digest,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub(crate) fn latest_observed_manifest(
+        &self,
+    ) -> Result<ObservedPrivatemodeManifest, PrivatemodeDeploymentConfigError> {
+        let log = std::fs::read_to_string(&self.manifest_log_path).map_err(|source| {
+            PrivatemodeDeploymentConfigError::ReadManifestLog {
+                path: self.manifest_log_path.display().to_string(),
+                source,
+            }
+        })?;
+        let invalid_log = |message: &str| {
+            PrivatemodeDeploymentConfigError::InvalidManifestLog(message.to_string())
+        };
+        let line = log
+            .lines()
+            .next_back()
+            .ok_or_else(|| invalid_log("manifest log is empty"))?;
+        let mut fields = line.split_ascii_whitespace();
+        let (Some(observed_at), Some(logged_path), None) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            return Err(invalid_log(
+                "latest entry must contain a timestamp and manifest path",
+            ));
+        };
+        let file_name = Path::new(logged_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| invalid_log("latest entry has an invalid manifest path"))?;
+        let version = file_name
+            .strip_suffix(".json")
+            .ok_or_else(|| invalid_log("latest manifest filename must end in .json"))?;
+        if version.is_empty() || !version.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(invalid_log(
+                "latest manifest filename must be a numeric version",
+            ));
+        }
+        let manifest_path = self
+            .manifest_log_path
+            .parent()
+            .expect("an absolute manifest log path has a parent")
+            .join(file_name);
+        let bytes = std::fs::read(&manifest_path).map_err(|source| {
+            PrivatemodeDeploymentConfigError::ReadObservedManifest {
+                path: manifest_path.display().to_string(),
+                source,
+            }
+        })?;
+        Ok(ObservedPrivatemodeManifest {
+            sha256: sha256_hex(&bytes),
+            observed_at: observed_at.to_string(),
+            bytes,
+        })
+    }
+
+    pub(crate) fn manifest_evidence(&self, manifest: &ObservedPrivatemodeManifest) -> Value {
+        serde_json::json!({
+            "type": "privatemode_manifest_observation",
+            "observation": "latest_proxy_fetch_log",
+            "bound_to_active_secret": false,
+            "observed_at": manifest.observed_at,
+            "digest": format!("sha256:{}", manifest.sha256),
+            "data": format!(
+                "data:application/json;base64,{}",
+                BASE64.encode(&manifest.bytes)
+            ),
+        })
+    }
+
+    pub fn proxy_image_digest(&self) -> &str {
+        &self.proxy_image_digest
+    }
+
+    pub fn credential_sha256(&self) -> &str {
+        &self.credential_sha256
+    }
+
+    pub(crate) fn forwarding_client(
+        &self,
+        connect_timeout_seconds: u64,
+        read_timeout_seconds: u64,
+    ) -> Result<reqwest::Client, UpstreamError> {
+        reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(connect_timeout_seconds))
+            .read_timeout(Duration::from_secs(read_timeout_seconds))
+            .build()
+            .map_err(|err| UpstreamError::Transport(err.to_string()))
+    }
+
+    pub(crate) fn readiness_client(
+        &self,
+        connect_timeout_seconds: u64,
+        request_timeout_seconds: u64,
+    ) -> Result<reqwest::Client, UpstreamError> {
+        reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(connect_timeout_seconds))
+            .timeout(Duration::from_secs(request_timeout_seconds))
+            .build()
+            .map_err(|err| UpstreamError::Transport(err.to_string()))
+    }
+}
+
+pub struct PrivatemodeProviderBackend {
+    inner: OpenAICompatibleBackend,
+    deployment: Arc<PrivatemodeProxyDeployment>,
+}
+
+impl PrivatemodeProviderBackend {
+    pub fn new_with_timeouts(
+        deployment: Arc<PrivatemodeProxyDeployment>,
+        connect_timeout_seconds: u64,
+        read_timeout_seconds: u64,
+    ) -> Result<Self, UpstreamError> {
+        let client = deployment.forwarding_client(connect_timeout_seconds, read_timeout_seconds)?;
+        let inner = OpenAICompatibleBackend::new_with_timeouts(
+            deployment.base_url(),
+            connect_timeout_seconds,
+            read_timeout_seconds,
+        )?
+        .with_client(client);
+        Ok(Self { inner, deployment })
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.inner = self.inner.with_name(name);
+        self
+    }
+
+    fn enforce_proxy_binding(&self, event: &UpstreamVerifiedEvent) -> Result<(), UpstreamError> {
+        if event.result != VerificationResult::Verified {
+            return Err(binding_mismatch(
+                "Privatemode forwarding requires a verified event",
+            ));
+        }
+        if event.provider_type.as_deref() != Some(PROVIDER) {
+            return Err(binding_mismatch(format!(
+                "verification provider {:?} is not {PROVIDER:?}",
+                event.provider_type
+            )));
+        }
+        if event.url_origin.as_deref() != self.url_origin() {
+            return Err(binding_mismatch(format!(
+                "verified proxy origin {:?} does not match co-deployed service {:?}",
+                event.url_origin,
+                self.url_origin()
+            )));
+        }
+        let [ChannelBinding::ProxyImageSha256 {
+            provider,
+            proxy_image_digest,
+            credential_sha256,
+        }] = event.channel_bindings.as_slice()
+        else {
+            return Err(binding_mismatch(
+                "Privatemode verification must produce exactly one proxy_image_sha256 binding",
+            ));
+        };
+        if provider != PROVIDER
+            || proxy_image_digest != self.deployment.proxy_image_digest()
+            || credential_sha256 != self.deployment.credential_sha256()
+        {
+            return Err(binding_mismatch(
+                "Privatemode event does not match the measured proxy deployment",
+            ));
+        }
+        Ok(())
+    }
+
+    fn enforce_encrypted_path(&self, req: &PreparedUpstreamRequest) -> Result<(), UpstreamError> {
+        let path = req
+            .request
+            .path
+            .as_deref()
+            .unwrap_or(DEFAULT_ENCRYPTED_PATH);
+        if ENCRYPTED_PATHS.contains(&path) {
+            return Ok(());
+        }
+        Err(UpstreamError::Routing(format!(
+            "Privatemode refuses path {path:?}: the pinned proxy does not encrypt that handler"
+        )))
+    }
+}
+
+#[async_trait]
+impl UpstreamBackend for PrivatemodeProviderBackend {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn url_origin(&self) -> Option<&str> {
+        self.inner.url_origin()
+    }
+
+    fn preserves_chat_surface_path(&self) -> bool {
+        true
+    }
+
+    fn prepare(&self, req: UpstreamRequest) -> Result<PreparedUpstreamRequest, UpstreamError> {
+        self.inner.prepare(req)
+    }
+
+    async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        self.enforce_encrypted_path(&req)?;
+        self.enforce_proxy_binding(event)?;
+        self.inner.forward_prepared(req).await
+    }
+
+    async fn forward_stream(
+        &self,
+        _req: UpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_stream_prepared(
+        &self,
+        _req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        Err(verification_required())
+    }
+
+    async fn forward_stream_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        self.enforce_encrypted_path(&req)?;
+        self.enforce_proxy_binding(event)?;
+        self.inner.forward_stream_prepared(req).await
+    }
+}
+
+fn normalize_origin(value: &str) -> Result<String, PrivatemodeDeploymentConfigError> {
+    let mut url = reqwest::Url::parse(value.trim())
+        .map_err(|err| PrivatemodeDeploymentConfigError::InvalidBaseUrl(err.to_string()))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/"
+    {
+        return Err(PrivatemodeDeploymentConfigError::InvalidBaseUrl(
+            "expected scheme, host, and optional port only".to_string(),
+        ));
+    }
+    url.set_path("");
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
+fn normalize_sha256_hex(value: &str) -> Result<String, String> {
+    let value = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
+    let bytes = hex::decode(value).map_err(|err| err.to_string())?;
+    if bytes.len() != 32 {
+        return Err(format!("expected 32 bytes, got {}", bytes.len()));
+    }
+    Ok(hex::encode(bytes))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn binding_mismatch(message: impl Into<String>) -> UpstreamError {
+    UpstreamError::ChannelBindingMismatch(message.into())
+}
+
+fn verification_required() -> UpstreamError {
+    UpstreamError::ChannelBindingMismatch(
+        "Privatemode forwarding requires an active co-deployed proxy binding".to_string(),
+    )
+}

--- a/src/aci/upstream/router.rs
+++ b/src/aci/upstream/router.rs
@@ -171,23 +171,15 @@ impl UpstreamBackend for ModelRouterBackend {
         };
         let mut request = req;
         request.body = rewrite_request_model(&request.body, &route.upstream_model_id)?;
-        // The chat-shaped downstream surfaces (`/v1/chat/completions` and the
-        // Anthropic `/v1/messages`) are converted to the upstream's chat
-        // request format before they reach here, so both must target the
-        // upstream's chat path rather than the downstream surface path: a
-        // configured per-upstream path when set (e.g. native Anthropic
-        // upstreams use `/v1/messages`), otherwise the OpenAI-compatible
-        // `/v1/chat/completions`. The path is resolved explicitly (rather than
-        // deferred to the backend default) so the forwarded request is
-        // deterministic. Other surfaces (`/v1/completions`, `/v1/embeddings`,
-        // `/v1/responses`) keep the caller-supplied path so they route to the
-        // matching upstream path.
+        // Most backends map both chat-shaped downstream surfaces onto one
+        // configured upstream chat path. Multi-protocol backends explicitly
+        // preserve `/v1/chat/completions` versus `/v1/messages`.
         let on_chat_surface = request
             .path
             .as_deref()
             .map(|path| path == "/v1/chat/completions" || path == "/v1/messages")
             .unwrap_or(true);
-        if on_chat_surface {
+        if on_chat_surface && !route.upstream.preserves_chat_surface_path() {
             request.path = Some(
                 route
                     .path
@@ -314,6 +306,10 @@ mod tests {
             None
         }
 
+        fn preserves_chat_surface_path(&self) -> bool {
+            self.name == "native-multiprotocol"
+        }
+
         async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
             Err(UpstreamError::Transport("not used".to_string()))
         }
@@ -375,13 +371,20 @@ mod tests {
     }
 
     fn single_route_router(path: Option<String>) -> ModelRouterBackend {
+        single_route_router_for_backend(path, "openai")
+    }
+
+    fn single_route_router_for_backend(
+        path: Option<String>,
+        backend_name: &'static str,
+    ) -> ModelRouterBackend {
         let mut router = ModelRouterBackend::new("model-router");
         router
             .add_route(
                 ModelRoute::new(
                     "openai/gpt-4o",
                     "gpt-4o",
-                    Arc::new(StubBackend { name: "openai" }),
+                    Arc::new(StubBackend { name: backend_name }),
                     "openai:gpt-4o",
                 )
                 .unwrap()
@@ -429,6 +432,19 @@ mod tests {
         assert_eq!(
             prepared_path(&router, "/v1/chat/completions").as_deref(),
             Some("/v1/messages")
+        );
+        assert_eq!(
+            prepared_path(&router, "/v1/messages").as_deref(),
+            Some("/v1/messages")
+        );
+    }
+
+    #[test]
+    fn multi_protocol_backends_preserve_native_chat_surface_paths() {
+        let router = single_route_router_for_backend(None, "native-multiprotocol");
+        assert_eq!(
+            prepared_path(&router, "/v1/chat/completions").as_deref(),
+            Some("/v1/chat/completions")
         );
         assert_eq!(
             prepared_path(&router, "/v1/messages").as_deref(),

--- a/src/aci/verifier/mod.rs
+++ b/src/aci/verifier/mod.rs
@@ -45,7 +45,8 @@ pub use aci_service::{
 pub use external::ProviderVerifierConfigError;
 pub use providers::{
     ChutesProviderVerifier, NearAiProviderVerifier, PhalaDirectProviderVerifier,
-    RoutingUpstreamVerifier, SecretAiProviderVerifier, TinfoilProviderVerifier,
+    PrivatemodeProviderVerifier, RoutingUpstreamVerifier, SecretAiProviderVerifier,
+    TinfoilProviderVerifier,
 };
 pub use report::{validate_aci_report_binding, AciReportValidationError, ValidatedAciReport};
 pub use simple::{PreverifiedUpstreamVerifier, StaticUpstreamVerifier};

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -2,17 +2,20 @@
 //! origin/name routing verifier that dispatches to them.
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use futures_util::StreamExt;
 
 use super::external::ExternalProviderVerifier;
 #[cfg(test)]
 use super::external::ProviderVerifierConfigError;
-use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
-use crate::aci::upstream::ChutesSessionStore;
+use crate::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
+use crate::aci::upstream::{ChutesSessionStore, PrivatemodeProxyDeployment, UpstreamError};
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
 use crate::aggregator::upstream_config::UpstreamProvider;
+
+const MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct ChutesProviderVerifier {
@@ -314,6 +317,238 @@ impl UpstreamVerifier for SecretAiProviderVerifier {
 
     fn invalidate(&self, request: &UpstreamVerificationRequest) {
         self.verifier.invalidate(request);
+    }
+}
+
+/// Verifier for the exact official Privatemode proxy deployment measured with
+/// the gateway. The proxy completes its initial Contrast verification and
+/// secret exchange before serving, so the model-list probe corroborates startup
+/// and liveness. Dynamic manifest history is reported as an observation only:
+/// v1.48 does not bind a logged manifest to the secret used for a request.
+#[derive(Debug, Clone)]
+pub struct PrivatemodeProviderVerifier {
+    deployment: Arc<PrivatemodeProxyDeployment>,
+    client: reqwest::Client,
+    cache_ttl_seconds: u64,
+    cache: Arc<RwLock<Option<CachedPrivatemodeEvent>>>,
+    verify_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedPrivatemodeEvent {
+    expires_at: u64,
+    event: UpstreamVerifiedEvent,
+}
+
+impl CachedPrivatemodeEvent {
+    fn event_for(&self, request: &UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        let mut event = self.event.clone();
+        event.upstream_name = request.upstream_name.clone();
+        event.model_id = request.model_id.clone();
+        event.url_origin = request.url_origin.clone();
+        event.required = request.required;
+        event
+    }
+}
+
+impl PrivatemodeProviderVerifier {
+    pub fn new(
+        deployment: Arc<PrivatemodeProxyDeployment>,
+        connect_timeout_seconds: u64,
+        request_timeout_seconds: u64,
+        cache_ttl_seconds: u64,
+    ) -> Result<Self, UpstreamError> {
+        let client =
+            deployment.readiness_client(connect_timeout_seconds, request_timeout_seconds)?;
+        Ok(Self {
+            deployment,
+            client,
+            cache_ttl_seconds,
+            cache: Arc::new(RwLock::new(None)),
+            verify_lock: Arc::new(tokio::sync::Mutex::new(())),
+        })
+    }
+
+    async fn verify_deployment(
+        &self,
+        request: UpstreamVerificationRequest,
+    ) -> UpstreamVerifiedEvent {
+        if let Err(err) = self.probe().await {
+            return UpstreamVerifiedEvent {
+                upstream_name: request.upstream_name,
+                provider_type: Some("privatemode".to_string()),
+                model_id: request.model_id,
+                url_origin: Some(self.deployment.base_url().to_string()),
+                verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+                result: VerificationResult::Failed,
+                required: request.required,
+                reason: Some(err.to_string()),
+                ..Default::default()
+            };
+        }
+        let manifest = match self.deployment.latest_observed_manifest() {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                return UpstreamVerifiedEvent {
+                    upstream_name: request.upstream_name,
+                    provider_type: Some("privatemode".to_string()),
+                    model_id: request.model_id,
+                    url_origin: Some(self.deployment.base_url().to_string()),
+                    verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+                    result: VerificationResult::Failed,
+                    required: request.required,
+                    reason: Some(err.to_string()),
+                    ..Default::default()
+                };
+            }
+        };
+        UpstreamVerifiedEvent {
+            upstream_name: request.upstream_name,
+            provider_type: Some("privatemode".to_string()),
+            model_id: request.model_id,
+            url_origin: Some(self.deployment.base_url().to_string()),
+            verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+            result: VerificationResult::Verified,
+            required: request.required,
+            evidence: Some(self.deployment.manifest_evidence(&manifest)),
+            channel_bindings: vec![ChannelBinding::ProxyImageSha256 {
+                provider: "privatemode".to_string(),
+                proxy_image_digest: self.deployment.proxy_image_digest().to_string(),
+                credential_sha256: self.deployment.credential_sha256().to_string(),
+            }],
+            provider_claims: Some(serde_json::json!({
+                "trust_boundary": "attested-compose-privatemode-proxy",
+                "attestation_scope": "contrast-attested-e2ee-secret",
+                "request_encryption": "privatemode-oae",
+                "success_response_authentication": "privatemode-oae",
+                "inference_secret_policy": "latest-per-attempt-fail-closed",
+                "manifest_mode": "dynamic",
+                "observed_manifest_sha256": manifest.sha256,
+                "manifest_observed_at": manifest.observed_at,
+                "manifest_observation": "latest-proxy-fetch-log",
+                "manifest_bound_to_active_secret": false,
+            })),
+            reason: None,
+        }
+    }
+
+    async fn probe(&self) -> Result<(), UpstreamError> {
+        let response = self
+            .client
+            .get(format!("{}/v1/models", self.deployment.base_url()))
+            .header("accept", "application/json")
+            .send()
+            .await
+            .map_err(|err| {
+                UpstreamError::Transport(format!("Privatemode proxy probe failed: {err}"))
+            })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            return Err(UpstreamError::Transport(format!(
+                "Privatemode proxy readiness probe returned {status}"
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES as u64)
+        {
+            return Err(UpstreamError::Transport(format!(
+                "Privatemode proxy readiness response exceeds {MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES} bytes"
+            )));
+        }
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|err| {
+                UpstreamError::Transport(format!("Privatemode proxy readiness body failed: {err}"))
+            })?;
+            let next_len = body.len().checked_add(chunk.len()).ok_or_else(|| {
+                UpstreamError::Transport(
+                    "Privatemode proxy readiness response length overflowed".to_string(),
+                )
+            })?;
+            if next_len > MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES {
+                return Err(UpstreamError::Transport(format!(
+                    "Privatemode proxy readiness response exceeds {MAX_PRIVATEMODE_MODELS_RESPONSE_BYTES} bytes"
+                )));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let payload: serde_json::Value = serde_json::from_slice(&body).map_err(|err| {
+            UpstreamError::Transport(format!(
+                "Privatemode proxy readiness returned invalid JSON: {err}"
+            ))
+        })?;
+        if !payload.get("data").is_some_and(serde_json::Value::is_array) {
+            return Err(UpstreamError::Transport(
+                "Privatemode proxy readiness returned an invalid model list".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn cached_event(&self, request: &UpstreamVerificationRequest) -> Option<UpstreamVerifiedEvent> {
+        if self.cache_ttl_seconds == 0 {
+            return None;
+        }
+        let cached = self
+            .cache
+            .read()
+            .expect("Privatemode verifier cache poisoned")
+            .clone();
+        match cached {
+            Some(cached) if super::current_unix_secs() < cached.expires_at => {
+                Some(cached.event_for(request))
+            }
+            // Leave an expired entry in place until the serialized verify or
+            // refresh replaces it. Clearing it after dropping the read lock
+            // could erase a fresh event written concurrently by refresh.
+            Some(_) => None,
+            None => None,
+        }
+    }
+
+    fn maybe_cache(&self, event: &UpstreamVerifiedEvent) {
+        if self.cache_ttl_seconds == 0 || event.result != VerificationResult::Verified {
+            return;
+        }
+        *self
+            .cache
+            .write()
+            .expect("Privatemode verifier cache poisoned") = Some(CachedPrivatemodeEvent {
+            expires_at: super::current_unix_secs().saturating_add(self.cache_ttl_seconds),
+            event: event.clone(),
+        });
+    }
+}
+
+#[async_trait]
+impl UpstreamVerifier for PrivatemodeProviderVerifier {
+    async fn verify(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        if let Some(event) = self.cached_event(&request) {
+            return event;
+        }
+        let _verify_guard = self.verify_lock.lock().await;
+        if let Some(event) = self.cached_event(&request) {
+            return event;
+        }
+        let event = self.verify_deployment(request).await;
+        self.maybe_cache(&event);
+        event
+    }
+
+    async fn refresh(&self, request: UpstreamVerificationRequest) -> UpstreamVerifiedEvent {
+        let _verify_guard = self.verify_lock.lock().await;
+        let event = self.verify_deployment(request).await;
+        self.maybe_cache(&event);
+        event
+    }
+
+    fn invalidate(&self, _request: &UpstreamVerificationRequest) {
+        *self
+            .cache
+            .write()
+            .expect("Privatemode verifier cache poisoned") = None;
     }
 }
 

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -97,7 +97,7 @@ fn custody_report(identity: &SigningKey, signature_chain: Vec<String>) -> Attest
 /// and the seam accepts `None`. Stubs mirror that so the real accept paths run.
 fn declared_scope(provider: &str) -> Option<&'static str> {
     match provider {
-        "near-ai" | "tinfoil" | "secret-ai" => Some("router"),
+        "near-ai" | "tinfoil" | "secret-ai" | "privatemode" => Some("router"),
         _ => None,
     }
 }

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -30,6 +30,7 @@ pub(super) fn claim_mapper(provider_type: Option<&str>) -> &'static dyn Provider
     match provider_type {
         Some("tinfoil") => &TinfoilClaims,
         Some("secret-ai") => &SecretAiClaims,
+        Some("privatemode") => &PrivatemodeClaims,
         Some("near-ai") | Some("chutes") | Some("phala-direct") => &IntelTdxClaims,
         _ => &GenericClaims,
     }
@@ -209,6 +210,22 @@ impl ProviderClaimMapper for SecretAiClaims {
             serving_software_known_good: secret_ai_software_claim(event),
             os_known_good: secret_ai_os_claim(event),
             gpu_attested: secret_ai_gpu_claim(event),
+            ..SessionClaims::default()
+        }
+    }
+}
+
+/// Privatemode: the measured official proxy establishes a Contrast-attested
+/// E2EE secret before serving. Its dynamic manifest observation is not bound to
+/// the active secret, so manifest-specific transitive claims stay unknown.
+pub(super) struct PrivatemodeClaims;
+impl ProviderClaimMapper for PrivatemodeClaims {
+    fn claims(&self, _event: &UpstreamVerifiedEvent) -> SessionClaims {
+        SessionClaims {
+            tee_attested: Claim::asserted(
+                ClaimSource::VerifierDerived,
+                "measured Privatemode proxy established a Contrast-attested E2EE secret before serving",
+            ),
             ..SessionClaims::default()
         }
     }
@@ -697,6 +714,29 @@ mod claim_mapping_tests {
             claims.serving_software_known_good.status,
             ClaimStatus::Unknown
         );
+    }
+
+    #[test]
+    fn privatemode_asserts_only_manifest_independent_proof() {
+        let claims = session_claims_for_event(&event(
+            Some("privatemode"),
+            VerificationResult::Verified,
+            None,
+        ));
+        assert_eq!(claims.tee_attested.status, ClaimStatus::Asserted);
+        assert_eq!(
+            claims.tee_attested.source,
+            Some(ClaimSource::VerifierDerived)
+        );
+        for claim in [
+            &claims.gpu_attested,
+            &claims.os_known_good,
+            &claims.serving_software_known_good,
+            &claims.model_weights_provenance,
+        ] {
+            assert_eq!(claim.status, ClaimStatus::Unknown);
+        }
+        assert_eq!(claims.tcb_up_to_date.status, ClaimStatus::Unknown);
     }
 
     #[test]

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -11,12 +11,13 @@ use super::{
 use crate::aci::canonical;
 use crate::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ModelRoute, ModelRouterBackend,
-    OpenAICompatibleBackend, UpstreamBackend,
+    OpenAICompatibleBackend, PrivatemodeProviderBackend, UpstreamBackend,
 };
 use crate::aci::verifier::{
     AciServiceUpstreamVerifier, AciServiceVerifierPolicy, ChutesProviderVerifier,
     NearAiProviderVerifier, PhalaDirectProviderVerifier, PreverifiedUpstreamVerifier,
-    RoutingUpstreamVerifier, SecretAiProviderVerifier, TinfoilProviderVerifier,
+    PrivatemodeProviderVerifier, RoutingUpstreamVerifier, SecretAiProviderVerifier,
+    TinfoilProviderVerifier,
 };
 use crate::aggregator::service::UpstreamVerifier;
 
@@ -79,6 +80,7 @@ fn provider_is_tee(provider: UpstreamProvider) -> bool {
         | UpstreamProvider::Tinfoil
         | UpstreamProvider::NearAi
         | UpstreamProvider::SecretAi
+        | UpstreamProvider::Privatemode
         | UpstreamProvider::PhalaDirect => true,
     }
 }
@@ -107,6 +109,23 @@ fn build_provider_backend(
                 options,
                 session_store,
             )?))
+        }
+        UpstreamProvider::Privatemode => {
+            let deployment = options.privatemode_proxy.clone().ok_or_else(|| {
+                UpstreamConfigError::InvalidConfig(format!(
+                    "Privatemode upstream {:?} requires static privatemode_proxy gateway config",
+                    cfg.name
+                ))
+            })?;
+            enforce_privatemode_deployment(cfg, &deployment)?;
+            let backend = PrivatemodeProviderBackend::new_with_timeouts(
+                deployment,
+                connect_timeout_seconds,
+                read_timeout_seconds,
+            )
+            .map_err(|e| UpstreamConfigError::InvalidConfig(e.to_string()))?
+            .with_name(cfg.name.clone());
+            Ok(Arc::new(backend))
         }
         UpstreamProvider::OpenAiCompatible
         | UpstreamProvider::Anthropic
@@ -266,6 +285,25 @@ fn build_provider_verifier(
                 .with_accepted_workload_ids(cfg.accepted_workload_ids.clone().unwrap_or_default());
                 Some(Arc::new(verifier))
             }
+            UpstreamProvider::Privatemode => {
+                let deployment = options.privatemode_proxy.clone().ok_or_else(|| {
+                    UpstreamConfigError::InvalidConfig(format!(
+                        "Privatemode upstream {:?} requires static privatemode_proxy gateway config",
+                        cfg.name
+                    ))
+                })?;
+                enforce_privatemode_deployment(cfg, &deployment)?;
+                Some(Arc::new(
+                    PrivatemodeProviderVerifier::new(
+                        deployment,
+                        cfg.connect_timeout_seconds
+                            .unwrap_or(options.connect_timeout_seconds),
+                        request_timeout_seconds,
+                        cache_seconds,
+                    )
+                    .map_err(|err| UpstreamConfigError::InvalidConfig(err.to_string()))?,
+                ))
+            }
             UpstreamProvider::PhalaDirect => {
                 let mut verifier = PhalaDirectProviderVerifier::new_with_cache(
                     request_timeout_seconds,
@@ -286,6 +324,21 @@ fn build_provider_verifier(
         }
     }
     Ok(Some(Arc::new(router)))
+}
+
+fn enforce_privatemode_deployment(
+    cfg: &UpstreamConfig,
+    deployment: &crate::aci::upstream::PrivatemodeProxyDeployment,
+) -> Result<(), UpstreamConfigError> {
+    if cfg.base_url.trim_end_matches('/') != deployment.base_url() {
+        return Err(UpstreamConfigError::InvalidConfig(format!(
+            "Privatemode upstream {:?} base_url {:?} does not match static proxy endpoint {:?}",
+            cfg.name,
+            cfg.base_url,
+            deployment.base_url()
+        )));
+    }
+    Ok(())
 }
 
 fn build_global_verifier_for_config(

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::aci::canonical;
 use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
-use crate::aci::upstream::{ChutesSessionStore, UpstreamBackend, UpstreamError};
+use crate::aci::upstream::{
+    ChutesSessionStore, PrivatemodeProxyDeployment, UpstreamBackend, UpstreamError,
+};
 use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
 
 mod builders;
@@ -165,6 +167,7 @@ pub enum UpstreamProvider {
     Tinfoil,
     NearAi,
     SecretAi,
+    Privatemode,
     PhalaDirect,
 }
 
@@ -173,9 +176,10 @@ impl UpstreamProvider {
     /// must choose its scope rather than inherit a default.
     pub(crate) fn attestation_scope(self) -> AttestationScope {
         match self {
-            UpstreamProvider::NearAi | UpstreamProvider::Tinfoil | UpstreamProvider::SecretAi => {
-                AttestationScope::PerRouter
-            }
+            UpstreamProvider::NearAi
+            | UpstreamProvider::Tinfoil
+            | UpstreamProvider::SecretAi
+            | UpstreamProvider::Privatemode => AttestationScope::PerRouter,
             UpstreamProvider::Chutes => AttestationScope::PerInstance,
             UpstreamProvider::PhalaDirect => AttestationScope::PerModel,
             // Plain cloud APIs (OpenAI-compatible, Anthropic) have no verifier
@@ -258,6 +262,9 @@ pub struct UpstreamRuntimeOptions {
     pub connect_timeout_seconds: u64,
     pub read_timeout_seconds: u64,
     pub verifier_request_timeout_seconds: u64,
+    /// Statically measured Privatemode sidecar policy. Dynamic upstream config
+    /// may select this deployment but cannot replace its endpoint or pins.
+    pub privatemode_proxy: Option<Arc<PrivatemodeProxyDeployment>>,
 }
 
 /// Connection details for fetching a model's attestation report from its

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -1,4 +1,4 @@
-use super::builders::build_verifier;
+use super::builders::{build_state, build_verifier};
 use super::dynamic::{DynamicUpstreamVerifier, EmptyUpstreamBackend};
 use super::*;
 use crate::aci::receipt::{UpstreamVerifiedEvent, VerificationResult};
@@ -78,6 +78,7 @@ fn provider_attestation_scopes() {
     assert_eq!(UpstreamProvider::NearAi.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::Tinfoil.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::SecretAi.attestation_scope(), PerRouter);
+    assert_eq!(UpstreamProvider::Privatemode.attestation_scope(), PerRouter);
     assert_eq!(UpstreamProvider::PhalaDirect.attestation_scope(), PerModel);
     assert_eq!(UpstreamProvider::Chutes.attestation_scope(), PerInstance);
     assert_eq!(
@@ -130,6 +131,99 @@ fn parse_secret_ai_rejects_invalid_origins() {
             "{base_url:?}: {err}"
         );
     }
+}
+
+#[test]
+fn parse_config_forbids_privatemode_credentials_and_keeps_deployment_fields_static() {
+    let valid_text = r#"[{
+          "name": "privatemode",
+          "provider": "privatemode",
+          "base_url": "http://privatemode-proxy:8080",
+          "models": {"public-model": "provider-model"}
+        }]"#;
+    let valid = parse_config_text(valid_text).expect("Privatemode route should parse");
+    assert_eq!(valid[0].provider, UpstreamProvider::Privatemode);
+
+    for (field, expected) in [
+        (
+            r#""bearer_token": "must-not-cross-the-internal-hop""#,
+            "forbids bearer_token",
+        ),
+        (r#""path": "/v1/models""#, "forbids path"),
+        (
+            r#""privatemode_manifest_path": "/run/privatemode/manifest.json""#,
+            "unknown field",
+        ),
+    ] {
+        let candidate = valid_text.replace(
+            r#""models": {"public-model": "provider-model"}"#,
+            &format!(r#""models": {{"public-model": "provider-model"}}, {field}"#),
+        );
+        let err = parse_config_text(&candidate).expect_err("field must be rejected");
+        assert!(err.to_string().contains(expected), "{field}: {err}");
+    }
+}
+
+#[test]
+fn privatemode_route_must_match_the_static_proxy_deployment() {
+    let manifest_log_path = std::env::temp_dir().join(format!(
+        "private-ai-gateway-privatemode-manifest-log-{}-{}.txt",
+        std::process::id(),
+        rand::random::<u64>()
+    ));
+    let credential_path = manifest_log_path.with_extension("credential");
+    std::fs::write(&credential_path, b"secret").unwrap();
+    let deployment = Arc::new(
+        crate::aci::upstream::PrivatemodeProxyDeployment::new(
+            "http://privatemode-proxy:8080",
+            &manifest_log_path,
+            &credential_path,
+            crate::aci::canonical::sha256_hex(b"secret"),
+            format!("sha256:{}", "22".repeat(32)),
+        )
+        .unwrap(),
+    );
+    let _ = std::fs::remove_file(credential_path);
+
+    let mut route = test_upstream_config(
+        "privatemode",
+        UpstreamProvider::Privatemode,
+        "public-model",
+        "provider-model",
+    );
+    route.base_url = deployment.base_url().to_string();
+    let mut options = UpstreamRuntimeOptions {
+        verifier_mode: UpstreamVerifierMode::None,
+        accepted_workload_ids: Vec::new(),
+        accepted_image_digests: Vec::new(),
+        accepted_dstack_kms_root_public_keys: Vec::new(),
+        pccs_url: None,
+        verifier_cache_seconds: 300,
+        connect_timeout_seconds: 10,
+        read_timeout_seconds: 600,
+        verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
+    };
+
+    let err = match build_state(&[route.clone()], &options) {
+        Ok(_) => panic!("Privatemode route without static deployment must fail"),
+        Err(err) => err,
+    };
+    assert!(err
+        .to_string()
+        .contains("requires static privatemode_proxy"));
+
+    options.privatemode_proxy = Some(deployment);
+    build_state(&[route.clone()], &options)
+        .expect("matching static Privatemode deployment should build");
+    route.base_url = "http://different-proxy:8080".to_string();
+    let err = match build_state(&[route], &options) {
+        Ok(_) => panic!("mutable route must not redirect the static proxy"),
+        Err(err) => err,
+    };
+    assert!(err
+        .to_string()
+        .contains("does not match static proxy endpoint"));
 }
 
 #[async_trait]
@@ -242,6 +336,7 @@ fn global_aci_service_does_not_require_policy_for_plain_openai_compatible_upstre
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     };
 
     let verifier = build_verifier(&config, &options, &ProviderSessionRegistry::default())
@@ -333,6 +428,7 @@ async fn prewarm_verification_deduplicates_upstream_models() {
             connect_timeout_seconds: 10,
             read_timeout_seconds: 600,
             verifier_request_timeout_seconds: 60,
+            privatemode_proxy: None,
         },
         state,
         session_sink: Arc::new(RwLock::new(None)),

--- a/src/aggregator/upstream_config/validation.rs
+++ b/src/aggregator/upstream_config/validation.rs
@@ -281,6 +281,18 @@ pub(super) fn validate_config(config: &[UpstreamConfig]) -> Result<(), UpstreamC
                 upstream.name
             )));
         }
+        if upstream.provider == UpstreamProvider::Privatemode && upstream.bearer_token.is_some() {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} provider privatemode forbids bearer_token; the measured proxy reads its credential from the shared Compose secret",
+                upstream.name
+            )));
+        }
+        if upstream.provider == UpstreamProvider::Privatemode && upstream.path.is_some() {
+            return Err(UpstreamConfigError::InvalidConfig(format!(
+                "upstream {:?} provider privatemode forbids path; the measured proxy backend pins encrypted handler paths",
+                upstream.name
+            )));
+        }
         // The native Anthropic API only serves /v1/messages; without an
         // explicit path the router falls back to /v1/chat/completions and
         // every request 404s with no config-time signal.

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -7,9 +7,11 @@
 //!   `report_data` (URL-decoded UTF-8 string, or JSON `null` when
 //!   absent).
 //! * `POST /v1/chat/completions` - OpenAI-shaped chat-completion
-//!   forwarding with ACI-side hashing and receipt signing. An
-//!   optional `Authorization: Bearer <token>` is recorded on the
-//!   receipt so later lookups can authenticate the original requester.
+//!   forwarding with ACI-side hashing and receipt signing. When an inference
+//!   token digest is configured in direct mode, `Authorization: Bearer <token>`
+//!   must match it; the bearer also owns the receipt for later authenticated
+//!   retrieval. Middleware mode instead preserves each client's bearer for
+//!   control-plane authorization and attribution.
 //! * `POST /v1/completions` - compatibility surface. The aggregator
 //!   forwards legacy prompt completions through the same ACI receipt
 //!   path as chat completions. ACI E2EE is an optional add-on here;
@@ -91,6 +93,7 @@ const MAX_REQUEST_BODY_BYTES: usize = 32 * 1024 * 1024;
 use crate::aggregator::service::AciService;
 use crate::aggregator::upstream_config::UpstreamConfigManager;
 use crate::middleware::Middleware;
+use util::enforce_inference;
 
 mod backend;
 mod error_responses;
@@ -109,19 +112,27 @@ pub struct AppState {
     pub service: Arc<AciService>,
     pub upstream_config: Option<Arc<UpstreamConfigManager>>,
     pub admin_token: Option<String>,
+    pub inference_token_sha256: Option<[u8; 32]>,
     middleware: Option<Arc<Middleware>>,
 }
 
 pub fn build_router(service: Arc<AciService>) -> Router {
-    build_router_inner(service, None, None, None)
+    build_router_inner(service, None, None, None, None)
 }
 
 pub fn build_router_with_admin(
     service: Arc<AciService>,
     upstream_config: Arc<UpstreamConfigManager>,
     admin_token: Option<String>,
+    inference_token_sha256: Option<[u8; 32]>,
 ) -> Router {
-    build_router_inner(service, Some(upstream_config), admin_token, None)
+    build_router_inner(
+        service,
+        Some(upstream_config),
+        admin_token,
+        inference_token_sha256,
+        None,
+    )
 }
 
 /// Build the gateway router with the middleware, which consults the
@@ -136,6 +147,7 @@ pub fn build_router_with_admin_and_middleware(
         service,
         Some(upstream_config),
         admin_token,
+        None,
         Some(middleware),
     )
 }
@@ -144,26 +156,34 @@ fn build_router_inner(
     service: Arc<AciService>,
     upstream_config: Option<Arc<UpstreamConfigManager>>,
     admin_token: Option<String>,
+    inference_token_sha256: Option<[u8; 32]>,
     middleware: Option<Arc<Middleware>>,
 ) -> Router {
     let state = AppState {
         service,
         upstream_config,
         admin_token,
+        inference_token_sha256,
         middleware,
     };
     Router::new()
-        .route("/", get(root))
-        .route("/health", get(health))
-        // OpenAI- and Anthropic-compatible inference surface.
-        .route("/v1/models", get(models))
-        .route("/v1/models/*rest", get(models_subpath))
-        .route("/v1/embeddings/models", get(embeddings_models))
+        // Apply inference authentication before any handler polls a body
+        // extractor. `route_layer` affects only the inference routes declared
+        // above it; catalogs and operational endpoints remain public.
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/completions", post(completions))
         .route("/v1/embeddings", post(embeddings))
         .route("/v1/messages", post(messages))
         .route("/v1/responses", post(responses))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            inference_auth_middleware,
+        ))
+        .route("/", get(root))
+        .route("/health", get(health))
+        .route("/v1/models", get(models))
+        .route("/v1/models/*rest", get(models_subpath))
+        .route("/v1/embeddings/models", get(embeddings_models))
         // Gateway operations.
         .route("/v1/metrics", get(metrics))
         .route(
@@ -197,6 +217,17 @@ fn build_router_inner(
         // legitimate payloads fit.
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         .with_state(state)
+}
+
+async fn inference_auth_middleware(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if let Some(response) = enforce_inference(&state, req.headers()) {
+        return response;
+    }
+    next.run(req).await
 }
 
 /// Middleware that stamps `X-ACI-Version`, `X-ACI-Identity`, and

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -5,6 +5,8 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::Response,
 };
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 
 use crate::aggregator::service::ReceiptOwner;
 
@@ -130,6 +132,27 @@ pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Res
             StatusCode::FORBIDDEN,
             "forbidden",
             "invalid admin bearer token",
+        ))
+    }
+}
+
+pub(super) fn enforce_inference(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+    let expected = state.inference_token_sha256?;
+    let Some(token) = extract_bearer(headers) else {
+        return Some(error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "inference bearer token required",
+        ));
+    };
+    let actual: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+    if bool::from(actual.ct_eq(&expected)) {
+        None
+    } else {
+        Some(error_response(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "invalid inference bearer token",
         ))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ use private_ai_gateway::aci::types::{
     KeysetEpoch, ServiceCapabilities, SourceProvenance, TlsSpki, WorkloadIdentity, WorkloadKeyset,
 };
 use private_ai_gateway::aci::upstream::{
-    DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS, DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
+    PrivatemodeProxyDeployment, DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+    DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
 };
 use private_ai_gateway::aci::verifier::DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS;
 use private_ai_gateway::aggregator::keyset_epoch::{self, DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS};
@@ -61,6 +62,76 @@ fn env_non_empty(name: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn env_file_non_empty(path: &str, name: &str) -> Result<Option<String>, String> {
+    let entries = dotenvy::from_path_iter(path)
+        .map_err(|err| format!("failed to read encrypted environment file {path}: {err}"))?;
+    let mut value = None;
+    for entry in entries {
+        let (key, candidate) = entry
+            .map_err(|err| format!("failed to parse encrypted environment file {path}: {err}"))?;
+        if key == name {
+            value = Some(candidate);
+        }
+    }
+    Ok(value
+        .map(|candidate| candidate.trim().to_string())
+        .filter(|candidate| !candidate.is_empty()))
+}
+
+fn validate_sha256_secret_policy(
+    name: &str,
+    secret: Option<&str>,
+    expected: Option<&str>,
+) -> Result<(), String> {
+    let Some(expected_bytes) = parse_sha256_policy(name, expected)? else {
+        return Ok(());
+    };
+    let secret = secret.ok_or_else(|| format!("{name}_sha256 requires {name}"))?;
+    let actual: [u8; 32] = Sha256::digest(secret.as_bytes()).into();
+    if actual != expected_bytes {
+        return Err(format!("{name} does not match static {name}_sha256 policy"));
+    }
+    Ok(())
+}
+
+fn parse_sha256_policy(name: &str, expected: Option<&str>) -> Result<Option<[u8; 32]>, String> {
+    let Some(expected) = expected else {
+        return Ok(None);
+    };
+    let expected = expected
+        .trim()
+        .strip_prefix("sha256:")
+        .unwrap_or(expected.trim());
+    let expected_bytes =
+        hex::decode(expected).map_err(|err| format!("invalid {name}_sha256: {err}"))?;
+    expected_bytes
+        .try_into()
+        .map(Some)
+        .map_err(|bytes: Vec<u8>| {
+            format!(
+                "invalid {name}_sha256: expected 32 bytes, got {}",
+                bytes.len()
+            )
+        })
+}
+
+fn validate_inference_auth_policy(
+    privatemode_configured: bool,
+    middleware_configured: bool,
+    inference_token_sha256: Option<[u8; 32]>,
+) -> Result<(), String> {
+    if middleware_configured && inference_token_sha256.is_some() {
+        return Err(
+            "inference_token_sha256 cannot be used with middleware; middleware authorizes each client bearer"
+                .to_string(),
+        );
+    }
+    if privatemode_configured && !middleware_configured && inference_token_sha256.is_none() {
+        return Err("privatemode_proxy requires inference_token_sha256".to_string());
+    }
+    Ok(())
+}
+
 fn invalid_input(message: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidInput, message.into())
 }
@@ -72,12 +143,31 @@ struct GatewayConfigFile {
     state_dir: Option<String>,
     upstream_config_seed_path: Option<String>,
     admin_token: Option<String>,
+    admin_token_sha256: Option<String>,
+    /// Optional measured digest of the downstream bearer accepted by direct-mode
+    /// inference endpoints. Middleware mode preserves each client's bearer for
+    /// control-plane authorization instead.
+    inference_token_sha256: Option<String>,
     /// Bounded keyset-epoch validity window in seconds (§4.7). Defaults to
     /// [`DEFAULT_KEYSET_EPOCH_WINDOW_SECONDS`] (~4 weeks).
     keyset_epoch_window_seconds: Option<u64>,
     tls: GatewayTlsConfig,
     dstack_endpoint: Option<String>,
     middleware: Option<MiddlewareConfig>,
+    /// Deployment-owned Privatemode sidecar policy. Unlike upstream routes,
+    /// this is static so the admin API cannot redirect plaintext to another
+    /// proxy or change the measured proxy-image pin.
+    privatemode_proxy: Option<PrivatemodeProxyConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrivatemodeProxyConfig {
+    base_url: String,
+    manifest_log_path: String,
+    credential_path: String,
+    credential_sha256: String,
+    proxy_image_digest: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -351,11 +441,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let upstream_config_path = upstream_config_path(&state_dir);
     let session_log_path = session_log_path(&state_dir);
     let upstream_config_seed_path = gateway_config.upstream_config_seed_path.clone();
-    let admin_token = gateway_config.admin_token.clone();
+    let admin_token = match env_non_empty("PRIVATE_AI_GATEWAY_ADMIN_TOKEN") {
+        Some(token) => Some(token),
+        None => match env_non_empty("PRIVATE_AI_GATEWAY_ENV_FILE") {
+            Some(path) => env_file_non_empty(&path, "PRIVATE_AI_GATEWAY_ADMIN_TOKEN")
+                .map_err(invalid_input)?,
+            None => gateway_config.admin_token.clone(),
+        },
+    };
+    validate_sha256_secret_policy(
+        "admin_token",
+        admin_token.as_deref(),
+        gateway_config.admin_token_sha256.as_deref(),
+    )
+    .map_err(invalid_input)?;
+    let inference_token_sha256 = parse_sha256_policy(
+        "inference_token",
+        gateway_config.inference_token_sha256.as_deref(),
+    )
+    .map_err(invalid_input)?;
+    validate_inference_auth_policy(
+        gateway_config.privatemode_proxy.is_some(),
+        gateway_config.middleware.is_some(),
+        inference_token_sha256,
+    )
+    .map_err(invalid_input)?;
     let source_provenance = resolve_source_provenance()?;
     let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
     let dstack_endpoint = gateway_config.dstack_endpoint.clone();
     let middleware_config = gateway_config.middleware.clone();
+    let privatemode_proxy = gateway_config
+        .privatemode_proxy
+        .as_ref()
+        .map(|config| {
+            PrivatemodeProxyDeployment::new(
+                &config.base_url,
+                &config.manifest_log_path,
+                &config.credential_path,
+                &config.credential_sha256,
+                &config.proxy_image_digest,
+            )
+            .map(Arc::new)
+            .map_err(|err| invalid_input(err.to_string()))
+        })
+        .transpose()?;
 
     let provider = Arc::new(
         DstackAciProvider::new(dstack_endpoint, DstackAciProviderConfig::default()).await?,
@@ -375,6 +504,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             connect_timeout_seconds: DEFAULT_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
             read_timeout_seconds: DEFAULT_UPSTREAM_READ_TIMEOUT_SECONDS,
             verifier_request_timeout_seconds: DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS,
+            privatemode_proxy,
         },
     )?);
     let upstream = upstream_config.backend();
@@ -504,7 +634,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         build_router_with_admin_and_middleware(service, upstream_config, admin_token, middleware)
     } else {
-        build_router_with_admin(service, upstream_config, admin_token)
+        build_router_with_admin(
+            service,
+            upstream_config,
+            admin_token,
+            inference_token_sha256,
+        )
     };
 
     tracing::info!(%bind, "private-ai-gateway listening");
@@ -628,9 +763,11 @@ mod tests {
     use private_ai_gateway::aggregator::upstream_config::{parse_config_text, UpstreamProvider};
 
     use super::{
-        keyset_epoch_path, load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
-        revocations_path, seed_upstream_config_if_empty, session_log_path,
+        env_file_non_empty, keyset_epoch_path, load_gateway_config, parse_sha256_policy,
+        resolve_state_dir, resolve_tls_public_keys, revocations_path,
+        seed_upstream_config_if_empty, session_log_path,
         source_provenance_from_git_launcher_config, upstream_config_path,
+        validate_inference_auth_policy, validate_sha256_secret_policy,
     };
 
     const TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -667,6 +804,58 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
         path
     }
 
+    #[test]
+    fn encrypted_env_admin_token_is_parsed_and_digest_bound() {
+        let path = temp_path("gateway-encrypted-env");
+        std::fs::write(
+            &path,
+            "IGNORED=value\nPRIVATE_AI_GATEWAY_ADMIN_TOKEN='admin token'\n",
+        )
+        .unwrap();
+        let token =
+            env_file_non_empty(path.to_str().unwrap(), "PRIVATE_AI_GATEWAY_ADMIN_TOKEN").unwrap();
+        assert_eq!(token.as_deref(), Some("admin token"));
+        let digest = private_ai_gateway::aci::canonical::sha256_hex(b"admin token");
+        validate_sha256_secret_policy("admin_token", token.as_deref(), Some(&digest)).unwrap();
+        let err = validate_sha256_secret_policy("admin_token", Some("different"), Some(&digest))
+            .unwrap_err();
+        assert!(err.contains("does not match static admin_token_sha256"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn inference_token_digest_policy_is_validated_without_loading_the_secret() {
+        let prefixed = private_ai_gateway::aci::canonical::sha256_hex(b"client token");
+        let digest = prefixed.strip_prefix("sha256:").unwrap();
+        let parsed = parse_sha256_policy("inference_token", Some(digest))
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed.as_slice(), hex::decode(digest).unwrap());
+
+        assert_eq!(
+            parse_sha256_policy("inference_token", Some(&prefixed)).unwrap(),
+            Some(parsed)
+        );
+        let err = parse_sha256_policy("inference_token", Some("00")).unwrap_err();
+        assert!(err.contains("expected 32 bytes"));
+    }
+
+    #[test]
+    fn privatemode_static_policy_requires_downstream_inference_auth() {
+        assert!(validate_inference_auth_policy(false, false, None).is_ok());
+        assert!(validate_inference_auth_policy(false, false, Some([7; 32])).is_ok());
+        assert!(validate_inference_auth_policy(true, false, Some([7; 32])).is_ok());
+        let err = validate_inference_auth_policy(true, false, None).unwrap_err();
+        assert_eq!(err, "privatemode_proxy requires inference_token_sha256");
+
+        assert!(validate_inference_auth_policy(true, true, None).is_ok());
+        let err = validate_inference_auth_policy(true, true, Some([7; 32])).unwrap_err();
+        assert_eq!(
+            err,
+            "inference_token_sha256 cannot be used with middleware; middleware authorizes each client bearer"
+        );
+    }
+
     fn temp_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
             "private-ai-gateway-{name}-{}-{}.json",
@@ -692,6 +881,45 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
         let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
 
         assert_eq!(config.state_dir.as_deref(), Some("/gateway/state"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn gateway_config_parses_static_privatemode_proxy_policy() {
+        let config_path = temp_path("gateway-config-privatemode");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"{{
+                    "privatemode_proxy": {{
+                        "base_url": "http://privatemode-proxy:8080",
+                        "manifest_log_path": "/run/privatemode-manifests/log.txt",
+                        "credential_path": "/run/secrets/privatemode-api-key",
+                        "credential_sha256": "{}",
+                        "proxy_image_digest": "sha256:{}"
+                    }}
+                }}"#,
+                "33".repeat(32),
+                "22".repeat(32)
+            ),
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+        let proxy = config
+            .privatemode_proxy
+            .expect("static Privatemode policy should parse");
+        assert_eq!(proxy.base_url, "http://privatemode-proxy:8080");
+        assert_eq!(
+            proxy.manifest_log_path,
+            "/run/privatemode-manifests/log.txt"
+        );
+        assert_eq!(proxy.credential_path, "/run/secrets/privatemode-api-key");
+        assert_eq!(proxy.credential_sha256, "33".repeat(32));
+        assert_eq!(
+            proxy.proxy_image_digest,
+            format!("sha256:{}", "22".repeat(32))
+        );
         let _ = std::fs::remove_file(config_path);
     }
 

--- a/tests/entrypoint.rs
+++ b/tests/entrypoint.rs
@@ -25,6 +25,102 @@ fn script_text() -> String {
     std::fs::read_to_string(script_path()).expect("entrypoint.sh must exist at repo root")
 }
 
+fn compose_service<'a>(body: &'a str, name: &str, next_section: &str) -> &'a str {
+    let heading = format!("\n  {name}:\n");
+    body.split(&heading)
+        .nth(1)
+        .and_then(|rest| rest.split(next_section).next())
+        .unwrap_or_else(|| panic!("compose must declare a {name} service"))
+}
+
+#[test]
+fn privatemode_deployment_contract_is_pinned() {
+    let compose = std::fs::read_to_string(repo_root().join("deploy/compose.privatemode.yaml"))
+        .expect("Privatemode deployment compose must exist");
+    let gateway = compose_service(&compose, "private-ai-gateway", "\n  privatemode-proxy:\n");
+    let proxy = compose_service(&compose, "privatemode-proxy", "\nconfigs:\n");
+    let renderer_path = repo_root().join("deploy/render-privatemode-compose.sh");
+    let renderer =
+        std::fs::read_to_string(&renderer_path).expect("Privatemode renderer must exist");
+    let checks: &[(&str, &str, &[&str], &[&str])] = &[
+        (
+            "proxy service",
+            proxy,
+            &[
+                "ghcr.io/edgelesssys/privatemode/privatemode-proxy@sha256:ff900b263a51a437633d15da809e7893a31fa4b1f4acfa4e526c075682d84307",
+                "--apiKey", "@/run/secrets/privatemode-api-key",
+                "--nvidiaOCSPAllowUnknown=false", "--nvidiaOCSPRevokedGracePeriod=0",
+                "source: privatemode-api-key", "tmpfs:",
+                "privatemode-manifests:/var/lib/privatemode/manifests",
+                "ai.private-gateway.privatemode-credential-sha256",
+            ],
+            &["ports:", "privatemode-state", "--manifestPath"],
+        ),
+        (
+            "whole compose",
+            &compose,
+            &[
+                r#""base_url": "http://privatemode-proxy:8080""#,
+                r#""manifest_log_path": "/run/privatemode-manifests/log.txt""#,
+                r#""credential_path": "/run/secrets/privatemode-api-key""#,
+                "PRIVATEMODE_CREDENTIAL_SHA256:?",
+                "PRIVATE_AI_GATEWAY_ADMIN_TOKEN_SHA256:?",
+                "PRIVATE_AI_GATEWAY_INFERENCE_TOKEN_SHA256:?",
+                "/dstack/.host-shared/.decrypted-env",
+                "PRIVATE_AI_GATEWAY_ENV_FILE: /run/secrets/dstack-encrypted-env",
+                "environment: PRIVATEMODE_API_KEY",
+            ],
+            &[
+                r#""admin_token": "${PRIVATE_AI_GATEWAY_ADMIN_TOKEN"#,
+                "--apiKey=${PRIVATEMODE_API_KEY}",
+                "PRIVATEMODE_MANIFEST_PATH",
+                "PRIVATEMODE_MANIFEST_SHA256",
+            ],
+        ),
+        (
+            "gateway service",
+            gateway,
+            &[
+                "ai.private-gateway.source-commit", "ai.private-gateway.admin-token-sha256",
+                "ai.private-gateway.inference-token-sha256",
+                "ai.private-gateway.privatemode-credential-sha256",
+                "privatemode-manifests:/run/privatemode-manifests:ro",
+            ],
+            &[],
+        ),
+        (
+            "renderer",
+            &renderer,
+            &[
+                "PRIVATEMODE_CREDENTIAL_SHA256=$(",
+                r#"printf '%s' "$PRIVATEMODE_API_KEY""#,
+                "PRIVATE_AI_GATEWAY_ADMIN_TOKEN", "PRIVATE_AI_GATEWAY_INFERENCE_TOKEN",
+                "PRIVATEMODE_API_KEY",
+            ],
+            &["jq", "PRIVATEMODE_MANIFEST"],
+        ),
+    ];
+    for (scope, body, required, forbidden) in checks {
+        for needle in *required {
+            assert!(body.contains(needle), "{scope} missing {needle}");
+        }
+        for needle in *forbidden {
+            assert!(!body.contains(needle), "{scope} contains {needle}");
+        }
+    }
+    assert_eq!(compose.matches("source: privatemode-manifest").count(), 0);
+    assert_eq!(compose.matches("source: privatemode-api-key").count(), 2);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(renderer_path)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_ne!(mode & 0o111, 0, "Privatemode renderer must be executable");
+    }
+}
+
 #[test]
 fn entrypoint_sh_exists_and_is_executable() {
     let p = script_path();
@@ -122,6 +218,10 @@ fn entrypoint_sh_apt_install_is_strict() {
     assert!(
         body.contains("apt-get install -y --no-install-recommends"),
         "apt-get install line must use --no-install-recommends to keep the trust surface minimal"
+    );
+    assert!(
+        body.contains("command -v cc") && body.contains("apt_packages+=(build-essential)"),
+        "entrypoint.sh must install a native compiler/linker when the launcher image only supplies Rust"
     );
     assert!(
         body.contains("rustup default stable"),

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -3,7 +3,11 @@
 //! Uses `tower::ServiceExt::oneshot` to drive the router directly,
 //! avoiding a TCP listener.
 
-use std::sync::{Arc, Mutex};
+use std::convert::Infallible;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 
 mod common;
 
@@ -32,6 +36,7 @@ use private_ai_gateway::aggregator::upstream_config::{
 };
 use private_ai_gateway::http::{build_router, build_router_with_admin};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tower::ServiceExt;
 
 use common::{verified_event, StaticKeyProvider, StubQuoter};
@@ -397,6 +402,63 @@ async fn attestation_report_nonce_null_when_absent() {
             .unwrap(),
         expected_hex
     );
+}
+
+#[tokio::test]
+async fn configured_inference_token_blocks_unauthenticated_paid_forwarding() {
+    let h = make_harness();
+    let manager = load_manager("[]");
+    let expected: [u8; 32] = Sha256::digest(b"client-inference-token").into();
+    let app = build_router_with_admin(h.service.clone(), manager, None, Some(expected));
+
+    let body_polled = Arc::new(AtomicBool::new(false));
+    let body_polled_by_stream = body_polled.clone();
+    let body = Body::from_stream(futures_util::stream::once(async move {
+        body_polled_by_stream.store(true, Ordering::SeqCst);
+        Ok::<_, Infallible>(br#"{"model":"x","messages":[]}"#.to_vec())
+    }));
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(body)
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        !body_polled.load(Ordering::SeqCst),
+        "authentication must reject the request before polling its body"
+    );
+
+    for (token, expected_status) in [
+        (Some("wrong-token"), StatusCode::FORBIDDEN),
+        (Some("client-inference-token"), StatusCode::OK),
+    ] {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json");
+        if let Some(token) = token {
+            request = request.header("authorization", format!("Bearer {token}"));
+        }
+        let response = app
+            .clone()
+            .oneshot(
+                request
+                    .body(Body::from(br#"{"model":"x","messages":[]}"#.to_vec()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), expected_status);
+    }
+
+    assert!(h.received.lock().unwrap().is_some());
 }
 
 #[tokio::test]
@@ -931,10 +993,11 @@ fn upstream_runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 30,
         verifier_request_timeout_seconds: 30,
+        privatemode_proxy: None,
     }
 }
 
-fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
+fn load_manager(config_json: &str) -> Arc<UpstreamConfigManager> {
     // Unique per call: a coarse system clock can hand concurrent tests the same
     // nanos, so an atomic counter guarantees distinct temp paths.
     static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -944,7 +1007,11 @@ fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
         SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
     ));
     std::fs::write(&path, config_json).unwrap();
-    let manager = Arc::new(UpstreamConfigManager::load(&path, upstream_runtime_options()).unwrap());
+    Arc::new(UpstreamConfigManager::load(&path, upstream_runtime_options()).unwrap())
+}
+
+fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
+    let manager = load_manager(config_json);
     let keys = Arc::new(StaticKeyProvider::default());
     let service = Arc::new(
         AciService::new_with_upstream_verifier(
@@ -958,7 +1025,7 @@ fn setup_with_config(config_json: &str) -> (Arc<AciService>, Router) {
         )
         .unwrap(),
     );
-    let app = build_router_with_admin(service.clone(), manager, None);
+    let app = build_router_with_admin(service.clone(), manager, None, None);
     (service, app)
 }
 

--- a/tests/keyset_revocation.rs
+++ b/tests/keyset_revocation.rs
@@ -47,6 +47,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -74,7 +75,7 @@ fn build_harness(dir: &std::path::Path) -> Harness {
         .with_revocation_store(revocation_store),
     );
     Harness {
-        app: build_router_with_admin(service, manager, Some(ADMIN_TOKEN.to_string())),
+        app: build_router_with_admin(service, manager, Some(ADMIN_TOKEN.to_string()), None),
         revocations_path,
     }
 }

--- a/tests/middleware_catalog.rs
+++ b/tests/middleware_catalog.rs
@@ -4,7 +4,7 @@
 //! catalog endpoints to the control plane, and that direct-upstream mode keeps
 //! its unchanged sub-catalog behavior (404).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 mod common;
 
@@ -12,7 +12,7 @@ use axum::{
     body::{to_bytes, Body},
     extract::RawQuery,
     http::{Request, StatusCode},
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use private_ai_gateway::aggregator::service::{
@@ -22,7 +22,7 @@ use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::http::{build_router_with_admin, build_router_with_admin_and_middleware};
-use private_ai_gateway::middleware::{Middleware, MiddlewareConfig};
+use private_ai_gateway::middleware::{hash_api_key, Middleware, MiddlewareConfig};
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
 use tower::ServiceExt;
@@ -51,6 +51,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -104,6 +105,27 @@ async fn spawn_stub_control() -> String {
     format!("http://{addr}")
 }
 
+async fn spawn_control_capturing_auth() -> (String, Arc<Mutex<Vec<Value>>>) {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let captured_by_route = captured.clone();
+    let app = Router::new().route(
+        "/consult/pre",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_by_route.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                Json(json!({ "allow": false }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), captured)
+}
+
 async fn get_json(app: Router, uri: &str) -> (StatusCode, Value) {
     let resp = app
         .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
@@ -113,6 +135,53 @@ async fn get_json(app: Router, uri: &str) -> (StatusCode, Value) {
     let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
     (status, body)
+}
+
+#[tokio::test]
+async fn middleware_preserves_distinct_client_bearers_for_authorization() {
+    let (control_url, captured) = spawn_control_capturing_auth().await;
+    let middleware = Arc::new(
+        Middleware::new(&MiddlewareConfig {
+            control_url,
+            control_token: None,
+            control_timeout_ms: Some(2_000),
+            control_post_timeout_ms: Some(2_000),
+            sse_keepalive_ms: None,
+            tee_only_domains: Vec::new(),
+        })
+        .unwrap(),
+    );
+    let (service, manager) = build_service();
+    let app = build_router_with_admin_and_middleware(service, manager, None, middleware);
+
+    for token in ["client-one", "client-two"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        br#"{"model":"private-model","messages":[]}"#.to_vec(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "the request must reach the control plane's denial"
+        );
+    }
+
+    let captured = captured.lock().unwrap();
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0]["apiKeyHash"], hash_api_key("client-one"));
+    assert_eq!(captured[1]["apiKeyHash"], hash_api_key("client-two"));
+    assert_ne!(captured[0]["apiKeyHash"], captured[1]["apiKeyHash"]);
 }
 
 #[tokio::test]
@@ -193,7 +262,7 @@ async fn relays_catalog_query_string_to_control() {
 #[tokio::test]
 async fn direct_mode_sub_catalogs_remain_not_found() {
     let (service, manager) = build_service();
-    let app = build_router_with_admin(service, manager, None);
+    let app = build_router_with_admin(service, manager, None, None);
 
     let (status, _) = get_json(app.clone(), "/v1/models/my-namespace").await;
     assert_eq!(status, StatusCode::NOT_FOUND);

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -269,6 +269,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 

--- a/tests/provider_e2e.rs
+++ b/tests/provider_e2e.rs
@@ -6,17 +6,23 @@
 //! struct.
 
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 use std::io::{Read, Write};
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
 
 mod common;
 
 use axum::{
     body::{to_bytes, Body, Bytes},
-    extract::{Path, Query, State},
+    extract::{OriginalUri, Path, Query, State},
     http::{HeaderMap, Request, StatusCode},
     response::IntoResponse,
-    routing::{get, post},
+    routing::{any, get, post},
     Json, Router,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -25,6 +31,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Nonce,
 };
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use futures_util::StreamExt;
 use ml_kem::{
     kem::{Decapsulate, Encapsulate, Kem, KeyExport, TryKeyInit},
     ml_kem_768::{
@@ -35,15 +42,19 @@ use ml_kem::{
 };
 use private_ai_gateway::aci::canonical::sha256_hex;
 use private_ai_gateway::aci::receipt::{
-    ChannelBinding, UpstreamVerifiedEvent, EVENT_REQUEST_FORWARDED, EVENT_UPSTREAM_VERIFIED,
+    ChannelBinding, UpstreamVerifiedEvent, VerificationResult, EVENT_REQUEST_FORWARDED,
+    EVENT_UPSTREAM_VERIFIED,
 };
 use private_ai_gateway::aci::upstream::{
     ChutesProviderBackend, ChutesSessionStore, ChutesVerifiedDiscovery, ChutesVerifiedInstance,
-    OpenAICompatibleBackend, UpstreamRequest,
+    OpenAICompatibleBackend, PrivatemodeProviderBackend, PrivatemodeProxyDeployment,
+    UpstreamBackend, UpstreamRequest,
 };
-use private_ai_gateway::aci::verifier::StaticUpstreamVerifier;
+use private_ai_gateway::aci::verifier::{PrivatemodeProviderVerifier, StaticUpstreamVerifier};
 use private_ai_gateway::aggregator::service::{
-    AciService, AciServiceConfig, FixedClock, InMemoryReceiptStore,
+    AciService, AciServiceConfig, ChatCompletionRequest, FixedClock, ForwardCandidate,
+    GatewayRequestContext, InMemoryReceiptStore, MiddlewareForwardResult, MiddlewareReceiptJournal,
+    UpstreamVerificationRequest, UpstreamVerifier,
 };
 use private_ai_gateway::aggregator::upstream_config::{
     UpstreamConfig, UpstreamConfigManager, UpstreamProvider, UpstreamRuntimeOptions,
@@ -103,15 +114,17 @@ struct ProviderCall {
 #[derive(Clone)]
 struct ProviderState {
     calls: Arc<Mutex<Vec<ProviderCall>>>,
+    plaintext_path_hits: Arc<AtomicUsize>,
 }
 
 async fn chat_handler(
     State(state): State<ProviderState>,
+    OriginalUri(uri): OriginalUri,
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
     state.calls.lock().unwrap().push(ProviderCall {
-        path: "/v1/chat/completions".to_string(),
+        path: uri.path().to_string(),
         authorization: headers
             .get("authorization")
             .and_then(|value| value.to_str().ok())
@@ -148,6 +161,39 @@ async fn models_handler() -> impl IntoResponse {
             "owned_by": "provider-fixture"
         }]
     }))
+}
+
+async fn privatemode_models_handler(headers: HeaderMap) -> axum::response::Response {
+    if headers.contains_key("authorization") {
+        let reflected_credential = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("invalid authorization")
+            .to_string();
+        return (StatusCode::BAD_REQUEST, reflected_credential).into_response();
+    }
+    models_handler().await.into_response()
+}
+
+async fn privatemode_chat_handler(
+    State(state): State<ProviderState>,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    if headers.contains_key("authorization") {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    chat_handler(State(state), uri, headers, body)
+        .await
+        .into_response()
+}
+
+async fn privatemode_plaintext_path_handler(
+    State(state): State<ProviderState>,
+) -> impl IntoResponse {
+    state.plaintext_path_hits.fetch_add(1, Ordering::SeqCst);
+    StatusCode::NO_CONTENT
 }
 
 async fn embeddings_handler(
@@ -192,6 +238,7 @@ async fn serve_openai_provider_fixture() -> (String, Arc<Mutex<Vec<ProviderCall>
         .route("/v1/models", get(models_handler))
         .with_state(ProviderState {
             calls: calls.clone(),
+            plaintext_path_hits: Arc::new(AtomicUsize::new(0)),
         });
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -199,6 +246,321 @@ async fn serve_openai_provider_fixture() -> (String, Arc<Mutex<Vec<ProviderCall>
         axum::serve(listener, app).await.unwrap();
     });
     (format!("http://{addr}"), calls)
+}
+
+async fn serve_privatemode_provider_fixture(
+) -> (String, Arc<Mutex<Vec<ProviderCall>>>, Arc<AtomicUsize>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let plaintext_path_hits = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/v1/chat/completions", post(privatemode_chat_handler))
+        .route("/v1/completions", post(privatemode_chat_handler))
+        .route("/v1/embeddings", post(privatemode_chat_handler))
+        .route("/v1/messages", post(privatemode_chat_handler))
+        .route(
+            "/v1/models",
+            get(privatemode_models_handler).post(privatemode_plaintext_path_handler),
+        )
+        .with_state(ProviderState {
+            calls: calls.clone(),
+            plaintext_path_hits: plaintext_path_hits.clone(),
+        });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), calls, plaintext_path_hits)
+}
+
+#[derive(Clone)]
+struct PrivatemodeCapacityState {
+    calls: Arc<Mutex<Vec<PrivatemodeCapacityCall>>>,
+    attempts: Arc<AtomicUsize>,
+    readiness_checks: Arc<AtomicUsize>,
+}
+
+struct PrivatemodeCapacityCall {
+    path: String,
+    authorization: Option<String>,
+    body: Vec<u8>,
+}
+
+async fn privatemode_capacity_models_handler(
+    State(state): State<PrivatemodeCapacityState>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    state.readiness_checks.fetch_add(1, Ordering::SeqCst);
+    privatemode_models_handler(headers).await
+}
+
+async fn privatemode_capacity_chat_handler(
+    State(state): State<PrivatemodeCapacityState>,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    state.calls.lock().unwrap().push(PrivatemodeCapacityCall {
+        path: uri.path().to_string(),
+        authorization: headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        body: body.to_vec(),
+    });
+
+    if state.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("content-type", "application/json")],
+            r#"{"error":{"message":"capacity"}}"#,
+        )
+            .into_response();
+    }
+
+    let content_type = headers
+        .get("accept")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| *value == "text/event-stream")
+        .unwrap_or("application/json");
+    (
+        StatusCode::OK,
+        [("content-type", content_type)],
+        CHAT_RESPONSE,
+    )
+        .into_response()
+}
+
+async fn serve_privatemode_capacity_fixture() -> (
+    String,
+    Arc<Mutex<Vec<PrivatemodeCapacityCall>>>,
+    Arc<AtomicUsize>,
+) {
+    let state = PrivatemodeCapacityState {
+        calls: Arc::new(Mutex::new(Vec::new())),
+        attempts: Arc::new(AtomicUsize::new(0)),
+        readiness_checks: Arc::new(AtomicUsize::new(0)),
+    };
+    let calls = state.calls.clone();
+    let readiness_checks = state.readiness_checks.clone();
+    let app = Router::new()
+        .route("/v1/models", get(privatemode_capacity_models_handler))
+        .route("/v1/messages", post(privatemode_capacity_chat_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), calls, readiness_checks)
+}
+
+async fn redirect_sink(State(hits): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+    hits.fetch_add(1, Ordering::SeqCst);
+    StatusCode::NO_CONTENT
+}
+
+async fn cross_origin_redirect(State(location): State<String>) -> impl IntoResponse {
+    (StatusCode::TEMPORARY_REDIRECT, [("location", location)])
+}
+
+async fn serve_cross_origin_privatemode_redirect_fixture() -> (String, Arc<AtomicUsize>) {
+    let sink_hits = Arc::new(AtomicUsize::new(0));
+    let sink = Router::new()
+        .route("/credential-sink", any(redirect_sink))
+        .with_state(sink_hits.clone());
+    let sink_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let sink_addr = sink_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(sink_listener, sink).await.unwrap();
+    });
+
+    let redirect = Router::new()
+        .route("/v1/models", get(cross_origin_redirect))
+        .route("/v1/chat/completions", post(cross_origin_redirect))
+        .with_state(format!("http://{sink_addr}/credential-sink"));
+    let redirect_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let redirect_addr = redirect_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(redirect_listener, redirect).await.unwrap();
+    });
+
+    (format!("http://{redirect_addr}"), sink_hits)
+}
+
+async fn oversized_models_with_content_length() -> axum::response::Response {
+    (
+        StatusCode::OK,
+        [("content-type", "application/json")],
+        vec![b' '; 1024 * 1024 + 1],
+    )
+        .into_response()
+}
+
+async fn oversized_chunked_models() -> axum::response::Response {
+    let chunks = futures_util::stream::iter([
+        Ok::<_, Infallible>(Bytes::from(vec![b' '; 768 * 1024])),
+        Ok::<_, Infallible>(Bytes::from(vec![b' '; 768 * 1024])),
+    ]);
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from_stream(chunks))
+        .unwrap()
+}
+
+async fn indefinitely_trickled_models() -> axum::response::Response {
+    let chunks = futures_util::stream::unfold((), |()| async {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        Some((Ok::<_, Infallible>(Bytes::from_static(b" ")), ()))
+    });
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from_stream(chunks))
+        .unwrap()
+}
+
+async fn counted_models(State(hits): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+    hits.fetch_add(1, Ordering::SeqCst);
+    Json(json!({"object": "list", "data": [{"id": "provider-model"}]}))
+}
+
+async fn serve_models_fixture(app: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn serve_counted_models_fixture() -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let base_url = serve_models_fixture(
+        Router::new()
+            .route("/v1/models", get(counted_models))
+            .with_state(hits.clone()),
+    )
+    .await;
+    (base_url, hits)
+}
+
+struct PrivatemodeTestDeployment {
+    base_url: String,
+    manifest_dir: PathBuf,
+    manifest_log_path: PathBuf,
+    manifest_path: PathBuf,
+    credential_path: PathBuf,
+    manifest_digest: String,
+    credential_digest: String,
+    image_digest: String,
+    deployment: Arc<PrivatemodeProxyDeployment>,
+}
+
+impl PrivatemodeTestDeployment {
+    fn new(base_url: String) -> Self {
+        let policy_hash = "11".repeat(32);
+        let manifest = serde_json::to_vec(&json!({
+            "Policies": {
+                (&policy_hash): {"Role": "coordinator"}
+            }
+        }))
+        .unwrap();
+        let manifest_dir = temp_config_path();
+        std::fs::create_dir(&manifest_dir).unwrap();
+        let manifest_log_path = manifest_dir.join("log.txt");
+        let manifest_path = manifest_dir.join("1.json");
+        let credential_path = temp_config_path();
+        let credential = b"provider-secret";
+        std::fs::write(&manifest_path, &manifest).unwrap();
+        std::fs::write(
+            &manifest_log_path,
+            "2026-07-31T00:00:00Z /var/lib/privatemode/manifests/1.json\n",
+        )
+        .unwrap();
+        std::fs::write(&credential_path, credential).unwrap();
+        let manifest_digest = normalized_sha256(&manifest);
+        let credential_digest = normalized_sha256(credential);
+        let image_digest = format!("sha256:{}", "33".repeat(32));
+        let deployment = Arc::new(
+            PrivatemodeProxyDeployment::new(
+                &base_url,
+                &manifest_log_path,
+                &credential_path,
+                &credential_digest,
+                &image_digest,
+            )
+            .unwrap(),
+        );
+        Self {
+            base_url,
+            manifest_dir,
+            manifest_log_path,
+            manifest_path,
+            credential_path,
+            manifest_digest,
+            credential_digest,
+            image_digest,
+            deployment,
+        }
+    }
+
+    fn verifier(
+        &self,
+        request_timeout_seconds: u64,
+        cache_ttl_seconds: u64,
+    ) -> PrivatemodeProviderVerifier {
+        PrivatemodeProviderVerifier::new(
+            self.deployment.clone(),
+            2,
+            request_timeout_seconds,
+            cache_ttl_seconds,
+        )
+        .unwrap()
+    }
+
+    fn verification_request(&self, model_id: &str) -> UpstreamVerificationRequest {
+        UpstreamVerificationRequest {
+            upstream_name: "privatemode-provider".to_string(),
+            url_origin: Some(self.base_url.clone()),
+            model_id: model_id.to_string(),
+            forwarded_body_hash: sha256_hex(PROVIDER_CHAT_REQUEST),
+            required: true,
+        }
+    }
+
+    fn verified_event(&self) -> UpstreamVerifiedEvent {
+        UpstreamVerifiedEvent {
+            upstream_name: "privatemode-provider".to_string(),
+            provider_type: Some("privatemode".to_string()),
+            model_id: "provider-model".to_string(),
+            url_origin: Some(self.base_url.clone()),
+            verifier_id: "privatemode-proxy/co-deployed-contrast/v1".to_string(),
+            result: VerificationResult::Verified,
+            required: true,
+            channel_bindings: vec![ChannelBinding::ProxyImageSha256 {
+                provider: "privatemode".to_string(),
+                proxy_image_digest: self.image_digest.clone(),
+                credential_sha256: self.credential_digest.clone(),
+            }],
+            ..Default::default()
+        }
+    }
+}
+
+impl Drop for PrivatemodeTestDeployment {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.manifest_dir);
+        let _ = std::fs::remove_file(&self.credential_path);
+    }
+}
+
+fn normalized_sha256(bytes: &[u8]) -> String {
+    sha256_hex(bytes)
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string()
 }
 
 #[derive(Clone)]
@@ -444,6 +806,33 @@ fn runtime_options(mode: UpstreamVerifierMode) -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
+    }
+}
+
+fn privatemode_upstream_config(base_url: String, verifier_cache_seconds: u64) -> UpstreamConfig {
+    UpstreamConfig {
+        name: "privatemode-provider".to_string(),
+        provider: UpstreamProvider::Privatemode,
+        base_url,
+        path: None,
+        models: BTreeMap::from([("public-model".to_string(), "provider-model".to_string())]),
+        bearer_token: None,
+        basic_auth: false,
+        accepted_workload_ids: None,
+        accepted_image_digests: None,
+        accepted_dstack_kms_root_public_keys: None,
+        pccs_url: None,
+        verifier_cache_seconds: Some(verifier_cache_seconds),
+        connect_timeout_seconds: Some(2),
+        read_timeout_seconds: Some(10),
+        verifier_request_timeout_seconds: Some(10),
+        verification_refresh_seconds: Some(0),
+        session_refresh_seconds: None,
+        chutes_e2ee_api_base: None,
+        chutes_chute_ids: None,
+        chutes_e2ee_discovery_rounds: None,
+        chutes_e2ee_discovery_interval_seconds: None,
     }
 }
 
@@ -753,6 +1142,462 @@ async fn openai_compatible_provider_e2e_via_runtime_config() {
     assert_eq!(upstream_verified["result"], "verified");
 
     let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn privatemode_backend_forwards_buffered_and_streaming_only_with_its_binding() {
+    let (base_url, provider_calls, plaintext_path_hits) =
+        serve_privatemode_provider_fixture().await;
+    let fixture = PrivatemodeTestDeployment::new(base_url.clone());
+    let err = PrivatemodeProxyDeployment::new(
+        &base_url,
+        &fixture.manifest_log_path,
+        &fixture.credential_path,
+        sha256_hex(b"wrong-secret"),
+        &fixture.image_digest,
+    )
+    .expect_err("the measured credential digest must bind the mounted secret");
+    assert!(err.to_string().contains("does not match configured digest"));
+    let backend = PrivatemodeProviderBackend::new_with_timeouts(fixture.deployment.clone(), 2, 10)
+        .unwrap()
+        .with_name("privatemode-provider");
+    let event = fixture
+        .verifier(10, 300)
+        .verify(fixture.verification_request("provider-model"))
+        .await;
+    assert_eq!(event.result.as_str(), "verified");
+    // The event retains the observed bytes even if the proxy log changes after
+    // verification.
+    std::fs::write(&fixture.manifest_path, b"tampered after verification").unwrap();
+    assert_eq!(event.url_origin.as_deref(), Some(base_url.as_str()));
+    assert!(matches!(
+        event.channel_bindings.as_slice(),
+        [ChannelBinding::ProxyImageSha256 {
+            proxy_image_digest,
+            credential_sha256,
+            ..
+        }] if proxy_image_digest == &fixture.image_digest
+            && credential_sha256 == &fixture.credential_digest
+    ));
+    assert_eq!(
+        event.provider_claims.as_ref().unwrap()["observed_manifest_sha256"],
+        fixture.manifest_digest
+    );
+
+    let request = || UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        ..Default::default()
+    };
+    let plaintext_path_request = UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        path: Some("/v1/models".to_string()),
+        ..Default::default()
+    };
+    let prepared = backend.prepare(plaintext_path_request).unwrap();
+    let err = backend
+        .forward_verified_prepared(prepared.clone(), &event)
+        .await
+        .expect_err("buffered forwarding must reject an unencrypted proxy handler");
+    assert!(err.to_string().contains("does not encrypt that handler"));
+    let err = match backend
+        .forward_stream_verified_prepared(prepared, &event)
+        .await
+    {
+        Ok(_) => panic!("streaming forwarding must reject an unencrypted proxy handler"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("does not encrypt that handler"));
+    assert_eq!(plaintext_path_hits.load(Ordering::SeqCst), 0);
+
+    let response = backend
+        .forward_verified_prepared(backend.prepare(request()).unwrap(), &event)
+        .await
+        .unwrap();
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body, CHAT_RESPONSE);
+
+    let response = backend
+        .forward_stream_verified_prepared(backend.prepare(request()).unwrap(), &event)
+        .await
+        .unwrap();
+    assert_eq!(response.status_code, 200);
+    let streamed = response
+        .body
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await
+        .concat();
+    assert_eq!(streamed, CHAT_RESPONSE);
+
+    let calls = provider_calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|call| call.authorization.is_none()));
+}
+
+#[tokio::test]
+async fn privatemode_never_follows_cross_origin_redirects() {
+    let (base_url, sink_hits) = serve_cross_origin_privatemode_redirect_fixture().await;
+    let fixture = PrivatemodeTestDeployment::new(base_url);
+    let readiness = fixture
+        .verifier(10, 300)
+        .verify(fixture.verification_request("provider-model"))
+        .await;
+    assert_eq!(readiness.result, VerificationResult::Failed);
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+
+    let verified = fixture.verified_event();
+    let backend = PrivatemodeProviderBackend::new_with_timeouts(fixture.deployment.clone(), 2, 10)
+        .unwrap()
+        .with_name("privatemode-provider");
+    let request = || UpstreamRequest {
+        body: PROVIDER_CHAT_REQUEST.to_vec(),
+        ..Default::default()
+    };
+
+    let buffered = backend
+        .forward_verified_prepared(backend.prepare(request()).unwrap(), &verified)
+        .await
+        .unwrap();
+    assert_eq!(buffered.status_code, 307);
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+
+    let streaming = backend
+        .forward_stream_verified_prepared(backend.prepare(request()).unwrap(), &verified)
+        .await
+        .unwrap();
+    assert_eq!(streaming.status_code, 307);
+    let _ = streaming
+        .body
+        .map(|chunk| chunk.unwrap())
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(sink_hits.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn privatemode_readiness_rejects_declared_and_chunked_oversized_bodies() {
+    let declared = serve_models_fixture(
+        Router::new().route("/v1/models", get(oversized_models_with_content_length)),
+    )
+    .await;
+    let chunked =
+        serve_models_fixture(Router::new().route("/v1/models", get(oversized_chunked_models)))
+            .await;
+
+    for base_url in [declared, chunked] {
+        let fixture = PrivatemodeTestDeployment::new(base_url);
+        let event = fixture
+            .verifier(10, 0)
+            .verify(fixture.verification_request("provider-model"))
+            .await;
+        assert_eq!(event.result, VerificationResult::Failed);
+        assert!(
+            event
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("exceeds 1048576 bytes")),
+            "unexpected readiness failure: {:?}",
+            event.reason
+        );
+    }
+}
+
+#[tokio::test]
+async fn privatemode_readiness_has_an_end_to_end_deadline() {
+    let base_url =
+        serve_models_fixture(Router::new().route("/v1/models", get(indefinitely_trickled_models)))
+            .await;
+    let fixture = PrivatemodeTestDeployment::new(base_url);
+    let event = tokio::time::timeout(
+        Duration::from_secs(3),
+        fixture
+            .verifier(1, 0)
+            .verify(fixture.verification_request("provider-model")),
+    )
+    .await
+    .expect("readiness request must honor its total deadline");
+    assert_eq!(event.result, VerificationResult::Failed);
+}
+
+#[tokio::test]
+async fn privatemode_verification_cache_and_refresh_follow_the_configured_lease() {
+    let (base_url, hits) = serve_counted_models_fixture().await;
+    let fixture = PrivatemodeTestDeployment::new(base_url);
+    let verifier = fixture.verifier(10, 300);
+
+    let first = verifier
+        .verify(fixture.verification_request("model-a"))
+        .await;
+    let updated_policy_hash = "44".repeat(32);
+    let updated_manifest = serde_json::to_vec(&json!({
+        "Policies": {
+            (&updated_policy_hash): {"Role": "coordinator"}
+        }
+    }))
+    .unwrap();
+    std::fs::write(fixture.manifest_dir.join("2.json"), &updated_manifest).unwrap();
+    std::fs::write(
+        &fixture.manifest_log_path,
+        concat!(
+            "2026-07-31T00:00:00Z /var/lib/privatemode/manifests/1.json\n",
+            "2026-07-31T01:00:00Z /var/lib/privatemode/manifests/2.json\n"
+        ),
+    )
+    .unwrap();
+    let cached = verifier
+        .verify(fixture.verification_request("model-b"))
+        .await;
+    assert_eq!(first.result, VerificationResult::Verified);
+    assert_eq!(cached.result, VerificationResult::Verified);
+    assert_eq!(cached.model_id, "model-b");
+    assert_eq!(
+        cached.provider_claims.as_ref().unwrap()["observed_manifest_sha256"],
+        fixture.manifest_digest
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+    let refreshed = verifier
+        .refresh(fixture.verification_request("model-c"))
+        .await;
+    assert_eq!(refreshed.result, VerificationResult::Verified);
+    assert_eq!(
+        refreshed.provider_claims.as_ref().unwrap()["observed_manifest_sha256"],
+        normalized_sha256(&updated_manifest)
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+    verifier.invalidate(&fixture.verification_request("model-d"));
+    let after_invalidate = verifier
+        .verify(fixture.verification_request("model-d"))
+        .await;
+    assert_eq!(after_invalidate.result, VerificationResult::Verified);
+    assert_eq!(hits.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn privatemode_runtime_config_binds_the_measured_sidecar_in_the_receipt() {
+    let (base_url, provider_calls, _plaintext_path_hits) =
+        serve_privatemode_provider_fixture().await;
+    let fixture = PrivatemodeTestDeployment::new(base_url.clone());
+
+    let config_path = temp_config_path();
+    let mut options = runtime_options(UpstreamVerifierMode::None);
+    options.privatemode_proxy = Some(fixture.deployment.clone());
+    let manager = Arc::new(UpstreamConfigManager::load(&config_path, options).unwrap());
+    manager
+        .replace(vec![privatemode_upstream_config(base_url.clone(), 300)])
+        .unwrap();
+    let service = service_for_manager(manager);
+    let app = build_router(service.clone());
+    let (status, headers, body) =
+        call(app.clone(), "POST", "/v1/chat/completions", CHAT_REQUEST).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(body, CHAT_RESPONSE);
+
+    let receipt_id = headers
+        .get("x-receipt-id")
+        .and_then(|value| value.to_str().ok())
+        .unwrap();
+    let receipt = service.get_receipt_by_receipt_id(receipt_id).unwrap();
+    let event = receipt_event(&receipt, EVENT_UPSTREAM_VERIFIED);
+    assert_eq!(event["result"], "verified");
+    assert_eq!(event["provider_type"], "privatemode");
+    assert_eq!(
+        event["verifier_id"],
+        "privatemode-proxy/co-deployed-contrast/v1"
+    );
+    assert_eq!(
+        event["provider_claims"]["attestation_scope"],
+        "contrast-attested-e2ee-secret"
+    );
+    assert_eq!(event["provider_claims"]["manifest_mode"], "dynamic");
+    assert_eq!(
+        event["provider_claims"]["manifest_bound_to_active_secret"],
+        false
+    );
+    assert_eq!(event["claims"]["gpu_attested"]["status"], "unknown");
+    assert_eq!(
+        event["claims"]["model_weights_provenance"]["status"],
+        "unknown"
+    );
+    assert_eq!(event["claims"]["tcb_up_to_date"]["status"], "unknown");
+    assert_eq!(
+        event["provider_claims"]["observed_manifest_sha256"],
+        fixture.manifest_digest
+    );
+    assert_eq!(
+        event["channel_bindings"][0]["proxy_image_digest"],
+        fixture.image_digest
+    );
+    assert_eq!(event["url_origin"], base_url);
+
+    for stream in [false, true] {
+        let request = serde_json::to_vec(&json!({
+            "model": "public-model",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": stream
+        }))
+        .unwrap();
+        let (status, _, body) = call(app.clone(), "POST", "/v1/messages", request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(body, CHAT_RESPONSE);
+    }
+    for stream in [false, true] {
+        let request = serde_json::to_vec(&json!({
+            "model": "public-model",
+            "prompt": "hello",
+            "stream": stream
+        }))
+        .unwrap();
+        let (status, _, _) = call(app.clone(), "POST", "/v1/completions", request).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let embeddings_request = serde_json::to_vec(&json!({
+        "model": "public-model",
+        "input": "hello"
+    }))
+    .unwrap();
+    let (status, _, _) = call(app, "POST", "/v1/embeddings", embeddings_request).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let calls = provider_calls.lock().unwrap();
+    assert_eq!(
+        calls
+            .iter()
+            .map(|call| call.path.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "/v1/chat/completions",
+            "/v1/messages",
+            "/v1/messages",
+            "/v1/completions",
+            "/v1/completions",
+            "/v1/embeddings",
+        ]
+    );
+    for call in calls.iter() {
+        assert!(call.authorization.is_none());
+    }
+    for call in &calls[1..3] {
+        assert_eq!(call.path, "/v1/messages");
+        let forwarded: Value = serde_json::from_slice(&call.body).unwrap();
+        assert_eq!(forwarded["model"], "provider-model");
+        assert_eq!(forwarded["max_tokens"], 16);
+        assert_eq!(forwarded["messages"][0]["content"], "hello");
+    }
+
+    let _ = std::fs::remove_file(config_path);
+}
+
+#[tokio::test]
+async fn privatemode_middleware_capacity_retry_reverifies_the_bound_native_route() {
+    for stream in [false, true] {
+        let (base_url, provider_calls, readiness_checks) =
+            serve_privatemode_capacity_fixture().await;
+        let fixture = PrivatemodeTestDeployment::new(base_url.clone());
+        let config_path = temp_config_path();
+        let mut options = runtime_options(UpstreamVerifierMode::None);
+        options.privatemode_proxy = Some(fixture.deployment.clone());
+        let manager = Arc::new(UpstreamConfigManager::load(&config_path, options).unwrap());
+        // The capacity backoff is longer than this lease, so the second pass
+        // must refresh the proxy readiness evidence rather than reuse it.
+        manager
+            .replace(vec![privatemode_upstream_config(base_url, 1)])
+            .unwrap();
+        let service = service_for_manager(manager);
+
+        let request_body = serde_json::to_vec(&json!({
+            "model": "public-model",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": stream
+        }))
+        .unwrap();
+        let journal = MiddlewareReceiptJournal::default();
+        let result = service
+            .forward_chat_completion_for_middleware(
+                ChatCompletionRequest {
+                    context: GatewayRequestContext {
+                        user_model: Some("public-model".to_string()),
+                        ..GatewayRequestContext::default()
+                    },
+                    endpoint_path: "/v1/messages",
+                    received_body: &request_body,
+                    forwarded_body: None,
+                    aci_required: true,
+                    aci_session_ids: Vec::new(),
+                    upstream_verification_event: None,
+                    requester: None,
+                    e2ee: None,
+                },
+                vec![ForwardCandidate {
+                    route_id: "privatemode-provider:public-model".to_string(),
+                    body: request_body.clone(),
+                }],
+                stream,
+                journal.clone(),
+            )
+            .await
+            .unwrap();
+
+        match result {
+            MiddlewareForwardResult::Forwarded(forward) => {
+                assert!(!stream);
+                assert_eq!(forward.upstream_status, 200);
+                assert_eq!(forward.selected_route, "privatemode-provider:public-model");
+                assert_eq!(
+                    forward.failed_attempts,
+                    vec![("privatemode-provider:public-model".to_string(), 429)]
+                );
+                assert_eq!(forward.upstream_body, CHAT_RESPONSE);
+                assert!(forward.session_id.is_some());
+            }
+            MiddlewareForwardResult::Stream(mut forward) => {
+                assert!(stream);
+                assert_eq!(forward.upstream_status, 200);
+                assert_eq!(forward.selected_route, "privatemode-provider:public-model");
+                assert_eq!(
+                    forward.failed_attempts,
+                    vec![("privatemode-provider:public-model".to_string(), 429)]
+                );
+                assert!(forward.session_id.is_some());
+                while let Some(chunk) = forward.body.next().await {
+                    chunk.unwrap();
+                }
+                assert!(
+                    journal.take().is_some(),
+                    "the committed stream drafts one receipt"
+                );
+                assert!(journal.take().is_none(), "no duplicate receipt was drafted");
+            }
+            _ => panic!("the delayed Privatemode retry must commit its second response"),
+        }
+
+        assert_eq!(
+            readiness_checks.load(Ordering::SeqCst),
+            2,
+            "each capacity pass must run Privatemode verification"
+        );
+        assert_eq!(
+            service
+                .list_attested_sessions(Some("privatemode-provider"))
+                .len(),
+            1,
+            "only the committed response may seal an attested session"
+        );
+        let calls = provider_calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        for call in calls.iter() {
+            assert_eq!(call.path, "/v1/messages");
+            assert!(call.authorization.is_none());
+            let forwarded: Value = serde_json::from_slice(&call.body).unwrap();
+            assert_eq!(forwarded["model"], "provider-model");
+            assert_eq!(forwarded["stream"], stream);
+        }
+
+        let _ = std::fs::remove_file(config_path);
+    }
 }
 
 #[tokio::test]

--- a/tests/receipt.rs
+++ b/tests/receipt.rs
@@ -168,6 +168,11 @@ fn upstream_verified_event_records_channel_bindings() {
                 algorithm: "chutes-ml-kem-768".to_string(),
                 public_key_sha256: "cc".repeat(32),
             },
+            ChannelBinding::ProxyImageSha256 {
+                provider: "privatemode".to_string(),
+                proxy_image_digest: format!("sha256:{}", "ff".repeat(32)),
+                credential_sha256: "56".repeat(32),
+            },
         ],
         provider_claims: Some(serde_json::json!({
             "trust_boundary": "fixture",
@@ -198,6 +203,18 @@ fn upstream_verified_event_records_channel_bindings() {
     assert_eq!(
         upstream.fields["channel_bindings"][1]["public_key_sha256"],
         "cc".repeat(32)
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][2]["type"],
+        "proxy_image_sha256"
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][2]["proxy_image_digest"],
+        format!("sha256:{}", "ff".repeat(32))
+    );
+    assert_eq!(
+        upstream.fields["channel_bindings"][2]["credential_sha256"],
+        "56".repeat(32)
     );
     assert_eq!(
         upstream.fields["provider_claims"]["trust_boundary"],

--- a/tests/upstream_config_admin.rs
+++ b/tests/upstream_config_admin.rs
@@ -42,6 +42,7 @@ fn runtime_options() -> UpstreamRuntimeOptions {
         connect_timeout_seconds: 10,
         read_timeout_seconds: 600,
         verifier_request_timeout_seconds: 60,
+        privatemode_proxy: None,
     }
 }
 
@@ -86,7 +87,7 @@ async fn admin_can_replace_single_upstream_config_file_at_runtime() {
         )
         .unwrap(),
     );
-    let app = build_router_with_admin(service, manager, Some("admin-secret".to_string()));
+    let app = build_router_with_admin(service, manager, Some("admin-secret".to_string()), None);
 
     let (status, models) = call(app.clone(), "GET", "/v1/models", Vec::new(), None).await;
     assert_eq!(status, StatusCode::OK);


### PR DESCRIPTION
## Why

Add Privatemode through its audited official proxy instead of reimplementing its attestation, secret rotation, authentication, and full-body E2EE protocol. The proxy runs beside the gateway in the same measured dstack Compose workload.

## Review guide

1. **Deployment boundary:** `deploy/compose.privatemode.yaml`, `deploy/render-privatemode-compose.sh`, and `entrypoint.sh`
2. **Upstream adapter and routing:** `src/aci/upstream/privatemode.rs`, `src/aci/upstream/router.rs`, and `src/aggregator/upstream_config/`
3. **Evidence and claims:** `src/aci/verifier/providers.rs` and `src/aggregator/service/claims.rs`
4. **Direct-mode authentication:** `src/http/app/`, `src/main.rs`, and the corresponding HTTP tests
5. **Trust analysis and operations:** `docs/providers/privatemode/` and `deploy/README.md`

## Security invariants

- The proxy image, shared credential digest, internal origin, allowed encrypted handlers, and gateway source commit are pinned in the measured deployment.
- Mutable upstream configuration cannot change the proxy origin, add credentials, select an unencrypted handler, follow redirects, or use an ambient HTTP proxy.
- Direct deployments require downstream inference authentication before request-body processing, preventing an anonymous paid relay.
- Plaintext crosses only the private measured Compose network between the gateway and proxy. The proxy remains responsible for Privatemode E2EE and upstream verification.

## Dynamic manifest semantics

The proxy runs in its supported dynamic-manifest mode. Its latest public manifest-history entry is exposed in attested sessions and receipts as observation evidence:

- `manifest_mode: dynamic`
- `observed_manifest_sha256`
- `manifest_observed_at`
- `manifest_observation: latest-proxy-fetch-log`
- `manifest_bound_to_active_secret: false`

The signed `proxy_image_sha256` binding covers the measured proxy image and shared credential digest. It deliberately does **not** claim that the latest observed manifest produced the secret used for a request: Privatemode v1.48 logs the fetched manifest before Coordinator verification and secret exchange complete, and does not expose that active-secret binding.

The adapter therefore derives only the manifest-independent `tee_attested` claim. GPU, OS, serving-software, model-weight, and TCB claims remain unknown. #111 tracks binding the active manifest to each inference response so reviewed `(proxy image digest, active manifest digest)` profiles can safely promote those transitive claims.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` — 448 passed, 5 ignored
- `python3 -m unittest scripts.live_e2e.tests.test_launch_aggregator` — 2 passed
- deployment renderer and entrypoint shell checks
- rendered `docker compose config` validation
- nested tmpfs/read-only manifest-history volume smoke test
- `git diff --check`

A pre-rebase static-manifest predecessor was deployed on Phala with a real Privatemode API key and successfully exercised buffered and streaming `gpt-oss-120b` traffic. The final dynamic-manifest version has not been redeployed; its manifest observation and rotation behavior are covered by integration tests.