### PR TITLE
Reconcile backend thinking flags with canonical reasoning

### DIFF
--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -10,7 +10,7 @@
 //! Strongly typed endpoint structs may replace `serde_json::Value` later; for now
 //! the dynamic shape keeps behavior aligned with the source.
 
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use super::reasoning::validate_effective;
 use super::types::{
@@ -210,6 +210,9 @@ fn candidate_params(
             candidate.route_id
         ))
     })?;
+    if candidate.engine.is_some() {
+        sync_chat_template_reasoning(object, effective);
+    }
     let reasoning_format = candidate.reasoning_format.unwrap_or_else(|| {
         if candidate.engine.is_some() {
             ReasoningFormat::ReasoningEffort
@@ -238,6 +241,23 @@ fn candidate_params(
         (ProviderFormat::Anthropic, _) => return invalid_reasoning(candidate, "has no adapter"),
     }
     Ok(params)
+}
+
+fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &ReasoningConfig) {
+    let Some(Value::Object(kwargs)) = object.get_mut("chat_template_kwargs") else {
+        return;
+    };
+    let enabled = reasoning.enabled.unwrap_or_else(|| {
+        reasoning.max_tokens.is_some()
+            || reasoning
+                .effort
+                .is_some_and(|effort| effort != ReasoningEffort::None)
+    });
+    for key in ["thinking", "enable_thinking"] {
+        if let Some(value) = kwargs.get_mut(key) {
+            *value = Value::Bool(enabled);
+        }
+    }
 }
 
 fn invalid_reasoning<T>(candidate: &RouteCandidate, message: &str) -> Result<T, TransformError> {
@@ -1334,6 +1354,58 @@ mod tests {
         assert!(bodies[1].1.get("reasoning").is_none());
         assert_eq!(bodies[2].1["reasoning"]["effort"], "medium");
         assert!(bodies[2].1.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn selected_reasoning_reconciles_chat_template_aliases() {
+        for (requested, controlled, original, expected) in [
+            (ReasoningEffort::None, None, true, false),
+            (
+                ReasoningEffort::High,
+                Some(ReasoningEffort::None),
+                true,
+                false,
+            ),
+            (
+                ReasoningEffort::None,
+                Some(ReasoningEffort::High),
+                false,
+                true,
+            ),
+        ] {
+            let reasoning = |effort| ReasoningConfig {
+                effort: Some(effort),
+                ..Default::default()
+            };
+            let params = json!({
+                "model": "m",
+                "messages": [],
+                "chat_template_kwargs": {
+                    "thinking": original,
+                    "enable_thinking": original,
+                    "tokenize": false
+                }
+            });
+            let candidate = RouteCandidate {
+                route_id: "self-hosted:m".into(),
+                format: ProviderFormat::Openai,
+                engine: Some(Engine::Sglang),
+                reasoning_format: None,
+                effective_reasoning: controlled.map(reasoning),
+            };
+
+            let bodies = build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                &[candidate],
+                Some(&reasoning(requested)),
+            )
+            .unwrap();
+            let kwargs = &bodies[0].1["chat_template_kwargs"];
+            assert_eq!(kwargs["thinking"], expected);
+            assert_eq!(kwargs["enable_thinking"], expected);
+            assert_eq!(kwargs["tokenize"], false);
+        }
     }
 
     #[test]

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -210,9 +210,7 @@ fn candidate_params(
             candidate.route_id
         ))
     })?;
-    if candidate.engine.is_some() {
-        sync_chat_template_reasoning(object, effective);
-    }
+    sync_chat_template_reasoning(object, effective);
     let reasoning_format = candidate.reasoning_format.unwrap_or_else(|| {
         if candidate.engine.is_some() {
             ReasoningFormat::ReasoningEffort
@@ -1358,15 +1356,17 @@ mod tests {
 
     #[test]
     fn selected_reasoning_reconciles_chat_template_aliases() {
-        for (requested, controlled, original, expected) in [
-            (ReasoningEffort::None, None, true, false),
+        for (engine, requested, controlled, original, expected) in [
+            (Engine::Vllm, ReasoningEffort::None, None, true, false),
             (
+                Engine::Sglang,
                 ReasoningEffort::High,
                 Some(ReasoningEffort::None),
                 true,
                 false,
             ),
             (
+                Engine::Vllm,
                 ReasoningEffort::None,
                 Some(ReasoningEffort::High),
                 false,
@@ -1389,7 +1389,7 @@ mod tests {
             let candidate = RouteCandidate {
                 route_id: "self-hosted:m".into(),
                 format: ProviderFormat::Openai,
-                engine: Some(Engine::Sglang),
+                engine: Some(engine),
                 reasoning_format: None,
                 effective_reasoning: controlled.map(reasoning),
             };

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -508,6 +508,50 @@ async fn allow_forwards_and_finalizes_receipt() {
 }
 
 #[tokio::test]
+async fn control_override_reconciles_openrouter_reasoning_before_forwarding() {
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{
+                "routeId": "phala:z-ai/glm-5.2",
+                "format": "openai",
+                "engine": "sglang",
+                "reasoningFormat": "reasoning_effort",
+                "effectiveReasoning": { "effort": "none" }
+            }]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let (service, _, forwarded) = build_sequenced_service(vec![200]);
+    let mut input = chat_input();
+    input.params = json!({
+        "model": "phala/glm-5.2",
+        "messages": [{ "role": "user", "content": "Return JSON" }],
+        "reasoning_effort": "high",
+        "response_format": { "type": "json_object" },
+        "max_tokens": 256,
+        "chat_template_kwargs": {
+            "thinking": true,
+            "enable_thinking": true,
+            "tokenize": false
+        }
+    });
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    let body: Value = serde_json::from_slice(&forwarded.lock().unwrap()[0]).unwrap();
+    assert_eq!(body["reasoning_effort"], "none");
+    assert_eq!(
+        body["chat_template_kwargs"],
+        json!({ "thinking": false, "enable_thinking": false, "tokenize": false })
+    );
+    assert_eq!(body["response_format"], json!({ "type": "json_object" }));
+    assert_eq!(body["max_tokens"], 256);
+}
+
+#[tokio::test]
 async fn buffered_success_transforms_injects_cost_and_meters() {
     // Anthropic upstream over /v1/chat/completions: response is transformed to the
     // OpenAI shape, cost is injected into the client body, and the metering report


### PR DESCRIPTION
## Summary

- synchronize existing `chat_template_kwargs.thinking` and `enable_thinking` flags with the selected canonical reasoning decision before per-route shaping
- apply the same rule whether reasoning comes from the caller or an authoritative control-plane override
- cover both SGLang and vLLM without deriving template behavior from the engine label
- preserve unrelated template arguments and leave template kwargs untouched when no canonical reasoning is selected

## Root cause

OpenRouter can send both `reasoning_effort: "high"` and backend template flags set to `true`. When the control plane overrides the canonical reasoning to `none`, the gateway previously rewrote only `reasoning_effort`; the stale template flags still enabled model thinking and exhausted a small structured-output budget.

This is a gateway request-rewrite fix only. It does not change the control-plane interface or require a control-plane deployment or engine configuration.

## Validation

- fresh OpenRouter `debug.echo_upstream_body` capture forced to Phala at `max_tokens: 256`
- live replay through the patched Rust rewrite to AUS1: HTTP 200, `finish_reason: stop`, schema-valid JSON, zero reasoning tokens
- exact in-process replay of the OpenRouter-shaped GLM-5.2 request
- caller-only, control-disable, and control-enable precedence cases
- explicit SGLang and vLLM coverage
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`