### PR TITLE
Delegate structured-output reasoning policy to control

### DIFF
--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -711,12 +711,12 @@ pub async fn run(
                 0 => None,
                 ms => Some(Duration::from_millis(ms)),
             };
-            // Order: provider stream (drafts response.received) -> format/
-            // compatibility normalization -> response visibility -> meter/cost
-            // -> keep-alive -> finalizer (hashes response.returned). Metering sits
-            // inside the keep-alive so it only ever buffers real upstream SSE
-            // bytes; heartbeat comments are injected downstream and never enter
-            // its line reassembly.
+            // Order: provider stream (drafts response.received) -> format
+            // transform (if cross-format) -> response visibility -> meter/cost ->
+            // keep-alive -> finalizer (hashes response.returned). Same-format
+            // streaming skips only the format transform. Metering sits inside the
+            // keep-alive so it only ever buffers real upstream SSE bytes; heartbeat
+            // comments are injected downstream and never enter its line reassembly.
             let response_header_map = response_headers(&forward.upstream_headers, &content_type);
             let selected_format = candidates
                 .iter()

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -316,6 +316,10 @@ pub async fn run(
     // Forward the routing block verbatim; the control plane validates it. Parsing
     // it here would silently drop a caller's restrictions on a malformed field.
     let provider = params.get("provider");
+    let structured_output = endpoint == Endpoint::ChatComplete
+        && params
+            .get("response_format")
+            .is_some_and(|value| !value.is_null());
 
     let consult = control
         .consult_pre(
@@ -323,6 +327,7 @@ pub async fn run(
             api_key_hash.as_deref(),
             provider,
             reasoning_requirements.as_ref(),
+            structured_output,
             tee_only,
         )
         .await;

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -706,12 +706,12 @@ pub async fn run(
                 0 => None,
                 ms => Some(Duration::from_millis(ms)),
             };
-            // Order: provider stream (drafts response.received) -> format
-            // transform (if cross-format) -> response visibility -> meter/cost ->
-            // keep-alive -> finalizer (hashes response.returned). Same-format
-            // streaming skips only the format transform. Metering sits inside the
-            // keep-alive so it only ever buffers real upstream SSE bytes; heartbeat
-            // comments are injected downstream and never enter its line reassembly.
+            // Order: provider stream (drafts response.received) -> format/
+            // compatibility normalization -> response visibility -> meter/cost
+            // -> keep-alive -> finalizer (hashes response.returned). Metering sits
+            // inside the keep-alive so it only ever buffers real upstream SSE
+            // bytes; heartbeat comments are injected downstream and never enter
+            // its line reassembly.
             let response_header_map = response_headers(&forward.upstream_headers, &content_type);
             let selected_format = candidates
                 .iter()

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -46,6 +46,29 @@ pub struct CatalogResponse {
     pub body: Vec<u8>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreConsultBody<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    api_key_hash: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+    // Forwarded verbatim so the control plane validates it (a malformed block
+    // must not silently drop the caller's routing restrictions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<&'a Value>,
+    // Canonical route-relevant controls only. Response visibility stays local.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<&'a ReasoningConfig>,
+    // Content-blind response-shape signal. The schema remains local.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    structured_output: bool,
+    // TEE-only host: the control plane 404s a non-TEE model. Only sent when set
+    // so the metadata-minimal payload is unchanged off these hosts.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    tee: bool,
+}
+
 #[derive(Clone)]
 pub struct ControlClient {
     client: reqwest::Client,
@@ -130,7 +153,7 @@ impl ControlClient {
     }
 
     /// Pre-request consult:
-    /// `{ apiKeyHash?, model?, provider?, reasoning? }` -> decision.
+    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput? }` -> decision.
     /// Fails closed — any non-200, invalid JSON, timeout, or transport error
     /// returns a 503 denial.
     pub async fn consult_pre(
@@ -139,34 +162,15 @@ impl ControlClient {
         api_key_hash: Option<&str>,
         provider: Option<&Value>,
         reasoning: Option<&ReasoningConfig>,
+        structured_output: bool,
         tee_only: bool,
     ) -> PreConsult {
-        #[derive(Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Body<'a> {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            api_key_hash: Option<&'a str>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            model: Option<&'a str>,
-            // Forwarded verbatim so the control plane validates it (a malformed
-            // block must not silently drop the caller's routing restrictions).
-            #[serde(skip_serializing_if = "Option::is_none")]
-            provider: Option<&'a Value>,
-            // Canonical route-relevant controls only. Response visibility stays
-            // local to the gateway.
-            #[serde(skip_serializing_if = "Option::is_none")]
-            reasoning: Option<&'a ReasoningConfig>,
-            // TEE-only host: the control plane 404s a non-TEE model. Only sent
-            // when set so the metadata-minimal payload is unchanged off these hosts.
-            #[serde(skip_serializing_if = "std::ops::Not::not")]
-            tee: bool,
-        }
-
-        let body = Body {
+        let body = PreConsultBody {
             api_key_hash,
             model,
             provider,
             reasoning,
+            structured_output,
             tee: tee_only,
         };
         let build = || {
@@ -300,12 +304,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn pre_consult_body_sends_only_the_structured_output_signal() {
+        let reasoning = ReasoningConfig {
+            effort: Some(crate::middleware::types::ReasoningEffort::High),
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let body = serde_json::to_value(PreConsultBody {
+            api_key_hash: None,
+            model: Some("m"),
+            provider: None,
+            reasoning: Some(&reasoning),
+            structured_output: true,
+            tee: false,
+        })
+        .unwrap();
+
+        assert_eq!(body["structuredOutput"], true);
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert!(body.get("responseFormat").is_none());
+        assert!(body.get("tee").is_none());
+    }
+
     #[tokio::test]
     async fn consult_pre_fails_closed_on_transport_error() {
         // Port 1 is unroutable in practice; the request fails fast within the
         // configured timeout and must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
-        let consult = client.consult_pre(Some("m"), None, None, None, false).await;
+        let consult = client
+            .consult_pre(Some("m"), None, None, None, false, false)
+            .await;
         assert!(!consult.allow);
         assert_eq!(consult.status, Some(503));
         assert_eq!(

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -46,29 +46,6 @@ pub struct CatalogResponse {
     pub body: Vec<u8>,
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PreConsultBody<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    api_key_hash: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    model: Option<&'a str>,
-    // Forwarded verbatim so the control plane validates it (a malformed block
-    // must not silently drop the caller's routing restrictions).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    provider: Option<&'a Value>,
-    // Canonical route-relevant controls only. Response visibility stays local.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning: Option<&'a ReasoningConfig>,
-    // Content-blind response-shape signal. The schema remains local.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    structured_output: bool,
-    // TEE-only host: the control plane 404s a non-TEE model. Only sent when set
-    // so the metadata-minimal payload is unchanged off these hosts.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    tee: bool,
-}
-
 #[derive(Clone)]
 pub struct ControlClient {
     client: reqwest::Client,
@@ -153,7 +130,7 @@ impl ControlClient {
     }
 
     /// Pre-request consult:
-    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput? }` -> decision.
+    /// `{ apiKeyHash?, model?, provider?, reasoningRequested?, structuredOutput? }` -> decision.
     /// Fails closed — any non-200, invalid JSON, timeout, or transport error
     /// returns a 503 denial.
     pub async fn consult_pre(
@@ -165,11 +142,33 @@ impl ControlClient {
         structured_output: bool,
         tee_only: bool,
     ) -> PreConsult {
-        let body = PreConsultBody {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            api_key_hash: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            model: Option<&'a str>,
+            // Forwarded verbatim so the control plane validates it (a malformed
+            // block must not silently drop the caller's routing restrictions).
+            #[serde(skip_serializing_if = "Option::is_none")]
+            provider: Option<&'a Value>,
+            // Content-blind request-shape signals; their values remain local.
+            #[serde(skip_serializing_if = "std::ops::Not::not")]
+            reasoning_requested: bool,
+            #[serde(skip_serializing_if = "std::ops::Not::not")]
+            structured_output: bool,
+            // TEE-only host: the control plane 404s a non-TEE model. Only sent
+            // when set so the metadata-minimal payload is unchanged off these hosts.
+            #[serde(skip_serializing_if = "std::ops::Not::not")]
+            tee: bool,
+        }
+
+        let body = Body {
             api_key_hash,
             model,
             provider,
-            reasoning,
+            reasoning_requested: reasoning.is_some(),
             structured_output,
             tee: tee_only,
         };
@@ -302,29 +301,6 @@ mod tests {
             client.url("/consult/pre"),
             "http://control.example/consult/pre"
         );
-    }
-
-    #[test]
-    fn pre_consult_body_sends_only_the_structured_output_signal() {
-        let reasoning = ReasoningConfig {
-            effort: Some(crate::middleware::types::ReasoningEffort::High),
-            enabled: Some(true),
-            ..Default::default()
-        };
-        let body = serde_json::to_value(PreConsultBody {
-            api_key_hash: None,
-            model: Some("m"),
-            provider: None,
-            reasoning: Some(&reasoning),
-            structured_output: true,
-            tee: false,
-        })
-        .unwrap();
-
-        assert_eq!(body["structuredOutput"], true);
-        assert_eq!(body["reasoning"]["effort"], "high");
-        assert!(body.get("responseFormat").is_none());
-        assert!(body.get("tee").is_none());
     }
 
     #[tokio::test]

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -130,7 +130,7 @@ impl ControlClient {
     }
 
     /// Pre-request consult:
-    /// `{ apiKeyHash?, model?, provider?, reasoningRequested?, structuredOutput? }` -> decision.
+    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput? }` -> decision.
     /// Fails closed — any non-200, invalid JSON, timeout, or transport error
     /// returns a 503 denial.
     pub async fn consult_pre(
@@ -153,9 +153,10 @@ impl ControlClient {
             // block must not silently drop the caller's routing restrictions).
             #[serde(skip_serializing_if = "Option::is_none")]
             provider: Option<&'a Value>,
-            // Content-blind request-shape signals; their values remain local.
-            #[serde(skip_serializing_if = "std::ops::Not::not")]
-            reasoning_requested: bool,
+            // Canonical route-relevant controls only. Response visibility stays local.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            reasoning: Option<&'a ReasoningConfig>,
+            // Content-blind response-shape signal. The schema remains local.
             #[serde(skip_serializing_if = "std::ops::Not::not")]
             structured_output: bool,
             // TEE-only host: the control plane 404s a non-TEE model. Only sent
@@ -168,7 +169,7 @@ impl ControlClient {
             api_key_hash,
             model,
             provider,
-            reasoning_requested: reasoning.is_some(),
+            reasoning,
             structured_output,
             tee: tee_only,
         };

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -225,12 +225,11 @@ fn candidate_params(
             if effective.max_tokens.is_some() {
                 return invalid_reasoning(candidate, "cannot represent max_tokens");
             }
-            let effort = effective
-                .effort
-                .or((effective.enabled == Some(false)).then_some(ReasoningEffort::None));
-            let Some(effort) = effort else {
-                return invalid_reasoning(candidate, "cannot represent enabled without effort");
-            };
+            let effort = effective.effort.unwrap_or_else(|| match effective.enabled {
+                Some(true) => ReasoningEffort::Medium,
+                Some(false) => ReasoningEffort::None,
+                None => unreachable!("validated reasoning has an effort, budget, or enabled flag"),
+            });
             object.insert(
                 "reasoning_effort".to_string(),
                 Value::String(effort.as_str().to_string()),
@@ -1338,11 +1337,11 @@ mod tests {
     }
 
     #[test]
-    fn explicit_candidate_reasoning_format_uses_openai_parameter() {
+    fn explicit_candidate_reasoning_format_maps_enabled_to_openai_parameter() {
         let request = json!({
             "model": "gpt-5",
             "messages": [{ "role": "user", "content": "hi" }],
-            "reasoning_effort": "high"
+            "reasoning": { "enabled": true }
         });
         let (params, requested, _) =
             crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
@@ -1361,7 +1360,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(bodies[0].1["reasoning_effort"], "high");
+        assert_eq!(bodies[0].1["reasoning_effort"], "medium");
         assert!(bodies[0].1.get("reasoning").is_none());
     }
 

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1391,6 +1391,21 @@ mod tests {
         assert_eq!(bodies[0].1["reasoning"]["max_tokens"], 1000);
         assert_eq!(bodies[0].1["reasoning"]["enabled"], true);
         assert!(bodies[0].1.get("reasoning_effort").is_none());
+
+        let effort_candidate: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "self-hosted:m",
+            "format": "openai",
+            "engine": "sglang"
+        }))
+        .unwrap();
+        let error = build_candidates(
+            &params,
+            Endpoint::ChatComplete,
+            &[effort_candidate],
+            requested.as_ref(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot represent max_tokens"));
     }
 
     #[test]

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -150,6 +150,7 @@ pub fn transform_to_provider_request(
 ) -> Result<Value, TransformError> {
     let mut params = params.clone();
     inject_stream_options(&mut params);
+    inject_sglang_structured_output_reasoning_default(&mut params, endpoint, engine);
     let config = select_config(format, endpoint, engine)?;
     transform_using_provider_config(&config, &params)
 }
@@ -194,6 +195,9 @@ fn candidate_params(
     for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
         object.remove(key);
     }
+    // The control plane's route-specific resolution is authoritative. Fall back
+    // to caller intent only when control did not resolve it; if both are absent,
+    // engine-specific shaping may install a safe default below.
     let Some(effective) = candidate
         .effective_reasoning
         .as_ref()
@@ -257,6 +261,28 @@ fn reasoning_object(config: &ReasoningConfig) -> Value {
         object.insert("enabled".into(), enabled.into());
     }
     Value::Object(object)
+}
+
+fn inject_sglang_structured_output_reasoning_default(
+    params: &mut Value,
+    endpoint: Endpoint,
+    engine: Option<Engine>,
+) {
+    if endpoint != Endpoint::ChatComplete || engine != Some(Engine::Sglang) {
+        return;
+    }
+    let Some(object) = params.as_object_mut() else {
+        return;
+    };
+    let has_structured_output = object
+        .get("response_format")
+        .is_some_and(|value| !value.is_null());
+    if has_structured_output
+        && !object.contains_key("reasoning")
+        && !object.contains_key("reasoning_effort")
+    {
+        object.insert("reasoning_effort".into(), json!("none"));
+    }
 }
 
 // ── Engine ───────────────────────────────────────────────────────────────────
@@ -1238,6 +1264,90 @@ mod tests {
         );
         // Managed OpenAI chatComplete has no top_k param, so it is dropped.
         assert!(managed.get("top_k").is_none());
+    }
+
+    #[test]
+    fn sglang_structured_output_defaults_reasoning_off() {
+        let params = json!({
+            "model": "m",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "response_format": { "type": "json_object" }
+        });
+        let sglang = chat(ProviderFormat::Openai, params.clone(), Some(Engine::Sglang));
+        assert_eq!(sglang["reasoning_effort"], "none");
+
+        let explicit = chat(
+            ProviderFormat::Openai,
+            json!({
+                "model": "m",
+                "messages": [],
+                "response_format": { "type": "json_object" },
+                "reasoning_effort": "high"
+            }),
+            Some(Engine::Sglang),
+        );
+        assert_eq!(explicit["reasoning_effort"], "high");
+
+        let vllm = chat(ProviderFormat::Openai, params, Some(Engine::Vllm));
+        assert!(vllm.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn sglang_structured_output_reasoning_precedence_is_control_then_caller_then_default() {
+        let request = json!({
+            "model": "m",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "response_format": { "type": "json_schema", "json_schema": {} }
+        });
+        let candidate: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "sglang:m",
+            "format": "openai",
+            "engine": "sglang",
+            "effectiveReasoning": { "effort": "high", "enabled": true }
+        }))
+        .unwrap();
+
+        let controlled = build_candidates(
+            &request,
+            Endpoint::ChatComplete,
+            std::slice::from_ref(&candidate),
+            None,
+        )
+        .unwrap();
+        assert_eq!(controlled[0].1["reasoning_effort"], "high");
+
+        let explicit_reasoning = ReasoningConfig {
+            effort: Some(ReasoningEffort::Medium),
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let explicit = build_candidates(
+            &request,
+            Endpoint::ChatComplete,
+            &[candidate],
+            Some(&explicit_reasoning),
+        )
+        .unwrap();
+        assert_eq!(explicit[0].1["reasoning_effort"], "high");
+
+        let uncontrolled: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "sglang:m",
+            "format": "openai",
+            "engine": "sglang"
+        }))
+        .unwrap();
+        let caller_controlled = build_candidates(
+            &request,
+            Endpoint::ChatComplete,
+            std::slice::from_ref(&uncontrolled),
+            Some(&explicit_reasoning),
+        )
+        .unwrap();
+        assert_eq!(caller_controlled[0].1["reasoning_effort"], "medium");
+
+        let defaulted =
+            build_candidates(&request, Endpoint::ChatComplete, &[uncontrolled], None).unwrap();
+        assert_eq!(defaulted[0].1["reasoning_effort"], "none");
     }
 
     #[test]

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1241,91 +1241,17 @@ mod tests {
         );
         // Managed OpenAI chatComplete has no top_k param, so it is dropped.
         assert!(managed.get("top_k").is_none());
-    }
 
-    #[test]
-    fn engine_does_not_infer_a_structured_output_reasoning_default() {
-        let params = json!({
-            "model": "m",
-            "messages": [{ "role": "user", "content": "hi" }],
-            "response_format": { "type": "json_object" }
-        });
-        let sglang = chat(ProviderFormat::Openai, params.clone(), Some(Engine::Sglang));
-        assert!(sglang.get("reasoning_effort").is_none());
-
-        let explicit = chat(
+        let structured = chat(
             ProviderFormat::Openai,
             json!({
                 "model": "m",
                 "messages": [],
-                "response_format": { "type": "json_object" },
-                "reasoning_effort": "high"
+                "response_format": { "type": "json_object" }
             }),
             Some(Engine::Sglang),
         );
-        assert_eq!(explicit["reasoning_effort"], "high");
-
-        let vllm = chat(ProviderFormat::Openai, params, Some(Engine::Vllm));
-        assert!(vllm.get("reasoning_effort").is_none());
-    }
-
-    #[test]
-    fn structured_output_reasoning_precedence_is_control_then_caller_then_absence() {
-        let request = json!({
-            "model": "m",
-            "messages": [{ "role": "user", "content": "hi" }],
-            "response_format": { "type": "json_schema", "json_schema": {} }
-        });
-        let candidate: RouteCandidate = serde_json::from_value(json!({
-            "routeId": "sglang:m",
-            "format": "openai",
-            "engine": "sglang",
-            "effectiveReasoning": { "effort": "high", "enabled": true }
-        }))
-        .unwrap();
-
-        let controlled = build_candidates(
-            &request,
-            Endpoint::ChatComplete,
-            std::slice::from_ref(&candidate),
-            None,
-        )
-        .unwrap();
-        assert_eq!(controlled[0].1["reasoning_effort"], "high");
-
-        let explicit_reasoning = ReasoningConfig {
-            effort: Some(ReasoningEffort::Medium),
-            enabled: Some(true),
-            ..Default::default()
-        };
-        let explicit = build_candidates(
-            &request,
-            Endpoint::ChatComplete,
-            &[candidate],
-            Some(&explicit_reasoning),
-        )
-        .unwrap();
-        assert_eq!(explicit[0].1["reasoning_effort"], "high");
-
-        let uncontrolled: RouteCandidate = serde_json::from_value(json!({
-            "routeId": "sglang:m",
-            "format": "openai",
-            "engine": "sglang"
-        }))
-        .unwrap();
-        let caller_controlled = build_candidates(
-            &request,
-            Endpoint::ChatComplete,
-            std::slice::from_ref(&uncontrolled),
-            Some(&explicit_reasoning),
-        )
-        .unwrap();
-        assert_eq!(caller_controlled[0].1["reasoning_effort"], "medium");
-
-        let defaulted =
-            build_candidates(&request, Endpoint::ChatComplete, &[uncontrolled], None).unwrap();
-        assert!(defaulted[0].1.get("reasoning_effort").is_none());
-        assert!(defaulted[0].1.get("reasoning").is_none());
+        assert!(structured.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -150,7 +150,6 @@ pub fn transform_to_provider_request(
 ) -> Result<Value, TransformError> {
     let mut params = params.clone();
     inject_stream_options(&mut params);
-    inject_sglang_structured_output_reasoning_default(&mut params, endpoint, engine);
     let config = select_config(format, endpoint, engine)?;
     transform_using_provider_config(&config, &params)
 }
@@ -196,8 +195,8 @@ fn candidate_params(
         object.remove(key);
     }
     // The control plane's route-specific resolution is authoritative. Fall back
-    // to caller intent only when control did not resolve it; if both are absent,
-    // engine-specific shaping may install a safe default below.
+    // to caller intent only when control did not resolve it. Absence remains
+    // absence: provider and engine labels do not imply reasoning capability.
     let Some(effective) = candidate
         .effective_reasoning
         .as_ref()
@@ -261,28 +260,6 @@ fn reasoning_object(config: &ReasoningConfig) -> Value {
         object.insert("enabled".into(), enabled.into());
     }
     Value::Object(object)
-}
-
-fn inject_sglang_structured_output_reasoning_default(
-    params: &mut Value,
-    endpoint: Endpoint,
-    engine: Option<Engine>,
-) {
-    if endpoint != Endpoint::ChatComplete || engine != Some(Engine::Sglang) {
-        return;
-    }
-    let Some(object) = params.as_object_mut() else {
-        return;
-    };
-    let has_structured_output = object
-        .get("response_format")
-        .is_some_and(|value| !value.is_null());
-    if has_structured_output
-        && !object.contains_key("reasoning")
-        && !object.contains_key("reasoning_effort")
-    {
-        object.insert("reasoning_effort".into(), json!("none"));
-    }
 }
 
 // ── Engine ───────────────────────────────────────────────────────────────────
@@ -1267,14 +1244,14 @@ mod tests {
     }
 
     #[test]
-    fn sglang_structured_output_defaults_reasoning_off() {
+    fn engine_does_not_infer_a_structured_output_reasoning_default() {
         let params = json!({
             "model": "m",
             "messages": [{ "role": "user", "content": "hi" }],
             "response_format": { "type": "json_object" }
         });
         let sglang = chat(ProviderFormat::Openai, params.clone(), Some(Engine::Sglang));
-        assert_eq!(sglang["reasoning_effort"], "none");
+        assert!(sglang.get("reasoning_effort").is_none());
 
         let explicit = chat(
             ProviderFormat::Openai,
@@ -1293,7 +1270,7 @@ mod tests {
     }
 
     #[test]
-    fn sglang_structured_output_reasoning_precedence_is_control_then_caller_then_default() {
+    fn structured_output_reasoning_precedence_is_control_then_caller_then_absence() {
         let request = json!({
             "model": "m",
             "messages": [{ "role": "user", "content": "hi" }],
@@ -1347,7 +1324,8 @@ mod tests {
 
         let defaulted =
             build_candidates(&request, Endpoint::ChatComplete, &[uncontrolled], None).unwrap();
-        assert_eq!(defaulted[0].1["reasoning_effort"], "none");
+        assert!(defaulted[0].1.get("reasoning_effort").is_none());
+        assert!(defaulted[0].1.get("reasoning").is_none());
     }
 
     #[test]

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -15,9 +15,12 @@ use super::types::ProviderFormat;
 
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
-/// Transform a 2xx upstream body for `format`/`endpoint` into the client surface.
-/// Returns the body unchanged when no transform applies (native passthrough).
-pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Value) -> Value {
+/// Transform a 2xx upstream body for `format`/`endpoint` into the client surface,
+/// applying OpenAI compatibility normalization before any format conversion.
+pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, mut body: Value) -> Value {
+    if format == ProviderFormat::Openai {
+        normalize_reasoning_usage(&mut body);
+    }
     use Endpoint::*;
     use ProviderFormat::*;
     match (format, endpoint) {
@@ -27,6 +30,37 @@ pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, body: Valu
         // Native passthrough: openai chat/complete/embed, anthropic messages,
         // responses (createModelResponse).
         _ => body,
+    }
+}
+
+/// Normalize the legacy reasoning-token usage alias into the OpenAI field.
+///
+/// Some OpenAI-compatible providers emit `usage.reasoning_tokens`, while clients
+/// read `usage.completion_tokens_details.reasoning_tokens`. Promote the legacy
+/// alias only when the canonical value is absent or null; a populated canonical
+/// value remains authoritative. Preserve the alias and sibling detail fields.
+pub(super) fn normalize_reasoning_usage(body: &mut Value) {
+    let Some(usage) = body.get_mut("usage").and_then(Value::as_object_mut) else {
+        return;
+    };
+    let Some(reasoning_tokens) = usage
+        .get("reasoning_tokens")
+        .filter(|value| !value.is_null())
+        .cloned()
+    else {
+        return;
+    };
+    let details = usage
+        .entry("completion_tokens_details")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if details.is_null() {
+        *details = Value::Object(serde_json::Map::new());
+    }
+    let Some(details) = details.as_object_mut() else {
+        return;
+    };
+    if details.get("reasoning_tokens").is_none_or(Value::is_null) {
+        details.insert("reasoning_tokens".into(), reasoning_tokens);
     }
 }
 
@@ -300,6 +334,46 @@ mod tests {
         assert_eq!(
             body["usage"]["completion_tokens_details"]["reasoning_tokens"],
             3
+        );
+    }
+
+    #[test]
+    fn legacy_reasoning_usage_is_normalized_without_losing_canonical_data() {
+        let body = json!({
+            "choices": [],
+            "usage": {
+                "completion_tokens": 128,
+                "reasoning_tokens": 128,
+                "completion_tokens_details": null
+            }
+        });
+        let out = transform_response(ProviderFormat::Openai, Endpoint::ChatComplete, body);
+        assert_eq!(
+            out["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            128
+        );
+        assert_eq!(out["usage"]["reasoning_tokens"], 128);
+
+        let canonical = transform_response(
+            ProviderFormat::Openai,
+            Endpoint::ChatComplete,
+            json!({
+                "usage": {
+                    "reasoning_tokens": 128,
+                    "completion_tokens_details": {
+                        "accepted_prediction_tokens": 4,
+                        "reasoning_tokens": 7
+                    }
+                }
+            }),
+        );
+        assert_eq!(
+            canonical["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            7
+        );
+        assert_eq!(
+            canonical["usage"]["completion_tokens_details"]["accepted_prediction_tokens"],
+            4
         );
     }
 }

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -41,35 +41,28 @@ pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, mut body: 
 /// value remains authoritative. Preserve the alias and sibling detail fields.
 pub(super) fn normalize_reasoning_usage(body: &mut Value) {
     if let Some(usage) = body.get_mut("usage") {
-        normalize_reasoning_usage_value(usage);
+        let _ = normalize_reasoning_usage_value(usage);
     }
 }
 
-pub(super) fn normalize_reasoning_usage_value(usage: &mut Value) -> bool {
-    let Some(usage) = usage.as_object_mut() else {
-        return false;
-    };
-    let Some(reasoning_tokens) = usage
+pub(super) fn normalize_reasoning_usage_value(usage: &mut Value) -> Option<bool> {
+    let usage = usage.as_object_mut()?;
+    let reasoning_tokens = usage
         .get("reasoning_tokens")
         .filter(|value| !value.is_null())
-        .cloned()
-    else {
-        return false;
-    };
+        .cloned()?;
     let details = usage
         .entry("completion_tokens_details")
         .or_insert_with(|| Value::Object(serde_json::Map::new()));
     if details.is_null() {
         *details = Value::Object(serde_json::Map::new());
     }
-    let Some(details) = details.as_object_mut() else {
-        return false;
-    };
+    let details = details.as_object_mut()?;
     if details.get("reasoning_tokens").is_none_or(Value::is_null) {
         details.insert("reasoning_tokens".into(), reasoning_tokens);
-        return true;
+        return Some(true);
     }
-    false
+    Some(false)
 }
 
 /// Remove reasoning traces from an OpenAI Chat Completions response while

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -40,15 +40,21 @@ pub fn transform_response(format: ProviderFormat, endpoint: Endpoint, mut body: 
 /// alias only when the canonical value is absent or null; a populated canonical
 /// value remains authoritative. Preserve the alias and sibling detail fields.
 pub(super) fn normalize_reasoning_usage(body: &mut Value) {
-    let Some(usage) = body.get_mut("usage").and_then(Value::as_object_mut) else {
-        return;
+    if let Some(usage) = body.get_mut("usage") {
+        normalize_reasoning_usage_value(usage);
+    }
+}
+
+pub(super) fn normalize_reasoning_usage_value(usage: &mut Value) -> bool {
+    let Some(usage) = usage.as_object_mut() else {
+        return false;
     };
     let Some(reasoning_tokens) = usage
         .get("reasoning_tokens")
         .filter(|value| !value.is_null())
         .cloned()
     else {
-        return;
+        return false;
     };
     let details = usage
         .entry("completion_tokens_details")
@@ -57,11 +63,13 @@ pub(super) fn normalize_reasoning_usage(body: &mut Value) {
         *details = Value::Object(serde_json::Map::new());
     }
     let Some(details) = details.as_object_mut() else {
-        return;
+        return false;
     };
     if details.get("reasoning_tokens").is_none_or(Value::is_null) {
         details.insert("reasoning_tokens".into(), reasoning_tokens);
+        return true;
     }
+    false
 }
 
 /// Remove reasoning traces from an OpenAI Chat Completions response while

--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -34,6 +34,7 @@ use super::completion::{
 };
 use super::control::ControlClient;
 use super::pricing;
+use super::response_transform;
 use super::types::{ErrorSource, PostReport, SpendMode};
 
 /// Cap on the partial-line reassembly buffer. An upstream that streams bytes
@@ -471,34 +472,38 @@ impl MeterStream {
                     };
                     self.detect_outcome(&parsed);
 
-                    let top_usage = parsed.get("usage").filter(|u| !u.is_null());
-                    let nested = parsed
+                    let top_usage = parsed.get("usage").is_some_and(|u| !u.is_null());
+                    let nested_usage = parsed
                         .get("response")
                         .and_then(|r| r.get("usage"))
-                        .filter(|u| !u.is_null());
-                    let Some(usage_obj) = top_usage.or(nested) else {
-                        return line.to_string();
-                    };
-                    self.last_usage = Some(usage_obj.clone());
-                    if !self.inject {
+                        .is_some_and(|u| !u.is_null());
+                    if !top_usage && !nested_usage {
                         return line.to_string();
                     }
-                    let pricing = self
-                        .report
-                        .pricing
-                        .as_ref()
-                        .expect("inject implies pricing");
-                    let cost = pricing::compute_cost(usage_obj, pricing);
-                    changed = true;
 
-                    let mut updated = parsed.clone();
-                    let target = if top_usage.is_some() {
+                    let mut updated = parsed;
+                    let usage_obj = if top_usage {
                         updated.get_mut("usage")
                     } else {
                         updated.get_mut("response").and_then(|r| r.get_mut("usage"))
-                    };
-                    if let Some(usage_map) = target.and_then(Value::as_object_mut) {
-                        usage_map.insert("cost".to_string(), pricing::cost_to_json(cost));
+                    }
+                    .expect("usage presence checked above");
+                    let normalized = response_transform::normalize_reasoning_usage_value(usage_obj);
+                    self.last_usage = Some(usage_obj.clone());
+                    if !self.inject && !normalized {
+                        return line.to_string();
+                    }
+                    changed = true;
+                    if self.inject {
+                        let pricing = self
+                            .report
+                            .pricing
+                            .as_ref()
+                            .expect("inject implies pricing");
+                        let cost = pricing::compute_cost(usage_obj, pricing);
+                        if let Some(usage_map) = usage_obj.as_object_mut() {
+                            usage_map.insert("cost".to_string(), pricing::cost_to_json(cost));
+                        }
                     }
                     format!(
                         "data: {}",
@@ -1001,6 +1006,29 @@ mod tests {
 
         // Byte fidelity: the buffered chunk is emitted intact, nothing dropped.
         assert_eq!(out.as_ref(), [a.as_ref(), b.as_ref()].concat().as_slice());
+    }
+
+    #[test]
+    fn legacy_reasoning_usage_is_normalized_without_rejecting_non_json_data() {
+        let mut meter = test_meter();
+        let chunk = Bytes::from(concat!(
+            "data: {\"choices\":[],\"usage\":{\"reasoning_tokens\":5,\"completion_tokens_details\":null}}\n",
+            "data: ping\n",
+        ));
+        let Fed::Emit(out) = meter.process(&chunk) else {
+            panic!("complete lines emit bytes");
+        };
+        let text = String::from_utf8(out.to_vec()).unwrap();
+
+        assert!(
+            text.contains("\"completion_tokens_details\":{\"reasoning_tokens\":5}"),
+            "{text}"
+        );
+        assert!(text.contains("data: ping\n"), "{text}");
+        assert_eq!(
+            meter.last_usage.as_ref().unwrap()["completion_tokens_details"]["reasoning_tokens"],
+            5
+        );
     }
 
     // `data:{...}` without the optional space is valid SSE; missing it would drop

--- a/src/middleware/sse.rs
+++ b/src/middleware/sse.rs
@@ -488,7 +488,8 @@ impl MeterStream {
                         updated.get_mut("response").and_then(|r| r.get_mut("usage"))
                     }
                     .expect("usage presence checked above");
-                    let normalized = response_transform::normalize_reasoning_usage_value(usage_obj);
+                    let normalized = response_transform::normalize_reasoning_usage_value(usage_obj)
+                        .unwrap_or(false);
                     self.last_usage = Some(usage_obj.clone());
                     if !self.inject && !normalized {
                         return line.to_string();

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -2,10 +2,9 @@
 //! events into the downstream client surface, event by event, threading mutable
 //! state across events (a per-stream transform state).
 //!
-//! Three provider conversions are supported. Same-format streaming also reaches
-//! this module for reasoning-usage normalization or when response reasoning must
-//! be excluded. Cost injection, TTFT, and outcome are a separate metering pass
-//! downstream (`sse`).
+//! Three provider conversions are supported. Same-format streaming reaches this
+//! module only when response reasoning must be excluded. Cost injection, TTFT,
+//! and outcome are a separate metering pass downstream (`sse`).
 
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
@@ -34,16 +33,14 @@ pub enum StreamTransform {
     AnthropicToOpenaiChat,
     OpenaiToAnthropicMessages,
     AnthropicCompleteToOpenai,
-    NormalizeReasoningUsage,
     ExcludeReasoning,
 }
 
 impl StreamTransform {
     fn provider(self) -> &'static str {
         match self {
-            StreamTransform::OpenaiToAnthropicMessages
-            | StreamTransform::NormalizeReasoningUsage
-            | StreamTransform::ExcludeReasoning => "openai",
+            StreamTransform::OpenaiToAnthropicMessages => "openai",
+            StreamTransform::ExcludeReasoning => "openai",
             _ => "anthropic",
         }
     }
@@ -61,12 +58,8 @@ impl StreamTransform {
         fallback_id: &str,
         state: &mut StreamState,
     ) -> Result<Option<String>, ()> {
-        match self {
-            StreamTransform::NormalizeReasoningUsage => {
-                return normalize_reasoning_usage_event(event).map(Some)
-            }
-            StreamTransform::ExcludeReasoning => return exclude_reasoning_event(event).map(Some),
-            _ => {}
+        if matches!(self, StreamTransform::ExcludeReasoning) {
+            return exclude_reasoning_event(event).map(Some);
         }
         let event = parse_event(event);
         match self {
@@ -77,9 +70,7 @@ impl StreamTransform {
                 openai_to_anthropic_messages_stream(&event, fallback_id, state)
             }
             StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(&event),
-            StreamTransform::NormalizeReasoningUsage | StreamTransform::ExcludeReasoning => {
-                unreachable!()
-            }
+            StreamTransform::ExcludeReasoning => unreachable!(),
         }
     }
 }
@@ -96,7 +87,6 @@ pub fn select_stream_transform(
         (Anthropic, ChatComplete) => Some(StreamTransform::AnthropicToOpenaiChat),
         (Anthropic, Complete) => Some(StreamTransform::AnthropicCompleteToOpenai),
         (Openai, Messages) => Some(StreamTransform::OpenaiToAnthropicMessages),
-        (Openai, ChatComplete) => Some(StreamTransform::NormalizeReasoningUsage),
         _ => None,
     }
 }
@@ -781,7 +771,7 @@ fn replace_data_fields(event: &str, replacement: &str) -> String {
     output
 }
 
-fn transform_json_event(event: &str, transform: fn(&mut Value)) -> Result<String, ()> {
+fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
     let parsed = parse_event(event);
     let Some(payload) = parsed.data.as_deref() else {
         return Ok(framed_event(event));
@@ -792,20 +782,12 @@ fn transform_json_event(event: &str, transform: fn(&mut Value)) -> Result<String
     }
     let mut body: Value = serde_json::from_str(payload).map_err(|_| ())?;
     let original = body.clone();
-    transform(&mut body);
+    response_transform::exclude_reasoning(&mut body);
     if body == original {
         Ok(framed_event(event))
     } else {
         Ok(replace_data_fields(event, &json_str(&body)))
     }
-}
-
-fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
-    transform_json_event(event, response_transform::exclude_reasoning)
-}
-
-fn normalize_reasoning_usage_event(event: &str) -> Result<String, ()> {
-    transform_json_event(event, response_transform::normalize_reasoning_usage)
 }
 
 /// Splits the provider byte stream into SSE events and applies a stateful
@@ -1401,25 +1383,6 @@ mod tests {
     }
 
     #[test]
-    fn legacy_stream_usage_is_normalized_and_preserves_sse_fields() {
-        let output = normalize_reasoning_usage_event(
-            "event: chunk\nid: 7\nretry: 100\n: keep\ndata: {\"choices\":[],\"usage\":{\"completion_tokens\":0,\"reasoning_tokens\":0,\"completion_tokens_details\":null}}",
-        )
-        .unwrap();
-        assert!(output.contains("event: chunk\n"), "{output}");
-        assert!(output.contains("id: 7\n"), "{output}");
-        assert!(output.contains("retry: 100\n"), "{output}");
-        assert!(output.contains(": keep\n"), "{output}");
-        let parsed = parse_event(&output);
-        let body: Value = serde_json::from_str(parsed.data.as_deref().unwrap()).unwrap();
-        assert_eq!(body["usage"]["reasoning_tokens"], 0);
-        assert_eq!(
-            body["usage"]["completion_tokens_details"]["reasoning_tokens"],
-            0
-        );
-    }
-
-    #[test]
     fn selection_matrix() {
         assert!(matches!(
             select_stream_transform(ProviderFormat::Anthropic, Endpoint::ChatComplete),
@@ -1429,9 +1392,6 @@ mod tests {
             select_stream_transform(ProviderFormat::Openai, Endpoint::Messages),
             Some(StreamTransform::OpenaiToAnthropicMessages)
         ));
-        assert!(matches!(
-            select_stream_transform(ProviderFormat::Openai, Endpoint::ChatComplete),
-            Some(StreamTransform::NormalizeReasoningUsage)
-        ));
+        assert!(select_stream_transform(ProviderFormat::Openai, Endpoint::ChatComplete).is_none());
     }
 }

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -2,9 +2,10 @@
 //! events into the downstream client surface, event by event, threading mutable
 //! state across events (a per-stream transform state).
 //!
-//! Three provider conversions are supported. Same-format streaming reaches this
-//! module only when response reasoning must be excluded. Cost injection, TTFT,
-//! and outcome are a separate metering pass downstream (`sse`).
+//! Three provider conversions are supported. Same-format streaming also reaches
+//! this module for reasoning-usage normalization or when response reasoning must
+//! be excluded. Cost injection, TTFT, and outcome are a separate metering pass
+//! downstream (`sse`).
 
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
@@ -33,14 +34,16 @@ pub enum StreamTransform {
     AnthropicToOpenaiChat,
     OpenaiToAnthropicMessages,
     AnthropicCompleteToOpenai,
+    NormalizeReasoningUsage,
     ExcludeReasoning,
 }
 
 impl StreamTransform {
     fn provider(self) -> &'static str {
         match self {
-            StreamTransform::OpenaiToAnthropicMessages => "openai",
-            StreamTransform::ExcludeReasoning => "openai",
+            StreamTransform::OpenaiToAnthropicMessages
+            | StreamTransform::NormalizeReasoningUsage
+            | StreamTransform::ExcludeReasoning => "openai",
             _ => "anthropic",
         }
     }
@@ -58,8 +61,12 @@ impl StreamTransform {
         fallback_id: &str,
         state: &mut StreamState,
     ) -> Result<Option<String>, ()> {
-        if matches!(self, StreamTransform::ExcludeReasoning) {
-            return exclude_reasoning_event(event).map(Some);
+        match self {
+            StreamTransform::NormalizeReasoningUsage => {
+                return normalize_reasoning_usage_event(event).map(Some)
+            }
+            StreamTransform::ExcludeReasoning => return exclude_reasoning_event(event).map(Some),
+            _ => {}
         }
         let event = parse_event(event);
         match self {
@@ -70,7 +77,9 @@ impl StreamTransform {
                 openai_to_anthropic_messages_stream(&event, fallback_id, state)
             }
             StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(&event),
-            StreamTransform::ExcludeReasoning => unreachable!(),
+            StreamTransform::NormalizeReasoningUsage | StreamTransform::ExcludeReasoning => {
+                unreachable!()
+            }
         }
     }
 }
@@ -87,6 +96,7 @@ pub fn select_stream_transform(
         (Anthropic, ChatComplete) => Some(StreamTransform::AnthropicToOpenaiChat),
         (Anthropic, Complete) => Some(StreamTransform::AnthropicCompleteToOpenai),
         (Openai, Messages) => Some(StreamTransform::OpenaiToAnthropicMessages),
+        (Openai, ChatComplete) => Some(StreamTransform::NormalizeReasoningUsage),
         _ => None,
     }
 }
@@ -771,7 +781,7 @@ fn replace_data_fields(event: &str, replacement: &str) -> String {
     output
 }
 
-fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
+fn transform_json_event(event: &str, transform: fn(&mut Value)) -> Result<String, ()> {
     let parsed = parse_event(event);
     let Some(payload) = parsed.data.as_deref() else {
         return Ok(framed_event(event));
@@ -782,12 +792,20 @@ fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
     }
     let mut body: Value = serde_json::from_str(payload).map_err(|_| ())?;
     let original = body.clone();
-    response_transform::exclude_reasoning(&mut body);
+    transform(&mut body);
     if body == original {
         Ok(framed_event(event))
     } else {
         Ok(replace_data_fields(event, &json_str(&body)))
     }
+}
+
+fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
+    transform_json_event(event, response_transform::exclude_reasoning)
+}
+
+fn normalize_reasoning_usage_event(event: &str) -> Result<String, ()> {
+    transform_json_event(event, response_transform::normalize_reasoning_usage)
 }
 
 /// Splits the provider byte stream into SSE events and applies a stateful
@@ -1383,6 +1401,25 @@ mod tests {
     }
 
     #[test]
+    fn legacy_stream_usage_is_normalized_and_preserves_sse_fields() {
+        let output = normalize_reasoning_usage_event(
+            "event: chunk\nid: 7\nretry: 100\n: keep\ndata: {\"choices\":[],\"usage\":{\"completion_tokens\":0,\"reasoning_tokens\":0,\"completion_tokens_details\":null}}",
+        )
+        .unwrap();
+        assert!(output.contains("event: chunk\n"), "{output}");
+        assert!(output.contains("id: 7\n"), "{output}");
+        assert!(output.contains("retry: 100\n"), "{output}");
+        assert!(output.contains(": keep\n"), "{output}");
+        let parsed = parse_event(&output);
+        let body: Value = serde_json::from_str(parsed.data.as_deref().unwrap()).unwrap();
+        assert_eq!(body["usage"]["reasoning_tokens"], 0);
+        assert_eq!(
+            body["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            0
+        );
+    }
+
+    #[test]
     fn selection_matrix() {
         assert!(matches!(
             select_stream_transform(ProviderFormat::Anthropic, Endpoint::ChatComplete),
@@ -1392,6 +1429,9 @@ mod tests {
             select_stream_transform(ProviderFormat::Openai, Endpoint::Messages),
             Some(StreamTransform::OpenaiToAnthropicMessages)
         ));
-        assert!(select_stream_transform(ProviderFormat::Openai, Endpoint::ChatComplete).is_none());
+        assert!(matches!(
+            select_stream_transform(ProviderFormat::Openai, Endpoint::ChatComplete),
+            Some(StreamTransform::NormalizeReasoningUsage)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Send the control plane the normalized caller `reasoning` object and a content-blind `structuredOutput` signal.
- Honor per-candidate `effectiveReasoning` as a complete control-plane replacement; otherwise preserve caller reasoning or omission.
- Encode the selected value using each candidate’s `reasoningFormat` without converting effort and token budgets: nested `reasoning` preserves `max_tokens`, `reasoning_effort` rejects an unrepresentable budget, and `enabled` maps to the documented `medium`/`none` defaults.
- Keep structured output from implying reasoning based on SGLang, vLLM, provider, or any other label.
- Normalize legacy `usage.reasoning_tokens` into `usage.completion_tokens_details.reasoning_tokens` for buffered responses and every metered SSE surface.
- Perform streaming normalization in the existing tolerant meter, preserving non-JSON SSE data and covering `/v1/completions`.

## Root cause

Live A/B probes across active Phala, Chutes, and Near AI chat deployments showed that reasoning capability is deployment-specific. Some deployments need `reasoning_effort: none`, some reject it with HTTP 400, some ignore it, and others have no implicit-reasoning problem. Inferring a default from `engine=sglang` or any provider label would regress valid requests.

The request-side policy now belongs to explicit deployment configuration in control. The gateway remains responsible for validating caller input, applying authoritative candidate decisions, translating wire dialects, and normalizing response usage.

Control-plane counterpart: redpill-ai/private-ai-control#41.

## Precedence

`candidate effectiveReasoning > caller reasoning > omission`

Control resolves its structured-output policy as `override > caller > default > omission`, so an override completely replaces caller fields rather than merging them.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets` (all tests passed; live-only tests ignored as designed)
- `cargo clippy --all-targets -- -D warnings`
- Live provider matrix: active Phala, Chutes, and Near AI chat deployments probed with omitted reasoning versus explicit `none`
- GLM-5.2 AUS1: `none` completes the strict schema at `max_tokens=128`; omission exhausts the reasoning budget

Closes #122

