### PR TITLE
Send output token limits to control

### DIFF
--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -25,7 +25,7 @@ use crate::aggregator::service::{
     ServiceError, ServiceResponseStream, UpstreamVerificationError,
 };
 
-use super::control::ControlClient;
+use super::control::{ControlClient, GenerationConstraints};
 use super::errors::{self, Surface};
 use super::reasoning;
 use super::request_transform::{build_candidates, Endpoint};
@@ -320,6 +320,7 @@ pub async fn run(
         && params
             .get("response_format")
             .is_some_and(|value| !value.is_null());
+    let output_token_limit = output_token_limit(endpoint, &params);
 
     let consult = control
         .consult_pre(
@@ -327,7 +328,10 @@ pub async fn run(
             api_key_hash.as_deref(),
             provider,
             reasoning_requirements.as_ref(),
-            structured_output,
+            GenerationConstraints {
+                structured_output,
+                output_token_limit,
+            },
             tee_only,
         )
         .await;
@@ -1309,6 +1313,18 @@ fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) {
     }
 }
 
+fn output_token_limit(endpoint: Endpoint, params: &Value) -> Option<u64> {
+    match endpoint {
+        Endpoint::ChatComplete => params
+            .get("max_completion_tokens")
+            .and_then(Value::as_u64)
+            .or_else(|| params.get("max_tokens").and_then(Value::as_u64)),
+        Endpoint::Complete | Endpoint::Messages => params.get("max_tokens").and_then(Value::as_u64),
+        Endpoint::CreateModelResponse => params.get("max_output_tokens").and_then(Value::as_u64),
+        Endpoint::Embed => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1346,5 +1362,39 @@ mod tests {
         // class — must trip the anomaly.
         assert!(finish_reasons_anomalous(["upstream_error"]));
         assert!(finish_reasons_anomalous(["stop", "weird_provider_reason"]));
+    }
+
+    #[test]
+    fn normalizes_output_token_limit_across_api_surfaces() {
+        let cases = [
+            (Endpoint::ChatComplete, r#"{"max_tokens":128}"#, Some(128)),
+            (
+                Endpoint::ChatComplete,
+                r#"{"max_tokens":128,"max_completion_tokens":64}"#,
+                Some(64),
+            ),
+            (
+                Endpoint::ChatComplete,
+                r#"{"max_tokens":64,"max_completion_tokens":null}"#,
+                Some(64),
+            ),
+            (
+                Endpoint::ChatComplete,
+                r#"{"max_tokens":64,"max_completion_tokens":"invalid"}"#,
+                Some(64),
+            ),
+            (Endpoint::Complete, r#"{"max_tokens":48}"#, Some(48)),
+            (Endpoint::Messages, r#"{"max_tokens":32}"#, Some(32)),
+            (
+                Endpoint::CreateModelResponse,
+                r#"{"max_output_tokens":16}"#,
+                Some(16),
+            ),
+            (Endpoint::Embed, r#"{"max_tokens":8}"#, None),
+        ];
+        for (endpoint, params, expected) in cases {
+            let params = serde_json::from_str(params).unwrap();
+            assert_eq!(output_token_limit(endpoint, &params), expected);
+        }
     }
 }

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -46,6 +46,15 @@ pub struct CatalogResponse {
     pub body: Vec<u8>,
 }
 
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct GenerationConstraints {
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub(super) structured_output: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) output_token_limit: Option<u64>,
+}
+
 #[derive(Clone)]
 pub struct ControlClient {
     client: reqwest::Client,
@@ -130,16 +139,17 @@ impl ControlClient {
     }
 
     /// Pre-request consult:
-    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput? }` -> decision.
+    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput?, outputTokenLimit? }`
+    /// -> decision.
     /// Fails closed — any non-200, invalid JSON, timeout, or transport error
     /// returns a 503 denial.
-    pub async fn consult_pre(
+    pub(super) async fn consult_pre(
         &self,
         model: Option<&str>,
         api_key_hash: Option<&str>,
         provider: Option<&Value>,
         reasoning: Option<&ReasoningConfig>,
-        structured_output: bool,
+        constraints: GenerationConstraints,
         tee_only: bool,
     ) -> PreConsult {
         #[derive(Serialize)]
@@ -156,9 +166,8 @@ impl ControlClient {
             // Canonical route-relevant controls only. Response visibility stays local.
             #[serde(skip_serializing_if = "Option::is_none")]
             reasoning: Option<&'a ReasoningConfig>,
-            // Content-blind response-shape signal. The schema remains local.
-            #[serde(skip_serializing_if = "std::ops::Not::not")]
-            structured_output: bool,
+            #[serde(flatten)]
+            constraints: GenerationConstraints,
             // TEE-only host: the control plane 404s a non-TEE model. Only sent
             // when set so the metadata-minimal payload is unchanged off these hosts.
             #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -170,7 +179,7 @@ impl ControlClient {
             model,
             provider,
             reasoning,
-            structured_output,
+            constraints,
             tee: tee_only,
         };
         let build = || {
@@ -304,13 +313,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn generation_constraints_pin_the_wire_names() {
+        assert_eq!(
+            serde_json::to_value(GenerationConstraints::default()).unwrap(),
+            serde_json::json!({})
+        );
+        let constraints = GenerationConstraints {
+            structured_output: true,
+            output_token_limit: Some(128),
+        };
+        assert_eq!(
+            serde_json::to_value(constraints).unwrap(),
+            serde_json::json!({ "structuredOutput": true, "outputTokenLimit": 128 })
+        );
+    }
+
     #[tokio::test]
     async fn consult_pre_fails_closed_on_transport_error() {
         // Port 1 is unroutable in practice; the request fails fast within the
         // configured timeout and must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
         let consult = client
-            .consult_pre(Some("m"), None, None, None, false, false)
+            .consult_pre(
+                Some("m"),
+                None,
+                None,
+                None,
+                GenerationConstraints::default(),
+                false,
+            )
             .await;
         assert!(!consult.allow);
         assert_eq!(consult.status, Some(503));


### PR DESCRIPTION
## Summary

- Send content-free generation constraints to `/consult/pre`.
- Normalize the chat, completions, messages, and responses output-token aliases into `outputTokenLimit`.
- Keep reasoning policy in control; the gateway only reports request metadata and applies the returned candidate decision.

## Privacy

Only `structuredOutput` and the numeric `outputTokenLimit` cross the gateway/control boundary. Prompts, messages, response schemas, and response-format contents remain inside the gateway.

## Compatibility

The field is optional. An older control ignores it, and a newer control leaves threshold policies inactive when an older gateway omits it. Either service may deploy first.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Local gateway + control wire probe

Companion control PR: https://github.com/redpill-ai/private-ai-control/pull/43
