### PR TITLE
Normalize reasoning controls before routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,13 @@ config; see the [configuration reference](docs/configuration-reference.md#middle
 | `GET /v1/admin/upstreams` | Authenticated upstream config snapshot. |
 | `PUT /v1/admin/upstreams` | Authenticated upstream config replacement. |
 
+In middleware mode, Chat Completions accepts the unified `reasoning` object and
+the legacy `reasoning_effort` and `include_reasoning` aliases. Contradictory
+controls return 400. `reasoning.exclude` and `include_reasoning: false` hide
+reasoning content without changing reasoning-token usage. Reasoning-aware
+control-plane routing is optional. When used, the control plane returns
+`effectiveReasoning` for each candidate.
+
 ## Runtime Configuration
 
 The full field and environment-variable reference is

--- a/README.md
+++ b/README.md
@@ -435,13 +435,6 @@ config; see the [configuration reference](docs/configuration-reference.md#middle
 | `GET /v1/admin/upstreams` | Authenticated upstream config snapshot. |
 | `PUT /v1/admin/upstreams` | Authenticated upstream config replacement. |
 
-In middleware mode, Chat Completions accepts the unified `reasoning` object and
-the legacy `reasoning_effort` and `include_reasoning` aliases. Contradictory
-controls return 400. `reasoning.exclude` and `include_reasoning: false` hide
-reasoning content without changing reasoning-token usage. Reasoning-aware
-control-plane routing is optional. A candidate's `effectiveReasoning` overrides
-the normalized request; omitting it leaves the requested setting unchanged.
-
 ## Runtime Configuration
 
 The full field and environment-variable reference is

--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ In middleware mode, Chat Completions accepts the unified `reasoning` object and
 the legacy `reasoning_effort` and `include_reasoning` aliases. Contradictory
 controls return 400. `reasoning.exclude` and `include_reasoning: false` hide
 reasoning content without changing reasoning-token usage. Reasoning-aware
-control-plane routing is optional. When used, the control plane returns
-`effectiveReasoning` for each candidate.
+control-plane routing is optional. A candidate's `effectiveReasoning` overrides
+the normalized request; omitting it leaves the requested setting unchanged.
 
 ## Runtime Configuration
 

--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -12,8 +12,8 @@ endpoints below).
   + ordered route candidates, all from the config. Denies unknown models; if
   `keys` is non-empty it requires the request's `apiKeyHash` to be in the list
   (empty list = anonymous allowed). Reasoning-aware routing is optional and this
-  minimal example does not implement it. Implementations that do return
-  `effectiveReasoning` on each candidate.
+  minimal example does not implement it. A candidate can return
+  `effectiveReasoning` to override the normalized request.
 - `POST /consult/post` — accepts the usage report and drops it (no billing).
 
 No database; configuration only.

--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -8,10 +8,12 @@ endpoints below).
 ## What it does
 
 - `GET /models` — lists the models from the config.
-- `POST /consult/pre` — `{apiKeyHash?, model}` → allow/deny + pricing + ordered
-  route candidates, all from the config. Denies unknown models; if `keys` is
-  non-empty it requires the request's `apiKeyHash` to be in the list (empty list
-  = anonymous allowed).
+- `POST /consult/pre` — `{apiKeyHash?, model, reasoning?}` → allow/deny + pricing
+  + ordered route candidates, all from the config. Denies unknown models; if
+  `keys` is non-empty it requires the request's `apiKeyHash` to be in the list
+  (empty list = anonymous allowed). Reasoning-aware routing is optional and this
+  minimal example does not implement it. Implementations that do return
+  `effectiveReasoning` on each candidate.
 - `POST /consult/post` — accepts the usage report and drops it (no billing).
 
 No database; configuration only.
@@ -39,7 +41,8 @@ Then point the gateway at it by setting `middleware.control_url` to
 ## Remote mode
 
 The control plane can run on a separate host that the gateway reaches over the
-network. The consult payloads carry only `{apiKeyHash, model}` and usage counts.
+network. The consult payloads carry only request metadata, including
+`apiKeyHash`, `model`, optional normalized `reasoning`, and usage counts.
 
 - **Authentication** — set `PRIVATE_AI_GATEWAY_CONTROL_TOKEN` on the control. When
   set, it enforces `Authorization: Bearer <token>` on `/consult/*` and `/models`;

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -1,10 +1,7 @@
 //! Completion forwarding.
 //!
-//! Runs the completion flow: consult the control plane, shape one
-//! body per candidate, call `AciService::forward_chat_completion_for_middleware`
-//! directly, consume the typed result, transform the buffered or streaming
-//! response, inject cost, post the usage report, and finalize through the
-//! existing receipt/E2EE finalizers.
+//! Consults control, shapes candidates, forwards, transforms and meters the
+//! response, then finalizes its receipt/E2EE envelope.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -27,9 +24,10 @@ use crate::aggregator::service::{
 
 use super::control::ControlClient;
 use super::errors::{self, Surface};
+use super::reasoning;
 use super::request_transform::{build_candidates, Endpoint};
 use super::sse::{KeepAliveStream, MeterStream, StreamReport};
-use super::stream_transform::SseTransformStream;
+use super::stream_transform::{SseTransformStream, StreamTransform};
 use super::types::{ErrorSource, PostReport, ProviderFormat, SpendMode};
 use super::{pricing, response_transform, stream_transform};
 
@@ -54,38 +52,19 @@ pub struct CompletionInput {
     pub request_id: String,
     pub user_model: Option<String>,
     pub stream: bool,
-    /// Request arrived on a TEE-only host: the pre-consult carries `tee: true`
-    /// so the control plane 404s a non-TEE model before any forward. Attested
-    /// serving itself is enforced via `aci_required` (forced true alongside this).
+    /// Makes control reject non-TEE models before forwarding.
     pub tee_only: bool,
 }
 
-/// Cap on the error-detail snippet in `request_outcome` lines. Long enough to
-/// carry a provider's error envelope, short enough to bound log growth and to
-/// avoid replaying large bodies into the log.
+/// Cap provider-controlled error detail in outcome logs.
 const MAX_DETAIL_CHARS: usize = 240;
 
-/// Whether a terminal failure with this client-facing status gets a
-/// `request_outcome` line. Always-on for every model; the only exclusion is
-/// final 429s — the highest-volume, lowest-information class, already recorded
-/// per-attempt in the usage pipeline. Every other failure (4xx/5xx, client
-/// disconnects, stream failures) is logged with content-free structured
-/// fields (statuses, route, phase, finish reasons, timings); the raw error
-/// detail appears only with `request_outcome=debug`. Silence the target via
-/// `RUST_LOG` if ever needed — there is deliberately no config knob.
+/// Log every terminal failure except 429, which the usage pipeline records.
 pub(super) fn should_log_failure(status: u16) -> bool {
     status != 429
 }
 
-/// Finish/stop reasons that mark a genuinely clean completion on the OpenAI
-/// and Anthropic surfaces. A completed stream whose collected reasons include
-/// anything outside this set is logged as an anomaly: an upstream signalling
-/// an error through a nonstandard finish reason would otherwise be recorded
-/// as a plain success.
-///
-/// This is a heuristic: a miss on a newly introduced legitimate value costs
-/// only an info-level false positive and a one-line addition here. Keep it a
-/// flat list — no provider-specific registries or runtime configuration.
+/// Standard cross-provider finish reasons; other values are logged as anomalies.
 pub(super) const STANDARD_FINISH_REASONS: &[&str] = &[
     "stop",
     "length",
@@ -107,16 +86,10 @@ pub(super) fn finish_reasons_anomalous<'a, I: IntoIterator<Item = &'a str>>(reas
         .any(|r| !STANDARD_FINISH_REASONS.contains(&r))
 }
 
-/// Per-reason length cap for logged finish reasons. Long enough for every
-/// standard value and any plausible provider-specific token, short enough
-/// that a provider-controlled string cannot become a content channel in the
-/// always-on log.
+/// Per-reason log length cap.
 const MAX_REASON_CHARS: usize = 32;
 
-/// Log-safe form of a client-controlled identifier (the requested model
-/// name): single-line, control characters replaced, length-capped. The
-/// request body allows megabytes, so an unbounded identifier in an always-on
-/// info log would be a log-injection and disk-amplification vector.
+/// Bound and flatten client-controlled identifiers before logging.
 pub(super) fn sanitize_identifier(value: &str) -> String {
     value
         .chars()
@@ -125,10 +98,7 @@ pub(super) fn sanitize_identifier(value: &str) -> String {
         .collect()
 }
 
-/// Log-safe form of a single provider-controlled finish reason:
-/// length-capped, with every control character (newlines, ANSI escapes)
-/// replaced — a JSON string can embed them after parsing, enabling forged
-/// log records or terminal-escape injection.
+/// Bound and flatten provider-controlled finish reasons before logging.
 pub(super) fn sanitize_reason(reason: &str) -> String {
     reason
         .chars()
@@ -137,9 +107,7 @@ pub(super) fn sanitize_reason(reason: &str) -> String {
         .collect()
 }
 
-/// Emission form of collected finish reasons: count-capped, each value
-/// sanitized. Anomaly *detection* runs on the raw values; only what gets
-/// stored or logged is bounded.
+/// Bound emitted reasons without changing anomaly detection.
 pub(super) fn sanitized_reasons<'a, I: IntoIterator<Item = &'a str>>(reasons: I) -> String {
     reasons
         .into_iter()
@@ -149,13 +117,7 @@ pub(super) fn sanitized_reasons<'a, I: IntoIterator<Item = &'a str>>(reasons: I)
         .join(",")
 }
 
-/// Whether raw error detail may be included in `request_outcome` lines.
-/// Upstream error bodies can echo request content (validation errors quoting
-/// input, signed URLs), and this gateway's confidentiality model treats logs
-/// as operator-visible — so raw detail is opt-in via the tracing filter
-/// (`RUST_LOG=request_outcome=debug`); at the default level the structured
-/// fields (statuses, route, phase, finish reasons, timings) still identify
-/// the failure class.
+/// Reveal potentially sensitive upstream detail only at debug level.
 pub(super) fn debug_gated_detail(detail: &str) -> &str {
     if tracing::enabled!(target: "request_outcome", tracing::Level::DEBUG) {
         detail
@@ -164,11 +126,7 @@ pub(super) fn debug_gated_detail(detail: &str) -> &str {
     }
 }
 
-/// Single-line, length-capped snippet of an error body/message for the
-/// `request_outcome` `detail` field (char-boundary safe). The input is
-/// byte-capped before the lossy conversion so a large non-UTF-8 body is never
-/// copied whole; a char split at the cap degrades to a replacement character,
-/// which is fine for a log snippet.
+/// Build a bounded, single-line, UTF-8-lossy error snippet.
 pub(super) fn detail_snippet(raw: &[u8]) -> String {
     let capped = &raw[..raw.len().min(4 * MAX_DETAIL_CHARS)];
     String::from_utf8_lossy(capped)
@@ -178,19 +136,12 @@ pub(super) fn detail_snippet(raw: &[u8]) -> String {
         .collect()
 }
 
-/// `request_outcome` line for a terminal path that never settles a stream or a
-/// buffered 2xx: consult denials, routing/shaping failures, upstream error
-/// responses, and forward errors. Together with the stream-settle and
-/// buffered-2xx lines this makes observation exhaustive. Contract: a request
-/// emits at most one primary line, and a late finalization failure may append
-/// one supplemental `phase=finalize_error` line for the same request_id —
-/// aggregate by unique request_id, with `finalize_error` superseding the
-/// earlier record.
-/// Identity fields threaded into response finalization so a late failure
-/// there (E2EE encryption of a generated body) can record the actual
-/// client-facing terminal as `phase=finalize_error`.
+/// Identity needed to supersede an outcome with a late finalization failure.
 #[derive(Clone, Copy)]
 struct OutcomeCtx<'a> {
+    surface: Surface,
+    service: &'a AciService,
+    endpoint_path: &'a str,
     request_id: &'a str,
     model: &'a str,
     started: Instant,
@@ -249,8 +200,54 @@ pub async fn run(
     } = input;
 
     let started = Instant::now();
+    let (params, reasoning_requirements, exclude_reasoning) = if endpoint == Endpoint::ChatComplete
+    {
+        match reasoning::normalize_chat_request(&params) {
+            Ok(normalized) => normalized,
+            Err(err) => {
+                let model = params.get("model").and_then(Value::as_str).unwrap_or("");
+                let message = err.to_string();
+                log_generated_outcome(
+                    &request_id,
+                    model,
+                    "reasoning_validation",
+                    400,
+                    0,
+                    "",
+                    0,
+                    started,
+                    &detail_snippet(message.as_bytes()),
+                );
+                let body = errors::envelope_bytes(
+                    surface,
+                    errors::error_type(surface, 400),
+                    &message,
+                    Some(&request_id),
+                );
+                return finalize_generated(
+                    400,
+                    body,
+                    &[],
+                    e2ee,
+                    OutcomeCtx {
+                        surface,
+                        service,
+                        endpoint_path,
+                        request_id: &request_id,
+                        model,
+                        started,
+                    },
+                );
+            }
+        }
+    } else {
+        (params, None, false)
+    };
     let model = params.get("model").and_then(Value::as_str);
     let outcome_ctx = OutcomeCtx {
+        surface,
+        service,
+        endpoint_path,
         request_id: &request_id,
         model: model.unwrap_or(""),
         started,
@@ -260,7 +257,13 @@ pub async fn run(
     let provider = params.get("provider");
 
     let consult = control
-        .consult_pre(model, api_key_hash.as_deref(), provider, tee_only)
+        .consult_pre(
+            model,
+            api_key_hash.as_deref(),
+            provider,
+            reasoning_requirements.as_ref(),
+            tee_only,
+        )
         .await;
 
     let meter = Meter {
@@ -292,9 +295,7 @@ pub async fn run(
                 &detail_snippet(message.as_bytes()),
             );
         }
-        // Record 5xx and 429 denials as gateway failures; other user denials
-        // (401/402/404) are caller-attributable and left unrecorded. Tagging
-        // these ErrorSource::Control keeps them out of upstream-health signals.
+        // Record control failures without affecting upstream health.
         if status == 429 || status >= 500 {
             meter.gateway_failure(status, ErrorSource::Control, message, stream);
         }
@@ -302,16 +303,7 @@ pub async fn run(
             if let Some(rate_limit) = &consult.rate_limit {
                 let body = errors::rate_limit_envelope_bytes(surface, message, Some(&request_id));
                 let extra = errors::rate_limit_headers(rate_limit.limit, rate_limit.reset_at);
-                return finalize_generated(
-                    surface,
-                    service,
-                    endpoint_path,
-                    429,
-                    body,
-                    &extra,
-                    e2ee,
-                    outcome_ctx,
-                );
+                return finalize_generated(429, body, &extra, e2ee, outcome_ctx);
             }
         }
         let body = errors::envelope_bytes(
@@ -320,16 +312,7 @@ pub async fn run(
             message,
             Some(&request_id),
         );
-        return finalize_generated(
-            surface,
-            service,
-            endpoint_path,
-            status,
-            body,
-            &[],
-            e2ee,
-            outcome_ctx,
-        );
+        return finalize_generated(status, body, &[], e2ee, outcome_ctx);
     }
 
     let candidates = consult.candidates.clone().unwrap_or_default();
@@ -349,20 +332,16 @@ pub async fn run(
             );
         }
         let body = errors::envelope_bytes(surface, "model_not_found", &message, Some(&request_id));
-        return finalize_generated(
-            surface,
-            service,
-            endpoint_path,
-            400,
-            body,
-            &[],
-            e2ee,
-            outcome_ctx,
-        );
+        return finalize_generated(400, body, &[], e2ee, outcome_ctx);
     }
 
     // Shape one body per candidate (typed per-route contract).
-    let shaped = match build_candidates(&params, endpoint, &candidates) {
+    let shaped = match build_candidates(
+        &params,
+        endpoint,
+        &candidates,
+        reasoning_requirements.is_some(),
+    ) {
         Ok(shaped) => shaped,
         Err(err) => {
             let message = format!("failed to shape provider request: {err}");
@@ -386,16 +365,7 @@ pub async fn run(
                 &message,
                 Some(&request_id),
             );
-            return finalize_generated(
-                surface,
-                service,
-                endpoint_path,
-                500,
-                body,
-                &[],
-                e2ee,
-                outcome_ctx,
-            );
+            return finalize_generated(500, body, &[], e2ee, outcome_ctx);
         }
     };
     let forward_candidates: Vec<ForwardCandidate> = shaped
@@ -438,14 +408,7 @@ pub async fn run(
     match result {
         Ok(MiddlewareForwardResult::Forwarded(forward)) => {
             let upstream_status = forward.upstream_status;
-            // The forwarder tries candidates in order and pushes exactly one
-            // `failed_attempts` entry per candidate it abandons, so the serving
-            // candidate's index is the number of attempts before it (all three
-            // arms derive it this way). Derived, not looked up by route id: the
-            // candidate list is not deduped here, and a repeated route id would
-            // resolve to the earlier copy — colliding with that attempt's report
-            // under control's (request_id, attempt, status) idempotency gate and
-            // mislabeling a failed-over serve as a first-choice one.
+            // Failed-attempt count is the serving candidate's stable index.
             let attempt_index = forward.failed_attempts.len() as u32;
             let selected_format = candidates
                 .iter()
@@ -454,16 +417,12 @@ pub async fn run(
                 .map(|c| c.format)
                 .unwrap_or(ProviderFormat::Openai);
 
-            // The buffered forward commits the candidate even on non-2xx; a
-            // non-2xx body is normalized rather than transformed, but the receipt
-            // is finalized either way.
+            // Normalize non-2xx bodies; transform successful bodies.
             let (client_status, final_body) = if (200..300).contains(&upstream_status) {
                 let upstream_json: Value = match serde_json::from_slice(&forward.upstream_body) {
                     Ok(value) => value,
                     Err(_) => {
-                        // A malformed 2xx body must not be coerced into a fabricated
-                        // success. Attribute it to the upstream (it sent an
-                        // unparseable success body) and return 502.
+                        // Never fabricate success from malformed upstream JSON.
                         let message = "upstream returned a malformed success body";
                         if should_log_failure(502) {
                             log_generated_outcome(
@@ -485,16 +444,7 @@ pub async fn run(
                             message,
                             Some(&request_id),
                         );
-                        return finalize_generated(
-                            surface,
-                            service,
-                            endpoint_path,
-                            502,
-                            body,
-                            &[],
-                            e2ee,
-                            outcome_ctx,
-                        );
+                        return finalize_generated(502, body, &[], e2ee, outcome_ctx);
                     }
                 };
                 let mut transformed = response_transform::transform_response(
@@ -502,14 +452,14 @@ pub async fn run(
                     endpoint,
                     upstream_json,
                 );
+                if exclude_reasoning {
+                    response_transform::exclude_reasoning(&mut transformed);
+                }
 
                 // Raw usage (pre-cost) goes to the report; cost is injected only
                 // into the client body's top-level usage.
                 let raw_usage = transformed.get("usage").cloned();
-                // A buffered 2xx is only observable when its finish reasons are
-                // nonstandard — an upstream error smuggled through a "success".
-                // Covers both response shapes: OpenAI `choices[].finish_reason`
-                // and Anthropic top-level `stop_reason`.
+                // Surface provider errors smuggled through nonstandard reasons.
                 let mut finish_reasons: Vec<&str> = transformed
                     .get("choices")
                     .and_then(Value::as_array)
@@ -617,9 +567,7 @@ pub async fn run(
                 // The receipt finalizer consumed the E2EE context, so a generated
                 // error here is necessarily cleartext.
                 Err(err) => {
-                    // Any earlier outcome line for this request described the
-                    // upstream outcome; the client actually receives this
-                    // finalization error, so record the real terminal too.
+                    // Record the final client-visible terminal.
                     let status = forward_error_status(&err);
                     if should_log_failure(status) {
                         log_generated_outcome(
@@ -634,7 +582,7 @@ pub async fn run(
                             &detail_snippet(err.to_string().as_bytes()),
                         );
                     }
-                    service_error_response(surface, endpoint_path, service, outcome_ctx, err, None)
+                    service_error_response(outcome_ctx, err, None)
                 }
             }
         }
@@ -648,9 +596,7 @@ pub async fn run(
             let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
 
-            // Set when the downstream finalizer (receipt drafting / E2EE)
-            // errors while the body is being consumed: the meter's drop must
-            // then record an internal failure, not a client disconnect.
+            // Distinguish downstream finalization failure from disconnect.
             let downstream_abort = Arc::new(AtomicBool::new(false));
             let meter_settled = Arc::new(AtomicBool::new(false));
             let report = StreamReport {
@@ -674,12 +620,8 @@ pub async fn run(
                 0 => None,
                 ms => Some(Duration::from_millis(ms)),
             };
-            // Order: provider stream (drafts response.received) -> format
-            // transform (if cross-format) -> meter/cost -> keep-alive -> finalizer
-            // (hashes response.returned). Same-format streaming is native
-            // passthrough (no transform). Metering sits inside the keep-alive so
-            // it only ever buffers real upstream SSE bytes; the heartbeat comments
-            // are injected downstream and never enter its line reassembly.
+            // Provider -> format -> visibility -> meter -> keepalive -> finalizer.
+            // Heartbeats stay outside metering and receipt input.
             let response_header_map = response_headers(&forward.upstream_headers, &content_type);
             let selected_format = candidates
                 .iter()
@@ -692,8 +634,16 @@ pub async fn run(
                     Some(transform) => Box::pin(SseTransformStream::new(forward.body, transform)),
                     None => forward.body,
                 };
+            let visible: ServiceResponseStream = if exclude_reasoning {
+                Box::pin(SseTransformStream::new(
+                    transformed,
+                    StreamTransform::ExcludeReasoning,
+                ))
+            } else {
+                transformed
+            };
             let metered: ServiceResponseStream = Box::pin(MeterStream::new(
-                transformed,
+                visible,
                 report,
                 errors::sse_protocol(endpoint_path),
             ));
@@ -730,13 +680,7 @@ pub async fn run(
                         HeaderName::from_static("cache-control"),
                         HeaderValue::from_static("no-cache"),
                     );
-                    // A response-stream error must not become a body Err: hyper
-                    // aborts the connection (TCP RST toward the proxy), which
-                    // clients experience as a silently killed stream and a
-                    // poisoned keep-alive pool, invisible to application logs.
-                    // Log the error (this is its only surface) and end the body
-                    // instead — a clean HTTP body termination (h1 terminal
-                    // chunk, h2 END_STREAM), leaving the connection reusable.
+                    // End cleanly on body errors so hyper does not reset the socket.
                     let stream_request_id = request_id.clone();
                     let stream_model = model.unwrap_or("").to_string();
                     let stream_route = forward.selected_route.clone();
@@ -744,10 +688,7 @@ pub async fn run(
                         std::future::ready(match chunk {
                             Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
                             Err(err) => {
-                                // Mark before the chain drops so the meter's
-                                // drop settles this as an internal failure
-                                // rather than misreading it as a client
-                                // disconnect.
+                                // Mark before meter drop classifies the terminal.
                                 downstream_abort.store(true, Ordering::Relaxed);
                                 tracing::warn!(
                                     target: "stream_abort",
@@ -755,10 +696,7 @@ pub async fn run(
                                     error = %err,
                                     "response stream error; ending body gracefully instead of aborting the connection"
                                 );
-                                // A finalizer error after a clean end-of-stream
-                                // (receipt store / E2EE finish): the meter has
-                                // already settled Completed and will not emit,
-                                // so record the client-visible failure here.
+                                // Meter already settled; record this late failure here.
                                 if meter_settled.load(Ordering::Relaxed) {
                                     log_generated_outcome(
                                         &stream_request_id,
@@ -779,9 +717,7 @@ pub async fn run(
                     (status, headers, body).into_response()
                 }
                 Err(err) => {
-                    // Synchronous finalizer failure: the stream never started,
-                    // so the meter never settles — this is the request's only
-                    // outcome line.
+                    // The stream never started, so emit its only outcome here.
                     let status = forward_error_status(&err);
                     if should_log_failure(status) {
                         log_generated_outcome(
@@ -796,14 +732,12 @@ pub async fn run(
                             &detail_snippet(err.to_string().as_bytes()),
                         );
                     }
-                    service_error_response(surface, endpoint_path, service, outcome_ctx, err, None)
+                    service_error_response(outcome_ctx, err, None)
                 }
             }
         }
         Ok(MiddlewareForwardResult::UpstreamError(forward)) => {
-            // Streaming non-2xx: no receipt (no completed stream to bind), but the
-            // attempt did reach an upstream, so it reports the serving route and
-            // every failed-over candidate exactly like the Stream arm.
+            // A streaming non-2xx has no receipt but still reports all attempts.
             let (status, body) = errors::normalize_upstream_error_parts(
                 surface,
                 forward.error.upstream_status,
@@ -831,23 +765,9 @@ pub async fn run(
                 attempt_index,
                 &forward.selected_route,
             );
-            finalize_generated(
-                surface,
-                service,
-                endpoint_path,
-                status,
-                body,
-                &[],
-                e2ee,
-                outcome_ctx,
-            )
+            finalize_generated(status, body, &[], e2ee, outcome_ctx)
         }
-        // Every candidate was attempted and failed without an HTTP response to
-        // relay (a chain that ends in an upstream HTTP status — including an
-        // all-429 chain — exits via the UpstreamError arm above, which relays
-        // that status). Report each attempt so deployment health and triage
-        // see the full chain, then a summary row placed after them carrying
-        // the aggregated error message.
+        // Report transport failures per attempt, followed by their summary.
         Ok(MiddlewareForwardResult::AllFailed(forward)) => {
             let status = forward_error_status(&forward.error);
             meter.failed_attempts(&forward.failed_attempts, stream);
@@ -873,21 +793,9 @@ pub async fn run(
                     stream,
                 );
             }
-            service_error_response(
-                surface,
-                endpoint_path,
-                service,
-                outcome_ctx,
-                forward.error,
-                e2ee,
-            )
+            service_error_response(outcome_ctx, forward.error, e2ee)
         }
-        // Failures where no attempt chain is available (pre-forward errors,
-        // plus the forwarder's rare mid-walk internal-error abort): record the
-        // failure so the request is visible to billing/health, attributed by
-        // `forward_error_source` (upstream, except the gateway's own TEE-policy
-        // rejection). Client-attributable errors (E2EE/4xx) are not recorded.
-        // The E2EE context is still available to encrypt the body.
+        // Report unattributed forwarding failures; preserve E2EE for the response.
         Err(err) => {
             let status = forward_error_status(&err);
             if should_log_failure(status) {
@@ -906,14 +814,12 @@ pub async fn run(
             if status >= 500 {
                 meter.gateway_failure(status, forward_error_source(&err), &err.to_string(), stream);
             }
-            service_error_response(surface, endpoint_path, service, outcome_ctx, err, e2ee)
+            service_error_response(outcome_ctx, err, e2ee)
         }
     }
 }
 
-// Posts usage reports to the control plane (fire-and-forget). Buffered reports
-// have no TTFT and `is_streaming = false`; the status recorded is the raw upstream
-// status, distinct from the client-facing mapped status.
+// Posts usage reports to control without blocking the response.
 struct Meter<'a> {
     control: &'a ControlClient,
     request_id: String,
@@ -994,10 +900,7 @@ impl Meter<'_> {
         self.gateway_failure_at(0, status, source, message, is_streaming);
     }
 
-    // Like `gateway_failure`, but placed at an explicit attempt index. Control
-    // dedupes reports by (request_id, attempt, status), so a summary row that
-    // follows per-attempt rows must sit after them or it collides with (and
-    // silently drops) the first attempt's row.
+    // Put summaries after attempt rows to avoid control's idempotency key.
     fn gateway_failure_at(
         &self,
         attempt_index: u32,
@@ -1028,10 +931,7 @@ fn truncate(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
-// The status reported to the control plane for a normalized upstream error: the
-// client-facing status when it is client-attributable (4xx) — a remapped
-// image-fetch failure must not count against the provider's health — otherwise
-// the raw upstream status, preserving the provider's real code in the logs.
+// Report client-attributable 4xx mappings; otherwise preserve upstream status.
 fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
     if (400..500).contains(&mapped) {
         mapped
@@ -1040,12 +940,7 @@ fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
     }
 }
 
-// Which component a terminal forward failure is attributable to.
-//
-// Upstream by default: a forward chain that ends in a 5xx is a provider
-// failure. The exceptions are ACI constraints that leave no eligible route or
-// current session — no prompt was forwarded, so attributing them to a provider
-// would report the gateway's policy decision as someone else's failure.
+// ACI eligibility is gateway policy; other forwarding failures are upstream.
 fn forward_error_source(err: &ServiceError) -> ErrorSource {
     match err {
         ServiceError::UpstreamVerification(
@@ -1066,17 +961,13 @@ fn forward_error_status(err: &ServiceError) -> u16 {
     }
 }
 
-// Map a forward/finalize `ServiceError` to a client-facing generated response.
-// E2EE clients still get an encrypted error body, except for `E2ee` errors
-// themselves (the E2EE setup failed, so the response cannot be encrypted).
+// Encrypt generated errors unless E2EE setup itself failed.
 fn service_error_response(
-    surface: Surface,
-    endpoint_path: &str,
-    service: &AciService,
     outcome: OutcomeCtx<'_>,
     err: ServiceError,
     e2ee: Option<E2eeRequestContext>,
 ) -> Response {
+    let surface = outcome.surface;
     let request_id = outcome.request_id;
     let status = forward_error_status(&err);
     let e2ee = match &err {
@@ -1089,32 +980,24 @@ fn service_error_response(
         &err.to_string(),
         Some(request_id),
     );
-    finalize_generated(
-        surface,
-        service,
-        endpoint_path,
-        status,
-        body,
-        &[],
-        e2ee,
-        outcome,
-    )
+    finalize_generated(status, body, &[], e2ee, outcome)
 }
 
-// Build a generated (no-receipt) response, E2EE-encrypting the body when a
-// request context is present. If encryption fails it is fail-closed: a generic
-// error is returned rather than the cleartext body.
+// Build a generated response; E2EE finalization fails closed.
 #[allow(clippy::too_many_arguments)]
 fn finalize_generated(
-    surface: Surface,
-    service: &AciService,
-    endpoint_path: &str,
     status: u16,
     body: Vec<u8>,
     extra_headers: &[(&'static str, String)],
     e2ee: Option<E2eeRequestContext>,
     outcome: OutcomeCtx<'_>,
 ) -> Response {
+    let OutcomeCtx {
+        surface,
+        service,
+        endpoint_path,
+        ..
+    } = outcome;
     let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -1137,8 +1020,7 @@ fn finalize_generated(
         // Fail-closed: never return the cleartext body when E2EE was requested.
         Err(err) => {
             tracing::error!(error = %err, "E2EE generated-response finalization failed");
-            // Any earlier outcome line recorded the pre-finalization status;
-            // the client actually receives this 500.
+            // Supersede the earlier outcome with the client-visible 500.
             log_generated_outcome(
                 outcome.request_id,
                 outcome.model,
@@ -1161,18 +1043,14 @@ fn finalize_generated(
     }
 }
 
-// Build response headers from the upstream response, dropping gateway-owned and
-// hop-by-hop headers, and forcing the content type. Provider auth/server headers
-// are not forwarded.
+// Drop gateway-owned/hop-by-hop headers and force content type.
 fn response_headers(
     upstream_headers: &std::collections::HashMap<String, String>,
     content_type: &str,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
     for (name, value) in upstream_headers {
-        // The body we emit is always identity-encoded (re-serialized JSON or a
-        // transformed/passthrough SSE stream), so a relayed `content-encoding`
-        // would mislabel it. `content-type` is set explicitly below.
+        // The reserialized body is identity-encoded.
         if is_gateway_owned(name)
             || is_hop_by_hop(name)
             || name.eq_ignore_ascii_case("content-type")

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -395,7 +395,7 @@ pub async fn run(
         &params,
         endpoint,
         &candidates,
-        reasoning_requirements.is_some(),
+        reasoning_requirements.as_ref(),
     ) {
         Ok(shaped) => shaped,
         Err(err) => {

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -1,7 +1,10 @@
 //! Completion forwarding.
 //!
-//! Consults control, shapes candidates, forwards, transforms and meters the
-//! response, then finalizes its receipt/E2EE envelope.
+//! Runs the completion flow: consult the control plane, shape one
+//! body per candidate, call `AciService::forward_chat_completion_for_middleware`
+//! directly, consume the typed result, transform the buffered or streaming
+//! response, inject cost, post the usage report, and finalize through the
+//! existing receipt/E2EE finalizers.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -52,19 +55,38 @@ pub struct CompletionInput {
     pub request_id: String,
     pub user_model: Option<String>,
     pub stream: bool,
-    /// Makes control reject non-TEE models before forwarding.
+    /// Request arrived on a TEE-only host: the pre-consult carries `tee: true`
+    /// so the control plane 404s a non-TEE model before any forward. Attested
+    /// serving itself is enforced via `aci_required` (forced true alongside this).
     pub tee_only: bool,
 }
 
-/// Cap provider-controlled error detail in outcome logs.
+/// Cap on the error-detail snippet in `request_outcome` lines. Long enough to
+/// carry a provider's error envelope, short enough to bound log growth and to
+/// avoid replaying large bodies into the log.
 const MAX_DETAIL_CHARS: usize = 240;
 
-/// Log every terminal failure except 429, which the usage pipeline records.
+/// Whether a terminal failure with this client-facing status gets a
+/// `request_outcome` line. Always-on for every model; the only exclusion is
+/// final 429s — the highest-volume, lowest-information class, already recorded
+/// per-attempt in the usage pipeline. Every other failure (4xx/5xx, client
+/// disconnects, stream failures) is logged with content-free structured
+/// fields (statuses, route, phase, finish reasons, timings); the raw error
+/// detail appears only with `request_outcome=debug`. Silence the target via
+/// `RUST_LOG` if ever needed — there is deliberately no config knob.
 pub(super) fn should_log_failure(status: u16) -> bool {
     status != 429
 }
 
-/// Standard cross-provider finish reasons; other values are logged as anomalies.
+/// Finish/stop reasons that mark a genuinely clean completion on the OpenAI
+/// and Anthropic surfaces. A completed stream whose collected reasons include
+/// anything outside this set is logged as an anomaly: an upstream signalling
+/// an error through a nonstandard finish reason would otherwise be recorded
+/// as a plain success.
+///
+/// This is a heuristic: a miss on a newly introduced legitimate value costs
+/// only an info-level false positive and a one-line addition here. Keep it a
+/// flat list — no provider-specific registries or runtime configuration.
 pub(super) const STANDARD_FINISH_REASONS: &[&str] = &[
     "stop",
     "length",
@@ -86,10 +108,16 @@ pub(super) fn finish_reasons_anomalous<'a, I: IntoIterator<Item = &'a str>>(reas
         .any(|r| !STANDARD_FINISH_REASONS.contains(&r))
 }
 
-/// Per-reason log length cap.
+/// Per-reason length cap for logged finish reasons. Long enough for every
+/// standard value and any plausible provider-specific token, short enough
+/// that a provider-controlled string cannot become a content channel in the
+/// always-on log.
 const MAX_REASON_CHARS: usize = 32;
 
-/// Bound and flatten client-controlled identifiers before logging.
+/// Log-safe form of a client-controlled identifier (the requested model
+/// name): single-line, control characters replaced, length-capped. The
+/// request body allows megabytes, so an unbounded identifier in an always-on
+/// info log would be a log-injection and disk-amplification vector.
 pub(super) fn sanitize_identifier(value: &str) -> String {
     value
         .chars()
@@ -98,7 +126,10 @@ pub(super) fn sanitize_identifier(value: &str) -> String {
         .collect()
 }
 
-/// Bound and flatten provider-controlled finish reasons before logging.
+/// Log-safe form of a single provider-controlled finish reason:
+/// length-capped, with every control character (newlines, ANSI escapes)
+/// replaced — a JSON string can embed them after parsing, enabling forged
+/// log records or terminal-escape injection.
 pub(super) fn sanitize_reason(reason: &str) -> String {
     reason
         .chars()
@@ -107,7 +138,9 @@ pub(super) fn sanitize_reason(reason: &str) -> String {
         .collect()
 }
 
-/// Bound emitted reasons without changing anomaly detection.
+/// Emission form of collected finish reasons: count-capped, each value
+/// sanitized. Anomaly *detection* runs on the raw values; only what gets
+/// stored or logged is bounded.
 pub(super) fn sanitized_reasons<'a, I: IntoIterator<Item = &'a str>>(reasons: I) -> String {
     reasons
         .into_iter()
@@ -117,7 +150,13 @@ pub(super) fn sanitized_reasons<'a, I: IntoIterator<Item = &'a str>>(reasons: I)
         .join(",")
 }
 
-/// Reveal potentially sensitive upstream detail only at debug level.
+/// Whether raw error detail may be included in `request_outcome` lines.
+/// Upstream error bodies can echo request content (validation errors quoting
+/// input, signed URLs), and this gateway's confidentiality model treats logs
+/// as operator-visible — so raw detail is opt-in via the tracing filter
+/// (`RUST_LOG=request_outcome=debug`); at the default level the structured
+/// fields (statuses, route, phase, finish reasons, timings) still identify
+/// the failure class.
 pub(super) fn debug_gated_detail(detail: &str) -> &str {
     if tracing::enabled!(target: "request_outcome", tracing::Level::DEBUG) {
         detail
@@ -126,7 +165,11 @@ pub(super) fn debug_gated_detail(detail: &str) -> &str {
     }
 }
 
-/// Build a bounded, single-line, UTF-8-lossy error snippet.
+/// Single-line, length-capped snippet of an error body/message for the
+/// `request_outcome` `detail` field (char-boundary safe). The input is
+/// byte-capped before the lossy conversion so a large non-UTF-8 body is never
+/// copied whole; a char split at the cap degrades to a replacement character,
+/// which is fine for a log snippet.
 pub(super) fn detail_snippet(raw: &[u8]) -> String {
     let capped = &raw[..raw.len().min(4 * MAX_DETAIL_CHARS)];
     String::from_utf8_lossy(capped)
@@ -136,7 +179,17 @@ pub(super) fn detail_snippet(raw: &[u8]) -> String {
         .collect()
 }
 
-/// Identity needed to supersede an outcome with a late finalization failure.
+/// `request_outcome` line for a terminal path that never settles a stream or a
+/// buffered 2xx: consult denials, routing/shaping failures, upstream error
+/// responses, and forward errors. Together with the stream-settle and
+/// buffered-2xx lines this makes observation exhaustive. Contract: a request
+/// emits at most one primary line, and a late finalization failure may append
+/// one supplemental `phase=finalize_error` line for the same request_id —
+/// aggregate by unique request_id, with `finalize_error` superseding the
+/// earlier record.
+/// Identity fields threaded into response finalization so a late failure
+/// there (E2EE encryption of a generated body) can record the actual
+/// client-facing terminal as `phase=finalize_error`.
 #[derive(Clone, Copy)]
 struct OutcomeCtx<'a> {
     surface: Surface,
@@ -295,7 +348,9 @@ pub async fn run(
                 &detail_snippet(message.as_bytes()),
             );
         }
-        // Record control failures without affecting upstream health.
+        // Record 5xx and 429 denials as gateway failures; other user denials
+        // (401/402/404) are caller-attributable and left unrecorded. Tagging
+        // these ErrorSource::Control keeps them out of upstream-health signals.
         if status == 429 || status >= 500 {
             meter.gateway_failure(status, ErrorSource::Control, message, stream);
         }
@@ -408,7 +463,14 @@ pub async fn run(
     match result {
         Ok(MiddlewareForwardResult::Forwarded(forward)) => {
             let upstream_status = forward.upstream_status;
-            // Failed-attempt count is the serving candidate's stable index.
+            // The forwarder tries candidates in order and pushes exactly one
+            // `failed_attempts` entry per candidate it abandons, so the serving
+            // candidate's index is the number of attempts before it (all three
+            // arms derive it this way). Derived, not looked up by route id: the
+            // candidate list is not deduped here, and a repeated route id would
+            // resolve to the earlier copy — colliding with that attempt's report
+            // under control's (request_id, attempt, status) idempotency gate and
+            // mislabeling a failed-over serve as a first-choice one.
             let attempt_index = forward.failed_attempts.len() as u32;
             let selected_format = candidates
                 .iter()
@@ -417,12 +479,16 @@ pub async fn run(
                 .map(|c| c.format)
                 .unwrap_or(ProviderFormat::Openai);
 
-            // Normalize non-2xx bodies; transform successful bodies.
+            // The buffered forward commits the candidate even on non-2xx; a
+            // non-2xx body is normalized rather than transformed, but the receipt
+            // is finalized either way.
             let (client_status, final_body) = if (200..300).contains(&upstream_status) {
                 let upstream_json: Value = match serde_json::from_slice(&forward.upstream_body) {
                     Ok(value) => value,
                     Err(_) => {
-                        // Never fabricate success from malformed upstream JSON.
+                        // A malformed 2xx body must not be coerced into a fabricated
+                        // success. Attribute it to the upstream (it sent an
+                        // unparseable success body) and return 502.
                         let message = "upstream returned a malformed success body";
                         if should_log_failure(502) {
                             log_generated_outcome(
@@ -459,7 +525,10 @@ pub async fn run(
                 // Raw usage (pre-cost) goes to the report; cost is injected only
                 // into the client body's top-level usage.
                 let raw_usage = transformed.get("usage").cloned();
-                // Surface provider errors smuggled through nonstandard reasons.
+                // A buffered 2xx is only observable when its finish reasons are
+                // nonstandard — an upstream error smuggled through a "success".
+                // Covers both response shapes: OpenAI `choices[].finish_reason`
+                // and Anthropic top-level `stop_reason`.
                 let mut finish_reasons: Vec<&str> = transformed
                     .get("choices")
                     .and_then(Value::as_array)
@@ -567,7 +636,9 @@ pub async fn run(
                 // The receipt finalizer consumed the E2EE context, so a generated
                 // error here is necessarily cleartext.
                 Err(err) => {
-                    // Record the final client-visible terminal.
+                    // Any earlier outcome line for this request described the
+                    // upstream outcome; the client actually receives this
+                    // finalization error, so record the real terminal too.
                     let status = forward_error_status(&err);
                     if should_log_failure(status) {
                         log_generated_outcome(
@@ -596,7 +667,9 @@ pub async fn run(
             let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
 
-            // Distinguish downstream finalization failure from disconnect.
+            // Set when the downstream finalizer (receipt drafting / E2EE)
+            // errors while the body is being consumed: the meter's drop must
+            // then record an internal failure, not a client disconnect.
             let downstream_abort = Arc::new(AtomicBool::new(false));
             let meter_settled = Arc::new(AtomicBool::new(false));
             let report = StreamReport {
@@ -620,8 +693,12 @@ pub async fn run(
                 0 => None,
                 ms => Some(Duration::from_millis(ms)),
             };
-            // Provider -> format -> visibility -> meter -> keepalive -> finalizer.
-            // Heartbeats stay outside metering and receipt input.
+            // Order: provider stream (drafts response.received) -> format
+            // transform (if cross-format) -> response visibility -> meter/cost ->
+            // keep-alive -> finalizer (hashes response.returned). Same-format
+            // streaming skips only the format transform. Metering sits inside the
+            // keep-alive so it only ever buffers real upstream SSE bytes; heartbeat
+            // comments are injected downstream and never enter its line reassembly.
             let response_header_map = response_headers(&forward.upstream_headers, &content_type);
             let selected_format = candidates
                 .iter()
@@ -680,7 +757,13 @@ pub async fn run(
                         HeaderName::from_static("cache-control"),
                         HeaderValue::from_static("no-cache"),
                     );
-                    // End cleanly on body errors so hyper does not reset the socket.
+                    // A response-stream error must not become a body Err: hyper
+                    // aborts the connection (TCP RST toward the proxy), which
+                    // clients experience as a silently killed stream and a
+                    // poisoned keep-alive pool, invisible to application logs.
+                    // Log the error (this is its only surface) and end the body
+                    // instead — a clean HTTP body termination (h1 terminal
+                    // chunk, h2 END_STREAM), leaving the connection reusable.
                     let stream_request_id = request_id.clone();
                     let stream_model = model.unwrap_or("").to_string();
                     let stream_route = forward.selected_route.clone();
@@ -688,7 +771,10 @@ pub async fn run(
                         std::future::ready(match chunk {
                             Ok(bytes) => Some(Ok::<_, std::io::Error>(bytes)),
                             Err(err) => {
-                                // Mark before meter drop classifies the terminal.
+                                // Mark before the chain drops so the meter's
+                                // drop settles this as an internal failure
+                                // rather than misreading it as a client
+                                // disconnect.
                                 downstream_abort.store(true, Ordering::Relaxed);
                                 tracing::warn!(
                                     target: "stream_abort",
@@ -696,7 +782,10 @@ pub async fn run(
                                     error = %err,
                                     "response stream error; ending body gracefully instead of aborting the connection"
                                 );
-                                // Meter already settled; record this late failure here.
+                                // A finalizer error after a clean end-of-stream
+                                // (receipt store / E2EE finish): the meter has
+                                // already settled Completed and will not emit,
+                                // so record the client-visible failure here.
                                 if meter_settled.load(Ordering::Relaxed) {
                                     log_generated_outcome(
                                         &stream_request_id,
@@ -717,7 +806,9 @@ pub async fn run(
                     (status, headers, body).into_response()
                 }
                 Err(err) => {
-                    // The stream never started, so emit its only outcome here.
+                    // Synchronous finalizer failure: the stream never started,
+                    // so the meter never settles — this is the request's only
+                    // outcome line.
                     let status = forward_error_status(&err);
                     if should_log_failure(status) {
                         log_generated_outcome(
@@ -737,7 +828,9 @@ pub async fn run(
             }
         }
         Ok(MiddlewareForwardResult::UpstreamError(forward)) => {
-            // A streaming non-2xx has no receipt but still reports all attempts.
+            // Streaming non-2xx: no receipt (no completed stream to bind), but the
+            // attempt did reach an upstream, so it reports the serving route and
+            // every failed-over candidate exactly like the Stream arm.
             let (status, body) = errors::normalize_upstream_error_parts(
                 surface,
                 forward.error.upstream_status,
@@ -767,7 +860,12 @@ pub async fn run(
             );
             finalize_generated(status, body, &[], e2ee, outcome_ctx)
         }
-        // Report transport failures per attempt, followed by their summary.
+        // Every candidate was attempted and failed without an HTTP response to
+        // relay (a chain that ends in an upstream HTTP status — including an
+        // all-429 chain — exits via the UpstreamError arm above, which relays
+        // that status). Report each attempt so deployment health and triage
+        // see the full chain, then a summary row placed after them carrying
+        // the aggregated error message.
         Ok(MiddlewareForwardResult::AllFailed(forward)) => {
             let status = forward_error_status(&forward.error);
             meter.failed_attempts(&forward.failed_attempts, stream);
@@ -795,7 +893,12 @@ pub async fn run(
             }
             service_error_response(outcome_ctx, forward.error, e2ee)
         }
-        // Report unattributed forwarding failures; preserve E2EE for the response.
+        // Failures where no attempt chain is available (pre-forward errors,
+        // plus the forwarder's rare mid-walk internal-error abort): record the
+        // failure so the request is visible to billing/health, attributed by
+        // `forward_error_source` (upstream, except the gateway's own TEE-policy
+        // rejection). Client-attributable errors (E2EE/4xx) are not recorded.
+        // The E2EE context is still available to encrypt the body.
         Err(err) => {
             let status = forward_error_status(&err);
             if should_log_failure(status) {
@@ -819,7 +922,9 @@ pub async fn run(
     }
 }
 
-// Posts usage reports to control without blocking the response.
+// Posts usage reports to the control plane (fire-and-forget). Buffered reports
+// have no TTFT and `is_streaming = false`; the status recorded is the raw upstream
+// status, distinct from the client-facing mapped status.
 struct Meter<'a> {
     control: &'a ControlClient,
     request_id: String,
@@ -900,7 +1005,10 @@ impl Meter<'_> {
         self.gateway_failure_at(0, status, source, message, is_streaming);
     }
 
-    // Put summaries after attempt rows to avoid control's idempotency key.
+    // Like `gateway_failure`, but placed at an explicit attempt index. Control
+    // dedupes reports by (request_id, attempt, status), so a summary row that
+    // follows per-attempt rows must sit after them or it collides with (and
+    // silently drops) the first attempt's row.
     fn gateway_failure_at(
         &self,
         attempt_index: u32,
@@ -931,7 +1039,10 @@ fn truncate(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
-// Report client-attributable 4xx mappings; otherwise preserve upstream status.
+// The status reported to the control plane for a normalized upstream error: the
+// client-facing status when it is client-attributable (4xx) — a remapped
+// image-fetch failure must not count against the provider's health — otherwise
+// the raw upstream status, preserving the provider's real code in the logs.
 fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
     if (400..500).contains(&mapped) {
         mapped
@@ -940,7 +1051,12 @@ fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
     }
 }
 
-// ACI eligibility is gateway policy; other forwarding failures are upstream.
+// Which component a terminal forward failure is attributable to.
+//
+// Upstream by default: a forward chain that ends in a 5xx is a provider
+// failure. The exceptions are ACI constraints that leave no eligible route or
+// current session — no prompt was forwarded, so attributing them to a provider
+// would report the gateway's policy decision as someone else's failure.
 fn forward_error_source(err: &ServiceError) -> ErrorSource {
     match err {
         ServiceError::UpstreamVerification(
@@ -961,7 +1077,9 @@ fn forward_error_status(err: &ServiceError) -> u16 {
     }
 }
 
-// Encrypt generated errors unless E2EE setup itself failed.
+// Map a forward/finalize `ServiceError` to a client-facing generated response.
+// E2EE clients still get an encrypted error body, except for `E2ee` errors
+// themselves (the E2EE setup failed, so the response cannot be encrypted).
 fn service_error_response(
     outcome: OutcomeCtx<'_>,
     err: ServiceError,
@@ -983,7 +1101,9 @@ fn service_error_response(
     finalize_generated(status, body, &[], e2ee, outcome)
 }
 
-// Build a generated response; E2EE finalization fails closed.
+// Build a generated (no-receipt) response, E2EE-encrypting the body when a
+// request context is present. If encryption fails it is fail-closed: a generic
+// error is returned rather than the cleartext body.
 #[allow(clippy::too_many_arguments)]
 fn finalize_generated(
     status: u16,
@@ -1020,7 +1140,8 @@ fn finalize_generated(
         // Fail-closed: never return the cleartext body when E2EE was requested.
         Err(err) => {
             tracing::error!(error = %err, "E2EE generated-response finalization failed");
-            // Supersede the earlier outcome with the client-visible 500.
+            // Any earlier outcome line recorded the pre-finalization status;
+            // the client actually receives this 500.
             log_generated_outcome(
                 outcome.request_id,
                 outcome.model,
@@ -1043,14 +1164,18 @@ fn finalize_generated(
     }
 }
 
-// Drop gateway-owned/hop-by-hop headers and force content type.
+// Build response headers from the upstream response, dropping gateway-owned and
+// hop-by-hop headers, and forcing the content type. Provider auth/server headers
+// are not forwarded.
 fn response_headers(
     upstream_headers: &std::collections::HashMap<String, String>,
     content_type: &str,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
     for (name, value) in upstream_headers {
-        // The reserialized body is identity-encoded.
+        // The body we emit is always identity-encoded (re-serialized JSON or a
+        // transformed/passthrough SSE stream), so a relayed `content-encoding`
+        // would mislabel it. `content-type` is set explicitly below.
         if is_gateway_owned(name)
             || is_hop_by_hop(name)
             || name.eq_ignore_ascii_case("content-type")

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -1,13 +1,4 @@
-//! Control-plane HTTP client.
-//!
-//! Reaches the control plane at `control_url` with an optional bearer token. The
-//! pre-request consult gates authorization and fails closed: any failure blocks
-//! the request rather than letting it through unauthorized. The post-request
-//! report is best-effort: it never fails the already-served response.
-//! Connections are kept alive and reused (default pooling); every request here
-//! retries once on a connection-level failure, so a keep-alive connection the
-//! control plane closed does not surface as a spurious denial or a dropped
-//! usage report.
+//! Control client: pre-consult fails closed; idempotent calls retry stale pools.
 
 use std::time::Duration;
 
@@ -16,7 +7,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use super::config::MiddlewareConfig;
-use super::types::{PostReport, PreConsult};
+use super::types::{PostReport, PreConsult, ReasoningConfig};
 
 const DEFAULT_CONTROL_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_CONTROL_POST_TIMEOUT_MS: u64 = 10_000;
@@ -61,11 +52,7 @@ impl ControlClient {
         if control_url.is_empty() {
             return Err("middleware.control_url must not be empty".to_string());
         }
-        // Keep control-plane connections alive (reqwest's default pooling) so the
-        // hot consult path avoids a fresh TCP + TLS handshake per request. A
-        // pooled connection the control plane closed can surface as a broken
-        // send; the idempotent consult/catalog requests retry once on a fresh
-        // connection (see `send_idempotent`) rather than failing the request.
+        // Reuse pooled connections; `send_idempotent` handles stale ones.
         let client = reqwest::Client::builder()
             .build()
             .map_err(|err| format!("failed to build control HTTP client: {err}"))?;
@@ -101,17 +88,7 @@ impl ControlClient {
         }
     }
 
-    /// Send an idempotent request, rebuilding it per attempt. Retries once on a
-    /// connection-level failure: a keep-alive connection the control plane
-    /// closed surfaces as a broken send that a fresh connection succeeds on. It
-    /// does not retry a timeout (the control plane is genuinely slow; a retry
-    /// would only double the wait) or a connect failure (the control plane is
-    /// unreachable; a retry cannot help).
-    ///
-    /// Every request routed through here must be safe to repeat. consult_pre and
-    /// the catalog GETs are decision queries with no persisted side effect.
-    /// consult_post carries a `request_id` so that a control plane can recognize
-    /// a replay; the contract requires it to ingest usage idempotently.
+    /// Retry an idempotent request once after a pooled-connection failure.
     async fn send_idempotent(
         &self,
         build: impl Fn() -> reqwest::RequestBuilder,
@@ -129,14 +106,13 @@ impl ControlClient {
         }
     }
 
-    /// Pre-request consult: `{ apiKeyHash?, model?, provider? }` -> decision.
-    /// Fails closed — any non-200, invalid JSON, timeout, or transport error
-    /// returns a 503 denial.
+    /// Fail-closed `{ apiKeyHash?, model?, provider?, reasoning? }` decision.
     pub async fn consult_pre(
         &self,
         model: Option<&str>,
         api_key_hash: Option<&str>,
         provider: Option<&Value>,
+        reasoning: Option<&ReasoningConfig>,
         tee_only: bool,
     ) -> PreConsult {
         #[derive(Serialize)]
@@ -146,12 +122,13 @@ impl ControlClient {
             api_key_hash: Option<&'a str>,
             #[serde(skip_serializing_if = "Option::is_none")]
             model: Option<&'a str>,
-            // Forwarded verbatim so the control plane validates it (a malformed
-            // block must not silently drop the caller's routing restrictions).
+            // Control validates this verbatim routing block.
             #[serde(skip_serializing_if = "Option::is_none")]
             provider: Option<&'a Value>,
-            // TEE-only host: the control plane 404s a non-TEE model. Only sent
-            // when set so the metadata-minimal payload is unchanged off these hosts.
+            // Response visibility stays local to the gateway.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            reasoning: Option<&'a ReasoningConfig>,
+            // Sent only when a TEE-only host requires control enforcement.
             #[serde(skip_serializing_if = "std::ops::Not::not")]
             tee: bool,
         }
@@ -160,6 +137,7 @@ impl ControlClient {
             api_key_hash,
             model,
             provider,
+            reasoning,
             tee: tee_only,
         };
         let build = || {
@@ -199,13 +177,7 @@ impl ControlClient {
         }
     }
 
-    /// Post-request usage report. Best-effort: a control-plane hiccup must never
-    /// fail the already-served response. Retried once on a broken pooled
-    /// connection, like the consult — otherwise a keep-alive connection the peer
-    /// has closed silently drops the report. A broken send cannot tell us whether
-    /// the report was already processed, so the replay relies on the contract's
-    /// idempotent-ingest requirement: the report carries a `request_id` for
-    /// exactly that purpose.
+    /// Best-effort idempotent usage report.
     pub async fn consult_post(&self, report: &PostReport) {
         let build = || {
             self.authorize(self.client.post(self.url("/consult/post")))
@@ -217,9 +189,7 @@ impl ControlClient {
         }
     }
 
-    /// Fetch a model catalog from the control plane and relay it verbatim.
-    /// Bounded by the consult timeout so a hung control plane cannot stall a
-    /// catalog request.
+    /// Relay a timeout-bounded model catalog.
     pub async fn catalog_get(&self, path: &str) -> Result<CatalogResponse, ControlError> {
         let build = || {
             self.authorize(self.client.get(self.url(path)))
@@ -295,10 +265,9 @@ mod tests {
 
     #[tokio::test]
     async fn consult_pre_fails_closed_on_transport_error() {
-        // Port 1 is unroutable in practice; the request fails fast within the
-        // configured timeout and must deny.
+        // An unroutable control must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
-        let consult = client.consult_pre(Some("m"), None, None, false).await;
+        let consult = client.consult_pre(Some("m"), None, None, None, false).await;
         assert!(!consult.allow);
         assert_eq!(consult.status, Some(503));
         assert_eq!(

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -1,4 +1,13 @@
-//! Control client: pre-consult fails closed; idempotent calls retry stale pools.
+//! Control-plane HTTP client.
+//!
+//! Reaches the control plane at `control_url` with an optional bearer token. The
+//! pre-request consult gates authorization and fails closed: any failure blocks
+//! the request rather than letting it through unauthorized. The post-request
+//! report is best-effort: it never fails the already-served response.
+//! Connections are kept alive and reused (default pooling); every request here
+//! retries once on a connection-level failure, so a keep-alive connection the
+//! control plane closed does not surface as a spurious denial or a dropped
+//! usage report.
 
 use std::time::Duration;
 
@@ -52,7 +61,11 @@ impl ControlClient {
         if control_url.is_empty() {
             return Err("middleware.control_url must not be empty".to_string());
         }
-        // Reuse pooled connections; `send_idempotent` handles stale ones.
+        // Keep control-plane connections alive (reqwest's default pooling) so the
+        // hot consult path avoids a fresh TCP + TLS handshake per request. A
+        // pooled connection the control plane closed can surface as a broken
+        // send; the idempotent consult/catalog requests retry once on a fresh
+        // connection (see `send_idempotent`) rather than failing the request.
         let client = reqwest::Client::builder()
             .build()
             .map_err(|err| format!("failed to build control HTTP client: {err}"))?;
@@ -88,7 +101,17 @@ impl ControlClient {
         }
     }
 
-    /// Retry an idempotent request once after a pooled-connection failure.
+    /// Send an idempotent request, rebuilding it per attempt. Retries once on a
+    /// connection-level failure: a keep-alive connection the control plane
+    /// closed surfaces as a broken send that a fresh connection succeeds on. It
+    /// does not retry a timeout (the control plane is genuinely slow; a retry
+    /// would only double the wait) or a connect failure (the control plane is
+    /// unreachable; a retry cannot help).
+    ///
+    /// Every request routed through here must be safe to repeat. consult_pre and
+    /// the catalog GETs are decision queries with no persisted side effect.
+    /// consult_post carries a `request_id` so that a control plane can recognize
+    /// a replay; the contract requires it to ingest usage idempotently.
     async fn send_idempotent(
         &self,
         build: impl Fn() -> reqwest::RequestBuilder,
@@ -106,7 +129,10 @@ impl ControlClient {
         }
     }
 
-    /// Fail-closed `{ apiKeyHash?, model?, provider?, reasoning? }` decision.
+    /// Pre-request consult:
+    /// `{ apiKeyHash?, model?, provider?, reasoning? }` -> decision.
+    /// Fails closed — any non-200, invalid JSON, timeout, or transport error
+    /// returns a 503 denial.
     pub async fn consult_pre(
         &self,
         model: Option<&str>,
@@ -122,13 +148,16 @@ impl ControlClient {
             api_key_hash: Option<&'a str>,
             #[serde(skip_serializing_if = "Option::is_none")]
             model: Option<&'a str>,
-            // Control validates this verbatim routing block.
+            // Forwarded verbatim so the control plane validates it (a malformed
+            // block must not silently drop the caller's routing restrictions).
             #[serde(skip_serializing_if = "Option::is_none")]
             provider: Option<&'a Value>,
-            // Response visibility stays local to the gateway.
+            // Canonical route-relevant controls only. Response visibility stays
+            // local to the gateway.
             #[serde(skip_serializing_if = "Option::is_none")]
             reasoning: Option<&'a ReasoningConfig>,
-            // Sent only when a TEE-only host requires control enforcement.
+            // TEE-only host: the control plane 404s a non-TEE model. Only sent
+            // when set so the metadata-minimal payload is unchanged off these hosts.
             #[serde(skip_serializing_if = "std::ops::Not::not")]
             tee: bool,
         }
@@ -177,7 +206,13 @@ impl ControlClient {
         }
     }
 
-    /// Best-effort idempotent usage report.
+    /// Post-request usage report. Best-effort: a control-plane hiccup must never
+    /// fail the already-served response. Retried once on a broken pooled
+    /// connection, like the consult — otherwise a keep-alive connection the peer
+    /// has closed silently drops the report. A broken send cannot tell us whether
+    /// the report was already processed, so the replay relies on the contract's
+    /// idempotent-ingest requirement: the report carries a `request_id` for
+    /// exactly that purpose.
     pub async fn consult_post(&self, report: &PostReport) {
         let build = || {
             self.authorize(self.client.post(self.url("/consult/post")))
@@ -189,7 +224,9 @@ impl ControlClient {
         }
     }
 
-    /// Relay a timeout-bounded model catalog.
+    /// Fetch a model catalog from the control plane and relay it verbatim.
+    /// Bounded by the consult timeout so a hung control plane cannot stall a
+    /// catalog request.
     pub async fn catalog_get(&self, path: &str) -> Result<CatalogResponse, ControlError> {
         let build = || {
             self.authorize(self.client.get(self.url(path)))
@@ -265,7 +302,8 @@ mod tests {
 
     #[tokio::test]
     async fn consult_pre_fails_closed_on_transport_error() {
-        // An unroutable control must deny.
+        // Port 1 is unroutable in practice; the request fails fast within the
+        // configured timeout and must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
         let consult = client.consult_pre(Some("m"), None, None, None, false).await;
         assert!(!consult.allow);

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod control;
 pub mod errors;
 pub mod pricing;
+pub mod reasoning;
 pub mod request_transform;
 pub mod response_transform;
 pub mod sse;

--- a/src/middleware/reasoning.rs
+++ b/src/middleware/reasoning.rs
@@ -1,0 +1,132 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::types::{ReasoningConfig, ReasoningEffort};
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublicReasoning {
+    effort: Option<ReasoningEffort>,
+    max_tokens: Option<u64>,
+    enabled: Option<bool>,
+    exclude: Option<bool>,
+}
+
+pub type NormalizedReasoning = (Value, Option<ReasoningConfig>, bool);
+
+fn implied_enabled(effort: Option<ReasoningEffort>, budget: Option<u64>) -> Option<bool> {
+    effort
+        .map(|effort| effort != ReasoningEffort::None)
+        .or(budget.map(|_| true))
+}
+
+fn validate(config: &ReasoningConfig) -> Result<(), String> {
+    if config.effort.is_none() && config.max_tokens.is_none() && config.enabled.is_none() {
+        return Err("reasoning configuration is empty".into());
+    }
+    if config.effort.is_some() && config.max_tokens.is_some() {
+        return Err("reasoning effort and max_tokens are mutually exclusive".into());
+    }
+    if config.max_tokens == Some(0) {
+        return Err("reasoning.max_tokens must be positive".into());
+    }
+    if let (Some(explicit), Some(implied)) = (
+        config.enabled,
+        implied_enabled(config.effort, config.max_tokens),
+    ) {
+        if explicit != implied {
+            return Err("reasoning enabled conflicts with effort or max_tokens".into());
+        }
+    }
+    Ok(())
+}
+
+pub fn normalize_chat_request(params: &Value) -> Result<NormalizedReasoning, String> {
+    let mut params = params.clone();
+    let input = params
+        .as_object_mut()
+        .ok_or("request body must be a JSON object")?;
+    let public: PublicReasoning = input
+        .remove("reasoning")
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| format!("invalid reasoning: {error}"))?
+        .unwrap_or_default();
+    let legacy = input
+        .remove("reasoning_effort")
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| format!("invalid reasoning_effort: {error}"))?;
+    if public.effort.is_some() && legacy.is_some() && public.effort != legacy {
+        return Err("reasoning.effort and reasoning_effort must not differ".into());
+    }
+    let effort = public.effort.or(legacy);
+    let enabled = public
+        .enabled
+        .or_else(|| implied_enabled(effort, public.max_tokens));
+    let requirements = (effort.is_some()
+        || public.max_tokens.is_some()
+        || public.enabled.is_some())
+    .then_some(ReasoningConfig {
+        effort,
+        max_tokens: public.max_tokens,
+        enabled,
+    });
+    if let Some(config) = &requirements {
+        validate(config)?;
+    }
+
+    let include: Option<bool> = input
+        .remove("include_reasoning")
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|_| "include_reasoning must be boolean")?;
+    if public
+        .exclude
+        .zip(include)
+        .is_some_and(|(exclude, include)| exclude == include)
+    {
+        return Err("reasoning.exclude conflicts with include_reasoning".into());
+    }
+    let exclude = public
+        .exclude
+        .or_else(|| include.map(|value| !value))
+        .unwrap_or(false);
+    Ok((params, requirements, exclude))
+}
+
+pub fn validate_effective(config: &ReasoningConfig) -> Result<(), String> {
+    validate(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn normalization_accepts_aliases_and_rejects_contradictions() {
+        for request in [
+            json!({"reasoning":{"effort":"high"}}),
+            json!({"reasoning_effort":"high"}),
+            json!({"reasoning":{"effort":"high"},"reasoning_effort":"high"}),
+        ] {
+            let normalized = normalize_chat_request(&request).unwrap();
+            assert_eq!(normalized.1.unwrap().effort, Some(ReasoningEffort::High));
+        }
+        for request in [
+            json!({"reasoning":{"effort":"high"},"reasoning_effort":"low"}),
+            json!({"reasoning":{"effort":"low","max_tokens":1}}),
+            json!({"reasoning":{"effort":"none","enabled":true}}),
+            json!({"reasoning":{"exclude":true},"include_reasoning":true}),
+            json!({"reasoning":{"effort":"unknown"}}),
+            json!({"reasoning":{"max_tokens":0}}),
+        ] {
+            assert!(normalize_chat_request(&request).is_err(), "{request}");
+        }
+        let normalized = normalize_chat_request(&json!({"include_reasoning":false})).unwrap();
+        assert!(normalized.2);
+        assert_eq!(normalized.0, json!({}));
+    }
+}

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -158,13 +158,13 @@ pub fn build_candidates(
     params: &Value,
     endpoint: Endpoint,
     candidates: &[RouteCandidate],
-    require_effective_reasoning: bool,
+    requested_reasoning: Option<&ReasoningConfig>,
 ) -> Result<Vec<(String, Value)>, TransformError> {
     candidates
         .iter()
         .map(|candidate| {
             let candidate_params =
-                candidate_params(params, endpoint, candidate, require_effective_reasoning)?;
+                candidate_params(params, endpoint, candidate, requested_reasoning)?;
             let body = transform_to_provider_request(
                 candidate.format,
                 &candidate_params,
@@ -180,7 +180,7 @@ fn candidate_params(
     params: &Value,
     endpoint: Endpoint,
     candidate: &RouteCandidate,
-    require_effective_reasoning: bool,
+    requested_reasoning: Option<&ReasoningConfig>,
 ) -> Result<Value, TransformError> {
     let mut params = params.clone();
     if endpoint != Endpoint::ChatComplete {
@@ -192,10 +192,12 @@ fn candidate_params(
     for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
         object.remove(key);
     }
-    let effective = match &candidate.effective_reasoning {
-        Some(value) => value,
-        None if !require_effective_reasoning => return Ok(params),
-        None => return invalid_reasoning(candidate, "missing effective reasoning"),
+    let Some(effective) = candidate
+        .effective_reasoning
+        .as_ref()
+        .or(requested_reasoning)
+    else {
+        return Ok(params);
     };
     validate_effective(effective).map_err(|err| {
         TransformError::InvalidRequest(format!(
@@ -1264,7 +1266,7 @@ mod tests {
     }
 
     #[test]
-    fn build_candidates_applies_each_routes_effective_reasoning() {
+    fn build_candidates_uses_effective_or_requested_reasoning() {
         let params = json!({ "model": "m", "messages": [{ "role": "user", "content": "hi" }], "max_tokens": 8 });
         let reasoning = |effort| {
             Some(ReasoningConfig {
@@ -1285,11 +1287,25 @@ mod tests {
                 engine: Some(Engine::Sglang),
                 effective_reasoning: reasoning(ReasoningEffort::Minimal),
             },
+            RouteCandidate {
+                route_id: "openai:c".into(),
+                format: ProviderFormat::Openai,
+                engine: None,
+                effective_reasoning: None,
+            },
         ];
-        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, true).unwrap();
-        assert_eq!(bodies.len(), 2);
+        let requested = reasoning(ReasoningEffort::Medium).unwrap();
+        let bodies = build_candidates(
+            &params,
+            Endpoint::ChatComplete,
+            &candidates,
+            Some(&requested),
+        )
+        .unwrap();
+        assert_eq!(bodies.len(), 3);
         assert_eq!(bodies[0].1["reasoning"]["effort"], "high");
         assert_eq!(bodies[1].1["reasoning_effort"], "low");
+        assert_eq!(bodies[2].1["reasoning"]["effort"], "medium");
     }
 
     #[test]
@@ -1320,7 +1336,7 @@ mod tests {
                 effective_reasoning: None,
             },
         ];
-        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, false).unwrap();
+        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, None).unwrap();
         assert_eq!(bodies.len(), 2);
         assert_eq!(bodies[0].0, "openai:m");
         // OpenAI passthrough keeps messages as-is.

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1,4 +1,14 @@
-//! Config-driven request transforms for each candidate's provider format.
+//! Request transforms: shape a downstream request body into each candidate
+//! upstream's request format.
+//!
+//! The design uses a config-driven engine: each ordered `ParamConfig` names its
+//! input key and output parameter. For every present input, the engine applies
+//! an optional transform, substitutes the `"gateway-default"` sentinel, clamps
+//! numeric values, and writes the result to the output (including dot-paths).
+//! Required entries with defaults backfill absent inputs.
+//!
+//! Strongly typed endpoint structs may replace `serde_json::Value` later; for now
+//! the dynamic shape keeps behavior aligned with the source.
 
 use serde_json::{json, Value};
 
@@ -38,7 +48,8 @@ pub enum TransformError {
         format: ProviderFormat,
         endpoint: Endpoint,
     },
-    /// A gateway-attributed request transform rejection.
+    /// A transform rejected the request body (e.g. unparseable tool-call
+    /// arguments). Surfaced as a gateway-attributed failure (error_source "gateway").
     InvalidRequest(String),
 }
 
@@ -127,7 +138,8 @@ macro_rules! pass {
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-/// Shape parameters for a provider format, endpoint, and optional engine.
+/// Shape `params` into the request body for `format`/`endpoint` (+ optional
+/// engine shaping for self-hosted OpenAI-compatible upstreams).
 pub fn transform_to_provider_request(
     format: ProviderFormat,
     params: &Value,
@@ -140,7 +152,8 @@ pub fn transform_to_provider_request(
     transform_using_provider_config(&config, &params)
 }
 
-/// Shape `(route_id, body)` entries in failover order.
+/// Shape one body per candidate, preserving failover order. Each entry is the
+/// candidate's `route_id` and its transformed body.
 pub fn build_candidates(
     params: &Value,
     endpoint: Endpoint,
@@ -333,7 +346,8 @@ fn set_nested_property(obj: &mut Value, path: &str, value: Value) {
         .insert(parts[parts.len() - 1].to_string(), value);
 }
 
-// Request streaming usage unless already enabled.
+// Mutate `params` to request usage on streaming: only
+// when `stream === true` and `stream_options.include_usage` is not already true.
 fn inject_stream_options(params: &mut Value) {
     if params.get("stream") != Some(&Value::Bool(true)) {
         return;
@@ -406,7 +420,8 @@ fn transform_assistant_message(msg: &Value) -> Result<Value, TransformError> {
                 .get("function")
                 .and_then(|f| f.get("arguments"))
                 .and_then(Value::as_str);
-            // Reject invalid arguments rather than forwarding changed input.
+            // Non-empty arguments are JSON-parsed; a parse failure rejects the
+            // request rather than forwarding a different input.
             let input = match arguments {
                 Some(s) if !s.is_empty() => serde_json::from_str(s).map_err(|e| {
                     TransformError::InvalidRequest(format!("invalid tool call arguments: {e}"))
@@ -1223,7 +1238,9 @@ mod tests {
         );
         assert_eq!(chat_out["stream_options"], json!({ "include_usage": true }));
 
-        // Legacy completions also need usage-only streaming chunks.
+        // Legacy /v1/completions must also carry include_usage to upstream, or
+        // usage-only streaming providers (e.g. vLLM) never emit a usage chunk
+        // and the meter records 0 tokens.
         let complete_out = transform_to_provider_request(
             ProviderFormat::Openai,
             &json!({ "model": "m", "prompt": "hi", "stream": true }),

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1,19 +1,9 @@
-//! Request transforms: shape a downstream request body into each candidate
-//! upstream's request format.
-//!
-//! The design uses a config-driven engine: a provider config is
-//! an ordered list of `(input_key, [ParamConfig])` entries. For each input key
-//! present in the request, the engine computes a value (optional transform, then
-//! a `"gateway-default"` sentinel substitution, then numeric clamping) and writes
-//! it to the output under the config's output param (dot-paths supported). A
-//! required entry with a default backfills when the input key is absent.
-//!
-//! Strongly typed endpoint structs may replace `serde_json::Value` later; for now
-//! the dynamic shape keeps behavior aligned with the source.
+//! Config-driven request transforms for each candidate's provider format.
 
 use serde_json::{json, Value};
 
-use super::types::{Engine, ProviderFormat, RouteCandidate};
+use super::reasoning::validate_effective;
+use super::types::{Engine, ProviderFormat, ReasoningConfig, ReasoningEffort, RouteCandidate};
 
 const PDF_MIME: &str = "application/pdf";
 const TXT_MIME: &str = "text/plain";
@@ -48,8 +38,7 @@ pub enum TransformError {
         format: ProviderFormat,
         endpoint: Endpoint,
     },
-    /// A transform rejected the request body (e.g. unparseable tool-call
-    /// arguments). Surfaced as a gateway-attributed failure (error_source "gateway").
+    /// A gateway-attributed request transform rejection.
     InvalidRequest(String),
 }
 
@@ -74,6 +63,7 @@ type TransformFn = fn(&Value) -> Result<Option<Value>, TransformError>;
 
 #[derive(Clone)]
 struct ParamConfig {
+    input: &'static str,
     param: &'static str,
     default: Option<Value>,
     min: Option<i64>,
@@ -82,9 +72,10 @@ struct ParamConfig {
     transform: Option<TransformFn>,
 }
 
-fn pc(param: &'static str) -> ParamConfig {
+fn pc(input: &'static str) -> ParamConfig {
     ParamConfig {
-        param,
+        input,
+        param: input,
         default: None,
         min: None,
         max: None,
@@ -94,6 +85,10 @@ fn pc(param: &'static str) -> ParamConfig {
 }
 
 impl ParamConfig {
+    fn to(mut self, param: &'static str) -> Self {
+        self.param = param;
+        self
+    }
     fn with_default(mut self, value: Value) -> Self {
         self.default = Some(value);
         self
@@ -116,12 +111,23 @@ impl ParamConfig {
     }
 }
 
-type ProviderConfig = Vec<(&'static str, Vec<ParamConfig>)>;
+type ProviderConfig = Vec<ParamConfig>;
+
+macro_rules! p {
+    ($input:literal $(=> $output:literal)? $(, $method:ident $(($arg:expr))? )* $(,)?) => {
+        pc($input)$(.to($output))?$(.$method($($arg)?))*
+    };
+}
+
+macro_rules! pass {
+    ($($key:literal),* $(,)?) => {
+        vec![$(pc($key)),*]
+    };
+}
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-/// Shape `params` into the request body for `format`/`endpoint` (+ optional
-/// engine shaping for self-hosted OpenAI-compatible upstreams).
+/// Shape parameters for a provider format, endpoint, and optional engine.
 pub fn transform_to_provider_request(
     format: ProviderFormat,
     params: &Value,
@@ -134,25 +140,99 @@ pub fn transform_to_provider_request(
     transform_using_provider_config(&config, &params)
 }
 
-/// Shape one body per candidate, preserving failover order. Each entry is the
-/// candidate's `route_id` and its transformed body.
+/// Shape `(route_id, body)` entries in failover order.
 pub fn build_candidates(
     params: &Value,
     endpoint: Endpoint,
     candidates: &[RouteCandidate],
+    require_effective_reasoning: bool,
 ) -> Result<Vec<(String, Value)>, TransformError> {
     candidates
         .iter()
         .map(|candidate| {
+            let candidate_params =
+                candidate_params(params, endpoint, candidate, require_effective_reasoning)?;
             let body = transform_to_provider_request(
                 candidate.format,
-                params,
+                &candidate_params,
                 endpoint,
                 candidate.engine,
             )?;
             Ok((candidate.route_id.clone(), body))
         })
         .collect()
+}
+
+fn candidate_params(
+    params: &Value,
+    endpoint: Endpoint,
+    candidate: &RouteCandidate,
+    require_effective_reasoning: bool,
+) -> Result<Value, TransformError> {
+    let mut params = params.clone();
+    if endpoint != Endpoint::ChatComplete {
+        return Ok(params);
+    }
+    let object = params.as_object_mut().ok_or_else(|| {
+        TransformError::InvalidRequest("request body must be a JSON object".to_string())
+    })?;
+    for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
+        object.remove(key);
+    }
+    let effective = match &candidate.effective_reasoning {
+        Some(value) => value,
+        None if !require_effective_reasoning => return Ok(params),
+        None => return invalid_reasoning(candidate, "missing effective reasoning"),
+    };
+    validate_effective(effective).map_err(|err| {
+        TransformError::InvalidRequest(format!(
+            "route {} returned invalid effective reasoning: {err}",
+            candidate.route_id
+        ))
+    })?;
+    match (candidate.format, candidate.engine) {
+        (ProviderFormat::Openai, None) => {
+            object.insert("reasoning".to_string(), reasoning_object(effective));
+        }
+        (ProviderFormat::Openai, Some(_)) => {
+            if effective.max_tokens.is_some() {
+                return invalid_reasoning(candidate, "cannot represent max_tokens");
+            }
+            let effort = effective
+                .effort
+                .or((effective.enabled == Some(false)).then_some(ReasoningEffort::None));
+            let Some(effort) = effort else {
+                return invalid_reasoning(candidate, "cannot represent enabled without effort");
+            };
+            object.insert(
+                "reasoning_effort".to_string(),
+                Value::String(effort.as_str().to_string()),
+            );
+        }
+        (ProviderFormat::Anthropic, _) => return invalid_reasoning(candidate, "has no adapter"),
+    }
+    Ok(params)
+}
+
+fn invalid_reasoning<T>(candidate: &RouteCandidate, message: &str) -> Result<T, TransformError> {
+    Err(TransformError::InvalidRequest(format!(
+        "route {} {message}",
+        candidate.route_id
+    )))
+}
+
+fn reasoning_object(config: &ReasoningConfig) -> Value {
+    let mut object = serde_json::Map::new();
+    if let Some(effort) = config.effort {
+        object.insert("effort".into(), effort.as_str().into());
+    }
+    if let Some(max_tokens) = config.max_tokens {
+        object.insert("max_tokens".into(), max_tokens.into());
+    }
+    if let Some(enabled) = config.enabled {
+        object.insert("enabled".into(), enabled.into());
+    }
+    Value::Object(object)
 }
 
 // ── Engine ───────────────────────────────────────────────────────────────────
@@ -185,30 +265,24 @@ fn transform_using_provider_config(
     params: &Value,
 ) -> Result<Value, TransformError> {
     let mut out = json!({});
-    for (input_key, param_configs) in config {
-        for cfg in param_configs {
-            if params.get(input_key).is_some() {
-                if let Some(value) = get_value(input_key, params, cfg)? {
-                    set_nested_property(&mut out, cfg.param, value);
-                }
-            } else if cfg.required {
-                if let Some(default) = &cfg.default {
-                    set_nested_property(&mut out, cfg.param, default.clone());
-                }
+    for cfg in config {
+        if params.get(cfg.input).is_some() {
+            if let Some(value) = get_value(params, cfg)? {
+                set_nested_property(&mut out, cfg.param, value);
+            }
+        } else if cfg.required {
+            if let Some(default) = &cfg.default {
+                set_nested_property(&mut out, cfg.param, default.clone());
             }
         }
     }
     Ok(out)
 }
 
-fn get_value(
-    input_key: &str,
-    params: &Value,
-    cfg: &ParamConfig,
-) -> Result<Option<Value>, TransformError> {
+fn get_value(params: &Value, cfg: &ParamConfig) -> Result<Option<Value>, TransformError> {
     let mut value: Option<Value> = match cfg.transform {
         Some(transform) => transform(params)?,
-        None => params.get(input_key).cloned(),
+        None => params.get(cfg.input).cloned(),
     };
 
     // "gateway-default" sentinel: substitute the configured default.
@@ -259,8 +333,7 @@ fn set_nested_property(obj: &mut Value, path: &str, value: Value) {
         .insert(parts[parts.len() - 1].to_string(), value);
 }
 
-// Mutate `params` to request usage on streaming: only
-// when `stream === true` and `stream_options.include_usage` is not already true.
+// Request streaming usage unless already enabled.
 fn inject_stream_options(params: &mut Value) {
     if params.get("stream") != Some(&Value::Bool(true)) {
         return;
@@ -333,8 +406,7 @@ fn transform_assistant_message(msg: &Value) -> Result<Value, TransformError> {
                 .get("function")
                 .and_then(|f| f.get("arguments"))
                 .and_then(Value::as_str);
-            // Non-empty arguments are JSON-parsed; a parse failure rejects the
-            // request rather than forwarding a different input.
+            // Reject invalid arguments rather than forwarding changed input.
             let input = match arguments {
                 Some(s) if !s.is_empty() => serde_json::from_str(s).map_err(|e| {
                     TransformError::InvalidRequest(format!("invalid tool call arguments: {e}"))
@@ -890,302 +962,228 @@ fn map_sglang_reasoning_effort(params: &Value) -> Result<Option<Value>, Transfor
 // ── Config tables ────────────────────────────────────────────────────────────
 
 fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
-    let mut config: ProviderConfig = vec![
-        (
-            "model",
-            vec![pc("model").with_default(json!("gpt-3.5-turbo")).required()],
-        ),
-        ("messages", vec![pc("messages").with_default(json!(""))]),
-        ("functions", vec![pc("functions")]),
-        ("function_call", vec![pc("function_call")]),
-        (
-            "max_tokens",
-            vec![pc("max_tokens").with_default(json!(100)).with_min(0)],
-        ),
-        (
+    let mut config = pass!(
+        "functions",
+        "function_call",
+        "stop",
+        "logit_bias",
+        "user",
+        "seed",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "top_logprobs",
+        "stream_options",
+        "service_tier",
+        "parallel_tool_calls",
+        "max_completion_tokens",
+        "store",
+        "metadata",
+        "modalities",
+        "audio",
+        "prediction",
+        "reasoning",
+        "reasoning_effort",
+        "web_search_options",
+        "prompt_cache_key",
+        "safety_identifier",
+        "verbosity",
+    );
+    config.extend([
+        p!("model", with_default(json!("gpt-3.5-turbo")), required),
+        p!("messages", with_default(json!(""))),
+        p!("max_tokens", with_default(json!(100)), with_min(0)),
+        p!(
             "temperature",
-            vec![pc("temperature")
-                .with_default(json!(1))
-                .with_min(0)
-                .with_max(2)],
+            with_default(json!(1)),
+            with_min(0),
+            with_max(2)
         ),
-        (
-            "top_p",
-            vec![pc("top_p").with_default(json!(1)).with_min(0).with_max(1)],
-        ),
-        ("n", vec![pc("n").with_default(json!(1))]),
-        ("stream", vec![pc("stream").with_default(json!(false))]),
-        ("stop", vec![pc("stop")]),
-        (
-            "presence_penalty",
-            vec![pc("presence_penalty").with_min(-2).with_max(2)],
-        ),
-        (
-            "frequency_penalty",
-            vec![pc("frequency_penalty").with_min(-2).with_max(2)],
-        ),
-        ("logit_bias", vec![pc("logit_bias")]),
-        ("user", vec![pc("user")]),
-        ("seed", vec![pc("seed")]),
-        ("tools", vec![pc("tools")]),
-        ("tool_choice", vec![pc("tool_choice")]),
-        ("response_format", vec![pc("response_format")]),
-        ("logprobs", vec![pc("logprobs").with_default(json!(false))]),
-        ("top_logprobs", vec![pc("top_logprobs")]),
-        ("stream_options", vec![pc("stream_options")]),
-        ("service_tier", vec![pc("service_tier")]),
-        ("parallel_tool_calls", vec![pc("parallel_tool_calls")]),
-        ("max_completion_tokens", vec![pc("max_completion_tokens")]),
-        ("store", vec![pc("store")]),
-        ("metadata", vec![pc("metadata")]),
-        ("modalities", vec![pc("modalities")]),
-        ("audio", vec![pc("audio")]),
-        ("prediction", vec![pc("prediction")]),
-        ("reasoning_effort", vec![pc("reasoning_effort")]),
-        ("web_search_options", vec![pc("web_search_options")]),
-        ("prompt_cache_key", vec![pc("prompt_cache_key")]),
-        ("safety_identifier", vec![pc("safety_identifier")]),
-        ("verbosity", vec![pc("verbosity")]),
-    ];
-
+        p!("top_p", with_default(json!(1)), with_min(0), with_max(1)),
+        p!("n", with_default(json!(1))),
+        p!("stream", with_default(json!(false))),
+        p!("presence_penalty", with_min(-2), with_max(2)),
+        p!("frequency_penalty", with_min(-2), with_max(2)),
+        p!("logprobs", with_default(json!(false))),
+    ]);
     if let Some(engine) = engine {
-        config.push(("top_k", vec![pc("top_k")]));
-        config.push(("min_p", vec![pc("min_p")]));
-        config.push(("repetition_penalty", vec![pc("repetition_penalty")]));
-        config.push(("chat_template_kwargs", vec![pc("chat_template_kwargs")]));
+        config.extend(pass!(
+            "top_k",
+            "min_p",
+            "repetition_penalty",
+            "chat_template_kwargs",
+        ));
         if engine == Engine::Sglang {
-            for entry in config.iter_mut() {
-                if entry.0 == "reasoning_effort" {
-                    entry.1 =
-                        vec![pc("reasoning_effort").with_transform(map_sglang_reasoning_effort)];
-                }
-            }
+            *config
+                .iter_mut()
+                .find(|config| config.input == "reasoning_effort")
+                .unwrap() = p!(
+                "reasoning_effort",
+                with_transform(map_sglang_reasoning_effort)
+            );
         }
     }
-
     config
 }
 
 fn openai_complete_config() -> ProviderConfig {
-    vec![
-        (
-            "model",
-            vec![pc("model")
-                .with_default(json!("text-davinci-003"))
-                .required()],
-        ),
-        ("prompt", vec![pc("prompt").with_default(json!(""))]),
-        (
-            "max_tokens",
-            vec![pc("max_tokens").with_default(json!(100)).with_min(0)],
-        ),
-        (
+    let mut config = pass!(
+        "stream_options",
+        "stop",
+        "best_of",
+        "logit_bias",
+        "user",
+        "seed",
+        "suffix",
+    );
+    config.extend([
+        p!("model", with_default(json!("text-davinci-003")), required),
+        p!("prompt", with_default(json!(""))),
+        p!("max_tokens", with_default(json!(100)), with_min(0)),
+        p!(
             "temperature",
-            vec![pc("temperature")
-                .with_default(json!(1))
-                .with_min(0)
-                .with_max(2)],
+            with_default(json!(1)),
+            with_min(0),
+            with_max(2)
         ),
-        (
-            "top_p",
-            vec![pc("top_p").with_default(json!(1)).with_min(0).with_max(1)],
-        ),
-        ("n", vec![pc("n").with_default(json!(1))]),
-        ("stream", vec![pc("stream").with_default(json!(false))]),
-        ("stream_options", vec![pc("stream_options")]),
-        ("logprobs", vec![pc("logprobs").with_max(5)]),
-        ("echo", vec![pc("echo").with_default(json!(false))]),
-        ("stop", vec![pc("stop")]),
-        (
-            "presence_penalty",
-            vec![pc("presence_penalty").with_min(-2).with_max(2)],
-        ),
-        (
-            "frequency_penalty",
-            vec![pc("frequency_penalty").with_min(-2).with_max(2)],
-        ),
-        ("best_of", vec![pc("best_of")]),
-        ("logit_bias", vec![pc("logit_bias")]),
-        ("user", vec![pc("user")]),
-        ("seed", vec![pc("seed")]),
-        ("suffix", vec![pc("suffix")]),
-    ]
+        p!("top_p", with_default(json!(1)), with_min(0), with_max(1)),
+        p!("n", with_default(json!(1))),
+        p!("stream", with_default(json!(false))),
+        p!("logprobs", with_max(5)),
+        p!("echo", with_default(json!(false))),
+        p!("presence_penalty", with_min(-2), with_max(2)),
+        p!("frequency_penalty", with_min(-2), with_max(2)),
+    ]);
+    config
 }
 
 fn openai_embed_config() -> ProviderConfig {
-    vec![
-        (
+    let mut config = pass!("encoding_format", "dimensions", "user");
+    config.extend([
+        p!(
             "model",
-            vec![pc("model")
-                .with_default(json!("text-embedding-ada-002"))
-                .required()],
+            with_default(json!("text-embedding-ada-002")),
+            required
         ),
-        ("input", vec![pc("input").required()]),
-        ("encoding_format", vec![pc("encoding_format")]),
-        ("dimensions", vec![pc("dimensions")]),
-        ("user", vec![pc("user")]),
-    ]
+        p!("input", required),
+    ]);
+    config
 }
 
 fn openai_create_model_response_config() -> ProviderConfig {
-    vec![
-        ("input", vec![pc("input").required()]),
-        ("model", vec![pc("model").required()]),
-        ("background", vec![pc("background")]),
-        ("include", vec![pc("include")]),
-        ("instructions", vec![pc("instructions")]),
-        ("max_output_tokens", vec![pc("max_output_tokens")]),
-        ("metadata", vec![pc("metadata")]),
-        ("modalities", vec![pc("modalities")]),
-        ("parallel_tool_calls", vec![pc("parallel_tool_calls")]),
-        ("previous_response_id", vec![pc("previous_response_id")]),
-        ("prompt", vec![pc("prompt")]),
-        ("prompt_cache_key", vec![pc("prompt_cache_key")]),
-        ("reasoning", vec![pc("reasoning")]),
-        ("store", vec![pc("store")]),
-        ("stream", vec![pc("stream")]),
-        ("temperature", vec![pc("temperature")]),
-        ("text", vec![pc("text")]),
-        ("tool_choice", vec![pc("tool_choice")]),
-        ("tools", vec![pc("tools")]),
-        ("top_p", vec![pc("top_p")]),
-        ("truncation", vec![pc("truncation")]),
-        ("user", vec![pc("user")]),
-        ("verbosity", vec![pc("verbosity")]),
-    ]
+    let mut config = pass!(
+        "background",
+        "include",
+        "instructions",
+        "max_output_tokens",
+        "metadata",
+        "modalities",
+        "parallel_tool_calls",
+        "previous_response_id",
+        "prompt",
+        "prompt_cache_key",
+        "reasoning",
+        "store",
+        "stream",
+        "temperature",
+        "text",
+        "tool_choice",
+        "tools",
+        "top_p",
+        "truncation",
+        "user",
+        "verbosity",
+    );
+    config.extend([p!("input", required), p!("model", required)]);
+    config
 }
 
 fn openai_to_anthropic_messages_config() -> ProviderConfig {
     vec![
-        ("model", vec![pc("model").required()]),
-        (
-            "messages",
-            vec![pc("messages")
-                .required()
-                .with_transform(oai_transform_messages)],
-        ),
-        ("max_tokens", vec![pc("max_tokens").required()]),
-        (
-            "temperature",
-            vec![pc("temperature").with_min(0).with_max(2)],
-        ),
-        ("top_p", vec![pc("top_p").with_min(0).with_max(1)]),
-        ("top_k", vec![pc("top_k")]),
-        ("stream", vec![pc("stream").with_default(json!(false))]),
-        ("stream_options", vec![pc("stream_options")]),
-        (
-            "stop_sequences",
-            vec![pc("stop").with_transform(oai_transform_stop_sequences)],
-        ),
-        (
-            "tools",
-            vec![pc("tools").with_transform(oai_transform_tools)],
-        ),
-        (
-            "tool_choice",
-            vec![pc("tool_choice").with_transform(oai_transform_tool_choice)],
-        ),
-        (
-            "metadata",
-            vec![pc("user").with_transform(oai_user_from_metadata)],
-        ),
+        p!("model", required),
+        p!("messages", required, with_transform(oai_transform_messages)),
+        p!("max_tokens", required),
+        p!("temperature", with_min(0), with_max(2)),
+        p!("top_p", with_min(0), with_max(1)),
+        p!("top_k"),
+        p!("stream", with_default(json!(false))),
+        p!("stream_options"),
+        p!("stop_sequences" => "stop", with_transform(oai_transform_stop_sequences)),
+        p!("tools", with_transform(oai_transform_tools)),
+        p!("tool_choice", with_transform(oai_transform_tool_choice)),
+        p!("metadata" => "user", with_transform(oai_user_from_metadata)),
     ]
 }
 
 fn anthropic_chat_complete_config() -> ProviderConfig {
     vec![
-        (
-            "model",
-            vec![pc("model").with_default(json!("claude-2.1")).required()],
-        ),
-        (
-            "messages",
-            vec![
-                pc("messages").required().with_transform(anthropic_messages),
-                pc("system").with_transform(anthropic_system),
-            ],
-        ),
-        ("tools", vec![pc("tools").with_transform(anthropic_tools)]),
-        (
-            "tool_choice",
-            vec![pc("tool_choice").with_transform(anthropic_tool_choice)],
-        ),
-        ("max_tokens", vec![pc("max_tokens").required()]),
-        ("max_completion_tokens", vec![pc("max_tokens")]),
-        (
+        p!("model", with_default(json!("claude-2.1")), required),
+        p!("messages", required, with_transform(anthropic_messages)),
+        p!("messages" => "system", with_transform(anthropic_system)),
+        p!("tools", with_transform(anthropic_tools)),
+        p!("tool_choice", with_transform(anthropic_tool_choice)),
+        p!("max_tokens", required),
+        p!("max_completion_tokens" => "max_tokens"),
+        p!(
             "temperature",
-            vec![pc("temperature")
-                .with_default(json!(1))
-                .with_min(0)
-                .with_max(1)],
+            with_default(json!(1)),
+            with_min(0),
+            with_max(1)
         ),
-        (
-            "top_p",
-            vec![pc("top_p").with_default(json!(-1)).with_min(-1)],
-        ),
-        ("top_k", vec![pc("top_k").with_default(json!(-1))]),
-        ("stop", vec![pc("stop_sequences")]),
-        ("stream", vec![pc("stream").with_default(json!(false))]),
-        ("user", vec![pc("metadata.user_id")]),
-        ("thinking", vec![pc("thinking")]),
+        p!("top_p", with_default(json!(-1)), with_min(-1)),
+        p!("top_k", with_default(json!(-1))),
+        p!("stop" => "stop_sequences"),
+        p!("stream", with_default(json!(false))),
+        p!("user" => "metadata.user_id"),
+        p!("thinking"),
     ]
 }
 
 fn anthropic_complete_config() -> ProviderConfig {
     vec![
-        (
-            "model",
-            vec![pc("model")
-                .with_default(json!("claude-instant-1"))
-                .required()],
-        ),
-        (
+        p!("model", with_default(json!("claude-instant-1")), required),
+        p!(
             "prompt",
-            vec![pc("prompt")
-                .required()
-                .with_transform(anthropic_complete_prompt)],
+            required,
+            with_transform(anthropic_complete_prompt)
         ),
-        ("max_tokens", vec![pc("max_tokens_to_sample").required()]),
-        (
+        p!("max_tokens" => "max_tokens_to_sample", required),
+        p!(
             "temperature",
-            vec![pc("temperature")
-                .with_default(json!(1))
-                .with_min(0)
-                .with_max(1)],
+            with_default(json!(1)),
+            with_min(0),
+            with_max(1)
         ),
-        (
-            "top_p",
-            vec![pc("top_p").with_default(json!(-1)).with_min(-1)],
-        ),
-        ("top_k", vec![pc("top_k").with_default(json!(-1))]),
-        (
-            "stop",
-            vec![pc("stop_sequences").with_transform(anthropic_complete_stop)],
-        ),
-        ("stream", vec![pc("stream").with_default(json!(false))]),
-        ("user", vec![pc("metadata.user_id")]),
+        p!("top_p", with_default(json!(-1)), with_min(-1)),
+        p!("top_k", with_default(json!(-1))),
+        p!("stop" => "stop_sequences", with_transform(anthropic_complete_stop)),
+        p!("stream", with_default(json!(false))),
+        p!("user" => "metadata.user_id"),
     ]
 }
 
 fn anthropic_messages_config() -> ProviderConfig {
-    vec![
-        ("model", vec![pc("model").required()]),
-        ("messages", vec![pc("messages").required()]),
-        ("max_tokens", vec![pc("max_tokens").required()]),
-        ("container", vec![pc("container")]),
-        ("mcp_servers", vec![pc("mcp_servers")]),
-        ("metadata", vec![pc("metadata")]),
-        ("service_tier", vec![pc("service_tier")]),
-        ("stop_sequences", vec![pc("stop_sequences")]),
-        ("stream", vec![pc("stream")]),
-        ("system", vec![pc("system")]),
-        ("temperature", vec![pc("temperature")]),
-        ("thinking", vec![pc("thinking")]),
-        ("tool_choice", vec![pc("tool_choice")]),
-        ("tools", vec![pc("tools")]),
-        ("top_k", vec![pc("top_k")]),
-        ("top_p", vec![pc("top_p")]),
-    ]
+    let mut config = pass!(
+        "container",
+        "mcp_servers",
+        "metadata",
+        "service_tier",
+        "stop_sequences",
+        "stream",
+        "system",
+        "temperature",
+        "thinking",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+    );
+    config.extend([
+        p!("model", required),
+        p!("messages", required),
+        p!("max_tokens", required),
+    ]);
+    config
 }
 
 #[cfg(test)]
@@ -1225,9 +1223,7 @@ mod tests {
         );
         assert_eq!(chat_out["stream_options"], json!({ "include_usage": true }));
 
-        // Legacy /v1/completions must also carry include_usage to upstream, or
-        // usage-only streaming providers (e.g. vLLM) never emit a usage chunk
-        // and the meter records 0 tokens.
+        // Legacy completions also need usage-only streaming chunks.
         let complete_out = transform_to_provider_request(
             ProviderFormat::Openai,
             &json!({ "model": "m", "prompt": "hi", "stream": true }),
@@ -1251,27 +1247,32 @@ mod tests {
     }
 
     #[test]
-    fn build_candidates_emits_one_body_per_route_even_when_identical() {
-        // This path consumes typed per-route bodies; it emits one body
-        // per route and does not collapse identical candidates into a shared body.
+    fn build_candidates_applies_each_routes_effective_reasoning() {
         let params = json!({ "model": "m", "messages": [{ "role": "user", "content": "hi" }], "max_tokens": 8 });
+        let reasoning = |effort| {
+            Some(ReasoningConfig {
+                effort: Some(effort),
+                ..Default::default()
+            })
+        };
         let candidates = vec![
             RouteCandidate {
                 route_id: "openai:a".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
+                effective_reasoning: reasoning(ReasoningEffort::High),
             },
             RouteCandidate {
                 route_id: "openai:b".into(),
                 format: ProviderFormat::Openai,
-                engine: None,
+                engine: Some(Engine::Sglang),
+                effective_reasoning: reasoning(ReasoningEffort::Minimal),
             },
         ];
-        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates).unwrap();
+        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, true).unwrap();
         assert_eq!(bodies.len(), 2);
-        assert_eq!(bodies[0].0, "openai:a");
-        assert_eq!(bodies[1].0, "openai:b");
-        assert_eq!(bodies[0].1, bodies[1].1);
+        assert_eq!(bodies[0].1["reasoning"]["effort"], "high");
+        assert_eq!(bodies[1].1["reasoning_effort"], "low");
     }
 
     #[test]
@@ -1293,14 +1294,16 @@ mod tests {
                 route_id: "openai:m".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
+                effective_reasoning: None,
             },
             RouteCandidate {
                 route_id: "anthropic:m".into(),
                 format: ProviderFormat::Anthropic,
                 engine: None,
+                effective_reasoning: None,
             },
         ];
-        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates).unwrap();
+        let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, false).unwrap();
         assert_eq!(bodies.len(), 2);
         assert_eq!(bodies[0].0, "openai:m");
         // OpenAI passthrough keeps messages as-is.

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -1,4 +1,10 @@
-//! Buffered 2xx transforms; errors, SSE, and metering are separate.
+//! Buffered response transforms: convert an upstream provider's 2xx response
+//! body into the downstream client surface. Non-2xx responses are normalized by
+//! `errors` before reaching here, so these assume a success body. Streaming (SSE)
+//! transforms live in `stream_transform`.
+//!
+//! Cost injection is a separate metering pass; these transforms only normalize
+//! the body shape (including the canonical `usage`).
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -9,7 +15,8 @@ use super::types::ProviderFormat;
 
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
-/// Transform a 2xx body, or return it unchanged for native passthrough.
+/// Transform a 2xx upstream body for `format`/`endpoint` into the client surface.
+/// Returns the body unchanged when no transform applies (native passthrough).
 pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Value) -> Value {
     use Endpoint::*;
     use ProviderFormat::*;
@@ -17,12 +24,15 @@ pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Valu
         (Anthropic, ChatComplete) => anthropic_chat_to_openai(body, STRICT_OPENAI_COMPLIANCE),
         (Anthropic, Complete) => anthropic_complete_to_openai(body),
         (Openai, Messages) => openai_to_anthropic_messages(body),
-        // Native passthrough.
+        // Native passthrough: openai chat/complete/embed, anthropic messages,
+        // responses (createModelResponse).
         _ => body,
     }
 }
 
-/// Remove chat reasoning traces without touching usage.
+/// Remove reasoning traces from an OpenAI Chat Completions response while
+/// leaving usage (including `completion_tokens_details.reasoning_tokens`)
+/// untouched.
 pub fn exclude_reasoning(body: &mut Value) {
     for choice in body
         .get_mut("choices")
@@ -131,7 +141,8 @@ fn anthropic_chat_to_openai(response: Value, strict: bool) -> Value {
         "completion_tokens": output,
         "total_tokens": input + output + cache_creation + cache_read,
     });
-    // Echo only source cache buckets.
+    // Echo the cache buckets only when present in the source: spread the raw
+    // fields and drop undefined ones.
     if cache_creation != 0 || cache_read != 0 {
         let map = usage.as_object_mut().unwrap();
         if let Some(value) = usage_src.get("cache_read_input_tokens") {
@@ -149,7 +160,8 @@ fn anthropic_chat_to_openai(response: Value, strict: bool) -> Value {
             .unwrap()
             .insert("tool_calls".into(), Value::Array(tool_calls));
     }
-    // Non-strict mode attaches raw non-tool blocks.
+    // When not strict, the raw Anthropic blocks (minus tool_use) are attached as
+    // a content_blocks extension. Strict mode (the default) omits them.
     if !strict {
         let blocks: Vec<Value> = content_items
             .iter()

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -1,10 +1,4 @@
-//! Buffered response transforms: convert an upstream provider's 2xx response
-//! body into the downstream client surface. Non-2xx responses are normalized by
-//! `errors` before reaching here, so these assume a success body. Streaming (SSE)
-//! transforms live in `stream_transform`.
-//!
-//! Cost injection is a separate metering pass; these transforms only normalize
-//! the body shape (including the canonical `usage`).
+//! Buffered 2xx transforms; errors, SSE, and metering are separate.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -15,8 +9,7 @@ use super::types::ProviderFormat;
 
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
-/// Transform a 2xx upstream body for `format`/`endpoint` into the client surface.
-/// Returns the body unchanged when no transform applies (native passthrough).
+/// Transform a 2xx body, or return it unchanged for native passthrough.
 pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Value) -> Value {
     use Endpoint::*;
     use ProviderFormat::*;
@@ -24,20 +17,37 @@ pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Valu
         (Anthropic, ChatComplete) => anthropic_chat_to_openai(body, STRICT_OPENAI_COMPLIANCE),
         (Anthropic, Complete) => anthropic_complete_to_openai(body),
         (Openai, Messages) => openai_to_anthropic_messages(body),
-        // Native passthrough: openai chat/complete/embed, anthropic messages,
-        // responses (createModelResponse).
+        // Native passthrough.
         _ => body,
     }
 }
 
-fn now_secs() -> u64 {
+/// Remove chat reasoning traces without touching usage.
+pub fn exclude_reasoning(body: &mut Value) {
+    for choice in body
+        .get_mut("choices")
+        .and_then(Value::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        for container in ["message", "delta"] {
+            if let Some(object) = choice.get_mut(container).and_then(Value::as_object_mut) {
+                for key in ["reasoning", "reasoning_content", "reasoning_details"] {
+                    object.remove(key);
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
 }
 
-fn now_millis() -> u128 {
+pub(super) fn now_millis() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis())
@@ -45,7 +55,7 @@ fn now_millis() -> u128 {
 }
 
 // Read a token count, accepting integer- or float-encoded numbers.
-fn i64_field(value: &Value, key: &str) -> i64 {
+pub(super) fn i64_field(value: &Value, key: &str) -> i64 {
     value
         .get(key)
         .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
@@ -53,7 +63,7 @@ fn i64_field(value: &Value, key: &str) -> i64 {
 }
 
 // Anthropic stop_reason -> OpenAI finish_reason (strict compliance maps it).
-fn transform_finish_reason(stop_reason: Option<&str>, strict: bool) -> String {
+pub(super) fn transform_finish_reason(stop_reason: Option<&str>, strict: bool) -> String {
     let Some(reason) = stop_reason else {
         return "stop".to_string();
     };
@@ -70,7 +80,7 @@ fn transform_finish_reason(stop_reason: Option<&str>, strict: bool) -> String {
 }
 
 // OpenAI finish_reason -> Anthropic stop_reason (downstream surface).
-fn map_finish_reason(finish_reason: Option<&str>) -> &'static str {
+pub(super) fn map_finish_reason(finish_reason: Option<&str>) -> &'static str {
     match finish_reason {
         Some("length") => "max_tokens",
         Some("tool_calls") | Some("function_call") => "tool_use",
@@ -121,8 +131,7 @@ fn anthropic_chat_to_openai(response: Value, strict: bool) -> Value {
         "completion_tokens": output,
         "total_tokens": input + output + cache_creation + cache_read,
     });
-    // Echo the cache buckets only when present in the source: spread the raw
-    // fields and drop undefined ones.
+    // Echo only source cache buckets.
     if cache_creation != 0 || cache_read != 0 {
         let map = usage.as_object_mut().unwrap();
         if let Some(value) = usage_src.get("cache_read_input_tokens") {
@@ -140,8 +149,7 @@ fn anthropic_chat_to_openai(response: Value, strict: bool) -> Value {
             .unwrap()
             .insert("tool_calls".into(), Value::Array(tool_calls));
     }
-    // When not strict, the raw Anthropic blocks (minus tool_use) are attached as
-    // a content_blocks extension. Strict mode (the default) omits them.
+    // Non-strict mode attaches raw non-tool blocks.
     if !strict {
         let blocks: Vec<Value> = content_items
             .iter()
@@ -269,5 +277,17 @@ mod tests {
         let out = transform_response(ProviderFormat::Openai, Endpoint::Messages, body);
         assert_eq!(out["content"], json!([{ "type": "text", "text": "" }]));
         assert_eq!(out["stop_reason"], json!("end_turn"));
+    }
+
+    #[test]
+    fn reasoning_exclusion_preserves_usage() {
+        let mut body = json!({"choices":[{"message":{"content":"ok","reasoning":"secret"}}],
+            "usage":{"completion_tokens_details":{"reasoning_tokens":3}}});
+        exclude_reasoning(&mut body);
+        assert!(body["choices"][0]["message"].get("reasoning").is_none());
+        assert_eq!(
+            body["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            3
+        );
     }
 }

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -1,4 +1,10 @@
-//! Stateful, event-by-event SSE provider transforms. Metering is downstream.
+//! Stateful SSE response transforms: convert an upstream provider's streaming
+//! events into the downstream client surface, event by event, threading mutable
+//! state across events (a per-stream transform state).
+//!
+//! Three provider conversions are supported. Same-format streaming reaches this
+//! module only when response reasoning must be excluded. Cost injection, TTFT,
+//! and outcome are a separate metering pass downstream (`sse`).
 
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
@@ -39,7 +45,13 @@ impl StreamTransform {
         }
     }
 
-    // Transform one event; malformed provider data ends the stream.
+    // Parse a raw event text (lines joined by `\n`) and transform it.
+    // `Err(())` means the provider sent an unparseable event; on the Anthropic
+    // paths this ends the stream and classifies it failed rather than skipping.
+    // Each transform dispatches known control events by name first, then skips
+    // any event whose payload is empty (per the SSE spec an empty data buffer
+    // aborts dispatch — covers `: PROCESSING` heartbeats, ignored fields, and
+    // name-only or empty-`data:` keep-alives).
     fn apply(
         self,
         event: &str,
@@ -84,7 +96,8 @@ pub fn select_stream_transform(
     }
 }
 
-/// Per-stream state, grouped by transform direction.
+/// Mutable per-stream state threaded across events. Fields are split by
+/// direction; a given stream only touches the ones for its transform.
 #[derive(Default)]
 struct StreamState {
     // Anthropic -> OpenAI chat.
@@ -102,13 +115,22 @@ struct StreamState {
     finish_reason: Option<String>,
 }
 
-/// Last event name plus data lines joined per the SSE spec.
+/// One SSE event reduced to the fields the transforms consume: the last
+/// `event:` name and the `data:` lines joined with `\n` (per the SSE spec).
 struct ParsedEvent {
     name: Option<String>,
     data: Option<String>,
 }
 
-// Parse SSE fields, accepting bare payloads only when no data field is present.
+// Parse an event's text per the SSE field rules: `:`-prefixed lines are
+// comments, a field's value starts after the colon with at most one leading
+// space stripped, and every field other than `event:`/`data:` (`id:`,
+// `retry:`, vendor extensions) is ignored per the spec. Lines with no field
+// shape at all — bare `[DONE]`, bare JSON (colons inside JSON do not make it a
+// field: a `{`/`[`/`"` opener marks a payload line), plain garbage — are
+// collected and become the data when no `data:` field is present, so a
+// prefix-less payload survives even when a comment or `event:` line shares
+// the event block, and garbage still reaches the transforms' fail-fast parse.
 fn parse_event(event: &str) -> ParsedEvent {
     let mut name = None;
     let mut data: Option<String> = None;
@@ -118,7 +140,8 @@ fn parse_event(event: &str) -> ParsedEvent {
         if line.is_empty() || line.starts_with(':') {
             continue;
         }
-        // Detect indented bare JSON while preserving its bytes.
+        // Judge the JSON opener on the trimmed line (upstreams may indent a
+        // bare payload) but keep the raw line as the payload.
         let json_like = matches!(
             line.trim_start().as_bytes().first(),
             Some(b'{' | b'[' | b'"')
@@ -129,7 +152,8 @@ fn parse_event(event: &str) -> ParsedEvent {
                 let value = &line[idx + 1..];
                 let value = value.strip_prefix(' ').unwrap_or(value);
                 match &line[..idx] {
-                    // Tolerate trailing whitespace in event names.
+                    // The name is trimmed: exact-match dispatch must tolerate
+                    // trailing whitespace an upstream leaves after the value.
                     "event" => name = Some(value.trim().to_string()),
                     "data" => {
                         let buf = data.get_or_insert_with(String::new);
@@ -170,7 +194,8 @@ fn anthropic_chat_stream(
         _ => {}
     }
     let payload = event.data.as_deref().unwrap_or("").trim();
-    // Empty payloads do not dispatch; malformed ones fail.
+    // No payload → no dispatch (name-only keep-alives included); a non-empty
+    // malformed payload must still fail the stream rather than be skipped.
     if payload.is_empty() {
         return Ok(None);
     }
@@ -297,7 +322,8 @@ fn anthropic_chat_chunk(
             .and_then(Value::as_str)
             == Some("tool_use");
     if is_tool_block_start {
-        // Preserve the source transform's tool-index wire behavior.
+        // Index logic: a falsy (None/0) index yields 0, otherwise increments.
+        // (A known quirk for >1 tool; kept for wire compatibility.)
         state.tool_index = Some(match state.tool_index {
             Some(n) if n != 0 => n + 1,
             _ => 0,
@@ -605,7 +631,14 @@ fn json_str(value: &Value) -> String {
 
 // ── Stream adapter ───────────────────────────────────────────────────────────
 
-/// Bounded incremental SSE tokenizer supporting LF, CRLF, and bare CR.
+/// Incremental SSE tokenizer: splits raw upstream bytes into events at blank
+/// lines. A line terminator is LF, CRLF, or bare CR — a CR-LF pair counts as a
+/// single terminator, tracked across chunk boundaries via `pending_cr`, so a
+/// chunk ending in `\r` never mis-splits. The pending event is one contiguous
+/// byte buffer (lines joined by `\n`), so the cap on its length — the same cap
+/// as the meter's line buffer, and covering the open line as a prefix of it —
+/// bounds actual memory, not just a logical byte count. Exceeding it is
+/// reported as an error (the caller ends the stream as failed).
 #[derive(Default)]
 struct SseEventReader {
     event_buf: Vec<u8>,
@@ -615,7 +648,8 @@ struct SseEventReader {
 }
 
 impl SseEventReader {
-    // Append events completed by this chunk; reject cap overflow.
+    // Feed one upstream chunk; events completed by it are appended to `events`.
+    // `Err(())` means the pending event (hence any single line) ran past the cap.
     fn push_chunk(&mut self, chunk: &[u8], events: &mut Vec<String>) -> Result<(), ()> {
         for &byte in chunk {
             if std::mem::take(&mut self.pending_cr) && byte == b'\n' {
@@ -637,7 +671,8 @@ impl SseEventReader {
 
     fn end_line(&mut self, events: &mut Vec<String>) {
         if self.event_buf.len() == self.line_start {
-            // Blank lines dispatch nonempty events.
+            // Blank line: dispatch the pending event, if any. Consecutive blank
+            // lines are empty events and dispatch nothing.
             if !self.event_buf.is_empty() {
                 events.push(event_string(std::mem::take(&mut self.event_buf)));
             }
@@ -648,14 +683,16 @@ impl SseEventReader {
         self.line_start = self.event_buf.len();
     }
 
-    // Salvage a residual event at clean EOF.
+    // Flush the residual at a clean end of stream: an event without a trailing
+    // blank line is still dispatched. The cap already held during accumulation.
     fn finish(&mut self) -> Option<String> {
         self.line_start = 0;
         (!self.event_buf.is_empty()).then(|| event_string(std::mem::take(&mut self.event_buf)))
     }
 }
 
-// Reuse valid UTF-8 buffers; repair invalid input lossily.
+// Reuse the event buffer's allocation when it is valid UTF-8 (the
+// overwhelmingly common case); fall back to a lossy copy only on invalid bytes.
 fn event_string(buf: Vec<u8>) -> String {
     String::from_utf8(buf).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
@@ -735,7 +772,10 @@ pub struct SseTransformStream {
     reader: SseEventReader,
     queue: VecDeque<Bytes>,
     inner_done: bool,
-    // Delay an error until already-completed events drain.
+    // Why the stream ended, when it ended badly. Held until the queue drains so
+    // events completed before the failure still reach the client, then yielded
+    // as the final item. Ending on a plain `None` would instead read downstream
+    // as a clean end-of-stream.
     pending_error: Option<ServiceError>,
 }
 
@@ -754,7 +794,8 @@ impl SseTransformStream {
         }
     }
 
-    // Transform failures are malformed upstream data.
+    // A transform-side failure is still an upstream failure: the provider sent
+    // bytes this surface cannot represent.
     fn fail(&mut self, reason: &'static str) {
         self.inner_done = true;
         self.pending_error.get_or_insert_with(|| {
@@ -762,7 +803,9 @@ impl SseTransformStream {
         });
     }
 
-    // False ends without a terminal marker so metering records failure.
+    // Returns false if the transform rejected the event (unparseable provider
+    // data): the stream must end there, with no terminal marker emitted, so the
+    // meter classifies it as failed.
     fn emit(&mut self, event: &str) -> bool {
         match self
             .transform
@@ -794,7 +837,8 @@ impl Stream for SseTransformStream {
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
                     let mut events = Vec::new();
-                    // Drain earlier events before reporting cap overflow.
+                    // A cap overflow ends the stream, but events completed
+                    // earlier in the same chunk are still emitted first.
                     let overflowed = this.reader.push_chunk(&bytes, &mut events).is_err();
                     for event in &events {
                         if !this.emit(event) {
@@ -809,7 +853,14 @@ impl Stream for SseTransformStream {
                 }
                 Poll::Ready(None) => {
                     this.inner_done = true;
-                    // Salvage and reframe a complete residual event once.
+                    // Flush a residual event once (no trailing blank line).
+                    // Deliberate cross-format framing normalization: a final
+                    // event whose lines are complete but which the upstream
+                    // never closed with a blank line is salvaged and re-framed,
+                    // rather than dropped as WHATWG would at EOF. Delivering a
+                    // valid last event beats losing it; a truncated (unparseable)
+                    // one still fails in `emit`. A byte passthrough cannot do
+                    // this, so the two paths differ for this one malformed shape.
                     if let Some(event) = this.reader.finish() {
                         if !this.emit(&event) {
                             this.fail("provider sent an event this surface cannot represent");
@@ -817,7 +868,10 @@ impl Stream for SseTransformStream {
                     }
                     // loop to drain any queued output, then end.
                 }
-                // Propagate errors without flushing a truncated residual.
+                // On an upstream error, end without flushing the (truncated)
+                // residual, so a partial event can't synthesize a spurious
+                // terminal marker. The error itself is propagated: swallowing
+                // it would read downstream as a clean end-of-stream.
                 Poll::Ready(Some(Err(err))) => {
                     this.inner_done = true;
                     this.pending_error.get_or_insert(err);
@@ -835,7 +889,8 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_anthropic_event_ends_stream_without_terminal() {
-        // Malformed events end before [DONE].
+        // A bad provider event must end the stream before [DONE], so the meter
+        // sees no terminal marker and classifies the stream as failed.
         let events: Vec<Result<Bytes, ServiceError>> = vec![
             Ok(Bytes::from(
                 "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"c\",\"usage\":{\"input_tokens\":1}}}\n\n",
@@ -864,7 +919,11 @@ mod tests {
         );
     }
 
-    // CRLF events split independently; extra blank events are ignored.
+    // A CRLF-framed upstream must be split per event, not buffered whole: with a
+    // fixed `\n\n` delimiter the events would only surface as one unparseable
+    // residual at end of stream (no [DONE], stream classified failed). The
+    // doubled blank line after the first event is an empty SSE event; it must be
+    // skipped, not surfaced as a lone-`\r` pseudo-event that fails the stream.
     #[tokio::test]
     async fn crlf_framed_events_are_split_and_transformed() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -892,7 +951,10 @@ mod tests {
         );
     }
 
-    // Comments and space-less data fields are valid SSE.
+    // Comment-only events (proxy heartbeats) and space-less `data:` lines are
+    // valid SSE; neither may end the stream. Both previously hit the
+    // malformed-event path on the Anthropic transforms (no terminal marker, so
+    // a healthy stream was metered as failed).
     #[tokio::test]
     async fn comment_and_spaceless_data_events_are_tolerated() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -918,7 +980,10 @@ mod tests {
         );
     }
 
-    // Exercise bare CR and cross-chunk CR/CRLF ambiguity.
+    // Bare-CR line terminators are valid SSE (a `\r\r` blank line ends an
+    // event); a CR-framed stream must split per event, not run into the cap.
+    // The first chunk ends in `\r` to exercise the cross-chunk CR/CRLF
+    // ambiguity: the reader must not mis-split when the next byte arrives.
     #[tokio::test]
     async fn cr_framed_events_are_split_and_transformed() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -943,7 +1008,9 @@ mod tests {
         );
     }
 
-    // Attached comments and space-less event fields remain valid.
+    // A comment line attached to the head of an event (a heartbeat injected
+    // without its own blank line) and a space-less `event:` field are both
+    // valid SSE; neither may derail the transform.
     #[test]
     fn comment_lines_and_spaceless_event_field_are_parsed() {
         let mut state = StreamState::default();
@@ -958,7 +1025,11 @@ mod tests {
         assert!(out.contains("[DONE]"), "{out}");
     }
 
-    // Cover bare payloads, ignored fields, empty data, and padded names.
+    // Regressions of the field parser against the old prefix-stripping code:
+    // a bare (data:-less) payload must survive an `event:` line or an injected
+    // comment in the same event block; `id:`/`retry:`-only and empty-data
+    // events must dispatch nothing instead of failing the stream; a trailing
+    // space after an event name must not break exact-match dispatch.
     #[test]
     fn bare_payloads_and_ignorable_events_are_handled() {
         let mut state = StreamState::default();
@@ -1024,7 +1095,9 @@ mod tests {
         assert!(out.contains("message_stop"), "{out}");
     }
 
-    // Unterminated input is bounded and fails without a terminal marker.
+    // A body that never yields an event boundary must not accumulate without
+    // bound: past the cap the stream ends with no terminal marker (metered
+    // failed), mirroring the meter's own line cap.
     #[tokio::test]
     async fn boundless_body_is_capped() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -1038,7 +1111,9 @@ mod tests {
         assert!(collected[0].is_err(), "and not a clean EOF");
     }
 
-    // Normalize replayed fixture output for comparison with Node goldens.
+    // Replay a fixture's input events through the transform (fixed fallback id),
+    // collecting emitted data objects with `created` stripped (and a `__done`
+    // sentinel for `[DONE]`), to compare against the Node-generated output.
     fn replay_fixture(transform: StreamTransform, events: &[Value]) -> Vec<Value> {
         let mut state = StreamState::default();
         let mut out = Vec::new();

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -1,16 +1,9 @@
-//! Stateful SSE response transforms: convert an upstream provider's streaming
-//! events into the downstream client surface, event by event, threading mutable
-//! state across events (a per-stream transform state).
-//!
-//! Three conversions are supported; same-format streaming is native passthrough
-//! and never reaches this module. Cost injection, TTFT, and outcome are a
-//! separate metering pass downstream (`sse`).
+//! Stateful, event-by-event SSE provider transforms. Metering is downstream.
 
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Bytes;
 use futures_util::Stream;
@@ -20,6 +13,9 @@ use crate::aci::upstream::UpstreamError;
 use crate::aggregator::service::{ServiceError, ServiceResponseStream};
 
 use super::request_transform::Endpoint;
+use super::response_transform::{
+    self, i64_field, map_finish_reason, now_millis, now_secs, transform_finish_reason,
+};
 use super::sse::MAX_SSE_LINE_BYTES;
 use super::types::ProviderFormat;
 
@@ -31,29 +27,28 @@ pub enum StreamTransform {
     AnthropicToOpenaiChat,
     OpenaiToAnthropicMessages,
     AnthropicCompleteToOpenai,
+    ExcludeReasoning,
 }
 
 impl StreamTransform {
     fn provider(self) -> &'static str {
         match self {
             StreamTransform::OpenaiToAnthropicMessages => "openai",
+            StreamTransform::ExcludeReasoning => "openai",
             _ => "anthropic",
         }
     }
 
-    // Parse a raw event text (lines joined by `\n`) and transform it.
-    // `Err(())` means the provider sent an unparseable event; on the Anthropic
-    // paths this ends the stream and classifies it failed rather than skipping.
-    // Each transform dispatches known control events by name first, then skips
-    // any event whose payload is empty (per the SSE spec an empty data buffer
-    // aborts dispatch — covers `: PROCESSING` heartbeats, ignored fields, and
-    // name-only or empty-`data:` keep-alives).
+    // Transform one event; malformed provider data ends the stream.
     fn apply(
         self,
         event: &str,
         fallback_id: &str,
         state: &mut StreamState,
     ) -> Result<Option<String>, ()> {
+        if matches!(self, StreamTransform::ExcludeReasoning) {
+            return exclude_reasoning_event(event).map(Some);
+        }
         let event = parse_event(event);
         match self {
             StreamTransform::AnthropicToOpenaiChat => {
@@ -68,6 +63,7 @@ impl StreamTransform {
                 ))
             }
             StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(&event),
+            StreamTransform::ExcludeReasoning => unreachable!(),
         }
     }
 }
@@ -88,8 +84,7 @@ pub fn select_stream_transform(
     }
 }
 
-/// Mutable per-stream state threaded across events. Fields are split by
-/// direction; a given stream only touches the ones for its transform.
+/// Per-stream state, grouped by transform direction.
 #[derive(Default)]
 struct StreamState {
     // Anthropic -> OpenAI chat.
@@ -107,36 +102,13 @@ struct StreamState {
     finish_reason: Option<String>,
 }
 
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
-fn now_millis() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0)
-}
-
-/// One SSE event reduced to the fields the transforms consume: the last
-/// `event:` name and the `data:` lines joined with `\n` (per the SSE spec).
+/// Last event name plus data lines joined per the SSE spec.
 struct ParsedEvent {
     name: Option<String>,
     data: Option<String>,
 }
 
-// Parse an event's text per the SSE field rules: `:`-prefixed lines are
-// comments, a field's value starts after the colon with at most one leading
-// space stripped, and every field other than `event:`/`data:` (`id:`,
-// `retry:`, vendor extensions) is ignored per the spec. Lines with no field
-// shape at all — bare `[DONE]`, bare JSON (colons inside JSON do not make it a
-// field: a `{`/`[`/`"` opener marks a payload line), plain garbage — are
-// collected and become the data when no `data:` field is present, so a
-// prefix-less payload survives even when a comment or `event:` line shares
-// the event block, and garbage still reaches the transforms' fail-fast parse.
+// Parse SSE fields, accepting bare payloads only when no data field is present.
 fn parse_event(event: &str) -> ParsedEvent {
     let mut name = None;
     let mut data: Option<String> = None;
@@ -146,8 +118,7 @@ fn parse_event(event: &str) -> ParsedEvent {
         if line.is_empty() || line.starts_with(':') {
             continue;
         }
-        // Judge the JSON opener on the trimmed line (upstreams may indent a
-        // bare payload) but keep the raw line as the payload.
+        // Detect indented bare JSON while preserving its bytes.
         let json_like = matches!(
             line.trim_start().as_bytes().first(),
             Some(b'{' | b'[' | b'"')
@@ -158,8 +129,7 @@ fn parse_event(event: &str) -> ParsedEvent {
                 let value = &line[idx + 1..];
                 let value = value.strip_prefix(' ').unwrap_or(value);
                 match &line[..idx] {
-                    // The name is trimmed: exact-match dispatch must tolerate
-                    // trailing whitespace an upstream leaves after the value.
+                    // Tolerate trailing whitespace in event names.
                     "event" => name = Some(value.trim().to_string()),
                     "data" => {
                         let buf = data.get_or_insert_with(String::new);
@@ -186,34 +156,6 @@ fn parse_event(event: &str) -> ParsedEvent {
     ParsedEvent { name, data }
 }
 
-fn i64_field(value: &Value, key: &str) -> i64 {
-    value.get(key).and_then(Value::as_i64).unwrap_or(0)
-}
-
-fn transform_finish_reason(stop_reason: Option<&str>, strict: bool) -> String {
-    let Some(reason) = stop_reason else {
-        return "stop".to_string();
-    };
-    if !strict {
-        return reason.to_string();
-    }
-    match reason {
-        "stop_sequence" | "end_turn" | "pause_turn" => "stop",
-        "tool_use" => "tool_calls",
-        "max_tokens" => "length",
-        _ => "stop",
-    }
-    .to_string()
-}
-
-fn map_finish_reason(finish_reason: Option<&str>) -> &'static str {
-    match finish_reason {
-        Some("length") => "max_tokens",
-        Some("tool_calls") | Some("function_call") => "tool_use",
-        _ => "end_turn",
-    }
-}
-
 // ── Anthropic Messages SSE → OpenAI chat.completion.chunk ────────────────────
 
 fn anthropic_chat_stream(
@@ -228,8 +170,7 @@ fn anthropic_chat_stream(
         _ => {}
     }
     let payload = event.data.as_deref().unwrap_or("").trim();
-    // No payload → no dispatch (name-only keep-alives included); a non-empty
-    // malformed payload must still fail the stream rather than be skipped.
+    // Empty payloads do not dispatch; malformed ones fail.
     if payload.is_empty() {
         return Ok(None);
     }
@@ -356,8 +297,7 @@ fn anthropic_chat_chunk(
             .and_then(Value::as_str)
             == Some("tool_use");
     if is_tool_block_start {
-        // Index logic: a falsy (None/0) index yields 0, otherwise increments.
-        // (A known quirk for >1 tool; kept for wire compatibility.)
+        // Preserve the source transform's tool-index wire behavior.
         state.tool_index = Some(match state.tool_index {
             Some(n) if n != 0 => n + 1,
             _ => 0,
@@ -665,14 +605,7 @@ fn json_str(value: &Value) -> String {
 
 // ── Stream adapter ───────────────────────────────────────────────────────────
 
-/// Incremental SSE tokenizer: splits raw upstream bytes into events at blank
-/// lines. A line terminator is LF, CRLF, or bare CR — a CR-LF pair counts as a
-/// single terminator, tracked across chunk boundaries via `pending_cr`, so a
-/// chunk ending in `\r` never mis-splits. The pending event is one contiguous
-/// byte buffer (lines joined by `\n`), so the cap on its length — the same cap
-/// as the meter's line buffer, and covering the open line as a prefix of it —
-/// bounds actual memory, not just a logical byte count. Exceeding it is
-/// reported as an error (the caller ends the stream as failed).
+/// Bounded incremental SSE tokenizer supporting LF, CRLF, and bare CR.
 #[derive(Default)]
 struct SseEventReader {
     event_buf: Vec<u8>,
@@ -682,8 +615,7 @@ struct SseEventReader {
 }
 
 impl SseEventReader {
-    // Feed one upstream chunk; events completed by it are appended to `events`.
-    // `Err(())` means the pending event (hence any single line) ran past the cap.
+    // Append events completed by this chunk; reject cap overflow.
     fn push_chunk(&mut self, chunk: &[u8], events: &mut Vec<String>) -> Result<(), ()> {
         for &byte in chunk {
             if std::mem::take(&mut self.pending_cr) && byte == b'\n' {
@@ -705,8 +637,7 @@ impl SseEventReader {
 
     fn end_line(&mut self, events: &mut Vec<String>) {
         if self.event_buf.len() == self.line_start {
-            // Blank line: dispatch the pending event, if any. Consecutive blank
-            // lines are empty events and dispatch nothing.
+            // Blank lines dispatch nonempty events.
             if !self.event_buf.is_empty() {
                 events.push(event_string(std::mem::take(&mut self.event_buf)));
             }
@@ -717,18 +648,81 @@ impl SseEventReader {
         self.line_start = self.event_buf.len();
     }
 
-    // Flush the residual at a clean end of stream: an event without a trailing
-    // blank line is still dispatched. The cap already held during accumulation.
+    // Salvage a residual event at clean EOF.
     fn finish(&mut self) -> Option<String> {
         self.line_start = 0;
         (!self.event_buf.is_empty()).then(|| event_string(std::mem::take(&mut self.event_buf)))
     }
 }
 
-// Reuse the event buffer's allocation when it is valid UTF-8 (the
-// overwhelmingly common case); fall back to a lossy copy only on invalid bytes.
+// Reuse valid UTF-8 buffers; repair invalid input lossily.
 fn event_string(buf: Vec<u8>) -> String {
     String::from_utf8(buf).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+fn framed_event(event: &str) -> String {
+    let mut output = event.to_string();
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output.push('\n');
+    output
+}
+
+fn replace_data_fields(event: &str, replacement: &str) -> String {
+    let has_data_field = event.lines().any(|line| {
+        line.trim_end_matches('\r')
+            .split_once(':')
+            .is_some_and(|(field, _)| field == "data")
+    });
+    let mut output = String::new();
+    let mut replaced = false;
+    for line in event.lines() {
+        let line = line.trim_end_matches('\r');
+        let is_data = line
+            .split_once(':')
+            .is_some_and(|(field, _)| field == "data");
+        let trimmed = line.trim_start();
+        let json_like = matches!(trimmed.as_bytes().first(), Some(b'{' | b'[' | b'"'));
+        let is_bare_payload = !has_data_field
+            && !line.is_empty()
+            && !line.starts_with(':')
+            && (json_like || !line.contains(':'));
+        if is_data || is_bare_payload {
+            if !replaced {
+                if has_data_field {
+                    output.push_str("data: ");
+                }
+                output.push_str(replacement);
+                output.push('\n');
+                replaced = true;
+            }
+        } else {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+    output.push('\n');
+    output
+}
+
+fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
+    let parsed = parse_event(event);
+    let Some(payload) = parsed.data.as_deref() else {
+        return Ok(framed_event(event));
+    };
+    let payload = payload.trim();
+    if payload.is_empty() || payload == "[DONE]" {
+        return Ok(framed_event(event));
+    }
+    let mut body: Value = serde_json::from_str(payload).map_err(|_| ())?;
+    let original = body.clone();
+    response_transform::exclude_reasoning(&mut body);
+    if body == original {
+        Ok(framed_event(event))
+    } else {
+        Ok(replace_data_fields(event, &json_str(&body)))
+    }
 }
 
 /// Splits the provider byte stream into SSE events and applies a stateful
@@ -741,10 +735,7 @@ pub struct SseTransformStream {
     reader: SseEventReader,
     queue: VecDeque<Bytes>,
     inner_done: bool,
-    // Why the stream ended, when it ended badly. Held until the queue drains so
-    // events completed before the failure still reach the client, then yielded
-    // as the final item. Ending on a plain `None` would instead read downstream
-    // as a clean end-of-stream.
+    // Delay an error until already-completed events drain.
     pending_error: Option<ServiceError>,
 }
 
@@ -763,8 +754,7 @@ impl SseTransformStream {
         }
     }
 
-    // A transform-side failure is still an upstream failure: the provider sent
-    // bytes this surface cannot represent.
+    // Transform failures are malformed upstream data.
     fn fail(&mut self, reason: &'static str) {
         self.inner_done = true;
         self.pending_error.get_or_insert_with(|| {
@@ -772,9 +762,7 @@ impl SseTransformStream {
         });
     }
 
-    // Returns false if the transform rejected the event (unparseable provider
-    // data): the stream must end there, with no terminal marker emitted, so the
-    // meter classifies it as failed.
+    // False ends without a terminal marker so metering records failure.
     fn emit(&mut self, event: &str) -> bool {
         match self
             .transform
@@ -806,8 +794,7 @@ impl Stream for SseTransformStream {
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
                     let mut events = Vec::new();
-                    // A cap overflow ends the stream, but events completed
-                    // earlier in the same chunk are still emitted first.
+                    // Drain earlier events before reporting cap overflow.
                     let overflowed = this.reader.push_chunk(&bytes, &mut events).is_err();
                     for event in &events {
                         if !this.emit(event) {
@@ -822,14 +809,7 @@ impl Stream for SseTransformStream {
                 }
                 Poll::Ready(None) => {
                     this.inner_done = true;
-                    // Flush a residual event once (no trailing blank line).
-                    // Deliberate cross-format framing normalization: a final
-                    // event whose lines are complete but which the upstream
-                    // never closed with a blank line is salvaged and re-framed,
-                    // rather than dropped as WHATWG would at EOF. Delivering a
-                    // valid last event beats losing it; a truncated (unparseable)
-                    // one still fails in `emit`. A byte passthrough cannot do
-                    // this, so the two paths differ for this one malformed shape.
+                    // Salvage and reframe a complete residual event once.
                     if let Some(event) = this.reader.finish() {
                         if !this.emit(&event) {
                             this.fail("provider sent an event this surface cannot represent");
@@ -837,10 +817,7 @@ impl Stream for SseTransformStream {
                     }
                     // loop to drain any queued output, then end.
                 }
-                // On an upstream error, end without flushing the (truncated)
-                // residual, so a partial event can't synthesize a spurious
-                // terminal marker. The error itself is propagated: swallowing
-                // it would read downstream as a clean end-of-stream.
+                // Propagate errors without flushing a truncated residual.
                 Poll::Ready(Some(Err(err))) => {
                     this.inner_done = true;
                     this.pending_error.get_or_insert(err);
@@ -858,8 +835,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_anthropic_event_ends_stream_without_terminal() {
-        // A bad provider event must end the stream before [DONE], so the meter
-        // sees no terminal marker and classifies the stream as failed.
+        // Malformed events end before [DONE].
         let events: Vec<Result<Bytes, ServiceError>> = vec![
             Ok(Bytes::from(
                 "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"c\",\"usage\":{\"input_tokens\":1}}}\n\n",
@@ -888,11 +864,7 @@ mod tests {
         );
     }
 
-    // A CRLF-framed upstream must be split per event, not buffered whole: with a
-    // fixed `\n\n` delimiter the events would only surface as one unparseable
-    // residual at end of stream (no [DONE], stream classified failed). The
-    // doubled blank line after the first event is an empty SSE event; it must be
-    // skipped, not surfaced as a lone-`\r` pseudo-event that fails the stream.
+    // CRLF events split independently; extra blank events are ignored.
     #[tokio::test]
     async fn crlf_framed_events_are_split_and_transformed() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -920,10 +892,7 @@ mod tests {
         );
     }
 
-    // Comment-only events (proxy heartbeats) and space-less `data:` lines are
-    // valid SSE; neither may end the stream. Both previously hit the
-    // malformed-event path on the Anthropic transforms (no terminal marker, so
-    // a healthy stream was metered as failed).
+    // Comments and space-less data fields are valid SSE.
     #[tokio::test]
     async fn comment_and_spaceless_data_events_are_tolerated() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -949,10 +918,7 @@ mod tests {
         );
     }
 
-    // Bare-CR line terminators are valid SSE (a `\r\r` blank line ends an
-    // event); a CR-framed stream must split per event, not run into the cap.
-    // The first chunk ends in `\r` to exercise the cross-chunk CR/CRLF
-    // ambiguity: the reader must not mis-split when the next byte arrives.
+    // Exercise bare CR and cross-chunk CR/CRLF ambiguity.
     #[tokio::test]
     async fn cr_framed_events_are_split_and_transformed() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -977,9 +943,7 @@ mod tests {
         );
     }
 
-    // A comment line attached to the head of an event (a heartbeat injected
-    // without its own blank line) and a space-less `event:` field are both
-    // valid SSE; neither may derail the transform.
+    // Attached comments and space-less event fields remain valid.
     #[test]
     fn comment_lines_and_spaceless_event_field_are_parsed() {
         let mut state = StreamState::default();
@@ -994,11 +958,7 @@ mod tests {
         assert!(out.contains("[DONE]"), "{out}");
     }
 
-    // Regressions of the field parser against the old prefix-stripping code:
-    // a bare (data:-less) payload must survive an `event:` line or an injected
-    // comment in the same event block; `id:`/`retry:`-only and empty-data
-    // events must dispatch nothing instead of failing the stream; a trailing
-    // space after an event name must not break exact-match dispatch.
+    // Cover bare payloads, ignored fields, empty data, and padded names.
     #[test]
     fn bare_payloads_and_ignorable_events_are_handled() {
         let mut state = StreamState::default();
@@ -1064,9 +1024,7 @@ mod tests {
         assert!(out.contains("message_stop"), "{out}");
     }
 
-    // A body that never yields an event boundary must not accumulate without
-    // bound: past the cap the stream ends with no terminal marker (metered
-    // failed), mirroring the meter's own line cap.
+    // Unterminated input is bounded and fails without a terminal marker.
     #[tokio::test]
     async fn boundless_body_is_capped() {
         let events: Vec<Result<Bytes, ServiceError>> = vec![
@@ -1080,9 +1038,7 @@ mod tests {
         assert!(collected[0].is_err(), "and not a clean EOF");
     }
 
-    // Replay a fixture's input events through the transform (fixed fallback id),
-    // collecting emitted data objects with `created` stripped (and a `__done`
-    // sentinel for `[DONE]`), to compare against the Node-generated output.
+    // Normalize replayed fixture output for comparison with Node goldens.
     fn replay_fixture(transform: StreamTransform, events: &[Value]) -> Vec<Value> {
         let mut state = StreamState::default();
         let mut out = Vec::new();
@@ -1173,6 +1129,21 @@ mod tests {
         let error = out.iter().find(|e| e["type"] == json!("error")).unwrap();
         assert_eq!(error["error"]["type"], json!("overloaded_error"));
         assert!(!out.iter().any(|e| e["type"] == json!("message_stop")));
+    }
+
+    #[test]
+    fn reasoning_exclusion_preserves_non_data_sse_fields() {
+        let output = exclude_reasoning_event(
+            "event: chunk\nid: 7\nretry: 100\n: keep\n{\"choices\":[{\"delta\":{\"content\":\"answer\",\"reasoning\":\"hidden\"}}],\"usage\":{\"completion_tokens_details\":{\"reasoning_tokens\":3}}}",
+        )
+        .unwrap();
+        assert!(output.contains("event: chunk\n"), "{output}");
+        assert!(output.contains("id: 7\n"), "{output}");
+        assert!(output.contains("retry: 100\n"), "{output}");
+        assert!(output.contains(": keep\n"), "{output}");
+        assert!(output.contains("\"content\":\"answer\""), "{output}");
+        assert!(output.contains("\"reasoning_tokens\":3"), "{output}");
+        assert!(!output.contains("hidden"), "{output}");
     }
 
     #[test]

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -1,4 +1,9 @@
-//! Typed camelCase control contracts; pricing stays opaque until metering.
+//! Control-plane consult types.
+//!
+//! The control plane speaks a camelCase wire shape; these structs mirror it so a
+//! pre-consult response deserializes and a post-consult report serializes without
+//! hand-built JSON. Pricing is carried as an opaque value, interpreted by the
+//! cost computation.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -14,7 +19,8 @@ pub enum ProviderFormat {
     Anthropic,
 }
 
-/// Self-hosted OpenAI-compatible engine; absent for managed APIs.
+/// Serving engine of a self-hosted OpenAI-compatible upstream. Selects
+/// engine-specific request shaping; absent for managed third-party APIs.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Engine {
@@ -78,7 +84,8 @@ pub struct RouteCandidate {
     pub route_id: String,
     /// API format that shapes the request and parses the response.
     pub format: ProviderFormat,
-    /// Self-hosted OpenAI-compatible engine; absent for managed APIs.
+    /// Serving engine when this upstream is a self-hosted OpenAI-compatible
+    /// server. Absent for managed APIs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine: Option<Engine>,
     /// Request-specific setting selected after capability filtering.
@@ -105,7 +112,8 @@ pub struct RateLimit {
     pub reset_at: i64,
 }
 
-/// Pre-consult denial or candidate/pricing decision.
+/// Pre-request consult response. On `allow: false`, `status` and `message` carry
+/// the client-facing denial; otherwise `candidates` and `pricing` drive routing.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreConsult {
@@ -130,7 +138,10 @@ pub struct PreConsult {
     pub rate_limit: Option<RateLimit>,
 }
 
-/// Attribution for a gateway-synthesized failure.
+/// Which component a gateway-synthesized failure (no real upstream attempt) is
+/// attributed to. Drives the control plane's error-source column: `control`
+/// (control-plane consult), `upstream` (provider forwarding/verification or a
+/// malformed upstream success body), or `gateway` (the gateway's own logic).
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ErrorSource {
@@ -139,7 +150,11 @@ pub enum ErrorSource {
     Gateway,
 }
 
-/// Fire-and-forget billing/log report.
+/// Post-request usage report. Fire-and-forget; drives billing and request logs.
+///
+/// `selected_route_id`, `usage`, and `pricing` are always present (serialized as
+/// `null` when absent) to match the control plane's expected shape; the rest are
+/// omitted when unset.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostReport {
@@ -153,7 +168,14 @@ pub struct PostReport {
     pub is_streaming: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempt_index: Option<u32>,
-    /// Selected route; null with `error_source` denotes a request summary.
+    /// `<provider>:<model>` from the backend's selected route, or `null`.
+    ///
+    /// Wire contract for consumers: a request may emit multiple per-attempt
+    /// reports — aggregate by `request_id`. A report with
+    /// `selected_route_id == null` and a non-empty `error_source` is a
+    /// request-level summary (e.g. the aggregate error after every candidate
+    /// failed), not an attempt; attempt counting must only consider reports
+    /// that carry a route.
     pub selected_route_id: Option<String>,
     pub request_model: String,
     /// Raw upstream usage before any cost injection, or `null`.

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -1,9 +1,4 @@
-//! Control-plane consult types.
-//!
-//! The control plane speaks a camelCase wire shape; these structs mirror it so a
-//! pre-consult response deserializes and a post-consult report serializes without
-//! hand-built JSON. Pricing is carried as an opaque value, interpreted by the
-//! cost computation.
+//! Typed camelCase control contracts; pricing stays opaque until metering.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -19,13 +14,51 @@ pub enum ProviderFormat {
     Anthropic,
 }
 
-/// Serving engine of a self-hosted OpenAI-compatible upstream. Selects
-/// engine-specific request shaping; absent for managed third-party APIs.
+/// Self-hosted OpenAI-compatible engine; absent for managed APIs.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Engine {
     Sglang,
     Vllm,
+}
+
+/// Canonical public/control reasoning effort.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    Max,
+    Xhigh,
+    High,
+    Medium,
+    Low,
+    Minimal,
+    None,
+}
+
+impl ReasoningEffort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Max => "max",
+            Self::Xhigh => "xhigh",
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+            Self::Minimal => "minimal",
+            Self::None => "none",
+        }
+    }
+}
+
+/// Route-relevant reasoning; response visibility remains gateway-local.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReasoningConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
 }
 
 /// Billing mode, carried from the pre-consult into the post-consult report.
@@ -45,10 +78,12 @@ pub struct RouteCandidate {
     pub route_id: String,
     /// API format that shapes the request and parses the response.
     pub format: ProviderFormat,
-    /// Serving engine when this upstream is a self-hosted OpenAI-compatible
-    /// server. Absent for managed APIs.
+    /// Self-hosted OpenAI-compatible engine; absent for managed APIs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine: Option<Engine>,
+    /// Request-specific setting selected after capability filtering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_reasoning: Option<ReasoningConfig>,
 }
 
 /// Provider routing block, forwarded verbatim to the control plane.
@@ -70,8 +105,7 @@ pub struct RateLimit {
     pub reset_at: i64,
 }
 
-/// Pre-request consult response. On `allow: false`, `status` and `message` carry
-/// the client-facing denial; otherwise `candidates` and `pricing` drive routing.
+/// Pre-consult denial or candidate/pricing decision.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreConsult {
@@ -96,10 +130,7 @@ pub struct PreConsult {
     pub rate_limit: Option<RateLimit>,
 }
 
-/// Which component a gateway-synthesized failure (no real upstream attempt) is
-/// attributed to. Drives the control plane's error-source column: `control`
-/// (control-plane consult), `upstream` (provider forwarding/verification or a
-/// malformed upstream success body), or `gateway` (the gateway's own logic).
+/// Attribution for a gateway-synthesized failure.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ErrorSource {
@@ -108,11 +139,7 @@ pub enum ErrorSource {
     Gateway,
 }
 
-/// Post-request usage report. Fire-and-forget; drives billing and request logs.
-///
-/// `selected_route_id`, `usage`, and `pricing` are always present (serialized as
-/// `null` when absent) to match the control plane's expected shape; the rest are
-/// omitted when unset.
+/// Fire-and-forget billing/log report.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostReport {
@@ -126,14 +153,7 @@ pub struct PostReport {
     pub is_streaming: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempt_index: Option<u32>,
-    /// `<provider>:<model>` from the backend's selected route, or `null`.
-    ///
-    /// Wire contract for consumers: a request may emit multiple per-attempt
-    /// reports — aggregate by `request_id`. A report with
-    /// `selected_route_id == null` and a non-empty `error_source` is a
-    /// request-level summary (e.g. the aggregate error after every candidate
-    /// failed), not an attempt; attempt counting must only consider reports
-    /// that carry a route.
+    /// Selected route; null with `error_source` denotes a request summary.
     pub selected_route_id: Option<String>,
     pub request_model: String,
     /// Raw upstream usage before any cost injection, or `null`.

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -1,4 +1,6 @@
-//! In-process consult, forwarding, transform, metering, and finalization tests.
+//! In-process completion orchestration tests: pre-consult reasoning validation,
+//! consult-driven denials, fail-closed control errors, rate limits, empty
+//! candidates, and successful forwarding through receipt finalization.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -68,7 +70,10 @@ impl UpstreamBackend for MockUpstream {
     }
 }
 
-// Classifies `tee-` routes and records actual forwards.
+// A mock upstream that classifies a route as attested by its `tee-` prefix and
+// records every route it was actually asked to forward to. Classification
+// happens in `prepare`, as the real config-driven router does it, so a route
+// the ACI constraint rejects can be told apart from one never reached.
 struct TeeAwareUpstream {
     forwarded: Arc<Mutex<Vec<String>>>,
     status: u16,
@@ -113,7 +118,9 @@ impl UpstreamBackend for TeeAwareUpstream {
     ) -> Result<UpstreamResponse, UpstreamError> {
         self.forward_prepared(req).await
     }
-    // Streaming needs its own forwarding record.
+    // Streaming resolves through `forward_stream_prepared`, not
+    // `forward_prepared`, so it needs its own recording hook — otherwise a
+    // streaming test cannot tell "never forwarded" from "not observed".
     async fn forward_stream_prepared(
         &self,
         req: PreparedUpstreamRequest,

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -1,7 +1,4 @@
-//! In-process completion orchestration tests: the consult-driven paths (denial,
-//! control-unavailable fail-closed, rate-limit, empty candidates) which return
-//! before any upstream forward, plus the success path (consult allow → candidate
-//! transform → forward → receipt finalization) against a mock upstream.
+//! In-process consult, forwarding, transform, metering, and finalization tests.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -71,10 +68,7 @@ impl UpstreamBackend for MockUpstream {
     }
 }
 
-// A mock upstream that classifies a route as attested by its `tee-` prefix and
-// records every route it was actually asked to forward to. Classification
-// happens in `prepare`, as the real config-driven router does it, so a route
-// the ACI constraint rejects can be told apart from one never reached.
+// Classifies `tee-` routes and records actual forwards.
 struct TeeAwareUpstream {
     forwarded: Arc<Mutex<Vec<String>>>,
     status: u16,
@@ -119,9 +113,7 @@ impl UpstreamBackend for TeeAwareUpstream {
     ) -> Result<UpstreamResponse, UpstreamError> {
         self.forward_prepared(req).await
     }
-    // Streaming resolves through `forward_stream_prepared`, not
-    // `forward_prepared`, so it needs its own recording hook — otherwise a
-    // streaming test cannot tell "never forwarded" from "not observed".
+    // Streaming needs its own forwarding record.
     async fn forward_stream_prepared(
         &self,
         req: PreparedUpstreamRequest,
@@ -422,6 +414,17 @@ async fn control_unavailable_fails_closed() {
     assert_eq!(status, 503);
     assert_eq!(body["error"]["type"], json!("service_unavailable"));
     assert_eq!(body["error"]["message"], json!("control plane unavailable"));
+}
+
+#[tokio::test]
+async fn reasoning_conflict_precedes_control() {
+    let mw = middleware("http://127.0.0.1:1".to_string());
+    let service = build_service();
+    let mut input = chat_input();
+    input.params["reasoning"] = json!({"effort":"high"});
+    input.params["reasoning_effort"] = json!("low");
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 400);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- Normalize unified and legacy Chat Completions reasoning controls before `/consult/pre`, rejecting malformed or contradictory inputs with a gateway-owned 400.
- Send only canonical route-relevant reasoning requirements to control and consume each candidate's `effectiveReasoning` policy.
- Translate effective settings for managed OpenAI-compatible, vLLM, and SGLang routes without forwarding contradictory aliases or silently dropping unsupported budgets.
- Enforce `reasoning.exclude` and `include_reasoning: false` for buffered and SSE responses while preserving reasoning-token usage.
- Keep the exact received request bytes unchanged for receipt generation.

## Why

The gateway forwarded legacy `reasoning_effort` but dropped the unified `reasoning` object. It also had no pre-routing conflict validation, candidate-specific effective policy, or gateway-level response exclusion guarantee. Behavior therefore depended on the caller's spelling and selected deployment.

This implements the gateway contract needed by the capability-aware control-plane companion change without hardcoding models or providers.

## Impact

Requests without reasoning controls continue to preserve model defaults. Invalid controls fail before control or upstream calls. Candidate shaping is applied consistently across initial and failover attempts.

Unrelated pre-existing code documentation is preserved.

## Validation

- `cargo test --locked --quiet` — 434 passed, 5 environment-dependent tests ignored
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

Closes #110

Companion: https://github.com/redpill-ai/private-ai-control/issues/35