### PR TITLE
Inject Phala request priority from user tier

### DIFF
--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -28,7 +28,7 @@ use crate::aggregator::service::{
 use super::control::ControlClient;
 use super::errors::{self, Surface};
 use super::reasoning;
-use super::request_transform::{build_candidates, Endpoint};
+use super::request_transform::{build_candidates_with_user_tier, Endpoint};
 use super::sse::{KeepAliveStream, MeterStream, StreamReport};
 use super::stream_transform::{SseTransformStream, StreamTransform};
 use super::types::{ErrorSource, PostReport, ProviderFormat, SpendMode};
@@ -402,11 +402,12 @@ pub async fn run(
     }
 
     // Shape one body per candidate (typed per-route contract).
-    let shaped = match build_candidates(
+    let shaped = match build_candidates_with_user_tier(
         &params,
         endpoint,
         &candidates,
         reasoning_requirements.as_ref(),
+        consult.user_tier.as_deref(),
     ) {
         Ok(shaped) => shaped,
         Err(err) => {

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -162,20 +162,46 @@ pub fn build_candidates(
     candidates: &[RouteCandidate],
     requested_reasoning: Option<&ReasoningConfig>,
 ) -> Result<Vec<(String, Value)>, TransformError> {
+    build_candidates_with_user_tier(params, endpoint, candidates, requested_reasoning, None)
+}
+
+/// Shape candidate bodies and apply tier-derived request priority to Phala routes.
+pub(super) fn build_candidates_with_user_tier(
+    params: &Value,
+    endpoint: Endpoint,
+    candidates: &[RouteCandidate],
+    requested_reasoning: Option<&ReasoningConfig>,
+    user_tier: Option<&str>,
+) -> Result<Vec<(String, Value)>, TransformError> {
     candidates
         .iter()
         .map(|candidate| {
             let candidate_params =
                 candidate_params(params, endpoint, candidate, requested_reasoning)?;
-            let body = transform_to_provider_request(
+            let mut body = transform_to_provider_request(
                 candidate.format,
                 &candidate_params,
                 endpoint,
                 candidate.engine,
             )?;
+            inject_phala_priority(&mut body, candidate, user_tier);
             Ok((candidate.route_id.clone(), body))
         })
         .collect()
+}
+
+fn inject_phala_priority(body: &mut Value, candidate: &RouteCandidate, user_tier: Option<&str>) {
+    let priority = match user_tier {
+        Some("premium") => -100,
+        _ => 0,
+    };
+    let is_phala = matches!(candidate.route_id.split_once(':'), Some(("phala", _)));
+    if !is_phala {
+        return;
+    }
+    if let Some(object) = body.as_object_mut() {
+        object.insert("priority".to_string(), Value::from(priority));
+    }
 }
 
 fn candidate_params(


### PR DESCRIPTION
## Summary

- inject a top-level `priority` after provider request shaping for `phala` candidates
- map `premium` to `-100` and every non-premium or missing tier to `0`
- override any client-supplied `priority`
- intentionally apply the rule by provider only, without `format` or `engine` restrictions
- keep the PR implementation-only; no test files or new `#[cfg(test)]` code are included

## Runtime assumptions

- vLLM backends must use priority scheduling for non-zero priority values
- SGLang backends must enable priority scheduling with lower values scheduled first so `-100` outranks `0`

## Validation

Executed on CVM `37f77da9-58ed-4c28-81e0-63fcad32f2e1` in a fresh `rust:1.94-bookworm` container.

A temporary remote-only test overlay verified:

- `premium` overrides a client priority with `-100`
- `basic`, missing, empty, and unknown tiers override with `0`
- the rule applies across OpenAI/Anthropic shaping and vLLM/SGLang engine metadata
- non-Phala candidates are unchanged
- premium and missing-tier values reach the forwarded request body

The overlay was removed before the final implementation-only validation:

- `cargo fmt --all --check`
- `cargo test --locked --all-targets`: 468 passed, 0 failed, 5 ignored
- `cargo build --locked --release`
- final diff audit: only `src/middleware/completion.rs` and `src/middleware/request_transform.rs`

Remote evidence:

- `/home/root/private-ai-gateway-tier-priority-b7ca97a-r4-test.log` (`39e00b2ea9fabdd9e84519eee381d4cd1dbf8790724745c9625b6c85cf2be313`)
- `/home/root/private-ai-gateway-tier-priority-b7ca97a-r4-final-tests.log` (`52eb9680b3649099143386360c1826d9756a8e26c1467e2089fa68014257e1e8`)
- `/home/root/private-ai-gateway-tier-priority-b7ca97a-r4-final-release.log` (`452fd91f305a229cfeb824a2dff4a7960c7eebf478ecb321776ebdab3684dc5f`)