### PR TITLE
Fix NEAR AI attestation authentication

### DIFF
--- a/scripts/confidential_verifier/providers/nearai.py
+++ b/scripts/confidential_verifier/providers/nearai.py
@@ -6,9 +6,10 @@ from ..types import AttestationReport
 
 
 class NearaiProvider(ServiceProvider):
-    def __init__(self, include_tls_fingerprint: bool = False):
+    def __init__(self, include_tls_fingerprint: bool = False, api_key: Optional[str] = None):
         self.api_base = "https://cloud-api.near.ai/v1"
         self.include_tls_fingerprint = include_tls_fingerprint
+        self.api_key = api_key
 
     def fetch_report(
         self,
@@ -44,7 +45,8 @@ class NearaiProvider(ServiceProvider):
         if use_tls_fingerprint:
             print(f"[Near] TLS fingerprint binding enabled")
 
-        response = requests.get(url, params=params)
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        response = requests.get(url, params=params, headers=headers)
         response.raise_for_status()
         data = response.json()
 

--- a/scripts/provider_verifier/nearai.py
+++ b/scripts/provider_verifier/nearai.py
@@ -34,7 +34,11 @@ async def verify_nearai(request: dict[str, Any]) -> None:
             verifier_id=verifier_id,
         )
         return
-    near_provider = NearaiProvider(include_tls_fingerprint=True)
+    provider_options = request.get("provider_options") or {}
+    near_provider = NearaiProvider(
+        include_tls_fingerprint=True,
+        api_key=provider_options.get("near_ai_api_key"),
+    )
     dstack_verifier_url = os.getenv("DSTACK_VERIFIER_URL", "http://localhost:8080")
     with contextlib.redirect_stdout(sys.stderr):
         report = await asyncio.to_thread(near_provider.fetch_report, request["model_id"])

--- a/src/aci/verifier/providers.rs
+++ b/src/aci/verifier/providers.rs
@@ -213,6 +213,11 @@ impl NearAiProviderVerifier {
         }
     }
 
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.verifier = self.verifier.with_option("near_ai_api_key", api_key);
+        self
+    }
+
     #[cfg(test)]
     pub(super) fn with_command(
         command: Vec<String>,

--- a/src/aci/verifier/tests.rs
+++ b/src/aci/verifier/tests.rs
@@ -127,13 +127,23 @@ fn provider_script(provider: &str, verifier_id: &str, binding: Value) -> Vec<Str
         output["attested_scope"] = json!(scope);
     }
     let output = output.to_string();
-    let script = format!(
-        r#"payload="$(cat)"
+    let script = if provider == "near-ai" {
+        format!(
+            r#"payload="$(cat)"
+case "$payload" in
+  *'"provider":"near-ai"'*'"model_id":"provider-model"'*'"near_ai_api_key":"secret-token"'*) printf '%s' '{output}' ;;
+  *) printf '%s' '{{"result":"failed","reason":"unexpected verifier input"}}' ;;
+esac"#
+        )
+    } else {
+        format!(
+            r#"payload="$(cat)"
 case "$payload" in
   *'"provider":"{provider}"'*'"model_id":"provider-model"'*) printf '%s' '{output}' ;;
   *) printf '%s' '{{"result":"failed","reason":"unexpected verifier input"}}' ;;
 esac"#
-    );
+        )
+    };
     vec!["/bin/sh".to_string(), "-c".to_string(), script]
 }
 
@@ -401,7 +411,8 @@ async fn near_ai_provider_verifier_runs_provider_owned_external_verifier() {
         ),
         5,
     )
-    .unwrap();
+    .unwrap()
+    .with_api_key("secret-token");
     assert_provider_script_verifier(
         &verifier,
         "near-ai",

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -250,10 +250,14 @@ fn build_provider_verifier(
                 request_timeout_seconds,
                 cache_seconds,
             ))),
-            UpstreamProvider::NearAi => Some(Arc::new(NearAiProviderVerifier::new_with_cache(
-                request_timeout_seconds,
-                cache_seconds,
-            ))),
+            UpstreamProvider::NearAi => {
+                let mut verifier =
+                    NearAiProviderVerifier::new_with_cache(request_timeout_seconds, cache_seconds);
+                if let Some(token) = &cfg.bearer_token {
+                    verifier = verifier.with_api_key(token.clone());
+                }
+                Some(Arc::new(verifier))
+            }
             UpstreamProvider::SecretAi => {
                 let verifier = SecretAiProviderVerifier::new_with_cache(
                     request_timeout_seconds,


### PR DESCRIPTION
## Fix

Forward the configured NEAR AI bearer token to `/v1/attestation/report`.

## Tests

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `uv run python scripts/contract_verifier_bridge.py`
