### PR TITLE
Route reasoning parameters by candidate format

### DIFF
--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -13,7 +13,11 @@ endpoints below).
   `keys` is non-empty it requires the request's `apiKeyHash` to be in the list
   (empty list = anonymous allowed). Reasoning-aware routing is optional and this
   minimal example does not implement it. A candidate can return
-  `effectiveReasoning` to override the normalized request.
+  `effectiveReasoning` to override the normalized request. Candidates can set
+  `reasoningFormat` to `"reasoning_effort"` or `"reasoning"` to select the
+  upstream parameter dialect explicitly. When omitted, the gateway preserves
+  its legacy behavior: managed routes use nested `reasoning`, while SGLang and
+  vLLM routes use `reasoning_effort`.
 - `POST /consult/post` — accepts the usage report and drops it (no billing).
 
 No database; configuration only.

--- a/examples/control-plane/src/config.ts
+++ b/examples/control-plane/src/config.ts
@@ -17,6 +17,8 @@ export interface RouteCandidate {
   format: Format;
   /** Self-hosted serving engine (sglang/vllm); absent for managed APIs. */
   engine?: 'sglang' | 'vllm';
+  /** Explicit upstream reasoning parameter dialect. */
+  reasoningFormat?: 'reasoning_effort' | 'reasoning';
 }
 
 export interface ModelEntry {

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -13,7 +13,9 @@
 use serde_json::{json, Value};
 
 use super::reasoning::validate_effective;
-use super::types::{Engine, ProviderFormat, ReasoningConfig, ReasoningEffort, RouteCandidate};
+use super::types::{
+    Engine, ProviderFormat, ReasoningConfig, ReasoningEffort, ReasoningFormat, RouteCandidate,
+};
 
 const PDF_MIME: &str = "application/pdf";
 const TXT_MIME: &str = "text/plain";
@@ -205,11 +207,18 @@ fn candidate_params(
             candidate.route_id
         ))
     })?;
-    match (candidate.format, candidate.engine) {
-        (ProviderFormat::Openai, None) => {
+    let reasoning_format = candidate.reasoning_format.unwrap_or_else(|| {
+        if candidate.engine.is_some() {
+            ReasoningFormat::ReasoningEffort
+        } else {
+            ReasoningFormat::Reasoning
+        }
+    });
+    match (candidate.format, reasoning_format) {
+        (ProviderFormat::Openai, ReasoningFormat::Reasoning) => {
             object.insert("reasoning".to_string(), reasoning_object(effective));
         }
-        (ProviderFormat::Openai, Some(_)) => {
+        (ProviderFormat::Openai, ReasoningFormat::ReasoningEffort) => {
             if effective.max_tokens.is_some() {
                 return invalid_reasoning(candidate, "cannot represent max_tokens");
             }
@@ -1279,18 +1288,21 @@ mod tests {
                 route_id: "openai:a".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
+                reasoning_format: Some(ReasoningFormat::Reasoning),
                 effective_reasoning: reasoning(ReasoningEffort::High),
             },
             RouteCandidate {
                 route_id: "openai:b".into(),
                 format: ProviderFormat::Openai,
                 engine: Some(Engine::Sglang),
+                reasoning_format: None,
                 effective_reasoning: reasoning(ReasoningEffort::Minimal),
             },
             RouteCandidate {
                 route_id: "openai:c".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
+                reasoning_format: None,
                 effective_reasoning: None,
             },
         ];
@@ -1304,8 +1316,67 @@ mod tests {
         .unwrap();
         assert_eq!(bodies.len(), 3);
         assert_eq!(bodies[0].1["reasoning"]["effort"], "high");
+        assert!(bodies[0].1.get("reasoning_effort").is_none());
         assert_eq!(bodies[1].1["reasoning_effort"], "low");
+        assert!(bodies[1].1.get("reasoning").is_none());
         assert_eq!(bodies[2].1["reasoning"]["effort"], "medium");
+        assert!(bodies[2].1.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn explicit_candidate_reasoning_format_uses_openai_parameter() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning_effort": "high"
+        });
+        let (params, requested, _) =
+            crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+        let candidate: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "openai:gpt-5",
+            "format": "openai",
+            "reasoningFormat": "reasoning_effort"
+        }))
+        .unwrap();
+
+        let bodies = build_candidates(
+            &params,
+            Endpoint::ChatComplete,
+            &[candidate],
+            requested.as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(bodies[0].1["reasoning_effort"], "high");
+        assert!(bodies[0].1.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn managed_candidate_without_dialect_preserves_reasoning_budget() {
+        let request = json!({
+            "model": "m",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning": { "max_tokens": 1000 }
+        });
+        let (params, requested, _) =
+            crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+        let candidate: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "compatible:m",
+            "format": "openai"
+        }))
+        .unwrap();
+
+        let bodies = build_candidates(
+            &params,
+            Endpoint::ChatComplete,
+            &[candidate],
+            requested.as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(bodies[0].1["reasoning"]["max_tokens"], 1000);
+        assert_eq!(bodies[0].1["reasoning"]["enabled"], true);
+        assert!(bodies[0].1.get("reasoning_effort").is_none());
     }
 
     #[test]
@@ -1327,12 +1398,14 @@ mod tests {
                 route_id: "openai:m".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
+                reasoning_format: None,
                 effective_reasoning: None,
             },
             RouteCandidate {
                 route_id: "anthropic:m".into(),
                 format: ProviderFormat::Anthropic,
                 engine: None,
+                reasoning_format: None,
                 effective_reasoning: None,
             },
         ];

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -28,6 +28,19 @@ pub enum Engine {
     Vllm,
 }
 
+/// Upstream parameter shape used for chat reasoning controls.
+///
+/// OpenAI Chat Completions uses `reasoning_effort`. Some OpenAI-compatible
+/// providers instead expose a richer nested `reasoning` object, so candidates
+/// can opt into that dialect explicitly.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub enum ReasoningFormat {
+    #[serde(rename = "reasoning_effort")]
+    ReasoningEffort,
+    #[serde(rename = "reasoning")]
+    Reasoning,
+}
+
 /// Canonical public/control reasoning effort.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -88,6 +101,11 @@ pub struct RouteCandidate {
     /// server. Absent for managed APIs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine: Option<Engine>,
+    /// Parameter dialect accepted by this route. When omitted, the gateway
+    /// preserves the legacy inference: managed routes use `reasoning`, while
+    /// self-hosted engines use `reasoning_effort`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_format: Option<ReasoningFormat>,
     /// Request-specific setting selected after capability filtering.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effective_reasoning: Option<ReasoningConfig>,


### PR DESCRIPTION
## Summary

- add a candidate-level reasoningFormat contract
- emit reasoning_effort for routes that require the OpenAI Chat Completions field
- retain nested reasoning for compatible providers and reasoning budgets
- preserve the legacy engine-based fallback when control metadata is absent
- document the contract in the example control plane

Companion control-plane change: https://github.com/redpill-ai/private-ai-control/pull/40

## Testing

- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check