### PR TITLE
feat(forward): delayed capacity retry for non-preemptible traffic

### DIFF
--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -23,8 +23,10 @@ use crate::aci::receipt::{ReceiptBuilder, TransparencyEventKind, UpstreamVerifie
 use crate::aci::upstream::{UpstreamError, UpstreamRequest, UpstreamResponse};
 use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
 use crate::aggregator::session::SessionClaims;
+use crate::middleware::errors::is_upstream_capacity_signal;
 use crate::sse_framing::SseFramingObserver;
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 // Provider statuses that make this candidate worth abandoning for the next one.
 // Beyond the transient 429/5xx signals, an auth/account failure specific to this
@@ -39,8 +41,33 @@ fn is_retryable_provider_status(status: u16) -> bool {
 // provider-specific/transient failure AND the error must not be the client's own
 // fault: a fetch failure on a client-supplied image URL fails identically on every
 // candidate, so it is terminal (committed and surfaced as a 400) rather than retried.
+// One delayed second pass for a request whose whole candidate chain died on
+// capacity. An upstream 429 is a transient: the upstream's free capacity
+// fluctuates on the scale of seconds, so a rejection often clears moments
+// later. After the chain is exhausted, the request sleeps briefly and
+// re-tries exactly the candidates that answered 429 — once. Requests whose
+// x-user-tier marks them preemptible ('basic') keep the fast 429 instead
+// (their callers are expected to handle capacity signals themselves), and a
+// request that already spent long in the chain is returned rather than
+// delayed further. The jittered delay de-synchronizes requests bounced by
+// the same capacity dip.
+const CAPACITY_RETRY_DELAY_MS: u64 = 2_000;
+const CAPACITY_RETRY_MAX_ELAPSED: Duration = Duration::from_secs(10);
+const PREEMPTIBLE_TIER: &str = "basic";
+
+/// Whether this request may still take the delayed capacity-retry pass.
+fn capacity_retry_eligible(done: bool, user_tier: Option<&str>, started: Instant) -> bool {
+    !done && user_tier != Some(PREEMPTIBLE_TIER) && started.elapsed() <= CAPACITY_RETRY_MAX_ELAPSED
+}
+
 fn should_fail_over(status: u16, received_body: &[u8], upstream_body: &[u8]) -> bool {
-    is_retryable_provider_status(status)
+    // The capacity signal must be failover-able regardless of the literal
+    // status: error normalization surfaces the recognized capacity body under
+    // ANY 5xx as a client 429, so a status outside the retryable whitelist
+    // (e.g. 520) carrying that body would otherwise be told "capacity" while
+    // having been denied both the failover and the capacity retry that
+    // capacity outcomes get.
+    (is_retryable_provider_status(status) || is_upstream_capacity_signal(status, upstream_body))
         && crate::middleware::errors::classify_image_input_error(
             received_body,
             status,
@@ -270,7 +297,6 @@ impl AciService {
         };
         let candidate_route_ids: Vec<String> =
             candidates.iter().map(|c| c.route_id.clone()).collect();
-        let last_index = candidates.len() - 1;
 
         // Optional x-user-tier passed through to every upstream attempt.
         let mut upstream_headers: HashMap<String, String> = HashMap::new();
@@ -299,91 +325,263 @@ impl AciService {
         // nothing better follows. See [`RetainedResponse`].
         let mut retained: Option<RetainedResponse> = None;
 
-        for (index, candidate) in candidates.iter().enumerate() {
-            let route_id = candidate.route_id.clone();
-            let is_last = index == last_index;
+        // Capacity-retry pass state (see CAPACITY_RETRY_DELAY_MS). The walk
+        // below runs at most twice; `failed_attempts`, `retained` and
+        // `aggregated_err` deliberately carry across passes so every attempt
+        // stays observable and attempt indices never collide.
+        let forward_started = Instant::now();
+        let mut capacity_retry_done = false;
+        let mut current: Vec<ForwardCandidate> = candidates;
 
-            let prepared = match self.upstream.prepare(UpstreamRequest {
-                body: candidate.body.clone(),
-                headers: upstream_headers.clone(),
-                path: Some(endpoint_path.to_string()),
-                target_route_id: Some(route_id.clone()),
-            }) {
-                Ok(prepared) => prepared,
-                Err(UpstreamError::Routing(message)) => {
-                    failed_attempts.push((route_id.clone(), 502));
+        // Candidate indices (into `current`) whose attempt this pass came back
+        // as a capacity signal — the exact set a retry pass replays. Tracked by
+        // index, not route id: route ids may repeat in a caller-supplied chain,
+        // and reconstructing the set from ids would replay a hard-failed twin.
+        let mut capacity_indices: Vec<usize> = Vec::new();
+
+        loop {
+            capacity_indices.clear();
+            let last_index = current.len() - 1;
+            for (index, candidate) in current.iter().enumerate() {
+                let route_id = candidate.route_id.clone();
+                let is_last = index == last_index;
+
+                let prepared = match self.upstream.prepare(UpstreamRequest {
+                    body: candidate.body.clone(),
+                    headers: upstream_headers.clone(),
+                    path: Some(endpoint_path.to_string()),
+                    target_route_id: Some(route_id.clone()),
+                }) {
+                    Ok(prepared) => prepared,
+                    Err(UpstreamError::Routing(message)) => {
+                        failed_attempts.push((route_id.clone(), 502));
+                        upgrade_err(
+                            &mut aggregated_err,
+                            1,
+                            ServiceError::Upstream(UpstreamError::Routing(message)),
+                        );
+                        continue;
+                    }
+                    Err(err) => {
+                        failed_attempts.push((route_id.clone(), 502));
+                        upgrade_err(&mut aggregated_err, 2, err.into());
+                        continue;
+                    }
+                };
+
+                // A route not known to be attested cannot serve an
+                // `aci_verified` request. Kept out of `failed_attempts`: this is a
+                // policy decision, and those are reported per route, which would
+                // charge a provider for a request it never saw.
+                if aci_required && !attested_route_eligible(prepared.is_tee) {
                     upgrade_err(
                         &mut aggregated_err,
-                        1,
-                        ServiceError::Upstream(UpstreamError::Routing(message)),
-                    );
-                    continue;
-                }
-                Err(err) => {
-                    failed_attempts.push((route_id.clone(), 502));
-                    upgrade_err(&mut aggregated_err, 2, err.into());
-                    continue;
-                }
-            };
-
-            // A route not known to be attested cannot serve an
-            // `aci_verified` request. Kept out of `failed_attempts`: this is a
-            // policy decision, and those are reported per route, which would
-            // charge a provider for a request it never saw.
-            if aci_required && !attested_route_eligible(prepared.is_tee) {
-                upgrade_err(
-                    &mut aggregated_err,
-                    0,
-                    ServiceError::UpstreamVerification(
-                        UpstreamVerificationError::NoEligibleAttestedRoute(
-                            user_model.clone().unwrap_or_default(),
+                        0,
+                        ServiceError::UpstreamVerification(
+                            UpstreamVerificationError::NoEligibleAttestedRoute(
+                                user_model.clone().unwrap_or_default(),
+                            ),
                         ),
-                    ),
-                );
-                continue;
-            }
-
-            // Only an explicit ACI constraint makes verification fail-closed.
-            // Unconstrained requests still record the verifier outcome.
-            let candidate_required = aci_required;
-
-            let mut recorded_event = match self
-                .recorded_upstream_event(&prepared, candidate_required, single_caller_event.clone())
-                .await
-            {
-                Ok(event) => event,
-                Err(ServiceError::UpstreamVerification(uv)) => {
-                    failed_attempts.push((route_id.clone(), 502));
-                    upgrade_err(
-                        &mut aggregated_err,
-                        3,
-                        ServiceError::UpstreamVerification(uv),
                     );
                     continue;
                 }
-                Err(err) => return Err(err),
-            };
 
-            if let Err(err) = self.apply_aci_session_constraint(
-                &mut recorded_event,
-                &req.aci_session_ids,
-                &prepared.model_id,
-            ) {
-                if matches!(
-                    err,
-                    ServiceError::UpstreamVerification(
-                        UpstreamVerificationError::NoEligibleAttestedSession(_)
+                // Only an explicit ACI constraint makes verification fail-closed.
+                // Unconstrained requests still record the verifier outcome.
+                let candidate_required = aci_required;
+
+                let mut recorded_event = match self
+                    .recorded_upstream_event(
+                        &prepared,
+                        candidate_required,
+                        single_caller_event.clone(),
                     )
+                    .await
+                {
+                    Ok(event) => event,
+                    Err(ServiceError::UpstreamVerification(uv)) => {
+                        failed_attempts.push((route_id.clone(), 502));
+                        upgrade_err(
+                            &mut aggregated_err,
+                            3,
+                            ServiceError::UpstreamVerification(uv),
+                        );
+                        continue;
+                    }
+                    Err(err) => return Err(err),
+                };
+
+                if let Err(err) = self.apply_aci_session_constraint(
+                    &mut recorded_event,
+                    &req.aci_session_ids,
+                    &prepared.model_id,
                 ) {
-                    upgrade_err(&mut aggregated_err, 0, err);
-                    continue;
+                    if matches!(
+                        err,
+                        ServiceError::UpstreamVerification(
+                            UpstreamVerificationError::NoEligibleAttestedSession(_)
+                        )
+                    ) {
+                        upgrade_err(&mut aggregated_err, 0, err);
+                        continue;
+                    }
+                    return Err(err);
                 }
-                return Err(err);
-            }
 
-            let forwarded_body = prepared.request.body.clone();
+                let forwarded_body = prepared.request.body.clone();
 
-            if stream {
+                if stream {
+                    let upstream_response = match self
+                        .forward_with_binding_reverify(
+                            &prepared,
+                            &mut recorded_event,
+                            candidate_required,
+                            caller_supplied_upstream_event,
+                            &req.aci_session_ids,
+                            // Failover path: flush a possibly-stale binding on any
+                            // terminal mismatch so the next candidate/request re-verifies.
+                            true,
+                            |prepared, event| async move {
+                                self.upstream
+                                    .forward_stream_verified_prepared(prepared, &event)
+                                    .await
+                            },
+                        )
+                        .await
+                    {
+                        ReverifyOutcome::Forwarded(response) => Some(response),
+                        ReverifyOutcome::RefreshFailed(err) => {
+                            let priority = if matches!(err, ServiceError::UpstreamVerification(_)) {
+                                3
+                            } else {
+                                2
+                            };
+                            upgrade_err(&mut aggregated_err, priority, err);
+                            None
+                        }
+                        ReverifyOutcome::Failed(err) => {
+                            // Terminal binding mismatch and transport errors
+                            // intentionally share failover priority 2 (a failed
+                            // reverify outranks them at 3).
+                            upgrade_err(&mut aggregated_err, 2, err.into());
+                            None
+                        }
+                    };
+                    let Some(upstream_response) = upstream_response else {
+                        failed_attempts.push((route_id.clone(), 502));
+                        continue;
+                    };
+
+                    let status = upstream_response.status_code;
+                    if status != 200 {
+                        self.metrics.record_upstream_response(
+                            endpoint_path,
+                            RequestMode::Streaming,
+                            status,
+                            None,
+                        );
+                        // Collect the (small) error body up front so the failover
+                        // decision can inspect it. A truncated/unreadable error body
+                        // must not abort the remaining candidates, so it degrades to
+                        // empty — the caller's normalizer emits its generic message.
+                        let upstream_headers = upstream_response.headers;
+                        let upstream_body = collect_upstream_body(upstream_response.body)
+                            .await
+                            .unwrap_or_default();
+                        // A last-candidate answer is retained rather than returned while
+                        // a capacity-retry pass is still available and this pass produced
+                        // any capacity signal: the walk exit decides whether to replay the
+                        // capacity rejections or commit the retained answer.
+                        let is_capacity = is_upstream_capacity_signal(status, &upstream_body);
+                        let last_may_retry = (is_capacity || !capacity_indices.is_empty())
+                            && capacity_retry_eligible(
+                                capacity_retry_done,
+                                req.context.user_tier.as_deref(),
+                                forward_started,
+                            );
+                        if (!is_last || last_may_retry)
+                            && should_fail_over(status, received_body, &upstream_body)
+                        {
+                            if is_capacity {
+                                capacity_indices.push(index);
+                            }
+                            retained = Some(RetainedResponse::Streaming {
+                                error: StreamingUpstreamError {
+                                    upstream_status: status,
+                                    upstream_headers,
+                                    upstream_body,
+                                },
+                                route_id: route_id.clone(),
+                                attempt_slot: failed_attempts.len(),
+                            });
+                            failed_attempts.push((route_id.clone(), status));
+                            continue;
+                        }
+                        self.metrics
+                            .record_stream_error(endpoint_path, StreamErrorKind::UpstreamNon2xx);
+                        return Ok(MiddlewareForwardResult::UpstreamError(Box::new(
+                            MiddlewareUpstreamError {
+                                error: StreamingUpstreamError {
+                                    upstream_status: status,
+                                    upstream_headers,
+                                    upstream_body,
+                                },
+                                selected_route: route_id,
+                                failed_attempts,
+                            },
+                        )));
+                    }
+
+                    // Commit this candidate.
+                    let upstream_headers = upstream_response.headers;
+                    let receipt_id = generate_receipt_id();
+                    let served_at = self.clock.now_secs();
+                    let sealed = self.record_attested_upstream_session(&recorded_event)?;
+                    let recorded = cite_served_session(
+                        &sealed,
+                        upstream_response.served_instance_id.as_deref(),
+                    );
+                    let session_id = recorded.as_ref().map(|(id, _)| id.clone());
+                    let builder =
+                        self.build_middleware_receipt_prefix(MiddlewareReceiptInputs {
+                            receipt_id: &receipt_id,
+                            chat_id: None,
+                            model: user_model.clone(),
+                            served_at,
+                            endpoint_path,
+                            received_body,
+                            middleware_forwarded_body: &candidate.body,
+                            selected_route_id: &route_id,
+                            forwarded_body: &forwarded_body,
+                            recorded_event,
+                            recorded,
+                        })?;
+                    receipt_journal.reserve_receipt_id(receipt_id.clone());
+
+                    let body = MiddlewareProviderResponseDraftingStream::new(
+                        upstream_response.body,
+                        builder,
+                        receipt_journal,
+                        receipt_id.clone(),
+                        endpoint_path.to_string(),
+                        self.metrics.clone(),
+                        status,
+                    );
+
+                    return Ok(MiddlewareForwardResult::Stream(Box::new(
+                        MiddlewareStreamingForwarded {
+                            receipt_id: receipt_id.clone(),
+                            upstream_status: status,
+                            upstream_headers,
+                            body: Box::pin(body),
+                            selected_route: route_id.clone(),
+                            failed_attempts: std::mem::take(&mut failed_attempts),
+                            session_id,
+                        },
+                    )));
+                }
+
+                // Buffered forward.
                 let upstream_response = match self
                     .forward_with_binding_reverify(
                         &prepared,
@@ -396,7 +594,7 @@ impl AciService {
                         true,
                         |prepared, event| async move {
                             self.upstream
-                                .forward_stream_verified_prepared(prepared, &event)
+                                .forward_verified_prepared(prepared, &event)
                                 .await
                         },
                     )
@@ -425,180 +623,90 @@ impl AciService {
                     continue;
                 };
 
+                // Counted once, here, where the response arrives — a response that is
+                // held back and committed after the walk must not be counted again
+                // on commit.
                 let status = upstream_response.status_code;
-                if status != 200 {
-                    self.metrics.record_upstream_response(
-                        endpoint_path,
-                        RequestMode::Streaming,
-                        status,
-                        None,
+                let response_model = accepted_response_model(status, &upstream_response.body);
+                self.metrics.record_upstream_response(
+                    endpoint_path,
+                    RequestMode::Buffered,
+                    status,
+                    response_model.as_deref(),
+                );
+                // A last-candidate answer is retained rather than returned while
+                // a capacity-retry pass is still available and this pass produced
+                // any capacity signal: the walk exit decides whether to replay the
+                // capacity rejections or commit the retained answer.
+                let is_capacity = is_upstream_capacity_signal(status, &upstream_response.body);
+                let last_may_retry = (is_capacity || !capacity_indices.is_empty())
+                    && capacity_retry_eligible(
+                        capacity_retry_done,
+                        req.context.user_tier.as_deref(),
+                        forward_started,
                     );
-                    // Collect the (small) error body up front so the failover
-                    // decision can inspect it. A truncated/unreadable error body
-                    // must not abort the remaining candidates, so it degrades to
-                    // empty — the caller's normalizer emits its generic message.
-                    let upstream_headers = upstream_response.headers;
-                    let upstream_body = collect_upstream_body(upstream_response.body)
-                        .await
-                        .unwrap_or_default();
-                    if !is_last && should_fail_over(status, received_body, &upstream_body) {
-                        retained = Some(RetainedResponse::Streaming {
-                            error: StreamingUpstreamError {
-                                upstream_status: status,
-                                upstream_headers,
-                                upstream_body,
-                            },
-                            route_id: route_id.clone(),
-                            attempt_slot: failed_attempts.len(),
-                        });
-                        failed_attempts.push((route_id.clone(), status));
-                        continue;
+                if (!is_last || last_may_retry)
+                    && should_fail_over(status, received_body, &upstream_response.body)
+                {
+                    if is_capacity {
+                        capacity_indices.push(index);
                     }
-                    self.metrics
-                        .record_stream_error(endpoint_path, StreamErrorKind::UpstreamNon2xx);
-                    return Ok(MiddlewareForwardResult::UpstreamError(Box::new(
-                        MiddlewareUpstreamError {
-                            error: StreamingUpstreamError {
-                                upstream_status: status,
-                                upstream_headers,
-                                upstream_body,
-                            },
-                            selected_route: route_id,
-                            failed_attempts,
-                        },
-                    )));
+                    retained = Some(RetainedResponse::Buffered {
+                        inputs: Box::new(BufferedCommit {
+                            response: upstream_response,
+                            response_model,
+                            recorded_event,
+                            route_id: route_id.clone(),
+                            middleware_forwarded_body: candidate.body.clone(),
+                            forwarded_body,
+                        }),
+                        attempt_slot: failed_attempts.len(),
+                    });
+                    failed_attempts.push((route_id.clone(), status));
+                    continue;
                 }
 
                 // Commit this candidate.
-                let upstream_headers = upstream_response.headers;
-                let receipt_id = generate_receipt_id();
-                let served_at = self.clock.now_secs();
-                let sealed = self.record_attested_upstream_session(&recorded_event)?;
-                let recorded =
-                    cite_served_session(&sealed, upstream_response.served_instance_id.as_deref());
-                let session_id = recorded.as_ref().map(|(id, _)| id.clone());
-                let builder = self.build_middleware_receipt_prefix(MiddlewareReceiptInputs {
-                    receipt_id: &receipt_id,
-                    chat_id: None,
-                    model: user_model.clone(),
-                    served_at,
-                    endpoint_path,
-                    received_body,
-                    middleware_forwarded_body: &candidate.body,
-                    selected_route_id: &route_id,
-                    forwarded_body: &forwarded_body,
-                    recorded_event,
-                    recorded,
-                })?;
-                receipt_journal.reserve_receipt_id(receipt_id.clone());
-
-                let body = MiddlewareProviderResponseDraftingStream::new(
-                    upstream_response.body,
-                    builder,
-                    receipt_journal,
-                    receipt_id.clone(),
-                    endpoint_path.to_string(),
-                    self.metrics.clone(),
-                    status,
-                );
-
-                return Ok(MiddlewareForwardResult::Stream(Box::new(
-                    MiddlewareStreamingForwarded {
-                        receipt_id: receipt_id.clone(),
-                        upstream_status: status,
-                        upstream_headers,
-                        body: Box::pin(body),
-                        selected_route: route_id.clone(),
-                        failed_attempts: std::mem::take(&mut failed_attempts),
-                        session_id,
-                    },
-                )));
-            }
-
-            // Buffered forward.
-            let upstream_response = match self
-                .forward_with_binding_reverify(
-                    &prepared,
-                    &mut recorded_event,
-                    candidate_required,
-                    caller_supplied_upstream_event,
-                    &req.aci_session_ids,
-                    // Failover path: flush a possibly-stale binding on any
-                    // terminal mismatch so the next candidate/request re-verifies.
-                    true,
-                    |prepared, event| async move {
-                        self.upstream
-                            .forward_verified_prepared(prepared, &event)
-                            .await
-                    },
-                )
-                .await
-            {
-                ReverifyOutcome::Forwarded(response) => Some(response),
-                ReverifyOutcome::RefreshFailed(err) => {
-                    let priority = if matches!(err, ServiceError::UpstreamVerification(_)) {
-                        3
-                    } else {
-                        2
-                    };
-                    upgrade_err(&mut aggregated_err, priority, err);
-                    None
-                }
-                ReverifyOutcome::Failed(err) => {
-                    // Terminal binding mismatch and transport errors
-                    // intentionally share failover priority 2 (a failed
-                    // reverify outranks them at 3).
-                    upgrade_err(&mut aggregated_err, 2, err.into());
-                    None
-                }
-            };
-            let Some(upstream_response) = upstream_response else {
-                failed_attempts.push((route_id.clone(), 502));
-                continue;
-            };
-
-            // Counted once, here, where the response arrives — a response that is
-            // held back and committed after the walk must not be counted again
-            // on commit.
-            let status = upstream_response.status_code;
-            let response_model = accepted_response_model(status, &upstream_response.body);
-            self.metrics.record_upstream_response(
-                endpoint_path,
-                RequestMode::Buffered,
-                status,
-                response_model.as_deref(),
-            );
-            if !is_last && should_fail_over(status, received_body, &upstream_response.body) {
-                retained = Some(RetainedResponse::Buffered {
-                    inputs: Box::new(BufferedCommit {
+                return self.commit_buffered_response(
+                    BufferedCommit {
                         response: upstream_response,
                         response_model,
                         recorded_event,
-                        route_id: route_id.clone(),
+                        route_id,
                         middleware_forwarded_body: candidate.body.clone(),
                         forwarded_body,
-                    }),
-                    attempt_slot: failed_attempts.len(),
-                });
-                failed_attempts.push((route_id.clone(), status));
-                continue;
+                    },
+                    std::mem::take(&mut failed_attempts),
+                    endpoint_path,
+                    received_body,
+                    user_model.clone(),
+                );
             }
 
-            // Commit this candidate.
-            return self.commit_buffered_response(
-                BufferedCommit {
-                    response: upstream_response,
-                    response_model,
-                    recorded_event,
-                    route_id,
-                    middleware_forwarded_body: candidate.body.clone(),
-                    forwarded_body,
-                },
-                std::mem::take(&mut failed_attempts),
-                endpoint_path,
-                received_body,
-                user_model.clone(),
-            );
+            // Chain exhausted without a 2xx. Non-preemptible traffic gets one
+            // delayed second pass over the candidates that answered 429 — a
+            // capacity wall is a second-scale transient, unlike the hard
+            // failures which stay abandoned.
+            if !capacity_indices.is_empty()
+                && capacity_retry_eligible(
+                    capacity_retry_done,
+                    req.context.user_tier.as_deref(),
+                    forward_started,
+                )
+            {
+                capacity_retry_done = true;
+                let jitter = rand::random::<u64>() % CAPACITY_RETRY_DELAY_MS;
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    CAPACITY_RETRY_DELAY_MS + jitter,
+                ))
+                .await;
+                current = capacity_indices
+                    .iter()
+                    .map(|&i| current[i].clone())
+                    .collect();
+                continue;
+            }
+            break;
         }
 
         // No candidate produced a 2xx, but one may still have answered — commit

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -295,6 +295,22 @@ const UPSTREAM_CAPACITY_MARKER: &[u8] = b"exhausted all available targets";
 /// (rate-limited) rather than a `5xx` outage, so it is treated as load, not an
 /// error. Peer to [`image_input_error_parts`] — both remap a recognized upstream
 /// error body to a specific client status.
+/// Whether an upstream outcome is a capacity signal: a literal 429, or the
+/// recognized 5xx capacity/no-targets body that error normalization also
+/// surfaces to clients as 429. The single classification shared by error
+/// normalization and the forwarder's capacity-retry targeting — the two must
+/// never disagree about what "capacity" means, or a request could be told
+/// 429 without ever having been eligible for the retry that 429s get.
+pub(crate) fn is_upstream_capacity_signal(status: u16, body: &[u8]) -> bool {
+    if status == 429 {
+        return true;
+    }
+    (500..600).contains(&status)
+        && body
+            .windows(UPSTREAM_CAPACITY_MARKER.len())
+            .any(|w| w == UPSTREAM_CAPACITY_MARKER)
+}
+
 fn capacity_error_parts(
     surface: Surface,
     upstream_status: u16,
@@ -304,10 +320,7 @@ fn capacity_error_parts(
     if !(500..600).contains(&upstream_status) {
         return None;
     }
-    if !upstream_body
-        .windows(UPSTREAM_CAPACITY_MARKER.len())
-        .any(|w| w == UPSTREAM_CAPACITY_MARKER)
-    {
+    if !is_upstream_capacity_signal(upstream_status, upstream_body) {
         return None;
     }
     Some((
@@ -391,6 +404,24 @@ pub fn normalize_upstream_error(
 
 #[cfg(test)]
 mod tests {
+    use super::is_upstream_capacity_signal;
+
+    #[test]
+    fn capacity_signal_is_429_or_the_marked_5xx_body() {
+        assert!(is_upstream_capacity_signal(429, b"anything"));
+        assert!(is_upstream_capacity_signal(
+            503,
+            br#"{"error":"exhausted all available targets"}"#
+        ));
+        // A plain 5xx is an outage, not capacity.
+        assert!(!is_upstream_capacity_signal(503, br#"{"error":"boom"}"#));
+        // The marker under a non-5xx status is not the recognized signal.
+        assert!(!is_upstream_capacity_signal(
+            400,
+            b"exhausted all available targets"
+        ));
+    }
+
     use super::*;
     use axum::body::to_bytes;
 

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -639,7 +639,9 @@ async fn streaming_upstream_non_2xx_reports_the_serving_route() {
     // load behind the 429s is never shed.
     let (control_url, posts) = spawn_control_capturing(
         200,
-        json!({ "allow": true, "candidates": [{ "routeId": "openai:gpt", "format": "openai" }] }),
+        // Preemptible tier: no capacity-retry second pass — this test asserts
+        // the single walk's terminal report.
+        json!({ "allow": true, "userTier": "basic", "candidates": [{ "routeId": "openai:gpt", "format": "openai" }] }),
     )
     .await;
     let mw = middleware(control_url);
@@ -685,6 +687,9 @@ async fn repeated_route_id_still_reports_distinct_attempt_indices() {
         200,
         json!({
             "allow": true,
+            // Preemptible tier: no capacity-retry second pass — this test
+            // asserts the single walk's per-attempt attribution.
+            "userTier": "basic",
             "candidates": [
                 { "routeId": "openai:dup", "format": "openai" },
                 { "routeId": "openai:dup", "format": "openai" }
@@ -962,6 +967,9 @@ async fn a_later_candidate_that_never_answers_does_not_swallow_a_real_status() {
             200,
             json!({
                 "allow": true,
+                // Preemptible tier: no capacity-retry second pass — this test
+                // asserts the single walk's status precedence.
+                "userTier": "basic",
                 "candidates": [
                     { "routeId": "plain:gpt-test", "format": "openai" },
                     { "routeId": "missing-b:gpt-test", "format": "openai" }
@@ -1279,4 +1287,403 @@ async fn downstream_abort_after_settle_does_not_double_report() {
         .filter(|r| r["requestId"] == json!("r-late"))
         .count();
     assert_eq!(count, 1, "no second, conflicting report after settle");
+}
+
+// A mock upstream that answers each forward with the next status in a script,
+// recording every contacted route — the capacity-retry tests need "429 first,
+// 200 on the delayed second pass" to be observable per attempt.
+struct SequencedUpstream {
+    forwarded: Arc<Mutex<Vec<String>>>,
+    bodies: Arc<Mutex<Vec<Vec<u8>>>>,
+    statuses: Mutex<std::collections::VecDeque<u16>>,
+}
+
+#[async_trait]
+impl UpstreamBackend for SequencedUpstream {
+    fn name(&self) -> &str {
+        "sequenced-upstream"
+    }
+    fn url_origin(&self) -> Option<&str> {
+        Some("https://sequenced-upstream.example")
+    }
+    fn prepare(&self, req: UpstreamRequest) -> Result<PreparedUpstreamRequest, UpstreamError> {
+        let route_id = req.target_route_id.clone().unwrap_or_default();
+        Ok(PreparedUpstreamRequest {
+            upstream_name: self.name().to_string(),
+            url_origin: self.url_origin().map(str::to_string),
+            model_id: "gpt-test".to_string(),
+            is_tee: Some(false),
+            route_id: Some(route_id),
+            request: req,
+        })
+    }
+    async fn forward_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        self.forwarded
+            .lock()
+            .unwrap()
+            .push(req.route_id.clone().unwrap_or_default());
+        self.bodies.lock().unwrap().push(req.request.body.clone());
+        let status = self
+            .statuses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("script exhausted");
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        let body = match status {
+            200 => br#"{"id":"ok","choices":[]}"#.to_vec(),
+            // The recognized upstream capacity/no-targets signal, under a
+            // status OUTSIDE the retryable whitelist — guards the shared
+            // classification contract, not the whitelist path.
+            520 => br#"{"error":"exhausted all available targets"}"#.to_vec(),
+            _ => br#"{"error":{"message":"capacity"}}"#.to_vec(),
+        };
+        Ok(UpstreamResponse {
+            status_code: status,
+            body,
+            headers,
+            served_instance_id: None,
+        })
+    }
+    async fn forward_verified_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+        _event: &UpstreamVerifiedEvent,
+    ) -> Result<UpstreamResponse, UpstreamError> {
+        self.forward_prepared(req).await
+    }
+    async fn forward_stream_prepared(
+        &self,
+        req: PreparedUpstreamRequest,
+    ) -> Result<UpstreamStreamResponse, UpstreamError> {
+        let response = self.forward_prepared(req).await?;
+        let body = Bytes::from(response.body);
+        Ok(UpstreamStreamResponse {
+            status_code: response.status_code,
+            headers: response.headers,
+            body: Box::pin(futures_util::stream::once(async move { Ok(body) })),
+            served_instance_id: response.served_instance_id,
+        })
+    }
+    async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
+        unreachable!("sequenced upstream forwards via prepared paths only")
+    }
+    async fn models(&self) -> Result<UpstreamResponse, UpstreamError> {
+        Ok(UpstreamResponse {
+            status_code: 200,
+            body: b"{}".to_vec(),
+            headers: HashMap::new(),
+            served_instance_id: None,
+        })
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn build_sequenced_service(
+    statuses: Vec<u16>,
+) -> (
+    Arc<AciService>,
+    Arc<Mutex<Vec<String>>>,
+    Arc<Mutex<Vec<Vec<u8>>>>,
+) {
+    let forwarded: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let bodies: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+    let service = Arc::new(
+        AciService::new_with_upstream_verifier(
+            Arc::new(StaticKeyProvider::default()),
+            Arc::new(StubQuoter::default()),
+            Arc::new(SequencedUpstream {
+                forwarded: forwarded.clone(),
+                bodies: bodies.clone(),
+                statuses: Mutex::new(statuses.into_iter().collect()),
+            }),
+            Arc::new(OkVerifier),
+            Arc::new(InMemoryReceiptStore::default()),
+            AciServiceConfig::for_test("private-ai-gateway"),
+            Arc::new(FixedClock(1_700_000_000)),
+        )
+        .unwrap(),
+    );
+    (service, forwarded, bodies)
+}
+
+fn capacity_retry_request(user_tier: Option<&str>) -> ChatCompletionRequest<'static> {
+    ChatCompletionRequest {
+        context: GatewayRequestContext {
+            user_model: Some("gpt-test".to_string()),
+            user_tier: user_tier.map(str::to_string),
+            ..GatewayRequestContext::default()
+        },
+        endpoint_path: "/v1/chat/completions",
+        received_body: br#"{"model":"gpt-test","messages":[]}"#,
+        forwarded_body: None,
+        aci_required: false,
+        aci_session_ids: Vec::new(),
+        upstream_verification_event: None,
+        requester: None,
+        e2ee: None,
+    }
+}
+
+fn plain_candidate(route: &str) -> ForwardCandidate {
+    ForwardCandidate {
+        route_id: route.to_string(),
+        body: br#"{"model":"gpt-test","messages":[]}"#.to_vec(),
+    }
+}
+
+// Virtual time: the retry sleep auto-advances, so the test runs instantly.
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_gives_non_preemptible_traffic_a_delayed_second_pass() {
+    let (service, forwarded, _) = build_sequenced_service(vec![429, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("plain:gpt-test")],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Forwarded(forward) => {
+            // The first attempt's 429 stays observable behind the commit.
+            assert_eq!(
+                forward.failed_attempts,
+                vec![("plain:gpt-test".to_string(), 429)]
+            );
+        }
+        _ => panic!("the delayed second pass must commit the 200"),
+    }
+    assert_eq!(
+        *forwarded.lock().unwrap(),
+        vec!["plain:gpt-test".to_string(), "plain:gpt-test".to_string()],
+        "exactly one delayed re-contact"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_skips_preemptible_traffic() {
+    let (service, forwarded, _) = build_sequenced_service(vec![429, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(Some("basic")),
+            vec![plain_candidate("plain:gpt-test")],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Forwarded(forward) => {
+            // Preemptible traffic keeps the fast 429: the walk commits the
+            // held-back answer without a second pass.
+            assert_eq!(forward.upstream_status, 429);
+        }
+        _ => panic!("expected the committed 429"),
+    }
+    assert_eq!(
+        *forwarded.lock().unwrap(),
+        vec!["plain:gpt-test".to_string()],
+        "preemptible traffic must not re-contact the upstream"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_replays_only_the_capacity_rejections() {
+    // Pass 1: a answers 500, b answers 429. The second pass replays b alone —
+    // re-hitting the hard-failed a would feed the breaker another failure for
+    // a request it cannot serve.
+    let (service, forwarded, _) = build_sequenced_service(vec![500, 429, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("a:gpt-test"), plain_candidate("b:gpt-test")],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Forwarded(forward) => {
+            assert_eq!(forward.selected_route, "b:gpt-test");
+            assert_eq!(
+                forward.failed_attempts,
+                vec![
+                    ("a:gpt-test".to_string(), 500),
+                    ("b:gpt-test".to_string(), 429)
+                ]
+            );
+        }
+        _ => panic!("the retried capacity rejection must commit"),
+    }
+    assert_eq!(
+        *forwarded.lock().unwrap(),
+        vec![
+            "a:gpt-test".to_string(),
+            "b:gpt-test".to_string(),
+            "b:gpt-test".to_string()
+        ],
+        "the hard failure is not replayed"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_triggers_regardless_of_candidate_order() {
+    // The mirror of the mixed-chain test: the capacity rejection comes FIRST
+    // and the hard failure last. The retry decision keys on "did this pass see
+    // any capacity signal", not on which candidate happened to sit last.
+    let (service, forwarded, _) = build_sequenced_service(vec![429, 500, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("a:gpt-test"), plain_candidate("b:gpt-test")],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Forwarded(forward) => {
+            assert_eq!(forward.selected_route, "a:gpt-test");
+            assert_eq!(
+                forward.failed_attempts,
+                vec![
+                    ("a:gpt-test".to_string(), 429),
+                    ("b:gpt-test".to_string(), 500)
+                ]
+            );
+        }
+        _ => panic!("the retried capacity rejection must commit"),
+    }
+    assert_eq!(
+        *forwarded.lock().unwrap(),
+        vec![
+            "a:gpt-test".to_string(),
+            "b:gpt-test".to_string(),
+            "a:gpt-test".to_string()
+        ],
+        "only the capacity rejection is replayed, wherever it sits in the chain"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_tracks_candidates_by_index_not_route_id() {
+    // Callers may repeat a route id with distinct bodies. The first twin hard-
+    // fails, the second hits capacity: the replay must re-send the SECOND
+    // twin's body only — reconstructing the target set from route ids would
+    // replay the hard-failed twin too.
+    let (service, forwarded, bodies) = build_sequenced_service(vec![500, 429, 200]);
+    let twin = |body: &[u8]| ForwardCandidate {
+        route_id: "dup:gpt-test".to_string(),
+        body: body.to_vec(),
+    };
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![twin(br#"{"n":1}"#), twin(br#"{"n":2}"#)],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(result, MiddlewareForwardResult::Forwarded(_)));
+    assert_eq!(forwarded.lock().unwrap().len(), 3, "exactly one replay");
+    assert_eq!(
+        *bodies.lock().unwrap(),
+        vec![
+            br#"{"n":1}"#.to_vec(),
+            br#"{"n":2}"#.to_vec(),
+            br#"{"n":2}"#.to_vec()
+        ],
+        "the replay carries the capacity-rejected twin's body, not the hard-failed one"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_covers_the_recognized_5xx_capacity_signal() {
+    // An upstream that reports "exhausted all available targets" under a 5xx
+    // is surfaced to clients as 429 by error normalization — the retry (and
+    // failover) must treat it as capacity too, even when the status sits
+    // outside the retryable whitelist (520 here), or a request could be told
+    // 429 without ever getting the second chance that 429s get.
+    let (service, forwarded, _) = build_sequenced_service(vec![520, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("plain:gpt-test")],
+            false,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Forwarded(forward) => {
+            assert_eq!(
+                forward.failed_attempts,
+                vec![("plain:gpt-test".to_string(), 520)]
+            );
+        }
+        _ => panic!("the capacity-signal 5xx must be replayed and commit the 200"),
+    }
+    assert_eq!(forwarded.lock().unwrap().len(), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_streaming_replays_and_commits_the_final_429() {
+    // The streaming walk has its own retention/exit code: a single-candidate
+    // 429 must take the delayed second pass, and a second 429 must commit as
+    // the terminal upstream error with both contacts observable.
+    let (service, forwarded, _) = build_sequenced_service(vec![429, 429]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("plain:gpt-test")],
+            true,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::UpstreamError(err) => {
+            assert_eq!(err.error.upstream_status, 429);
+            assert_eq!(err.selected_route, "plain:gpt-test");
+            // The pass-1 429 stays observable behind the terminal report.
+            assert_eq!(
+                err.failed_attempts,
+                vec![("plain:gpt-test".to_string(), 429)]
+            );
+        }
+        _ => panic!("both passes 429 must surface the terminal upstream error"),
+    }
+    assert_eq!(forwarded.lock().unwrap().len(), 2, "exactly one replay");
+}
+
+#[tokio::test(start_paused = true)]
+async fn capacity_retry_streaming_second_pass_commits_the_stream() {
+    let (service, forwarded, _) = build_sequenced_service(vec![429, 200]);
+    let result = service
+        .forward_chat_completion_for_middleware(
+            capacity_retry_request(None),
+            vec![plain_candidate("plain:gpt-test")],
+            true,
+            MiddlewareReceiptJournal::default(),
+        )
+        .await
+        .unwrap();
+    match result {
+        MiddlewareForwardResult::Stream(stream) => {
+            assert_eq!(stream.upstream_status, 200);
+            assert_eq!(
+                stream.failed_attempts,
+                vec![("plain:gpt-test".to_string(), 429)]
+            );
+        }
+        _ => panic!("the delayed second pass must commit the stream"),
+    }
+    assert_eq!(forwarded.lock().unwrap().len(), 2);
 }


### PR DESCRIPTION
## Problem

A request whose whole candidate chain dies on upstream 429s relays the rejection instantly. A 429 is a transient signal — the upstream's free capacity fluctuates on the scale of seconds — so the wall that rejected the request often clears moments later, and when the chain has no alternative route the instant 429 is the whole outcome.

## Change

After the candidate walk is exhausted, requests not marked preemptible via `x-user-tier: basic` sleep 2–4 s (jittered) and replay **exactly the candidates that answered 429, once**:

- **Chain-exhaustion level, not per-attempt**: with siblings available, immediate failover stays strictly better than waiting; the retry only engages when every route has failed. Single-candidate chains reduce to "429 → wait → try again" with no special-casing.
- **Capacity is classified once, shared with error normalization** (`is_upstream_capacity_signal`): a literal 429, or the recognized 5xx capacity/no-targets body that normalization also surfaces as 429 — the two paths cannot disagree about what "capacity" means. `should_fail_over` accepts the capacity signal too, so a marked body under a status outside the retryable whitelist (e.g. 520) fails over and retries like any capacity outcome instead of terminating the chain.
- **Known, deliberate residual**: a capacity-classified 5xx that fails over is still *reported* under its raw status (the reported-status remap needs a raw/reported split in the attempt model). No production traffic currently carries the capacity marker (0 occurrences in 14 days of logs); revisit when it appears.
- **Retry targets are tracked by candidate index during the walk**, not reconstructed from route ids afterwards: route ids may repeat in a caller-supplied chain, and an id-based rebuild would replay a hard-failed twin.
- **The retry decision keys on "did this pass see any capacity signal"**, not on which candidate happened to sit last — a 429 earlier in the chain triggers the pass even when the last candidate hard-failed.
- **Hard failures stay abandoned**: replaying a 5xx route would feed its breaker counters another failure for a request it cannot serve.
- **Preemptible requests keep the fast 429** — their callers are expected to handle capacity signals themselves.
- Guards: one pass only, jittered delay (de-synchronizes requests bounced by the same dip), skipped if the request already spent >10 s in the chain.
- A last-candidate 429 is now *retained* instead of committed while the retry is still available, so single-candidate chains reach the retry decision; with no retry following, the retained commit is equivalent to the old direct one.
- `failed_attempts` / retained answer / aggregated error carry across passes: every attempt stays observable, attempt indices never collide under the caller's `(request_id, attempt, status)` idempotency.

No configuration: constants with comments (`CAPACITY_RETRY_DELAY_MS = 2000`, max elapsed 10 s, tier literal), same release path as any behavior change.

## Tests

- `capacity_retry_gives_non_preemptible_traffic_a_delayed_second_pass` — 429 then 200 on the replay; the first 429 stays in `failed_attempts`
- `capacity_retry_skips_preemptible_traffic` — `basic` commits the fast 429, one upstream contact
- `capacity_retry_replays_only_the_capacity_rejections` — mixed 500/429 chain replays only the 429 route
- `capacity_retry_triggers_regardless_of_candidate_order` — 429-then-500 also retries (order independence)
- `capacity_retry_tracks_candidates_by_index_not_route_id` — duplicated route ids replay only the capacity-rejected twin's body
- `capacity_retry_covers_the_recognized_5xx_capacity_signal` — the marked capacity body under a non-whitelisted 5xx (520) fails over and is replayed like a 429
- streaming pair: the streaming walk's own retention/exit code replays and commits (429→429 terminal, 429→200 stream commit)
- unit: `is_upstream_capacity_signal` classification
- Three existing 429-walk tests (status precedence, repeated-route attempt indices, streaming terminal report) now pin `userTier: basic` — they assert single-walk semantics, which preemptible requests preserve
- Retry tests run under `start_paused` virtual time; full suite, fmt and `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
