### PR TITLE
Reuse TLS-pinned upstream clients

### DIFF
--- a/spec/aci.md
+++ b/spec/aci.md
@@ -905,7 +905,6 @@ upstream. Defined shapes:
 
 ```json
 { "type": "tls_spki_sha256",        "origin": "<https-origin>", "spki_sha256": "<hex>" }
-{ "type": "tls_certificate_sha256", "origin": "<https-origin>", "certificate_sha256": "<hex>" }
 { "type": "e2ee_public_key_sha256", "provider": "<label>", "key_id": "<optional>", "algorithm": "<algo>", "public_key_sha256": "<hex>" }
 ```
 
@@ -1282,7 +1281,7 @@ these sets requires a published extension document.
 | Signature algorithms | `ed25519` (RECOMMENDED), `ecdsa-secp256k1` | Reject |
 | E2EE suites | `x25519-aes-256-gcm-hkdf-sha256` (RECOMMENDED; HKDF info `aci.e2ee.v2.x25519`), `secp256k1-aes-256-gcm-hkdf-sha256` (HKDF info `aci.e2ee.v2.secp256k1`) | Reject; other keyset entries with unknown `algo` are ignored for E2EE |
 | Receipt event types | `request.received`, `request.forwarded`, `response.returned`, `response.received`, `upstream.verified`, `transparency.request_modified`, `transparency.response_modified` | Ignore; preserve for signature recomputation (§3.2) |
-| Channel binding types | `tls_spki_sha256`, `tls_certificate_sha256`, `e2ee_public_key_sha256` | Treat as not enforceable |
+| Channel binding types | `tls_spki_sha256`, `e2ee_public_key_sha256` | Treat as not enforceable |
 | Claim names | `tee_attested`, `gpu_attested`, `tcb_up_to_date`, `os_known_good`, `serving_software_known_good`, `model_weights_provenance` | Extra facts live in `claims.extra`; unknown entries are informational |
 | Claim statuses / sources | `asserted`, `refuted`, `unknown` / `hardware_proven`, `verifier_derived`, `provider_asserted`, `operator_asserted` | Treat the claim as `unknown` |
 | TEE types | `tdx`, `sev_snp` | Requires a published verifier extension (§5.2) |

--- a/src/aci/receipt.rs
+++ b/src/aci/receipt.rs
@@ -103,10 +103,6 @@ pub enum ChannelBinding {
         origin: String,
         spki_sha256: String,
     },
-    TlsCertificateSha256 {
-        origin: String,
-        certificate_sha256: String,
-    },
     E2eePublicKeySha256 {
         provider: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/aci/upstream/openai.rs
+++ b/src/aci/upstream/openai.rs
@@ -1,5 +1,6 @@
 //! Plain OpenAI-compatible upstream backend.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -44,8 +45,45 @@ pub struct OpenAICompatibleBackend {
     path: String,
     auth: Option<UpstreamAuth>,
     client: reqwest::Client,
+    pinned_client: PinnedClientCache,
     connect_timeout_seconds: u64,
     read_timeout_seconds: u64,
+}
+
+struct CachedPinnedClient {
+    accepted_spkis: Vec<String>,
+    client: reqwest::Client,
+}
+
+/// The backend has one immutable origin and timeout policy, so retaining only
+/// its current verified binding generation keeps the cache strictly bounded.
+#[derive(Default)]
+struct PinnedClientCache {
+    current: Mutex<Option<CachedPinnedClient>>,
+}
+
+impl PinnedClientCache {
+    fn get_or_build(
+        &self,
+        accepted_spkis: Vec<String>,
+        build: impl FnOnce(&[String]) -> Result<reqwest::Client, UpstreamError>,
+    ) -> Result<reqwest::Client, UpstreamError> {
+        // Building while holding the lock makes concurrent misses for one
+        // binding generation converge on the same connection pool.
+        let mut current = self.current.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(cached) = current.as_ref() {
+            if cached.accepted_spkis == accepted_spkis {
+                return Ok(cached.client.clone());
+            }
+        }
+
+        let client = build(&accepted_spkis)?;
+        *current = Some(CachedPinnedClient {
+            accepted_spkis,
+            client: client.clone(),
+        });
+        Ok(client)
+    }
 }
 
 impl OpenAICompatibleBackend {
@@ -77,6 +115,7 @@ impl OpenAICompatibleBackend {
             path: "/v1/chat/completions".to_string(),
             auth: None,
             client,
+            pinned_client: PinnedClientCache::default(),
             connect_timeout_seconds,
             read_timeout_seconds,
         })
@@ -284,7 +323,6 @@ impl OpenAICompatibleBackend {
             return Ok(self.client.clone());
         }
         let mut accepted_spkis = Vec::new();
-        let mut accepted_certificates = Vec::new();
         for binding in &event.channel_bindings {
             match binding {
                 ChannelBinding::TlsSpkiSha256 {
@@ -294,18 +332,6 @@ impl OpenAICompatibleBackend {
                 ChannelBinding::TlsSpkiSha256 { origin, .. } => {
                     return Err(UpstreamError::Transport(format!(
                         "verified TLS SPKI binding origin {origin:?} does not match upstream {:?}",
-                        self.base_url
-                    )));
-                }
-                ChannelBinding::TlsCertificateSha256 {
-                    origin,
-                    certificate_sha256,
-                } if origin == &self.base_url => {
-                    accepted_certificates.push(certificate_sha256.clone())
-                }
-                ChannelBinding::TlsCertificateSha256 { origin, .. } => {
-                    return Err(UpstreamError::Transport(format!(
-                        "verified TLS certificate binding origin {origin:?} does not match upstream {:?}",
                         self.base_url
                     )));
                 }
@@ -326,12 +352,16 @@ impl OpenAICompatibleBackend {
                 "TLS channel binding requires an https upstream".to_string(),
             ));
         }
-        pinned_spki_client(
-            accepted_spkis,
-            accepted_certificates,
-            self.connect_timeout_seconds,
-            self.read_timeout_seconds,
-        )
+        accepted_spkis.sort_unstable();
+        accepted_spkis.dedup();
+        self.pinned_client
+            .get_or_build(accepted_spkis, |accepted_spkis| {
+                pinned_spki_client(
+                    accepted_spkis.to_vec(),
+                    self.connect_timeout_seconds,
+                    self.read_timeout_seconds,
+                )
+            })
     }
 
     async fn get(
@@ -386,7 +416,25 @@ impl OpenAICompatibleBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+
     use super::*;
+
+    fn verified_event(origin: &str, bindings: Vec<ChannelBinding>) -> UpstreamVerifiedEvent {
+        UpstreamVerifiedEvent {
+            url_origin: Some(origin.to_string()),
+            channel_bindings: bindings,
+            ..Default::default()
+        }
+    }
+
+    fn spki_binding(origin: &str, digest: char) -> ChannelBinding {
+        ChannelBinding::TlsSpkiSha256 {
+            origin: origin.to_string(),
+            spki_sha256: digest.to_string().repeat(64),
+        }
+    }
 
     #[test]
     fn anthropic_auth_sends_x_api_key_not_bearer() {
@@ -413,5 +461,64 @@ mod tests {
             .unwrap();
         assert_eq!(req.headers().get("authorization").unwrap(), "Bearer tok");
         assert!(req.headers().get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn client_for_event_canonicalizes_pin_sets() {
+        let origin = "https://example.com";
+        let backend = OpenAICompatibleBackend::new(origin).unwrap();
+        backend
+            .client_for_event(&verified_event(
+                origin,
+                vec![
+                    spki_binding(origin, 'b'),
+                    spki_binding(origin, 'a'),
+                    spki_binding(origin, 'b'),
+                ],
+            ))
+            .unwrap();
+
+        let current = backend.pinned_client.current.lock().unwrap();
+        let cached = current.as_ref().unwrap();
+        assert_eq!(cached.accepted_spkis, vec!["a".repeat(64), "b".repeat(64)]);
+    }
+
+    #[test]
+    fn pinned_client_cache_converges_and_rotates() {
+        const THREADS: usize = 8;
+
+        let cache = Arc::new(PinnedClientCache::default());
+        let builds = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles = (0..THREADS)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let builds = Arc::clone(&builds);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    cache
+                        .get_or_build(vec!["a".to_string()], |_| {
+                            builds.fetch_add(1, Ordering::SeqCst);
+                            Ok(reqwest::Client::new())
+                        })
+                        .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+
+        for _ in 0..2 {
+            cache
+                .get_or_build(vec!["b".to_string()], |_| {
+                    builds.fetch_add(1, Ordering::SeqCst);
+                    Ok(reqwest::Client::new())
+                })
+                .unwrap();
+        }
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/aci/upstream/tls.rs
+++ b/src/aci/upstream/tls.rs
@@ -25,7 +25,6 @@ pub(super) fn response_headers(resp: &reqwest::Response) -> HashMap<String, Stri
 
 pub(super) fn pinned_spki_client(
     accepted_spkis: Vec<String>,
-    accepted_certificates: Vec<String>,
     connect_timeout_seconds: u64,
     read_timeout_seconds: u64,
 ) -> Result<reqwest::Client, UpstreamError> {
@@ -37,7 +36,6 @@ pub(super) fn pinned_spki_client(
     let verifier = Arc::new(SpkiPinVerifier {
         inner,
         accepted: accepted_spkis.into_iter().collect(),
-        accepted_certificates: accepted_certificates.into_iter().collect(),
     });
     let tls = rustls::ClientConfig::builder()
         .dangerous()
@@ -54,17 +52,12 @@ pub(super) fn pinned_spki_client(
 struct SpkiPinVerifier {
     inner: Arc<dyn ServerCertVerifier>,
     accepted: HashSet<String>,
-    accepted_certificates: HashSet<String>,
 }
 
 impl fmt::Debug for SpkiPinVerifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SpkiPinVerifier")
             .field("accepted_count", &self.accepted.len())
-            .field(
-                "accepted_certificate_count",
-                &self.accepted_certificates.len(),
-            )
             .finish()
     }
 }
@@ -78,14 +71,11 @@ impl ServerCertVerifier for SpkiPinVerifier {
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, RustlsError> {
-        if self.accepted.is_empty() && self.accepted_certificates.is_empty() {
+        if self.accepted.is_empty() {
             return Err(RustlsError::InvalidCertificate(
                 CertificateError::ApplicationVerificationFailure,
             ));
         }
-
-        let certificate_digest = hex::encode(Sha256::digest(end_entity.as_ref()));
-        let certificate_matches = self.accepted_certificates.contains(&certificate_digest);
 
         let (_, cert) = parse_x509_certificate(end_entity.as_ref())
             .map_err(|_| RustlsError::InvalidCertificate(CertificateError::BadEncoding))?;
@@ -93,7 +83,7 @@ impl ServerCertVerifier for SpkiPinVerifier {
         let digest = hex::encode(digest);
         let spki_matches = self.accepted.contains(&digest);
 
-        if certificate_matches || spki_matches {
+        if spki_matches {
             Ok(ServerCertVerified::assertion())
         } else {
             Err(RustlsError::InvalidCertificate(

--- a/src/aci/verifier/external.rs
+++ b/src/aci/verifier/external.rs
@@ -502,7 +502,6 @@ struct ExternalChannelBinding {
     binding_type: String,
     origin: Option<String>,
     spki_sha256: Option<String>,
-    certificate_sha256: Option<String>,
     provider: Option<String>,
     key_id: Option<String>,
     algorithm: Option<String>,
@@ -525,19 +524,6 @@ fn parse_external_channel_bindings(
                 out.push(ChannelBinding::TlsSpkiSha256 {
                     origin,
                     spki_sha256: normalize_sha256_hex(&spki_sha256)?,
-                });
-            }
-            "tls_certificate_sha256" => {
-                let origin = binding.origin.ok_or_else(|| {
-                    "tls_certificate_sha256 channel binding is missing origin".to_string()
-                })?;
-                let certificate_sha256 = binding.certificate_sha256.ok_or_else(|| {
-                    "tls_certificate_sha256 channel binding is missing certificate_sha256"
-                        .to_string()
-                })?;
-                out.push(ChannelBinding::TlsCertificateSha256 {
-                    origin,
-                    certificate_sha256: normalize_sha256_hex(&certificate_sha256)?,
                 });
             }
             "e2ee_public_key_sha256" => {

--- a/tests/receipt.rs
+++ b/tests/receipt.rs
@@ -162,10 +162,6 @@ fn upstream_verified_event_records_channel_bindings() {
                 origin: "https://upstream.example".to_string(),
                 spki_sha256: "aa".repeat(32),
             },
-            ChannelBinding::TlsCertificateSha256 {
-                origin: "https://upstream.example".to_string(),
-                certificate_sha256: "bb".repeat(32),
-            },
             ChannelBinding::E2eePublicKeySha256 {
                 provider: "chutes".to_string(),
                 key_id: Some("instance-a".to_string()),
@@ -197,18 +193,10 @@ fn upstream_verified_event_records_channel_bindings() {
     );
     assert_eq!(
         upstream.fields["channel_bindings"][1]["type"],
-        "tls_certificate_sha256"
-    );
-    assert_eq!(
-        upstream.fields["channel_bindings"][1]["certificate_sha256"],
-        "bb".repeat(32)
-    );
-    assert_eq!(
-        upstream.fields["channel_bindings"][2]["type"],
         "e2ee_public_key_sha256"
     );
     assert_eq!(
-        upstream.fields["channel_bindings"][2]["public_key_sha256"],
+        upstream.fields["channel_bindings"][1]["public_key_sha256"],
         "cc".repeat(32)
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- retain one SPKI-pinned `reqwest::Client` per configured backend and verified binding generation
- canonicalize SPKI pin sets so ordering and duplicates do not fragment connection pools
- atomically replace the cached client when verified bindings rotate
- remove the unused whole-certificate channel binding from the spec and runtime
- keep the existing persistent-client path for upstreams without channel bindings

## Root cause

The verified OpenAI-compatible forwarding path rebuilt its rustls configuration and `reqwest::Client` for every request. That discarded the client's connection pool, forcing repeated TCP/TLS setup on SPKI-pinned providers.

The cache remains bounded to one generation per backend. Concurrent misses for the same generation converge while origin mismatches, unsupported bindings, and non-HTTPS pinned upstreams continue to fail closed.

## Provider impact

ACI Service, Tinfoil, NEAR AI, Secret AI, and Phala Direct all emit SPKI bindings and share this forwarding path. No built-in provider emits whole-certificate hashes. Plain OpenAI-compatible and Anthropic routes retain their existing no-binding client. Chutes uses its separate E2EE transport and is unaffected.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- focused tests cover canonical SPKI sets, concurrent cache misses, reuse, and binding rotation
- live Phala GLM-5.2 smoke repeated after removing certificate pins: the ACI Service verifier accepted the deployed workload/KMS policy and returned exactly one router SPKI binding; three sequential pinned streaming requests returned HTTP 200; Hyper traced reuse of the idle router connection for requests 2 and 3

The live smoke exercised this branch's production ACI verifier and SPKI-pinned backend directly. A full local-gateway identity/receipt E2E was not possible because no SSH-accessible dev CVM was available for forwarding `/var/run/dstack.sock`.

Fixes #106