### PR TITLE
fix: 404 routing semantics — answer unroutable models with 404, fail over provider 404s

### DIFF
--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -31,10 +31,21 @@ use std::time::{Duration, Instant};
 // Provider statuses that make this candidate worth abandoning for the next one.
 // Beyond the transient 429/5xx signals, an auth/account failure specific to this
 // provider — 401 (invalid key), 402 (out of credit), 403 (key lacks access) — can
-// still be served by a sibling candidate on a different account. Request-level 4xx
-// (400/404/422) are excluded: they would fail identically on every candidate.
+// still be served by a sibling candidate on a different account.
+//
+// 404 belongs here too, and is the one that looks like it shouldn't. It reads as
+// a request-level fault, but a provider answering 404 is saying "I do not serve
+// this model" — a statement about that provider's catalog, not about the
+// request. Candidates are different vendors with different catalogs, and the
+// model is in OURS or the control plane would not have offered a route, so a
+// sibling is exactly what should be tried. Suppliers retiring a model is routine
+// and permanent, and without this the request dies on the one node that dropped
+// it while healthy siblings stand by.
+//
+// 400/422 stay excluded: those describe the request body, which every candidate
+// receives identically.
 fn is_retryable_provider_status(status: u16) -> bool {
-    matches!(status, 401 | 402 | 403 | 429 | 500 | 502 | 503 | 504)
+    matches!(status, 401 | 402 | 403 | 404 | 429 | 500 | 502 | 503 | 504)
 }
 
 // Whether to abandon this candidate and try the next. The status must be a
@@ -892,16 +903,17 @@ mod tests {
 
     #[test]
     fn retryable_covers_transient_and_account_specific_statuses() {
-        // Transient provider trouble (429/5xx) plus auth/account failures
-        // (401 invalid key, 402 out of credit, 403 no access) fail over.
-        for status in [401, 402, 403, 429, 500, 502, 503, 504] {
+        // Transient provider trouble (429/5xx), auth/account failures (401
+        // invalid key, 402 out of credit, 403 no access), and 404 (this provider
+        // dropped the model; a sibling's catalog may still have it) fail over.
+        for status in [401, 402, 403, 404, 429, 500, 502, 503, 504] {
             assert!(
                 is_retryable_provider_status(status),
                 "{status} should retry"
             );
         }
         // Request-level errors would fail identically on every candidate.
-        for status in [400, 404, 422] {
+        for status in [400, 422] {
             assert!(
                 !is_retryable_provider_status(status),
                 "{status} should not retry"

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -372,13 +372,16 @@ pub async fn run(
 
     let candidates = consult.candidates.clone().unwrap_or_default();
     if candidates.is_empty() {
+        // Not found, not malformed — 404 is what the `model_not_found` body has
+        // always said, and what an OpenAI-compatible client expects for a model
+        // it cannot reach.
         let message = format!("no route available for model {}", model.unwrap_or("(none)"));
-        if should_log_failure(400) {
+        if should_log_failure(404) {
             log_generated_outcome(
                 &request_id,
                 model.unwrap_or(""),
                 "no_route",
-                400,
+                404,
                 0,
                 "",
                 0,
@@ -387,7 +390,7 @@ pub async fn run(
             );
         }
         let body = errors::envelope_bytes(surface, "model_not_found", &message, Some(&request_id));
-        return finalize_generated(400, body, &[], e2ee, outcome_ctx);
+        return finalize_generated(404, body, &[], e2ee, outcome_ctx);
     }
 
     // Shape one body per candidate (typed per-route contract).

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -1166,7 +1166,7 @@ async fn empty_candidates_returns_model_not_found() {
 
     let (status, _, body) =
         response_parts(mw.handle_completion(&service, chat_input()).await).await;
-    assert_eq!(status, 400);
+    assert_eq!(status, 404);
     assert_eq!(body["error"]["type"], json!("model_not_found"));
     assert!(body["error"]["message"]
         .as_str()


### PR DESCRIPTION
Two independent fixes to how a 404 is produced and consumed. Both were found while diagnosing a live incident where a provider kept answering a model it no longer served.

## 1. An unroutable model answers 404, not 400

The empty-candidates arm has always sent a `model_not_found` body while pairing it with a **400**. The two disagree: 400 says the request was malformed, and nothing about it is — the model simply resolves to no route. A client branching on the status is told "fix your request"; a client branching on the type is told "no such model".

404 is what every OpenAI-compatible client already expects here, and it is what the body has been claiming all along, so **only the number changes** — the `model_not_found` type is deliberately kept (it is more specific than the generic `not_found_error`, and changing it would break clients that branch on it).

The arm still does not distinguish "no such model" from "the model exists but every node is down". The candidate list is empty either way and the gateway cannot tell them apart. Resolving that belongs in the control plane, which knows the catalog — and is not worth a lookup for a case that needs an operator regardless. Worth stating because the tempting fix here is a 502, which would answer every mistyped model name with "our service is down": the common cause of an empty list is a model we do not serve, so a 5xx would inflate our error rate continuously to be honest about a rare outage.

## 2. A provider 404 now fails over

**This is the consequential one.** A supplier retiring a model is routine, and the 404 it starts returning is permanent — it never decays the way a 429 or a 5xx does. Excluding 404 from failover stranded every request on the one node that had dropped the model while siblings that still served it sat unused.

Nothing recovered on its own, because a client 4xx is also outside the uptime denominator and is graded `ignored` by the breaker — so the node kept its health score and kept winning primary traffic, returning 404s until a human noticed. The only existing defence is an offline catalog diff someone has to go and run.

The old rule read:

> Request-level 4xx (400/404/422) are excluded: they would fail identically on every candidate.

That holds for 400 and 422, which describe the **request body** — every candidate receives the same bytes. It does not hold for 404: a provider answering 404 is describing **its own catalog**, and candidates are different vendors with different catalogs. By the time we are forwarding, the model is in *our* catalog or the control plane would not have offered a route, so a 404 from one provider is precisely the signal to try the next.

### Deliberately not included

The node is still not penalised for a 404. Moving it from `ignored` to a hard failure in the breaker is a one-line change but a separate call: the evidence that a 404 is provider-attributable only exists *after* this change, and retuning the breaker wants replay analysis rather than a drive-by edit next to a failover fix. Until then a dropped model costs every request one extra hop — which is a large improvement on costing it the whole request.

## Verification

- 438 tests pass, `cargo clippy --all-targets` clean. **Each commit was checked out and tested standalone.**
- `empty_candidates_returns_model_not_found` updated to assert 404; the `model_not_found` type assertion is unchanged, which is the point.
- `retryable_covers_transient_and_account_specific_statuses` moves 404 from the non-retryable list to the retryable one. No separate test was added — 404 is now an ordinary member of that set and the reasoning lives in the code comment it contradicts.