### PR TITLE
Encrypt reasoning fields in E2EE responses

### DIFF
--- a/src/aggregator/service/e2ee_crypto.rs
+++ b/src/aggregator/service/e2ee_crypto.rs
@@ -452,6 +452,13 @@ pub(super) fn encrypt_e2ee_response_body(
             )?;
             encrypt_response_field(
                 message,
+                "reasoning",
+                &format!("choices.{choice_index}.message.reasoning"),
+                ctx,
+                &response_id,
+            )?;
+            encrypt_response_field(
+                message,
                 "reasoning_content",
                 &format!("choices.{choice_index}.message.reasoning_content"),
                 ctx,
@@ -594,6 +601,13 @@ pub(super) fn encrypt_e2ee_stream_payload(
             )?;
             encrypt_response_field(
                 delta,
+                "reasoning",
+                &format!("choices.{choice_index}.delta.reasoning"),
+                ctx,
+                &response_id,
+            )?;
+            encrypt_response_field(
+                delta,
                 "reasoning_content",
                 &format!("choices.{choice_index}.delta.reasoning_content"),
                 ctx,
@@ -612,12 +626,23 @@ pub(super) fn encrypt_response_field(
     ctx: &E2eeRequestContext,
     response_id: &str,
 ) -> Result<(), E2eeError> {
-    let Some(Value::String(plaintext)) = container.get_mut(field_name) else {
+    let Some(value) = container.get_mut(field_name) else {
+        return Ok(());
+    };
+    let Some(plaintext) = optional_response_string(value)? else {
         return Ok(());
     };
     let aad = response_aad_for_context(ctx, response_id, aci_field)?;
     *plaintext = encrypt_response_plaintext(ctx, plaintext.as_bytes(), aad.as_deref())?;
     Ok(())
+}
+
+fn optional_response_string(value: &mut Value) -> Result<Option<&mut String>, E2eeError> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(value) => Ok(Some(value)),
+        _ => Err(E2eeError::EncryptionFailed),
+    }
 }
 
 /// Encrypt `message.audio.data` in place under the `choices.{i}.message.audio.data`
@@ -698,7 +723,8 @@ pub(super) fn encrypt_response_plaintext(
 
 #[cfg(test)]
 mod tests {
-    use super::{aci_request_aad, aci_response_aad};
+    use super::{aci_request_aad, aci_response_aad, optional_response_string};
+    use serde_json::json;
 
     // Byte-exact expected AAD from spec/test-vectors.md §7 (X25519 suite).
     const NONCE: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -730,6 +756,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(aad, RESPONSE_AAD.as_bytes());
+    }
+
+    #[test]
+    fn response_fields_reject_non_string_values() {
+        assert!(optional_response_string(&mut json!({"text": "secret"})).is_err());
     }
 
     #[test]

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -47,7 +47,7 @@ use common::{event_from_request, StaticKeyProvider, StubQuoter};
 const CHAT_REQUEST: &[u8] =
     br#"{"model":"aci-model","messages":[{"role":"user","content":"hello"}]}"#;
 const CHAT_RESPONSE: &[u8] = br#"{"id":"chat-aci-1","object":"chat.completion","choices":[]}"#;
-const E2EE_CHAT_RESPONSE: &[u8] = br#"{"id":"chat-aci-1","object":"chat.completion","model":"aci-model","choices":[{"index":0,"message":{"role":"assistant","content":"plain-answer"},"finish_reason":"stop"}]}"#;
+const E2EE_CHAT_RESPONSE: &[u8] = br#"{"id":"chat-aci-1","object":"chat.completion","model":"aci-model","choices":[{"index":0,"message":{"role":"assistant","reasoning":"private-thought","content":"plain-answer"},"finish_reason":"stop"}]}"#;
 
 #[derive(Clone)]
 struct HttpResult {
@@ -1053,6 +1053,14 @@ async fn e2ee_v2_success_sets_e2ee_headers_and_receipt_hashes_cleartext_and_wire
         decrypt_with_secret_key(&client_secret, encrypted_content, &response_aad).unwrap();
     assert_eq!(decrypted_response, b"plain-answer");
 
+    let encrypted_reasoning = encrypted_response["choices"][0]["message"]["reasoning"]
+        .as_str()
+        .unwrap();
+    let reasoning_aad = e2ee_response_aad(&h, nonce, "chat-aci-1", "choices.0.message.reasoning");
+    let decrypted_reasoning =
+        decrypt_with_secret_key(&client_secret, encrypted_reasoning, &reasoning_aad).unwrap();
+    assert_eq!(decrypted_reasoning, b"private-thought");
+
     let receipt_id = header(&resp.headers, "x-receipt-id");
     let receipt = h.service.get_receipt_by_receipt_id(receipt_id).unwrap();
     assert_eq!(
@@ -1297,6 +1305,12 @@ async fn legacy_ecdsa_e2ee_v1_matches_vllm_proxy_no_aad_shape() {
     let decrypted_response =
         decrypt_legacy_ecdsa_with_secret_key(&client_secret, encrypted_content, None).unwrap();
     assert_eq!(decrypted_response, b"plain-answer");
+    let encrypted_reasoning = encrypted_response["choices"][0]["message"]["reasoning"]
+        .as_str()
+        .unwrap();
+    let decrypted_reasoning =
+        decrypt_legacy_ecdsa_with_secret_key(&client_secret, encrypted_reasoning, None).unwrap();
+    assert_eq!(decrypted_reasoning, b"private-thought");
 }
 
 #[tokio::test]
@@ -2473,6 +2487,50 @@ async fn e2ee_streaming_rejects_a_non_sse_upstream_without_a_receipt() {
         resp.headers.get("x-receipt-id").is_none(),
         "a rejected E2EE response is not bound to a receipt"
     );
+}
+
+#[tokio::test]
+async fn e2ee_v2_encrypts_streamed_reasoning_field() {
+    let frame = format!(
+        "data: {}\n\n",
+        serde_json::json!({
+            "id": "chat-reasoning-stream-1",
+            "object": "chat.completion.chunk",
+            "model": "aci-model",
+            "choices": [{
+                "index": 7,
+                "delta": {"reasoning": "private streamed thought"},
+            }],
+        })
+    )
+    .into_bytes();
+    let stream_chunks = vec![Bytes::from(frame), Bytes::from_static(b"data: [DONE]\n\n")];
+    let h = harness_with_e2ee(RecordingUpstream::with_stream_chunks(stream_chunks));
+    let client_secret = k256::SecretKey::from_slice(&[0x67; 32]).unwrap();
+    let nonce = hex_nonce("nonce-reasoning-stream");
+    let nonce = nonce.as_str();
+    let (encrypted_body, headers) = e2ee_stream_request(&h, &client_secret, nonce);
+
+    let resp = h
+        .requester
+        .post_owned_headers("/v1/chat/completions", &encrypted_body, &headers)
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let events = sse_json_events(&resp.body);
+    assert_eq!(events.len(), 1);
+    let encrypted_reasoning = events[0]["choices"][0]["delta"]["reasoning"]
+        .as_str()
+        .unwrap();
+    let response_aad = e2ee_response_aad(
+        &h,
+        nonce,
+        "chat-reasoning-stream-1",
+        "choices.7.delta.reasoning",
+    );
+    let decrypted_reasoning =
+        decrypt_with_secret_key(&client_secret, encrypted_reasoning, &response_aad).unwrap();
+    assert_eq!(decrypted_reasoning, b"private streamed thought");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Encrypt buffered `message.reasoning` and streamed `delta.reasoning` in the shared field-level E2EE path. Unexpected non-string protected values now fail closed.

Covers ACI v2 and legacy v1 with exact AAD-path round-trip tests.

## Test

- `cargo test`
- Live RedPill `openai/gpt-oss-120b`: buffered and streamed legacy E2EE round trips