### PR TITLE
feat(clients): opencode provider plugin for the ACI protocol

### DIFF
--- a/.github/workflows/opencode-provider.yml
+++ b/.github/workflows/opencode-provider.yml
@@ -1,0 +1,49 @@
+name: opencode-provider
+
+on:
+  pull_request:
+    paths:
+      - 'clients/opencode-provider/**'
+      - 'clients/verifier-ts/**'
+      - '.github/workflows/opencode-provider.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'clients/opencode-provider/**'
+      - 'clients/verifier-ts/**'
+      - '.github/workflows/opencode-provider.yml'
+
+defaults:
+  run:
+    working-directory: clients/opencode-provider
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: clients/opencode-provider/package-lock.json
+
+      - name: Build the reference verifier (file: dependency)
+        run: |
+          cd clients/verifier-ts
+          npm ci
+          npm run build
+
+      - name: Install
+        run: npm ci
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ src/aggregator/service.rs      report, forwarding, E2EE, receipt finalization
 src/aggregator/upstream_config.rs runtime upstream config and provider adapters
 src/http/app.rs                Axum HTTP routers and middleware/backend wiring
 src/bin/aci/                   `aci` verifier CLI: verify, audit, sessions, send, serve
-clients/                       verifier-ts verifier library (browser + node); pi-provider pi provider extension
+clients/                       verifier-ts verifier library (browser + node); pi-provider / opencode-provider agent provider plugins
 docs/                          design notes, configuration reference, provider reviews
 deploy/                        git-launcher and dstack compose examples
 examples/                      cargo example binaries + a reference control plane (control-plane/)
@@ -582,6 +582,7 @@ tests/                         unit and integration coverage
 - [ACI spec, quickstart, and test vectors](spec/README.md)
 - [Client verifiers](clients/README.md)
 - [PI provider extension (use the gateway from pi)](clients/pi-provider/README.md)
+- [opencode provider plugin (use the gateway from opencode)](clients/opencode-provider/README.md)
 - [Deployment guide](deploy/README.md)
 - [Configuration reference](docs/configuration-reference.md)
 - [Live E2E test suite](docs/live-e2e-test-suite.md)

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,7 +1,7 @@
 # ACI clients
 
-Three client surfaces: a verifier library, a command-line verifier, and a
-pi provider extension:
+Four client surfaces: a verifier library, a command-line verifier, and two
+agent provider plugins (pi and opencode):
 
 - [`verifier-ts`](verifier-ts) — `@phala/aci-verifier`, a TypeScript verifier
   for the browser and Node. One call, `verifyService(url)`, fetches the
@@ -37,6 +37,19 @@ pi provider extension:
   `@phala/aci-verifier` under `vendor/`. Submodule checkouts:
   [`release/`](release/). Pack: `make -C pi-provider pack`.
   See [`pi-provider/README.md`](pi-provider/README.md).
+- [`opencode-provider`](opencode-provider) — an [opencode](https://opencode.ai)
+  provider plugin that wires the gateway into opencode via a custom `fetch`
+  injected into `@ai-sdk/openai-compatible` provider options: attested TLS
+  (SPKI) pinning per connection (Bun `tls.checkServerIdentity`, fail closed),
+  plus full receipt verification — the injected fetch sees the exact
+  request/response bytes, so body hashes are checked honestly (`verified`,
+  not pi's inspection-only `/aci-receipt`). The npm workspaces monorepo ships
+  the vendor-neutral
+  [`@phala/opencode-provider-aci`](opencode-provider/packages/opencode-provider-aci)
+  core plus the branded
+  [`opencode-provider-phala-cloud`](opencode-provider/packages/opencode-provider-phala-cloud)
+  distribution. See [`opencode-provider/README.md`](opencode-provider/README.md)
+  for install and use.
 
 [docs/quickstart.md](../docs/quickstart.md) exercises both verifier
 surfaces against a live deployment. For pi, install a brand artifact or load

--- a/clients/opencode-provider/.gitignore
+++ b/clients/opencode-provider/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.tgz
+.claude/
+storage/
+.doc-review/
+pi-session-*.html
+.pi

--- a/clients/opencode-provider/.oxfmtrc.json
+++ b/clients/opencode-provider/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/clients/opencode-provider/.oxlintrc.json
+++ b/clients/opencode-provider/.oxlintrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {},
+  "env": {
+    "builtin": true
+  }
+}

--- a/clients/opencode-provider/.pre-commit-config.yaml
+++ b/clients/opencode-provider/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: oxlint
+        name: oxlint
+        entry: npx oxlint
+        language: system
+        types_or: [javascript, jsx, ts, tsx]
+      - id: oxfmt
+        name: oxfmt
+        entry: npx oxfmt
+        language: system
+        types_or: [javascript, jsx, ts, tsx, markdown, json]

--- a/clients/opencode-provider/LICENSE
+++ b/clients/opencode-provider/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pi-provider-phala-cloud contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clients/opencode-provider/README.md
+++ b/clients/opencode-provider/README.md
@@ -1,0 +1,102 @@
+# private-ai-gateway opencode providers
+
+[opencode](https://opencode.ai) provider plugins for
+[private-ai-gateway](https://github.com/Dstack-TEE/private-ai-gateway) (the ACI
+protocol), with attested TLS (SPKI) pinning and per-response receipt
+verification.
+
+This mirrors `clients/pi-provider` (the pi-coding-agent provider) with the
+same architecture: a vendor-neutral core package plus thin branded skins.
+
+- [`@phala/opencode-provider-aci`](packages/opencode-provider-aci) — vendor-neutral core (protocol, pinning, verification)
+- [`opencode-provider-phala-cloud`](packages/opencode-provider-phala-cloud) — Phala Cloud branded distribution
+
+## Install (Phala Cloud)
+
+`opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-provider-phala-cloud"]
+}
+```
+
+Then either log in:
+
+```bash
+opencode auth login   # choose Phala Cloud (device flow)
+```
+
+or set an API key:
+
+```bash
+export PHALA_LLM_API_KEY=...
+```
+
+Select a model: `phala/<model-id>`.
+
+Plugin options can be passed via the tuple form:
+
+```json
+{
+  "plugin": [["opencode-provider-phala-cloud", { "failOpenOnUnpinned": true, "isTeeOnly": true }]]
+}
+```
+
+## How it works (and how it differs from the pi provider)
+
+The plugin injects a custom `fetch` into the provider options of
+`@ai-sdk/openai-compatible` (opencode reads `options.fetch` and routes all
+provider traffic through it). That one injection point provides:
+
+- **Attested TLS (SPKI) pinning** — opencode plugins run in opencode's Bun
+  runtime, whose fetch accepts `tls: { checkServerIdentity }` per request. At
+  first inference use the gateway attestation is validated and the TLS
+  connection is pinned to the attested `workload_keyset.tls_public_keys` SPKI.
+  **Fail closed by default**: an unpinnable session blocks inference rather
+  than silently downgrading to plain CA-TLS; the `failOpenOnUnpinned` option
+  opts into the old warning behavior.
+- **Full per-response receipt verification** — the injected fetch sees the
+  `x-receipt-id` headers AND the raw request/response bytes, so receipts are
+  verified completely: Ed25519 signature over JCS AND body hashes against the
+  exact bytes exchanged. (The pi provider cannot see response bytes and caps
+  at `verified*`; opencode's `verified` is honest.) Statuses:
+  `verified` / `verified*` / `routed` / `attested` / `mismatch`.
+- Verification is delegated to the repo's reference verifier
+  ([`@phala/aci-verifier`](../verifier-ts)) — the same code that ships with
+  the gateway, not a private reimplementation.
+
+Status surfacing: opencode has no persistent footer API for plugins, so the
+verification status is written to the opencode log after each response AND
+shown as a TUI toast (3s for routine statuses, 8s for `mismatch` / `UNPINNED`
+/ `PIN REQUIRED` alerts; identical consecutive statuses are not re-toasted).
+Structured status is always available via the `phala_verification_status`
+tool, and `phala_settings` shows/toggles runtime settings.
+
+## Known gaps vs the pi provider
+
+- **No thinking parameter mapping.** Pi's built-in handler sends
+  `enable_thinking` / `reasoning_effort` per model family; opencode's
+  `@ai-sdk/openai-compatible` has no equivalent config surface. Models are
+  still marked `reasoning: true` and streamed `reasoning_content` surfaces in
+  opencode, but no thinking parameter is sent.
+- **No settings TUI.** Pi ships a `/aci-settings` SettingsList; opencode
+  plugins have no menu surface. The `phala_settings` tool shows and toggles
+  runtime settings (pinning, fail-open, receipt auto-verify); persistent
+  configuration is via plugin options + `{PREFIX}_*` env vars.
+- Model discovery runs at startup using the env API key or the credential
+  stored by `opencode auth login` (read from opencode's auth.json). Logging
+  in mid-session does not refresh the model list — restart opencode.
+- **No proxy support for pinned connections.** The pi provider honors
+  HTTP(S)_PROXY via an EnvHttpProxyAgent; Bun's per-request `tls` init does
+  not compose with proxies. Pinned inference requires a direct connection.
+
+## Development
+
+```bash
+npm install        # requires clients/verifier-ts to be built (npm install && npm run build there)
+npm run check      # tsc --noEmit
+npm run lint       # oxlint
+npm test           # node --test
+```

--- a/clients/opencode-provider/package-lock.json
+++ b/clients/opencode-provider/package-lock.json
@@ -1,0 +1,1641 @@
+{
+  "name": "private-ai-gateway-opencode-providers",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "private-ai-gateway-opencode-providers",
+      "version": "0.1.0",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "@j178/prek": "^0.4.4",
+        "@opencode-ai/plugin": "^1.18.15",
+        "@opencode-ai/sdk": "^1.18.15",
+        "@types/node": "^24.0.0",
+        "oxfmt": "^0.44.0",
+        "oxlint": "^1.59.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "../verifier-ts": {
+      "name": "@phala/aci-verifier",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@phala/dcap-qvl": "^0.5.2"
+      },
+      "devDependencies": {
+        "buffer": "^6.0.3",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.4.12.tgz",
+      "integrity": "sha512-kWvvcb3UrrA9OUDFKf1zIGOxengkcwW9If2ugbMWIJuuAJu0dTA9TLQ9oJTLN5dyOku6HYWuLRBgQ375gTrC1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prek": "bin/prek.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@j178/prek-android-arm64": "0.4.12",
+        "@j178/prek-darwin-arm64": "0.4.12",
+        "@j178/prek-darwin-x64": "0.4.12",
+        "@j178/prek-linux-arm-gnueabihf": "0.4.12",
+        "@j178/prek-linux-arm-musleabihf": "0.4.12",
+        "@j178/prek-linux-arm64-gnu": "0.4.12",
+        "@j178/prek-linux-arm64-musl": "0.4.12",
+        "@j178/prek-linux-armv7-musleabihf": "0.4.12",
+        "@j178/prek-linux-ia32-gnu": "0.4.12",
+        "@j178/prek-linux-ia32-musl": "0.4.12",
+        "@j178/prek-linux-riscv64-gnu": "0.4.12",
+        "@j178/prek-linux-s390x-gnu": "0.4.12",
+        "@j178/prek-linux-x64-gnu": "0.4.12",
+        "@j178/prek-linux-x64-musl": "0.4.12",
+        "@j178/prek-win32-arm64-msvc": "0.4.12",
+        "@j178/prek-win32-ia32-msvc": "0.4.12",
+        "@j178/prek-win32-x64-msvc": "0.4.12"
+      }
+    },
+    "node_modules/@j178/prek-android-arm64": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-android-arm64/-/prek-android-arm64-0.4.12.tgz",
+      "integrity": "sha512-JcNFKqLz3b0Jj+IB8UH2atPoWDulBx/k9OU0zefApB/bmkOLpf5yuzvnjFAnU2/RPkq4oo92fWfkTnGQvdpnqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-arm64": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-arm64/-/prek-darwin-arm64-0.4.12.tgz",
+      "integrity": "sha512-hM+g3iRzR1Fxx7jy2bNarUyEGEJSrTNk34zWZS9hdThwD7bCJV9OdHWdr1/p1f/xJFFMx+vNzt2ZEFLNaelnJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-x64": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-x64/-/prek-darwin-x64-0.4.12.tgz",
+      "integrity": "sha512-l5iqFMnlo3nSgqlexfmWo07cf3/vOnWghNO5yOexIKwh10H2NCjL1DH82rtP6kv9JplJhgEKAAAcDxdfNIe1Ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-gnueabihf": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-gnueabihf/-/prek-linux-arm-gnueabihf-0.4.12.tgz",
+      "integrity": "sha512-ZYe+8IJDZNJHYmPqH/CTFo/pZnKMUnvCFIFBJ3eW1YhUiRf1AYu2uxU0hTw3iXGu+jUtbEw3Zg+tv81/xJVIyA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-musleabihf": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-musleabihf/-/prek-linux-arm-musleabihf-0.4.12.tgz",
+      "integrity": "sha512-Yzzm9SI5btdS+gr21eu9Ly4U117sqYmOQ+HVn5MFNMphMMHzD+xpwiF7YV+Ba5/0Jrj45kX8Kk3l18B1gw4SvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-gnu/-/prek-linux-arm64-gnu-0.4.12.tgz",
+      "integrity": "sha512-Kt4i+/d/jSG2Ml7Pyn66ztF5yu125kEER7XIt3PdJ/KLegNLDqMYHqX9d5kivEsF6Ncoyw0FBzdDPAd2NjE0yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-musl": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-musl/-/prek-linux-arm64-musl-0.4.12.tgz",
+      "integrity": "sha512-Uy1X9Ckx5UWWrhlXnar+ymFTv4wec0ICybxMoCe8b1jDezxM7X7O6dk/h7EFmI2ytQ0ZqOK649bnQGVHaeSnmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-armv7-musleabihf": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-armv7-musleabihf/-/prek-linux-armv7-musleabihf-0.4.12.tgz",
+      "integrity": "sha512-qnPodfL6YoBi8SrEtM5lUCl2v5LqfYfAXFyTTJ1MLbfFUPv4i9tZPPTQ4glmEhjaCK16qgpuF2rZFdnJRkPiKA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-gnu/-/prek-linux-ia32-gnu-0.4.12.tgz",
+      "integrity": "sha512-ZEUo/mW8vfEcqC48/3i8T03DbkgxDHVLx/aReoL3t/nJE7WLsfyg29vlzSWUE8e16NKzuuKFuOu9zdYgJBqm4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-musl": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-musl/-/prek-linux-ia32-musl-0.4.12.tgz",
+      "integrity": "sha512-fyjXUNnlVVmxMzhRbsiA7y2vOgb3nY64oEhf4kB0VA0OnpyzuxQhc4d+ZEWs1iduNPae5Rye8KUSZ6Ycxst5LA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-riscv64-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-riscv64-gnu/-/prek-linux-riscv64-gnu-0.4.12.tgz",
+      "integrity": "sha512-f+v3vkPrtAVyR3pfhUs/y8OCIoQzsqDgVaqv1JPLT3t0NGfKbTR/Je9i1CYXfkw0CZrWj+jiLuACey4WyciLJw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-s390x-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-s390x-gnu/-/prek-linux-s390x-gnu-0.4.12.tgz",
+      "integrity": "sha512-kgvjWI5lp0STIIn5fUDSD3BntcwlE4DehXES01zdbYvGntGyzrzPc7gldVEoFHZnnpKfpOtUXwUEiN9OMmtJ9g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-gnu/-/prek-linux-x64-gnu-0.4.12.tgz",
+      "integrity": "sha512-RrRlAioG+ocNXoEEA8A83MXCLdIdwKzjmgkw0NFACxBL1uKgNg58BcDlpori2DRTVdjeDfpO2P55fVKj7s4x9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-musl": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-musl/-/prek-linux-x64-musl-0.4.12.tgz",
+      "integrity": "sha512-WKKBZWPxcQ6ksowqb/2LM2H64AAf9HWAbm48YyGy6fyor4e3lV4n9+UtFhJtL94/0x1plUaxQE4VWbdI+oCG4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-arm64-msvc": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-arm64-msvc/-/prek-win32-arm64-msvc-0.4.12.tgz",
+      "integrity": "sha512-orAGgZoTq8A6L1lkjFlqajfyrQ0ZDZ8iC0knORyVp4wYrA/7bbfsblOsNNu5GDe6VWF+rJ/JfGcBYBsbfe9INw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-ia32-msvc": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-ia32-msvc/-/prek-win32-ia32-msvc-0.4.12.tgz",
+      "integrity": "sha512-epSH7iYzIuARNSMTs4oqtUzBYRqpMYU6mKpYiRyHosll4fKzbKhWGkCjMafzYI9Mo0Erc8schaDaEdX2BJ61OA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-x64-msvc": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-x64-msvc/-/prek-win32-x64-msvc-0.4.12.tgz",
+      "integrity": "sha512-6BdPhmboppon5uSLdeI2yosJbw0t5FCI/2ekq5dRrhkUR7e+f+j4ipDZOOM7CFoHnsJFQfgx7HmwJm0XsigeeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.18.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.15.tgz",
+      "integrity": "sha512-AY10RtFbzLkf951dbLkSGJdBeddeS6ojbjvqCpWnINedqlj2cK/GF91xWjWnlHpqQZ4GABLPCuoSJx8mGmKvCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.15",
+        "effect": "4.0.0-beta.83",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.15.tgz",
+      "integrity": "sha512-8sfo9nGiVwesAZW9Wqkvynyn7w4wYaHx1O9qOHpYL65+Bs2XUpHP3kBbZe58gjQydFgk6I74kUF7sqCiPu2arQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.44.0.tgz",
+      "integrity": "sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.44.0.tgz",
+      "integrity": "sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.44.0.tgz",
+      "integrity": "sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.44.0.tgz",
+      "integrity": "sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.44.0.tgz",
+      "integrity": "sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.44.0.tgz",
+      "integrity": "sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.44.0.tgz",
+      "integrity": "sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.44.0.tgz",
+      "integrity": "sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.44.0.tgz",
+      "integrity": "sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.44.0.tgz",
+      "integrity": "sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.44.0.tgz",
+      "integrity": "sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.44.0.tgz",
+      "integrity": "sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.44.0.tgz",
+      "integrity": "sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.44.0.tgz",
+      "integrity": "sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.44.0.tgz",
+      "integrity": "sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.44.0.tgz",
+      "integrity": "sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.44.0.tgz",
+      "integrity": "sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.44.0.tgz",
+      "integrity": "sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.44.0.tgz",
+      "integrity": "sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@phala/aci-verifier": {
+      "resolved": "../verifier-ts",
+      "link": true
+    },
+    "node_modules/@phala/opencode-provider-aci": {
+      "resolved": "packages/opencode-provider-aci",
+      "link": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/opencode-provider-phala-cloud": {
+      "resolved": "packages/opencode-provider-phala-cloud",
+      "link": true
+    },
+    "node_modules/oxfmt": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.44.0.tgz",
+      "integrity": "sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.44.0",
+        "@oxfmt/binding-android-arm64": "0.44.0",
+        "@oxfmt/binding-darwin-arm64": "0.44.0",
+        "@oxfmt/binding-darwin-x64": "0.44.0",
+        "@oxfmt/binding-freebsd-x64": "0.44.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.44.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.44.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.44.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.44.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.44.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.44.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.44.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.44.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.44.0",
+        "@oxfmt/binding-linux-x64-musl": "0.44.0",
+        "@oxfmt/binding-openharmony-arm64": "0.44.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.44.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.44.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.44.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.77.0",
+        "@oxlint/binding-android-arm64": "1.77.0",
+        "@oxlint/binding-darwin-arm64": "1.77.0",
+        "@oxlint/binding-darwin-x64": "1.77.0",
+        "@oxlint/binding-freebsd-x64": "1.77.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
+        "@oxlint/binding-linux-arm64-musl": "1.77.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-musl": "1.77.0",
+        "@oxlint/binding-openharmony-arm64": "1.77.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
+        "@oxlint/binding-win32-x64-msvc": "1.77.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/opencode-provider-aci": {
+      "name": "@phala/opencode-provider-aci",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@phala/aci-verifier": "file:../../../verifier-ts"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*"
+      }
+    },
+    "packages/opencode-provider-phala-cloud": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@phala/opencode-provider-aci": "file:../opencode-provider-aci"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*"
+      }
+    }
+  }
+}

--- a/clients/opencode-provider/package.json
+++ b/clients/opencode-provider/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "private-ai-gateway-opencode-providers",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vendor-neutral opencode provider for private-ai-gateway (ACI) + thin branded distributions (phala-cloud)",
+  "license": "MIT",
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "clean": "npm run clean --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present",
+    "check": "tsc --noEmit",
+    "test": "npm run test -w @phala/opencode-provider-aci",
+    "lint": "npm run lint -w @phala/opencode-provider-aci",
+    "format": "npm run format -w @phala/opencode-provider-aci",
+    "format:check": "npm run format:check -w @phala/opencode-provider-aci",
+    "pre-commit": "npm run pre-commit -w @phala/opencode-provider-aci"
+  },
+  "devDependencies": {
+    "@j178/prek": "^0.4.4",
+    "@opencode-ai/plugin": "^1.18.15",
+    "@opencode-ai/sdk": "^1.18.15",
+    "@types/node": "^24.0.0",
+    "oxfmt": "^0.44.0",
+    "oxlint": "^1.59.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-aci/README.md
@@ -1,0 +1,105 @@
+# @phala/opencode-provider-aci
+
+Vendor-neutral **opencode** provider plugin for [private-ai-gateway] (the ACI
+protocol), with attested TLS (SPKI) pinning and per-response receipt
+verification.
+
+This is the neutral core. Branded distributions add their identity on top and
+publish their own npm packages:
+
+- [`opencode-provider-phala-cloud`](https://www.npmjs.com/package/opencode-provider-phala-cloud) — Phala Cloud
+
+Branded shells are thin skins over this package (`createProvider` with a brand
+profile, imported from `@phala/opencode-provider-aci/core`) — the underlying
+protocol code lives here once. The package's default export is the neutral
+plugin itself; opencode's loader treats every runtime export as a plugin, so
+the library surface is kept on the `/core` subpath.
+
+## Install (core)
+
+`opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@phala/opencode-provider-aci"]
+}
+```
+
+```bash
+export ACI_BASE_URL=https://<your-gateway>/v1   # your private-ai-gateway endpoint
+export ACI_LLM_API_KEY=...
+```
+
+## What it adds
+
+- OpenAI-compatible provider (`aci`) with live model discovery from
+  `/v1/models` (no hardcoded catalog).
+- `is_tee` filtering — only confidentially-served models are registered by default.
+- **Attested TLS (SPKI) pinning** — at first inference use the gateway
+  attestation is validated and the TLS connection is pinned to the attested
+  `workload_keyset.tls_public_keys` SPKI (via Bun's per-request
+  `tls.checkServerIdentity`). **Fail closed by default**: with `pinning`
+  enabled (the default) an unpinnable session blocks inference rather than
+  silently downgrading to plain CA-TLS; the `failOpenOnUnpinned` plugin option
+  opts into running unpinned with a warning.
+- **Full per-response receipt verification** — the injected fetch captures the
+  exact request/response bytes, so `verified` means the receipt signature
+  validated AND the body hashes were checked against the bytes exchanged.
+  `mismatch` means a signature FAILED or the keyset did not match. Backed by
+  the repo's reference verifier ([`@phala/aci-verifier`](../../verifier-ts)).
+- `aci_verification_status` tool — structured pin/receipt/attestation status.
+
+## Configuration
+
+Layers, lowest to highest precedence:
+
+1. defaults (`isTeeOnly: true`, `autoFetchReceipt: true`, `pinning: true`, fail-closed)
+2. plugin options — `{"plugin": [["@phala/opencode-provider-aci", {...}]]}` with
+   flat keys: `baseUrl`, `isTeeOnly`, `allowlist`, `autoFetchReceipt`,
+   `requireAttestationMatch`, `failOpenOnUnpinned`, `pinning`
+3. env — `{PREFIX}_BASE_URL`, `{PREFIX}_IS_TEE_ONLY`, `{PREFIX}_MODEL_ALLOWLIST`,
+   `{PREFIX}_AUTO_FETCH_RECEIPT`, `{PREFIX}_REQUIRE_ATTESTATION_MATCH`,
+   `{PREFIX}_FAIL_OPEN_ON_UNPINNED`, `{PREFIX}_PINNING` (`ACI_` prefix for the core)
+4. runtime — `createProvider(profile, overrides)` patch
+
+User-declared `config.provider.aci` entries in opencode.json are respected:
+standard options (`baseURL`, `apiKey`, `headers`) and models merge over the
+plugin's defaults. Only `options.fetch` is not overridable — it is the
+security boundary (pin enforcement + receipt capture).
+
+## How verification is wired
+
+`src/aci-client.ts` fetches the ACI artifacts and delegates all cryptographic
+verification to `@phala/aci-verifier`:
+
+- report binding (`verifyReportBinding`) — keyset digest, `report_data`,
+  `not_after`;
+- receipt verification (`verifyReceipt`) — Ed25519 over JCS(document minus
+  `signature`), `api_version`, keyset binding;
+- body hashes (`checkRequestBodyHash` / `checkResponseBodyHash`).
+
+`src/pinned-fetch.ts` enforces the pin and captures the exchange bytes; the
+provider's own `src/verify.ts` is a thin re-export shim. We deliberately do
+not reimplement the protocol.
+
+## Branding / profiles
+
+`createProvider(profile)` registers the provider with a brand identity:
+
+```ts
+import { createProvider } from "@phala/opencode-provider-aci/core";
+export default createProvider({
+  providerId: "my-brand",
+  label: "My Brand",
+  defaultBaseUrl: "https://gateway.example/v1",
+  apiKeyEnv: "MY_LLM_API_KEY",
+  envPrefix: "MY",
+  logPrefix: "[my-brand]",
+  fallbackModels: [...],
+  // optional RFC 8628 device-flow login for `opencode auth login`:
+  oauth: { name: "My Brand", startDeviceFlow, pollDeviceFlow },
+});
+```
+
+[private-ai-gateway]: https://github.com/Dstack-TEE/private-ai-gateway

--- a/clients/opencode-provider/packages/opencode-provider-aci/core.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/core.ts
@@ -1,0 +1,505 @@
+/**
+ * Private AI Gateway (ACI) opencode provider plugin.
+ *
+ * Wires an attested private-ai-gateway into opencode as an OpenAI-compatible
+ * provider with attested TLS (SPKI) pinning and per-response receipt
+ * verification. This is the vendor-neutral core; branded distributions
+ * (opencode-provider-phala-cloud, ...) call createProvider() with their own
+ * profile.
+ *
+ * Usage:
+ *   opencode.json: { "plugin": ["@phala/opencode-provider-aci"] }
+ *   # Set ACI_LLM_API_KEY (+ ACI_BASE_URL), then select model aci/<model-id>
+ *
+ * Source layout:
+ *   src/profile.ts       — brand identity (provider id, env names, endpoint)
+ *   src/constants.ts     — module-level consts + env-driven endpoints
+ *   src/config.ts        — layered config (default/plugin options/env/runtime)
+ *   src/models.ts        — /v1/models discovery -> opencode models record
+ *   src/pinned-fetch.ts  — attested TLS SPKI pinning + request/response capture
+ *   src/aci-client.ts    — ACI artifact fetch + verification (reference verifier)
+ *   src/verify.ts        — stable re-export surface over aci-client
+ *   src/receipt-store.ts — last-response receipt cache + status text
+ */
+
+import { type Hooks, type Plugin, type PluginInput, tool } from "@opencode-ai/plugin";
+
+import { type AciCloudConfig, type AciCloudConfigPatch, loadAciCloudConfig } from "./src/config.ts";
+import {
+  API_KEY_ENV,
+  LOG_PREFIX,
+  PROVIDER_ID,
+  PROVIDER_VERSION,
+  applyProviderProfile,
+  getEnvApiKey,
+  getStoredApiKey,
+} from "./src/constants.ts";
+import { profile, type ProviderProfile } from "./src/profile.ts";
+import { type AciServerModel, discoverAciModels, fallbackModels } from "./src/models.ts";
+import { statusText, AciReceiptStore } from "./src/receipt-store.ts";
+import { attestedSpkiSha256ForHost } from "./src/verify.ts";
+import { TlsPinManager, createAciFetch } from "./src/pinned-fetch.ts";
+
+/** TLS SPKI pin state for the configured base host. */
+interface PinningStatus {
+  host: string;
+  status: "pinned" | "unpinned" | "blocked" | "disabled";
+}
+
+interface AciRuntimeState {
+  config: AciCloudConfig;
+  rawModels: AciServerModel[];
+  store: AciReceiptStore;
+  pinManager: TlsPinManager;
+  pinning?: PinningStatus;
+  /** API key captured by the auth loader (opencode auth login credentials). */
+  authApiKey?: string;
+  /** In-flight pin install (dedupes concurrent first requests). */
+  pinPromise?: Promise<boolean>;
+}
+
+/** Lowercase hostname of the configured base URL, or undefined when unparseable. */
+function hostOfBaseUrl(baseUrl: string): string | undefined {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveApiKey(state: AciRuntimeState): string {
+  // Preference order: the credential captured by the auth loader (this
+  // session's login), then the env var, then the credential opencode has on
+  // disk from a previous `opencode auth login`.
+  return state.authApiKey?.trim() || getEnvApiKey() || getStoredApiKey();
+}
+
+/** Debug tracing ({PREFIX}_DEBUG=1): writes exchange/status lines to stderr,
+ *  which `opencode run` surfaces. Not for normal operation. */
+function debugEnabled(): boolean {
+  return process.env[`${profile().envPrefix}_DEBUG`] === "1";
+}
+
+function debugLog(...args: unknown[]): void {
+  if (debugEnabled()) console.error(LOG_PREFIX, ...args);
+}
+
+/**
+ * Resolve the attested SPKI for the configured base host from a fresh,
+ * validated attestation and install the TLS pin. Default posture is fail
+ * CLOSED: with `pinning.enabled` (the default) an unpinnable session blocks
+ * inference with a clear error rather than silently downgrading to CA-TLS.
+ * Users can opt into the old fail-open behavior via `failOpenOnUnpinned`
+ * (runs unpinned with a status warning).
+ */
+async function ensurePinned(state: AciRuntimeState, host: string): Promise<boolean> {
+  if (!state.config.pinning.enabled) {
+    state.pinning = { host, status: "disabled" };
+    return false;
+  }
+  if (state.pinManager.getPin(host)) {
+    state.pinning = { host, status: "pinned" };
+    return true;
+  }
+  if (!state.pinPromise) {
+    state.pinPromise = (async (): Promise<boolean> => {
+      const failOpen = state.config.verify.failOpenOnUnpinned === true;
+      const unpinned = (): boolean => {
+        state.pinning = { host, status: failOpen ? "unpinned" : "blocked" };
+        return false;
+      };
+      const apiKey = resolveApiKey(state);
+      if (!apiKey) {
+        console.error(
+          `${LOG_PREFIX} no API key available; cannot fetch attestation for TLS pinning`,
+        );
+        return unpinned();
+      }
+      try {
+        const attested = await state.store.getAttestation(apiKey, state.config);
+        const spki = attested
+          ? attestedSpkiSha256ForHost(state.store.establishedKeyset, host)
+          : undefined;
+        if (!spki) return unpinned();
+        state.pinManager.setPin(host, spki);
+        state.pinning = { host, status: "pinned" };
+        return true;
+      } catch (error) {
+        console.error(`${LOG_PREFIX} TLS pin install failed:`, error);
+        return unpinned();
+      }
+    })().finally(() => {
+      state.pinPromise = undefined;
+    });
+  }
+  return state.pinPromise;
+}
+
+/** Short status suffix describing the TLS pin state. */
+function pinSuffix(state: AciRuntimeState): string {
+  if (!state.config.pinning.enabled) return "";
+  switch (state.pinning?.status) {
+    case "pinned":
+      return " | tls-pinned";
+    case "unpinned":
+      return " | UNPINNED";
+    case "blocked":
+      return " | PIN REQUIRED";
+    default:
+      return " | pin: pending";
+  }
+}
+
+function currentStatusText(state: AciRuntimeState): string {
+  return statusText(state.store) + pinSuffix(state);
+}
+
+/** True when the status is something the user must see (not routine info). */
+function isAlertStatus(text: string): boolean {
+  return (
+    text.includes("mismatch") ||
+    text.includes("UNPINNED") ||
+    text.includes("PIN REQUIRED") ||
+    text.includes("(no receipt)")
+  );
+}
+
+/** Last status text shown as a toast; identical consecutive statuses are not
+ *  re-toasted (a chat turn can trigger several streams, e.g. title gen + main). */
+let lastToastedStatus = "";
+
+/** Publish the verification status: always to the opencode log, and to the
+ *  TUI as a toast (opencode has no persistent footer surface for plugins, so
+ *  the toast is the visible equivalent of pi's footer; alerts stay longer).
+ *  The full status is always available via the verification-status tool. */
+async function publishStatus(input: PluginInput, state: AciRuntimeState): Promise<void> {
+  const text = currentStatusText(state);
+  try {
+    await input.client.app.log({
+      body: { service: PROVIDER_ID, level: "info", message: text },
+    });
+  } catch {
+    // Server log unavailable; never let status publishing break inference.
+  }
+  if (text === lastToastedStatus) return;
+  lastToastedStatus = text;
+  const alert = isAlertStatus(text);
+  try {
+    await input.client.tui.showToast({
+      body: {
+        title: profile().label,
+        message: text,
+        variant: alert
+          ? text.includes("mismatch") || text.includes("PIN REQUIRED")
+            ? "error"
+            : "warning"
+          : "info",
+        duration: alert ? 8000 : 3000,
+      },
+    });
+  } catch {
+    // No TUI attached (headless run); the log line above still records it.
+  }
+}
+
+/** Structured status report for the verification-status tool. */
+function statusReport(state: AciRuntimeState): Record<string, unknown> {
+  const classification = state.store.classification;
+  return {
+    provider: PROVIDER_ID,
+    version: PROVIDER_VERSION,
+    baseUrl: state.config.baseUrl,
+    status: currentStatusText(state),
+    pinning: state.pinning ?? {
+      host: hostOfBaseUrl(state.config.baseUrl) ?? "",
+      status: "pending",
+    },
+    receipt: state.store.snapshot(),
+    classification: classification
+      ? {
+          status: classification.status,
+          signatureValid: classification.signatureValid,
+          requestHashValid: classification.requestHashValid,
+          responseHashValid: classification.responseHashValid,
+          hashesChecked: classification.hashesChecked,
+          hashesNotCheckedReason: classification.hashesNotCheckedReason,
+          provider: classification.provider,
+          modelId: classification.modelId,
+          sessionId: classification.sessionId,
+        }
+      : undefined,
+    attestation: state.store.binding
+      ? {
+          workloadKeysetDigest: state.store.binding.workloadKeysetDigest,
+          bindingOk: state.store.binding.ok,
+        }
+      : undefined,
+    lastAttestationError: state.store.lastAttestationError,
+    modelsRegistered: state.rawModels.length,
+  };
+}
+
+/**
+ * Create the opencode provider plugin for the given brand profile (and
+ * optional runtime config patch). The neutral default profile ("aci") is used
+ * when no profile is supplied; branded shells pass their own identity.
+ */
+export function createProvider(
+  profileOverride?: Partial<ProviderProfile>,
+  overrides?: AciCloudConfigPatch,
+): Plugin {
+  applyProviderProfile(profileOverride);
+
+  return async (input: PluginInput, pluginOptions?: Record<string, unknown>): Promise<Hooks> => {
+    const config = loadAciCloudConfig({ pluginOptions, overrides });
+    const state: AciRuntimeState = {
+      config,
+      rawModels: [],
+      store: new AciReceiptStore(),
+      pinManager: new TlsPinManager(),
+    };
+    const baseHost = hostOfBaseUrl(config.baseUrl);
+
+    const aciFetch = createAciFetch({
+      manager: state.pinManager,
+      isGatewayHost: (host) => baseHost !== undefined && host === baseHost,
+      pinningEnabled: () => state.config.pinning.enabled,
+      failOpenOnUnpinned: () => state.config.verify.failOpenOnUnpinned,
+      ensurePinned: (host) => ensurePinned(state, host),
+      onExchange: (exchange) => {
+        state.store.recordResponseHeaders(exchange.headers);
+        if (exchange.requestBody) state.store.setLastRequestBody(exchange.requestBody);
+        if (exchange.responseBytes) state.store.setLastResponseBytes(exchange.responseBytes);
+        debugLog("exchange", {
+          completion: exchange.completion,
+          status: exchange.status,
+          receiptId: state.store.snapshot().receiptId,
+          responseBytes: exchange.responseBytes?.length,
+        });
+        if (!state.config.verify.autoFetchReceipt) {
+          void publishStatus(input, state);
+          return;
+        }
+        const key = resolveApiKey(state);
+        if (!key || !state.store.snapshot().receiptId) {
+          void publishStatus(input, state);
+          return;
+        }
+        void (async () => {
+          try {
+            await state.store.classifyLastResponse(key, state.config);
+          } catch (error) {
+            console.error(`${LOG_PREFIX} receipt classification failed:`, error);
+          }
+          debugLog("status", currentStatusText(state));
+          await publishStatus(input, state);
+        })();
+      },
+    });
+
+    const oauth = profile().oauth;
+
+    const hooks: Hooks = {
+      config: async (cfg) => {
+        cfg.provider ??= {};
+        const existing = (cfg.provider[PROVIDER_ID] ?? {}) as {
+          npm?: string;
+          name?: string;
+          options?: Record<string, unknown>;
+          models?: Record<string, unknown>;
+        };
+
+        // Discover the live catalog when a key is available (env only at this
+        // point — the auth loader runs later); branded shells fall back to
+        // their static catalog. User-declared models always win.
+        let models = fallbackModels();
+        const key = resolveApiKey(state);
+        if (key) {
+          const discovered = await discoverAciModels(key, state.config);
+          state.rawModels = discovered.raw;
+          if (Object.keys(discovered.models).length > 0) models = discovered.models;
+        }
+
+        cfg.provider[PROVIDER_ID] = {
+          ...existing,
+          npm: existing.npm ?? "@ai-sdk/openai-compatible",
+          name: existing.name ?? profile().label,
+          options: {
+            baseURL: state.config.baseUrl,
+            // Only pin the env template when the env key is actually set.
+            // opencode fills options.apiKey from the auth loader's provider.key
+            // ONLY when options.apiKey is undefined — an empty/unresolvable
+            // template here would shadow the logged-in credential and send a
+            // bad key (observed as gateway 401 "Invalid API key").
+            ...(getEnvApiKey() ? { apiKey: `{env:${API_KEY_ENV}}` } : {}),
+            ...existing.options,
+            // The attested-pinned fetch is not user-overridable: it is the
+            // security boundary (pin enforcement + receipt capture).
+            fetch: aciFetch,
+          },
+          models: { ...models, ...existing.models },
+        } as (typeof cfg.provider)[string];
+      },
+
+      tool: {
+        [`${PROVIDER_ID}_verification_status`]: tool({
+          description: `Show ${profile().label} verification status: TLS pin state, last receipt classification, attestation binding`,
+          args: {},
+          async execute() {
+            return JSON.stringify(statusReport(state), null, 2);
+          },
+        }),
+        [`${PROVIDER_ID}_settings`]: tool({
+          description: `Show or toggle ${profile().label} provider settings. Toggles are runtime-only (persist via plugin options or ${profile().envPrefix}_* env vars).`,
+          args: {
+            pinning: tool.schema
+              .boolean()
+              .optional()
+              .describe("Require the gateway TLS connection to present the attested SPKI"),
+            failOpenOnUnpinned: tool.schema
+              .boolean()
+              .optional()
+              .describe(
+                "When true, run unpinned with a warning if no attested pin can be established; when false (default), block inference",
+              ),
+            autoFetchReceipt: tool.schema
+              .boolean()
+              .optional()
+              .describe("Fetch + verify the receipt after each response"),
+            requireAttestationMatch: tool.schema
+              .boolean()
+              .optional()
+              .describe("Require receipts to bind to a validated attestation"),
+          },
+          async execute(args) {
+            if (args.pinning !== undefined) {
+              state.config.pinning.enabled = args.pinning;
+              if (!args.pinning) {
+                const host = state.pinning?.host ?? hostOfBaseUrl(state.config.baseUrl);
+                if (host) state.pinManager.clearPin(host);
+                state.pinning = { host: host ?? "", status: "disabled" };
+              }
+            }
+            if (args.failOpenOnUnpinned !== undefined) {
+              state.config.verify.failOpenOnUnpinned = args.failOpenOnUnpinned;
+            }
+            if (args.autoFetchReceipt !== undefined) {
+              state.config.verify.autoFetchReceipt = args.autoFetchReceipt;
+            }
+            if (args.requireAttestationMatch !== undefined) {
+              state.config.verify.requireAttestationMatch = args.requireAttestationMatch;
+            }
+            return JSON.stringify(
+              {
+                provider: PROVIDER_ID,
+                effective: {
+                  baseUrl: state.config.baseUrl,
+                  models: state.config.models,
+                  verify: state.config.verify,
+                  pinning: state.config.pinning,
+                },
+                pin: state.pinning,
+                note: "Runtime-only changes; persist via plugin options in opencode.json or env vars. isTeeOnly/allowlist changes require a restart (model discovery runs at startup).",
+              },
+              null,
+              2,
+            );
+          },
+        }),
+      },
+    };
+
+    if (oauth) {
+      hooks.auth = {
+        provider: PROVIDER_ID,
+        loader: async (getAuth) => {
+          try {
+            const auth = await getAuth();
+            if (auth.type === "oauth" && auth.access) {
+              state.authApiKey = auth.access;
+              return { apiKey: auth.access };
+            }
+            if (auth.type === "api" && auth.key) {
+              state.authApiKey = auth.key;
+              return { apiKey: auth.key };
+            }
+          } catch (error) {
+            console.error(`${LOG_PREFIX} auth loader failed:`, error);
+          }
+          return {};
+        },
+        methods: [
+          {
+            type: "oauth",
+            label: `Login with ${oauth.name}`,
+            authorize: async () => {
+              const start = await oauth.startDeviceFlow();
+              return {
+                url: start.verificationUri,
+                instructions: `Open the URL and approve access (code: ${start.userCode}). The CLI polls automatically.`,
+                method: "auto" as const,
+                callback: async () => {
+                  try {
+                    const creds = await oauth.pollDeviceFlow(start);
+                    return {
+                      type: "success" as const,
+                      access: creds.access,
+                      refresh: creds.refresh,
+                      expires: creds.expires,
+                    };
+                  } catch (error) {
+                    console.error(`${LOG_PREFIX} device login failed:`, error);
+                    return { type: "failed" as const };
+                  }
+                },
+              };
+            },
+          },
+          {
+            type: "api",
+            label: `${profile().label} API key`,
+            prompts: [
+              {
+                type: "text",
+                key: "key",
+                message: `Enter your ${profile().label} API key`,
+                validate: (value) => (value.trim() ? undefined : "API key required"),
+              },
+            ],
+            authorize: async (inputs) => {
+              const key = inputs?.key?.trim();
+              return key ? { type: "success" as const, key } : { type: "failed" as const };
+            },
+          },
+        ],
+      };
+    }
+
+    return hooks;
+  };
+}
+
+export { PROVIDER_ID, PROVIDER_VERSION };
+export { profile as getProviderProfile } from "./src/profile.ts";
+export type {
+  AciDeviceFlowStart,
+  AciOAuthConfig,
+  AciOAuthCredentials,
+  ProviderProfile,
+} from "./src/profile.ts";
+export { loadAciCloudConfig } from "./src/config.ts";
+export type { AciCloudConfig, AciCloudConfigPatch } from "./src/config.ts";
+export { discoverAciModels, mapAciServerModel, inferReasoning } from "./src/models.ts";
+export { TlsPinManager, createAciFetch, computeSpkiSha256Hex } from "./src/pinned-fetch.ts";
+export {
+  type AttestationReport,
+  type ReceiptEnvelope,
+  type WorkloadKeyset,
+  bindAttestation,
+  classifyReceipt,
+  fetchAttestation,
+  fetchReceipt,
+  fetchSession,
+  isFullyVerified,
+  newNonce,
+} from "./src/verify.ts";

--- a/clients/opencode-provider/packages/opencode-provider-aci/index.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/index.ts
@@ -1,0 +1,11 @@
+/**
+ * opencode plugin entry for the neutral ACI provider.
+ *
+ * opencode's plugin loader treats EVERY runtime export as a plugin and calls
+ * it, so this entry must export nothing but the plugin function. The library
+ * surface (createProvider, types, verifier helpers) lives in ./core.ts and is
+ * importable as `@phala/opencode-provider-aci/core`.
+ */
+import { createProvider } from "./core.ts";
+
+export default createProvider();

--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@phala/opencode-provider-aci",
+  "version": "0.1.0",
+  "description": "Vendor-neutral opencode provider for private-ai-gateway (ACI): attested TLS (SPKI) pinning + per-response receipt verification",
+  "keywords": [
+    "aci",
+    "ai-provider",
+    "attestation",
+    "confidential-ai",
+    "confidential-computing",
+    "gateway",
+    "llm",
+    "llm-provider",
+    "opencode",
+    "opencode-plugin",
+    "opencode-provider",
+    "private-ai",
+    "private-ai-gateway",
+    "tee",
+    "verifiable"
+  ],
+  "license": "MIT",
+  "files": [
+    "index.ts",
+    "core.ts",
+    "src",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./core": "./core.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "clean": "echo 'nothing to clean'",
+    "build": "echo 'nothing to build'",
+    "check": "tsc --noEmit",
+    "test": "node --test tests/*.test.ts",
+    "lint": "oxlint .",
+    "format": "oxfmt . --write",
+    "format:check": "oxfmt . --check",
+    "pre-commit": "prek run"
+  },
+  "dependencies": {
+    "@phala/aci-verifier": "file:../../../verifier-ts"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  }
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/aci-client.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/aci-client.ts
@@ -1,0 +1,340 @@
+// ACI verification client.
+//
+// This is a thin provider-side wrapper over the repo's reference verifier,
+// `@phala/aci-verifier` (clients/verifier-ts), which implements the ACI spec
+// this repo defines and ships. The provider deliberately does NOT reimplement
+// report binding, receipt signature verification, or body-hash checks — the
+// reference verifier is the single source of truth, verified against
+// spec/test-vectors.md. This module only:
+//   - fetches the ACI artifacts (attestation, receipt, session) over HTTP;
+//   - maps verifier-ts results onto the provider's footer classification
+//     (verified / verified* / routed / attested / mismatch);
+//   - extracts the attested TLS SPKI for pinning from the established keyset.
+//
+// Fail-closed philosophy: a `verified` footer requires the binding, the
+// signature, AND the body hashes to be checked and pass. When bytes are not
+// available (raw SSE bytes are surfaced by the pinned fetch, if attached) we
+// say so explicitly in the status rather than silently claiming byte-binding.
+
+import { randomBytes } from "node:crypto";
+
+import {
+  type AttestationReport,
+  type KeysetKey,
+  type ReceiptEnvelope,
+  type ReceiptPayload,
+  type ReportVerification,
+  type TlsKeyPin,
+  type WorkloadKeyset,
+  AciError,
+  checkRequestBodyHash,
+  checkResponseBodyHash,
+  findEvent,
+  verifyReceipt as verifyReceiptReference,
+  verifyReportBinding,
+} from "@phala/aci-verifier";
+
+import {
+  DEFAULT_ATTESTATION_FETCH_TIMEOUT_MS,
+  DEFAULT_RECEIPT_FETCH_TIMEOUT_MS,
+  LOG_PREFIX,
+  buildAttestationUrl,
+  buildReceiptUrl,
+  buildSessionUrl,
+} from "./constants.ts";
+
+// ----------------------------------------------------------------------------
+// Fetch layer (identical to the previous verify.ts; returns null on failure)
+// ----------------------------------------------------------------------------
+
+async function fetchJson(
+  url: string,
+  apiKey: string,
+  timeoutMs: number,
+  label: string,
+): Promise<unknown | null> {
+  if (!apiKey) return null;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs).unref();
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+    });
+    if (!response.ok) {
+      console.error(`${LOG_PREFIX} ${label} returned ${response.status} ${response.statusText}`);
+      return null;
+    }
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch (parseError) {
+      console.error(`${LOG_PREFIX} ${label} JSON parse failed:`, parseError);
+      return null;
+    }
+  } catch (error) {
+    console.error(`${LOG_PREFIX} ${label} failed:`, error);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchReceipt(
+  apiKey: string,
+  receiptId: string,
+  options: { timeoutMs?: number; baseUrl?: string } = {},
+): Promise<ReceiptEnvelope | null> {
+  const json = await fetchJson(
+    buildReceiptUrl(receiptId, options.baseUrl),
+    apiKey,
+    options.timeoutMs ?? DEFAULT_RECEIPT_FETCH_TIMEOUT_MS,
+    `receipt ${receiptId}`,
+  );
+  return json as ReceiptEnvelope | null;
+}
+
+export async function fetchAttestation(
+  apiKey: string,
+  nonce: string,
+  options: { timeoutMs?: number; baseUrl?: string } = {},
+): Promise<AttestationReport | null> {
+  const json = await fetchJson(
+    buildAttestationUrl(nonce, options.baseUrl),
+    apiKey,
+    options.timeoutMs ?? DEFAULT_ATTESTATION_FETCH_TIMEOUT_MS,
+    "attestation",
+  );
+  return json as AttestationReport | null;
+}
+
+export async function fetchSession(
+  apiKey: string,
+  sessionId: string,
+  options: { timeoutMs?: number; baseUrl?: string } = {},
+): Promise<unknown | null> {
+  const json = await fetchJson(
+    buildSessionUrl(sessionId, options.baseUrl),
+    apiKey,
+    options.timeoutMs ?? DEFAULT_RECEIPT_FETCH_TIMEOUT_MS,
+    `session ${sessionId}`,
+  );
+  return json ?? null;
+}
+
+// ----------------------------------------------------------------------------
+// Binding (verifier-ts §9.1 checks 2–3)
+// ----------------------------------------------------------------------------
+
+/** Validate an attestation report against the nonce we sent. Returns null when
+ *  the binding fails or the report is malformed — never throws for a failed
+ *  check (only for a bad caller nonce, which we always generate). */
+export async function bindAttestation(
+  report: AttestationReport,
+  nonce: string,
+): Promise<ReportVerification | null> {
+  try {
+    const verification = await verifyReportBinding(report, nonce);
+    if (!verification.ok) {
+      console.error(
+        `${LOG_PREFIX} attestation binding failed: ${verification.checks
+          .filter((c) => !c.ok)
+          .map((c) => `${c.name}: ${c.detail ?? "fail"}`)
+          .join("; ")}`,
+      );
+      return null;
+    }
+    return verification;
+  } catch (error) {
+    if (error instanceof AciError) {
+      console.error(`${LOG_PREFIX} attestation binding rejected:`, error.message);
+      return null;
+    }
+    throw error;
+  }
+}
+
+/** Server-freshness cut-off (Unix ms) from an established keyset, if the keyset
+ *  carries a numeric `not_after` (§9.1 check 3). Absent → undefined (caller
+ *  falls back to its own TTL). */
+export function keysetStaleAfterMs(keyset: WorkloadKeyset | undefined): number | undefined {
+  const notAfter = keyset?.not_after;
+  return typeof notAfter === "number" && Number.isFinite(notAfter) ? notAfter * 1000 : undefined;
+}
+
+// ----------------------------------------------------------------------------
+// TLS SPKI extraction for pinning (§3.1 tls_public_keys)
+// ----------------------------------------------------------------------------
+
+/** First TLS SPKI SHA-256 that matches the host (either unscoped or by its
+ *  `domain`), from an established keyset. Returns undefined when the keyset
+ *  carries no TLS keys for that host. */
+export function attestedSpkiSha256ForHost(
+  keyset: WorkloadKeyset | undefined,
+  host: string,
+): string | undefined {
+  if (!keyset || !Array.isArray(keyset.tls_public_keys)) return undefined;
+  const normalized = host.trim().toLowerCase();
+  const scoped = (keyset.tls_public_keys as TlsKeyPin[]).find(
+    (pin) => pin.domain !== undefined && pin.domain.toLowerCase() === normalized,
+  );
+  const entry =
+    scoped ?? (keyset.tls_public_keys as TlsKeyPin[]).find((pin) => pin.domain === undefined);
+  if (!entry || typeof entry.spki_sha256 !== "string" || entry.spki_sha256.length === 0) {
+    return undefined;
+  }
+  return entry.spki_sha256.toLowerCase();
+}
+
+// ----------------------------------------------------------------------------
+// Receipt verification + footer classification
+// ----------------------------------------------------------------------------
+
+export type ReceiptStatus = "verified" | "routed" | "unknown";
+
+export interface ReceiptClassification {
+  status: ReceiptStatus;
+  provider?: string;
+  modelId?: string;
+  sessionId?: string;
+  required?: boolean;
+  /** Receipt signature + version + keyset binding all passed (§9.3 checks 1–2). */
+  signatureValid?: boolean;
+  /** request.received.body_hash matched our sent bytes (checked only when provided). */
+  requestHashValid?: boolean;
+  /** response.returned.body_hash matched the bytes we saw (checked only when provided). */
+  responseHashValid?: boolean;
+  /** True when request/response hashes were actually checked (bytes were provided). */
+  hashesChecked?: boolean;
+  /** When hashes were not checked, why (pi does not expose the raw bytes). */
+  hashesNotCheckedReason?: string;
+  /** upstream.verified classification (aggregator receipts). */
+  upstreamVerified?: boolean;
+  witnessSkipped?: boolean;
+  sessionVerified?: boolean;
+}
+
+function classifyUpstream(payload: ReceiptPayload | undefined): {
+  status: ReceiptStatus;
+  provider?: string;
+  modelId?: string;
+  sessionId?: string;
+  required?: boolean;
+} {
+  if (!payload) return { status: "unknown" };
+  const event = findEvent(payload, "upstream.verified");
+  const base: {
+    status: ReceiptStatus;
+    provider?: string;
+    modelId?: string;
+    sessionId?: string;
+    required?: boolean;
+  } = {
+    status: "unknown",
+  };
+  if (!event) return base;
+  const result = event.result;
+  const required = event.required === true;
+  const provider = typeof event.provider === "string" ? event.provider : undefined;
+  const modelId = typeof event.model_id === "string" ? event.model_id : undefined;
+  const sessionId = typeof event.session_id === "string" ? event.session_id : undefined;
+  base.provider = provider;
+  base.modelId = modelId;
+  base.sessionId = sessionId;
+  base.required = required;
+  if (result === "verified" && required) base.status = "verified";
+  else if (result === "failed" && !required) base.status = "routed";
+  else base.status = "unknown";
+  return base;
+}
+
+/**
+ * Verify a receipt against an established (bound) keyset and classify it for
+ * the footer. `establishedDigest` is the digest the binding established. When
+ * `requestBody`/`responseBytes` are provided the body-hash checks run; when
+ * absent they are reported as un-checked (never silently passed).
+ */
+export async function classifyReceipt(
+  receipt: ReceiptEnvelope,
+  keyset: WorkloadKeyset,
+  establishedDigest: string,
+  options: { requestBody?: Uint8Array; responseBytes?: Uint8Array } = {},
+): Promise<ReceiptClassification> {
+  // §9.3 checks 1–2: signature over JCS(minus signature) + version + digest binding.
+  const verification = await verifyReceiptReference(receipt, keyset, establishedDigest);
+  const signatureValid = verification.ok;
+
+  const payload = verification.payload;
+  const upstream = classifyUpstream(payload);
+
+  const classification: ReceiptClassification = {
+    ...upstream,
+    signatureValid,
+  };
+
+  if (payload) {
+    classification.modelId = typeof payload.model === "string" ? payload.model : undefined;
+  }
+
+  // Body hashes (§9.3 checks 3–4). Only claim a check when we have the bytes.
+  if (options.requestBody) {
+    classification.requestHashValid = payload
+      ? await checkRequestBodyHash(payload, options.requestBody)
+      : false;
+  }
+  if (options.responseBytes) {
+    classification.responseHashValid = payload
+      ? await checkResponseBodyHash(payload, options.responseBytes)
+      : false;
+  }
+  const hashesChecked = options.requestBody !== undefined || options.responseBytes !== undefined;
+  classification.hashesChecked = hashesChecked;
+  if (!hashesChecked && payload) {
+    // Bytes were not captured for this exchange (the pinned fetch attaches
+    // them when the response streams through it). State it, don't hide it.
+    classification.hashesNotCheckedReason =
+      "response bytes were not captured for this exchange; body hashes not checked here";
+  }
+  return classification;
+}
+
+/** Overall verified for the status line: signature passed AND BOTH body
+ *  hashes were checked and passed. A request-only check (e.g. the SSE
+ *  "[DONE] but no EOF" stage, where post-frame keepalive padding makes the
+ *  response bytes unknowable) is reported as verified*, never verified. */
+export function isFullyVerified(classification: ReceiptClassification): boolean {
+  if (classification.signatureValid !== true) return false;
+  return classification.requestHashValid === true && classification.responseHashValid === true;
+}
+
+/** Extract a raw request body payload to later compare against
+ *  request.received.body_hash. Serializes with canonical (sorted) member
+ *  order so the bytes are stable regardless of insertion order. */
+export function canonicalRequestBytes(payload: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalizeJson(payload));
+}
+
+function canonicalizeJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalizeJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: string[] = [];
+    for (const key of Object.keys(obj)
+      .filter((k) => obj[k] !== undefined)
+      .sort()) {
+      out.push(`${JSON.stringify(key)}:${canonicalizeJson(obj[key])}`);
+    }
+    return `{${out.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Re-export the receipt key lookup (for the /attestation command). */
+export function receiptSigningKeys(keyset: WorkloadKeyset | undefined): KeysetKey[] {
+  return Array.isArray(keyset?.receipt_signing_keys) ? keyset.receipt_signing_keys : [];
+}
+
+/** Generate a fresh nonce (32 random bytes, 64 lowercase hex — §3.2). */
+export function newNonce(): string {
+  return randomBytes(32).toString("hex");
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/config.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/config.ts
@@ -1,0 +1,197 @@
+// Configuration for the ACI opencode provider.
+//
+// Layers, lowest to highest precedence:
+//   default -> plugin options (opencode.json `"plugin": [["pkg", {...}]]`)
+//           -> env (<PREFIX>_* variables, or brand aliases)
+//           -> runtime (programmatic override via createProvider(profile, patch))
+//
+// Unlike the pi provider there is no home/project file layering: opencode
+// already merges global + project opencode.json, and provider-level settings
+// a user writes into config.provider.<id>.options are respected by the config
+// hook (user values win over plugin defaults for standard AI-SDK options).
+
+import { getEnvBaseUrl } from "./constants.ts";
+import { profile } from "./profile.ts";
+
+export type AciConfigSource = "runtime" | "env" | "plugin" | "default";
+
+export interface AciModelsConfig {
+  /** Only register models whose /v1/models entry has is_tee === true. */
+  isTeeOnly: boolean;
+  /** Optional model-id allowlist. When set, only these ids are registered. */
+  allowlist?: string[];
+}
+
+export interface AciVerifyConfig {
+  /** Automatically fetch + verify the receipt after each response. */
+  autoFetchReceipt: boolean;
+  /** Require a cached attestation whose workload matches the receipt. */
+  requireAttestationMatch: boolean;
+  /** When true, an unpinnable session runs unpinned with a status warning
+   *  (fail-open). When false (default) an unpinned session blocks inference
+   *  with a clear error rather than silently downgrading to CA-TLS. */
+  failOpenOnUnpinned: boolean;
+}
+
+export interface AciTlsPinningConfig {
+  /** Require the gateway's TLS connection to present the attested SPKI
+   *  (fetched from a validated attestation report). Fail closed on mismatch. */
+  enabled: boolean;
+}
+
+export interface AciCloudConfig {
+  baseUrl: string;
+  models: AciModelsConfig;
+  verify: AciVerifyConfig;
+  pinning: AciTlsPinningConfig;
+}
+
+export type AciCloudConfigPatch = {
+  baseUrl?: unknown;
+  models?: Partial<{
+    isTeeOnly: unknown;
+    allowlist: unknown;
+  }>;
+  verify?: Partial<{
+    autoFetchReceipt: unknown;
+    requireAttestationMatch: unknown;
+    failOpenOnUnpinned: unknown;
+  }>;
+  pinning?: Partial<{ enabled: unknown }>;
+};
+
+export const DEFAULT_ACI_CLOUD_CONFIG: AciCloudConfig = {
+  // Resolved lazily: the profile default enters in loadAciCloudConfig (the
+  // profile is applied at factory time, after module evaluation).
+  baseUrl: "",
+  models: {
+    isTeeOnly: true,
+  },
+  verify: {
+    autoFetchReceipt: true,
+    requireAttestationMatch: false,
+    failOpenOnUnpinned: false,
+  },
+  pinning: {
+    enabled: true,
+  },
+};
+
+export interface LoadAciCloudConfigOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Plugin options from `"plugin": [["@phala/...", {...}]]` in opencode.json. */
+  pluginOptions?: Record<string, unknown>;
+  /** Runtime patch passed to createProvider(). */
+  overrides?: AciCloudConfigPatch;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (v === "true" || v === "1" || v === "yes") return true;
+    if (v === "false" || v === "0" || v === "no") return false;
+  }
+  return undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const list = value.filter((v): v is string => typeof v === "string" && v.length > 0);
+    return list.length > 0 ? list : undefined;
+  }
+  if (typeof value === "string") {
+    const list = value
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+    return list.length > 0 ? list : undefined;
+  }
+  return undefined;
+}
+
+function asBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.replace(/\/+$/, "") : undefined;
+}
+
+/** Apply one patch-shaped layer (plugin options or runtime overrides) onto a
+ *  draft config. Unknown/invalid values are ignored, never partially applied. */
+function applyPatch(draft: AciCloudConfig, patch: AciCloudConfigPatch | undefined): void {
+  if (!patch) return;
+  const baseUrl = asBaseUrl(patch.baseUrl);
+  if (baseUrl) draft.baseUrl = baseUrl;
+
+  const isTeeOnly = asBoolean(patch.models?.isTeeOnly);
+  if (isTeeOnly !== undefined) draft.models.isTeeOnly = isTeeOnly;
+  const allowlist = asStringArray(patch.models?.allowlist);
+  if (allowlist) draft.models.allowlist = allowlist;
+
+  const autoFetchReceipt = asBoolean(patch.verify?.autoFetchReceipt);
+  if (autoFetchReceipt !== undefined) draft.verify.autoFetchReceipt = autoFetchReceipt;
+  const requireAttestationMatch = asBoolean(patch.verify?.requireAttestationMatch);
+  if (requireAttestationMatch !== undefined)
+    draft.verify.requireAttestationMatch = requireAttestationMatch;
+  const failOpenOnUnpinned = asBoolean(patch.verify?.failOpenOnUnpinned);
+  if (failOpenOnUnpinned !== undefined) draft.verify.failOpenOnUnpinned = failOpenOnUnpinned;
+
+  const pinningEnabled = asBoolean(patch.pinning?.enabled);
+  if (pinningEnabled !== undefined) draft.pinning.enabled = pinningEnabled;
+}
+
+/** Plugin options use flat keys for ergonomics in opencode.json:
+ *  `{ "baseUrl": "...", "isTeeOnly": false, "failOpenOnUnpinned": true, ... }`. */
+function patchFromPluginOptions(options: Record<string, unknown> | undefined): AciCloudConfigPatch {
+  if (!options) return {};
+  return {
+    baseUrl: options.baseUrl,
+    models: { isTeeOnly: options.isTeeOnly, allowlist: options.allowlist },
+    verify: {
+      autoFetchReceipt: options.autoFetchReceipt,
+      requireAttestationMatch: options.requireAttestationMatch,
+      failOpenOnUnpinned: options.failOpenOnUnpinned,
+    },
+    pinning: { enabled: options.pinning },
+  };
+}
+
+function patchFromEnv(env: NodeJS.ProcessEnv): AciCloudConfigPatch {
+  const prefix = profile().envPrefix;
+  const read = (name: string): string | undefined => env[name]?.trim() || undefined;
+  return {
+    // Only explicit env vars participate in layering here; brand aliases and
+    // the profile default are resolved in loadAciCloudConfig.
+    baseUrl: env === process.env ? getEnvBaseUrl() : asBaseUrl(read(`${prefix}_BASE_URL`)),
+    models: {
+      isTeeOnly: read(`${prefix}_IS_TEE_ONLY`),
+      allowlist: read(`${prefix}_MODEL_ALLOWLIST`),
+    },
+    verify: {
+      autoFetchReceipt: read(`${prefix}_AUTO_FETCH_RECEIPT`),
+      requireAttestationMatch: read(`${prefix}_REQUIRE_ATTESTATION_MATCH`),
+      failOpenOnUnpinned: read(`${prefix}_FAIL_OPEN_ON_UNPINNED`),
+    },
+    pinning: { enabled: read(`${prefix}_PINNING`) },
+  };
+}
+
+function cloneDefaults(): AciCloudConfig {
+  return {
+    baseUrl: DEFAULT_ACI_CLOUD_CONFIG.baseUrl,
+    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models },
+    verify: { ...DEFAULT_ACI_CLOUD_CONFIG.verify },
+    pinning: { ...DEFAULT_ACI_CLOUD_CONFIG.pinning },
+  };
+}
+
+/** Load the effective config: default -> plugin options -> env -> runtime.
+ *  When no layer set the base URL, fall back to the brand profile default. */
+export function loadAciCloudConfig(options: LoadAciCloudConfigOptions = {}): AciCloudConfig {
+  const draft = cloneDefaults();
+  applyPatch(draft, patchFromPluginOptions(options.pluginOptions));
+  applyPatch(draft, patchFromEnv(options.env ?? process.env));
+  applyPatch(draft, options.overrides);
+  if (!draft.baseUrl) draft.baseUrl = profile().defaultBaseUrl;
+  return draft;
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/constants.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/constants.ts
@@ -1,0 +1,130 @@
+// Module-level identity + env-driven configuration shared across the provider's
+// modules. The identity values are live bindings populated by
+// `applyProviderProfile()` (called once by the factory entry point), so branded
+// shells (phala-cloud, ...) get their own provider id, env names, and default
+// endpoint without touching the protocol code.
+
+import { DEFAULT_PROFILE, profile, resolveProfile, type ProviderProfile } from "./profile.ts";
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+// --- Identity (live bindings; see applyProviderProfile) ---
+export let PROVIDER_ID = DEFAULT_PROFILE.providerId;
+export let API_KEY_ENV = DEFAULT_PROFILE.apiKeyEnv;
+export let DEFAULT_BASE_URL = DEFAULT_PROFILE.defaultBaseUrl;
+export let LOG_PREFIX = DEFAULT_PROFILE.logPrefix;
+
+export const PROVIDER_VERSION = "0.1.0";
+
+/** Apply a resolved brand profile. Idempotent; call once before registering.
+ *  Also updates profile()'s current profile so modules reading identity
+ *  values through profile() (env prefix, aliases, oauth, fallback catalog)
+ *  see the brand, not the neutral defaults. */
+export function applyProviderProfile(patch: Partial<ProviderProfile> | undefined): void {
+  const merged = resolveProfile(patch);
+  PROVIDER_ID = merged.providerId;
+  API_KEY_ENV = merged.apiKeyEnv;
+  DEFAULT_BASE_URL = merged.defaultBaseUrl;
+  LOG_PREFIX = merged.logPrefix;
+}
+
+function firstEnv(...names: (string | undefined)[]): string | undefined {
+  for (const name of names) {
+    if (!name) continue;
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/** Base URL from the environment only: {PREFIX}_{CLOUD_API_PREFIX|BASE_URL|
+ *  CLOUD_BASE_URL} or the brand's legacy aliases. Undefined when unset. */
+export function getEnvBaseUrl(): string | undefined {
+  const p = profile();
+  const prefixed = firstEnv(
+    `${p.envPrefix}_CLOUD_API_PREFIX`,
+    `${p.envPrefix}_BASE_URL`,
+    `${p.envPrefix}_CLOUD_BASE_URL`,
+  );
+  return prefixed || firstEnv(...(p.baseUrlAliases ?? []));
+}
+
+/** Read the base URL for the current profile: environment, then the profile
+ *  default. */
+export function getBaseUrl(): string {
+  return getEnvBaseUrl() || profile().defaultBaseUrl || DEFAULT_BASE_URL;
+}
+
+/** Read the inference API key from the environment ({PREFIX}_LLM_API_KEY or
+ *  brand aliases). OAuth-stored credentials are captured separately by the
+ *  auth loader (see core.ts); this is the env fallback. */
+export function getEnvApiKey(): string {
+  const p = profile();
+  return firstEnv(p.apiKeyEnv, ...(p.apiKeyAliases ?? [])) ?? "";
+}
+
+/** Read the credential opencode stored for this provider via
+ *  `opencode auth login` ($XDG_DATA_HOME/opencode/auth.json or
+ *  ~/.local/share/opencode/auth.json). Used for startup model discovery and
+ *  ACI artifact fetches before the auth loader has run. Returns "" when
+ *  absent or expired. */
+export function getStoredApiKey(): string {
+  try {
+    const dataHome = process.env.XDG_DATA_HOME?.trim() || join(os.homedir(), ".local", "share");
+    const path = join(dataHome, "opencode", "auth.json");
+    if (!existsSync(path)) return "";
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const entry = parsed[PROVIDER_ID];
+    if (!entry || typeof entry !== "object") return "";
+    const rec = entry as Record<string, unknown>;
+    if (rec.type === "oauth" && typeof rec.access === "string") {
+      const expires = rec.expires;
+      if (typeof expires === "number" && Number.isFinite(expires) && expires <= Date.now()) {
+        return "";
+      }
+      return rec.access;
+    }
+    if (rec.type === "api" && typeof rec.key === "string") return rec.key;
+  } catch {
+    // Unreadable storage; fall through to "".
+  }
+  return "";
+}
+
+// Build a gateway-root URL (no trailing /v1) for ACI endpoints
+// (/aci/receipts, /aci/attestation, /aci/sessions). The inference base URL is
+// `<root>/v1`; ACI endpoints hang off the same host.
+export function getGatewayRoot(baseUrl: string = getBaseUrl()): string {
+  return baseUrl.replace(/\/v\d+\/?$/, "").replace(/\/+$/, "");
+}
+
+export function buildModelsUrl(baseUrl: string = getBaseUrl()): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  return base.endsWith("/v1") ? `${base}/models` : `${base}/v1/models`;
+}
+
+export function buildReceiptUrl(receiptId: string, baseUrl: string = getBaseUrl()): string {
+  return `${getGatewayRoot(baseUrl)}/v1/aci/receipts/${encodeURIComponent(receiptId)}`;
+}
+
+export function buildAttestationUrl(nonce: string, baseUrl: string = getBaseUrl()): string {
+  return `${getGatewayRoot(baseUrl)}/v1/aci/attestation?nonce=${encodeURIComponent(nonce)}`;
+}
+
+export function buildSessionUrl(sessionId: string, baseUrl: string = getBaseUrl()): string {
+  return `${getGatewayRoot(baseUrl)}/v1/aci/sessions/${encodeURIComponent(sessionId)}`;
+}
+
+// ACI response headers attached to every inference response.
+export const HEADER_RECEIPT_ID = "x-receipt-id";
+export const HEADER_ACI_IDENTITY = "x-aci-identity";
+export const HEADER_ACI_KEYSET_DIGEST = "x-aci-keyset-digest";
+
+export const DEFAULT_DISCOVERY_TIMEOUT_MS = 5000;
+export const DEFAULT_RECEIPT_FETCH_TIMEOUT_MS = 8000;
+export const DEFAULT_ATTESTATION_FETCH_TIMEOUT_MS = 8000;
+
+// Attestation freshness: re-fetch when the cached report's stale_after has
+// passed, or after this fallback TTL if the report lacked freshness info.
+export const ATTESTATION_FALLBACK_TTL_MS = 30 * 60 * 1000;

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/models.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/models.ts
@@ -1,0 +1,191 @@
+// Model discovery and mapping. Pulls /v1/models from the ACI gateway and
+// converts each entry into opencode's provider model config shape. Responsible
+// for:
+//   - is_tee filtering (config.models.isTeeOnly)
+//   - allowlist filtering (config.models.allowlist)
+//   - embedding model exclusion (output_modalities === ["embeddings"])
+//   - reasoning inference (by model family id)
+//   - pricing conversion (per-token -> per-million-token)
+//
+// Note: unlike the pi provider there is no thinkingFormat mapping here. Pi's
+// built-in openai-completions handler sends `enable_thinking` /
+// `reasoning_effort` based on compat settings; opencode's
+// @ai-sdk/openai-compatible has no equivalent config surface, so reasoning is
+// advertised on the model (`reasoning: true`) and reasoning_content streamed
+// by the gateway still surfaces in opencode, but no thinking parameter is
+// sent. This is a documented fidelity gap vs the pi provider.
+
+import { type AciCloudConfig } from "./config.ts";
+import { DEFAULT_DISCOVERY_TIMEOUT_MS, LOG_PREFIX, buildModelsUrl } from "./constants.ts";
+import { profile } from "./profile.ts";
+
+export interface AciServerModel {
+  id?: unknown;
+  name?: unknown;
+  is_tee?: unknown;
+  context_length?: unknown;
+  max_output_length?: unknown;
+  pricing?: unknown;
+  providers?: unknown;
+  input_modalities?: unknown;
+  output_modalities?: unknown;
+  supported_parameters?: unknown;
+  description?: unknown;
+}
+
+/** opencode provider model config (config.provider.<id>.models.<modelId>). */
+export interface OpencodeModelConfig {
+  name: string;
+  reasoning: boolean;
+  cost: { input: number; output: number; cache_read: number; cache_write: number };
+  limit: { context: number; output: number };
+  modalities: { input: ("text" | "image")[]; output: "text"[] };
+}
+
+export type OpencodeModelsRecord = Record<string, OpencodeModelConfig>;
+
+// Pure inference. Exposed for tests so the model-family mapping can be
+// verified without hitting the network.
+export function inferReasoning(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  if (id.includes("qwen")) return true;
+  if (id.includes("gpt-oss")) return true;
+  if ((id.includes("deepseek") && id.includes("r1")) || id.includes("reasoner")) return true;
+  return false;
+}
+
+function parsePerTokenPrice(value: unknown): number {
+  if (typeof value !== "string" && typeof value !== "number") return 0;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  // ACI returns per-token pricing; opencode expects per-million-token.
+  return parsed * 1_000_000;
+}
+
+function mapInputModalities(raw: unknown): ("text" | "image")[] {
+  if (!Array.isArray(raw)) return ["text"];
+  const hasImage = raw.some((m) => m === "image");
+  return hasImage ? ["text", "image"] : ["text"];
+}
+
+function isEmbeddingModel(model: AciServerModel): boolean {
+  const output = model.output_modalities;
+  return Array.isArray(output) && output.length === 1 && output[0] === "embeddings";
+}
+
+// Pure mapping. Exposed for tests.
+export function mapAciServerModel(
+  model: AciServerModel,
+  config: AciCloudConfig,
+): OpencodeModelConfig | null {
+  if (typeof model.id !== "string" || model.id.length === 0) return null;
+  if (isEmbeddingModel(model)) return null;
+
+  if (config.models.isTeeOnly && model.is_tee !== true) return null;
+
+  if (config.models.allowlist && config.models.allowlist.length > 0) {
+    if (!config.models.allowlist.includes(model.id)) return null;
+  }
+
+  const contextWindow =
+    typeof model.context_length === "number" && model.context_length > 0
+      ? model.context_length
+      : 32768;
+  const maxTokens =
+    typeof model.max_output_length === "number" && model.max_output_length > 0
+      ? model.max_output_length
+      : Math.min(contextWindow, 8192);
+
+  const pricing =
+    model.pricing && typeof model.pricing === "object"
+      ? (model.pricing as { prompt?: unknown; completion?: unknown })
+      : {};
+
+  return {
+    name: typeof model.name === "string" && model.name ? model.name : model.id,
+    reasoning: inferReasoning(model.id),
+    cost: {
+      input: parsePerTokenPrice(pricing.prompt),
+      output: parsePerTokenPrice(pricing.completion),
+      cache_read: 0,
+      cache_write: 0,
+    },
+    limit: { context: contextWindow, output: maxTokens },
+    modalities: { input: mapInputModalities(model.input_modalities), output: ["text"] },
+  };
+}
+
+export interface DiscoverAciModelsOptions {
+  timeoutMs?: number;
+  baseUrl?: string;
+}
+
+export interface DiscoverAciModelsResult {
+  models: OpencodeModelsRecord;
+  raw: AciServerModel[];
+}
+
+export async function discoverAciModels(
+  apiKey: string,
+  config: AciCloudConfig,
+  options: DiscoverAciModelsOptions = {},
+): Promise<DiscoverAciModelsResult> {
+  if (!apiKey) return { models: {}, raw: [] };
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout =
+    timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs).unref() : undefined;
+
+  try {
+    const response = await fetch(buildModelsUrl(options.baseUrl ?? config.baseUrl), {
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      console.error(`${LOG_PREFIX} /v1/models returned ${response.status} ${response.statusText}`);
+      return { models: {}, raw: [] };
+    }
+    const json = (await response.json()) as { data?: unknown };
+    const list = Array.isArray(json.data)
+      ? (json.data as AciServerModel[]).filter((m) => m && typeof m === "object")
+      : [];
+    const models: OpencodeModelsRecord = {};
+    for (const raw of list) {
+      if (typeof raw.id !== "string" || raw.id.length === 0) continue;
+      const mapped = mapAciServerModel(raw, config);
+      if (mapped) models[raw.id] = mapped;
+    }
+    return { models, raw: list };
+  } catch (error) {
+    console.error(`${LOG_PREFIX} model discovery failed:`, error);
+    return { models: {}, raw: [] };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+/** Fallback model record used when discovery has no API key or fails. Drawn
+ *  from the active provider profile (branded shells supply their own
+ *  catalog); the live /v1/models catalog is authoritative. */
+export function fallbackModels(): OpencodeModelsRecord {
+  const out: OpencodeModelsRecord = {};
+  for (const m of profile().fallbackModels) {
+    out[m.id] = {
+      name: m.name,
+      reasoning: m.reasoning,
+      cost: {
+        input: m.cost.input,
+        output: m.cost.output,
+        cache_read: m.cost.cacheRead,
+        cache_write: m.cost.cacheWrite,
+      },
+      limit: { context: m.contextWindow, output: m.maxTokens },
+      modalities: { input: m.input, output: ["text"] },
+    };
+  }
+  return out;
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/pinned-fetch.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/pinned-fetch.ts
@@ -1,0 +1,366 @@
+// Attested TLS SPKI pinning + exchange capture for opencode.
+//
+// Where the pi provider wraps globalThis.fetch with an undici dispatcher, the
+// opencode provider injects a custom `fetch` into the provider options of
+// @ai-sdk/openai-compatible. That single injection point gives us everything
+// pi had to reach for events/global wrappers to approximate:
+//   - TLS pinning: opencode plugins run inside opencode's Bun runtime, and
+//     Bun's fetch accepts `tls: { checkServerIdentity }` per request, so the
+//     attested SPKI pin is enforced per connection for the gateway host (fail
+//     closed on mismatch). The pin comes from a fresh, validated attestation
+//     report (workload_keyset.tls_public_keys, see index.ts).
+//   - Receipt headers: x-receipt-id / x-aci-identity / x-aci-keyset-digest are
+//     read straight off the Response, no provider-response event needed.
+//   - Body-hash bytes: the request body and the streamed response bytes are
+//     captured as they pass through, so receipts can be FULLY verified
+//     (signature AND body hashes). The pi provider cannot see response bytes
+//     and caps its footer at "verified*"; here "verified" is honest.
+//
+// Fail-closed posture: when pinning is enabled and no pin is established (and
+// the user did not opt into failOpenOnUnpinned), inference traffic to the
+// gateway host is rejected before it leaves the process rather than silently
+// downgrading to plain CA-TLS. ACI bootstrap endpoints (/v1/aci/*) are exempt
+// so a fresh attestation can always be fetched to install or refresh a pin.
+
+import crypto from "node:crypto";
+
+import { LOG_PREFIX } from "./constants.ts";
+
+/** Minimal shape of the TLS peer certificate Bun/Node hand to
+ *  checkServerIdentity. `pubkey` is the DER SubjectPublicKeyInfo. */
+export interface PeerCertificateLike {
+  pubkey?: Uint8Array;
+  raw?: Uint8Array;
+}
+
+/** SHA-256 (lowercase hex) of the certificate's SPKI, matching how the
+ *  gateway computes `tls_public_keys[].spki_sha256` in its attestation.
+ *
+ *  IMPORTANT: `cert.pubkey` is NOT the SPKI DER — in both Node and Bun it is
+ *  the public key BIT STRING contents (no AlgorithmIdentifier wrapper), so
+ *  hashing it never matches the attested SPKI. The SPKI must be derived from
+ *  the full certificate (`cert.raw`) via X509 export, exactly as the pi
+ *  provider does. `pubkey` is only a last-resort fallback for runtimes whose
+ *  PeerCertificate carries no raw DER. */
+export function computeSpkiSha256Hex(cert: PeerCertificateLike): string {
+  if (cert.raw && cert.raw.length > 0) {
+    const x509 = new crypto.X509Certificate(cert.raw);
+    const spki = x509.publicKey.export({ type: "spki", format: "der" }) as Buffer;
+    return crypto.createHash("sha256").update(spki).digest("hex");
+  }
+  if (cert.pubkey && cert.pubkey.length > 0) {
+    return crypto.createHash("sha256").update(cert.pubkey).digest("hex");
+  }
+  throw new Error("peer certificate carries neither raw DER nor pubkey");
+}
+
+function hexEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length || a.length === 0) return false;
+  return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+/** Target hostname from fetch's first argument, if possible. */
+export function hostOfInput(input: RequestInfo | URL): string | undefined {
+  try {
+    if (typeof input === "string") return normalizeHost(new URL(input).hostname);
+    if (input instanceof URL) return normalizeHost(input.hostname);
+    const url = (input as Request).url;
+    return url ? normalizeHost(new URL(url).hostname) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pathnameOfInput(input: RequestInfo | URL): string {
+  try {
+    return new URL(typeof input === "string" ? input : ((input as Request).url ?? String(input)))
+      .pathname;
+  } catch {
+    return "";
+  }
+}
+
+/** True when the request targets a model-inference path (not an ACI bootstrap
+ *  endpoint like /v1/aci/attestation). Unparseable URLs are treated as
+ *  inference: stay strict. */
+export function isInferencePath(input: RequestInfo | URL): boolean {
+  const path = pathnameOfInput(input);
+  if (!path) return true;
+  return !path.startsWith("/v1/aci/");
+}
+
+/** Per-host attested SPKI pins. The callback shape matches Bun's
+ *  `fetch(init.tls.checkServerIdentity)` and node:tls. */
+export class TlsPinManager {
+  private pins = new Map<string, string>();
+
+  /** Register the attested SPKI pin for a host. Idempotent. */
+  setPin(host: string, spkiSha256Hex: string): void {
+    this.pins.set(normalizeHost(host), spkiSha256Hex.toLowerCase());
+  }
+
+  /** Remove the pin for a host. */
+  clearPin(host: string): void {
+    this.pins.delete(normalizeHost(host));
+  }
+
+  /** Current pin for a host, or undefined. */
+  getPin(host: string): string | undefined {
+    return this.pins.get(normalizeHost(host));
+  }
+
+  /** TLS callback; returns undefined to accept, or an Error to reject. Hosts
+   *  without a pin get default TLS validation (the callback is only attached
+   *  for pinned hosts, so this is defense in depth). */
+  checkServerIdentity = (hostname: string, cert: PeerCertificateLike): Error | undefined => {
+    // node:tls reports "host:port" when a custom port is in play; the pin is
+    // registered under the bare hostname from the configured base URL.
+    const bare = normalizeHost(hostname).split(":")[0];
+    const expected = this.pins.get(bare);
+    if (!expected) return undefined;
+    let actual: string;
+    try {
+      actual = computeSpkiSha256Hex(cert);
+    } catch (error) {
+      return new Error(
+        `${LOG_PREFIX} could not compute peer SPKI for ${hostname}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (hexEqualHex(actual, expected)) return undefined;
+    return new Error(
+      `${LOG_PREFIX} TLS SPKI pin mismatch for ${hostname}: peer=${actual} expected=${expected}`,
+    );
+  };
+}
+
+/** Terminal SSE marker: `data: [DONE]`. The gateway can append keepalive
+ *  padding (blank lines) after the [DONE] frame, so completion is "bytes,
+ *  ignoring trailing newlines, end with the marker" — NOT an exact tail
+ *  match. */
+const SSE_DONE_TEXT = new TextEncoder().encode("data: [DONE]");
+const LF = 0x0a;
+
+/** Non-null finish_reason marks the semantic end of a chat stream. Consumers
+ *  (the AI SDK) may stop reading right after this frame and cancel — the
+ *  [DONE] frame never enters the tee — so this is an alternative completion
+ *  trigger. Matched against a rolling text tail (the finish frame can be
+ *  split across TCP chunks). */
+const SSE_FINISH_RE =
+  /"finish_reason"\s*:\s*"(stop|length|tool_calls|content_filter|function_call)"/;
+
+/** True when the accumulated stream bytes end with the terminal SSE [DONE]
+ *  frame, tolerating any amount of trailing newline padding. Walks backwards
+ *  across chunk boundaries without joining the buffers. */
+function hasSseDoneTerminator(chunks: Uint8Array[]): boolean {
+  let ci = chunks.length - 1;
+  let offset = ci >= 0 ? chunks[ci].length - 1 : -1;
+  const advance = (): boolean => {
+    while (offset < 0) {
+      ci--;
+      if (ci < 0) return false;
+      offset = chunks[ci].length - 1;
+    }
+    return true;
+  };
+  // Skip trailing newline padding.
+  while (true) {
+    if (!advance()) return false;
+    if (chunks[ci][offset] !== LF) break;
+    offset--;
+  }
+  // Match the marker backwards.
+  for (let m = SSE_DONE_TEXT.length - 1; m >= 0; m--) {
+    if (!advance()) return false;
+    if (chunks[ci][offset] !== SSE_DONE_TEXT[m]) return false;
+    offset--;
+  }
+  return true;
+}
+
+export interface CapturedExchange {
+  url: string;
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  /** Exact request body bytes we sent, when captureable (string/Buffer JSON). */
+  requestBody?: Uint8Array;
+  /** Exact response bytes the model streamed back. Present ONLY when the
+   *  exchange closed at true EOF (complete bytes, safe for body-hash
+   *  verification). Absent on SSE [DONE] completion: the gateway can append
+   *  keepalive padding AFTER the [DONE] frame and its
+   *  response.returned.body_hash commits to those bytes too, so truncated
+   *  bytes must never be hash-checked. */
+  responseBytes?: Uint8Array;
+  /** "eof": stream read to completion (responseBytes present).
+   *  "sse-done": terminal [DONE] frame seen but consumer did not read to EOF
+   *  (responseBytes absent — signature/request-hash level only). */
+  completion: "eof" | "sse-done";
+}
+
+export interface AciFetchDeps {
+  manager: TlsPinManager;
+  /** Whether the request host is the configured gateway host. */
+  isGatewayHost(host: string): boolean;
+  /** Live config reads (config can change between requests). */
+  pinningEnabled(): boolean;
+  failOpenOnUnpinned(): boolean;
+  /** Resolve a fresh attestation and install the pin for the host. Returns
+   *  true when a pin is established. Implementations must dedupe concurrent
+   *  calls and may serve a cached attestation while fresh. */
+  ensurePinned(host: string): Promise<boolean>;
+  /** Called per gateway exchange with captured headers/bytes. May fire twice
+   *  for one SSE exchange: once on the terminal [DONE] frame (completion
+   *  "sse-done", no responseBytes) and again if the consumer then reads to
+   *  EOF (completion "eof", full responseBytes — an upgrade). */
+  onExchange?(exchange: CapturedExchange): void;
+  /** Underlying fetch (defaults to globalThis.fetch). */
+  baseFetch?: typeof fetch;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+/** Exact bytes of a fetch request body, when it is a synchronous body type
+ *  (the AI SDK sends JSON strings). Streams are not captured. */
+function bodyBytes(body: unknown): Uint8Array | undefined {
+  if (typeof body === "string") return new TextEncoder().encode(body);
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  return undefined;
+}
+
+/**
+ * Create the fetch injected into the provider's options. Traffic to hosts
+ * other than the configured gateway delegates to the underlying fetch
+ * untouched; gateway traffic is pinned/captured as described above.
+ */
+export function createAciFetch(deps: AciFetchDeps): typeof fetch {
+  const baseFetch = deps.baseFetch ?? globalThis.fetch;
+  const { manager } = deps;
+
+  return async function aciFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const host = hostOfInput(input);
+    if (!host || !deps.isGatewayHost(host)) {
+      return baseFetch(input, init);
+    }
+
+    const inference = isInferencePath(input);
+    let pinned = manager.getPin(host) !== undefined;
+
+    if (deps.pinningEnabled() && inference && !pinned) {
+      // Lazy pin install on first inference use: resolve the attested SPKI
+      // from a fresh, validated attestation before the request can leave.
+      pinned = await deps.ensurePinned(host);
+    }
+
+    if (deps.pinningEnabled() && inference && !pinned && !deps.failOpenOnUnpinned()) {
+      throw new Error(
+        `${LOG_PREFIX} host ${host} requires an attested TLS pin but none is established; ` +
+          `blocked to avoid a cleartext downgrade. Check the attestation/logs, or set ` +
+          `failOpenOnUnpinned to run unpinned with a warning.`,
+      );
+    }
+
+    const requestBody = bodyBytes(init?.body);
+    const pinnedNow = manager.getPin(host) !== undefined;
+
+    // Bun-specific init: `tls.checkServerIdentity` enforces the pin per
+    // connection. Unknown to standard RequestInit; cast deliberately.
+    const effectiveInit = pinnedNow
+      ? ({
+          ...init,
+          tls: { checkServerIdentity: manager.checkServerIdentity, rejectUnauthorized: true },
+        } as unknown as RequestInit)
+      : init;
+
+    const response = await baseFetch(input, effectiveInit);
+    const headers = headersToRecord(response.headers);
+
+    if (!response.body) {
+      deps.onExchange?.({
+        url: pathnameOfInput(input),
+        status: response.status,
+        ok: response.ok,
+        headers,
+        requestBody,
+        completion: "eof",
+      });
+      return response;
+    }
+
+    // Tee the response stream: pass chunks through untouched while collecting
+    // the exact bytes. Completion semantics (see CapturedExchange):
+    //   - SSE streams: consumers (AI SDK) typically CANCEL the body right
+    //     after the terminal `data: [DONE]` frame instead of reading to EOF.
+    //     Fire "sse-done" there (no responseBytes — the gateway's
+    //     response.returned.body_hash covers post-[DONE] keepalive padding
+    //     we may never see). If the consumer then reads on to EOF, fire
+    //     "eof" with the complete bytes (an upgrade: full body-hash check).
+    //   - Non-streaming responses: read to EOF, fires "eof" only.
+    //   - Any other cancel (mid-stream abort): nothing fires, so a partial
+    //     stream can never produce a hash "mismatch".
+    const chunks: Uint8Array[] = [];
+    let byteLength = 0;
+    let sawSseDone = false;
+    let sawEof = false;
+    const requestUrl = pathnameOfInput(input);
+    // Rolling decoded tail for finish_reason detection (JSON is ASCII; a
+    // streaming decoder keeps multibyte chars intact across chunks).
+    const tailDecoder = new TextDecoder();
+    let tailText = "";
+    const fire = (completion: "eof" | "sse-done", withBytes: boolean) => {
+      const bytes = withBytes ? new Uint8Array(byteLength) : undefined;
+      if (bytes) {
+        let offset = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.length;
+        }
+      }
+      deps.onExchange?.({
+        url: requestUrl,
+        status: response.status,
+        ok: response.ok,
+        headers,
+        requestBody,
+        responseBytes: bytes,
+        completion,
+      });
+    };
+    const tee = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        chunks.push(chunk);
+        byteLength += chunk.length;
+        tailText = (tailText + tailDecoder.decode(chunk, { stream: true })).slice(-512);
+        controller.enqueue(chunk);
+        if (!sawSseDone && (hasSseDoneTerminator(chunks) || SSE_FINISH_RE.test(tailText))) {
+          sawSseDone = true;
+          fire("sse-done", false);
+        }
+      },
+      flush() {
+        if (sawEof) return;
+        sawEof = true;
+        fire("eof", true);
+      },
+    });
+
+    const body = response.body.pipeThrough(tee);
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/profile.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/profile.ts
@@ -1,0 +1,107 @@
+// Provider identity/profile.
+//
+// The core is a vendor-neutral client of the private-ai-gateway "ACI"
+// protocol. A single default profile ("aci") is defined here; branded
+// distributions (`opencode-provider-phala-cloud`, ...) build
+// `createProvider(profile)` with their own identity. The core never
+// enumerates vendors.
+//
+// profile.ts owns the *identity* values (provider id, env names, default
+// endpoint, fallback catalog). Everything protocol-y (attestation, TLS SPKI
+// pinning, receipt verification, model discovery) lives elsewhere and is
+// identity-agnostic.
+
+export interface ProviderProfile {
+  /** Provider id registered in opencode (config.provider key). */
+  providerId: string;
+  /** Human-facing label for the provider display name / status. */
+  label: string;
+  /** Default gateway base URL (branded shells set this; core is operator-set). */
+  defaultBaseUrl: string;
+  /** Env var for the LLM/inference API key. */
+  apiKeyEnv: string;
+  /** Prefix for config env vars: {PREFIX}_BASE_URL, {PREFIX}_IS_TEE_ONLY, ... */
+  envPrefix: string;
+  /** Log prefix, e.g. "[aci]". */
+  logPrefix: string;
+  /** Fallback model catalog used when discovery has no API key. */
+  fallbackModels: Array<{
+    id: string;
+    name: string;
+    reasoning: boolean;
+    input: ("text" | "image")[];
+    cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+    contextWindow: number;
+    maxTokens: number;
+  }>;
+  /** Optional legacy env-var aliases for the base URL / API key (brand
+   *  backward-compat). */
+  baseUrlAliases?: string[];
+  apiKeyAliases?: string[];
+  /** Optional OAuth login block (RFC 8628 device flow). Branded shells that
+   *  support `opencode auth login` supply this; the core adapts it onto
+   *  opencode's auth hook (authorize -> verification URL, callback -> poll).
+   *  The shell owns the HTTP flow; the core only transports the config. */
+  oauth?: AciOAuthConfig;
+}
+
+/** Credentials minted by a completed device-flow login. */
+export interface AciOAuthCredentials {
+  access: string;
+  refresh: string;
+  /** Absolute expiry (Unix ms). Keys that do not expire use a far-future value. */
+  expires: number;
+}
+
+/** Device-flow session returned by the authorization endpoint (RFC 8628 §3.2). */
+export interface AciDeviceFlowStart {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+}
+
+/** OAuth config the core adapts onto opencode's `auth` hook. */
+export interface AciOAuthConfig {
+  /** Display name shown in `opencode auth login`. */
+  name: string;
+  /** Begin the device authorization flow (POST device/code). */
+  startDeviceFlow(signal?: AbortSignal): Promise<AciDeviceFlowStart>;
+  /** Poll the token endpoint until the user approves, the code expires, or
+   *  the flow fails. Throws on failure/expiry. */
+  pollDeviceFlow(start: AciDeviceFlowStart, signal?: AbortSignal): Promise<AciOAuthCredentials>;
+}
+
+export const DEFAULT_PROFILE: ProviderProfile = {
+  providerId: "aci",
+  label: "Private AI Gateway",
+  defaultBaseUrl: "",
+  apiKeyEnv: "ACI_LLM_API_KEY",
+  envPrefix: "ACI",
+  logPrefix: "[aci]",
+  fallbackModels: [],
+};
+
+let current: ProviderProfile = DEFAULT_PROFILE;
+
+/** Resolve a (possibly partial) profile over the neutral defaults. */
+export function resolveProfile(patch: Partial<ProviderProfile> | undefined): ProviderProfile {
+  current = { ...DEFAULT_PROFILE, ...stripEmpty(patch) };
+  return current;
+}
+
+/** The currently active profile (set by the factory entry point). */
+export function profile(): ProviderProfile {
+  return current;
+}
+
+function stripEmpty<T extends Record<string, unknown>>(patch: T | undefined): T {
+  if (!patch) return {} as T;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    out[k] = v;
+  }
+  return out as T;
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/receipt-store.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/receipt-store.ts
@@ -1,0 +1,242 @@
+// In-memory store for the last response's receipt metadata, a cached attestation
+// report (with freshness), and the verified classification. The user-facing
+// verification status (statusText) is derived from this store.
+
+import type { AciCloudConfig } from "./config.ts";
+import {
+  ATTESTATION_FALLBACK_TTL_MS,
+  HEADER_ACI_IDENTITY,
+  HEADER_ACI_KEYSET_DIGEST,
+  HEADER_RECEIPT_ID,
+  LOG_PREFIX,
+  PROVIDER_ID,
+} from "./constants.ts";
+import {
+  type AttestationReport,
+  type ReceiptEnvelope,
+  type ReportVerification,
+  type WorkloadKeyset,
+  bindAttestation,
+  classifyReceipt,
+  fetchAttestation,
+  fetchReceipt,
+  isFullyVerified,
+  keysetStaleAfterMs,
+  newNonce,
+} from "./verify.ts";
+import type { ReceiptClassification } from "./verify.ts";
+
+export interface ResponseHeaderSnapshot {
+  receiptId?: string;
+  aciIdentity?: string;
+  keysetDigest?: string;
+}
+
+export interface Attested {
+  report: AttestationReport;
+  verification: ReportVerification;
+  fetchedAt: number;
+}
+
+export class AciReceiptStore {
+  private lastReceiptId?: string;
+  private lastAciIdentity?: string;
+  private lastKeysetDigest?: string;
+  private lastClassification?: ReceiptClassification;
+  private _lastAttestationError?: string;
+  private cachedAttestation?: Attested;
+  private lastRequestBody?: Uint8Array;
+  private lastResponseBytes?: Uint8Array;
+
+  recordResponseHeaders(headers: Record<string, string>): ResponseHeaderSnapshot {
+    const lower = lowerHeaders(headers);
+    this.lastReceiptId = lower[HEADER_RECEIPT_ID] ?? lower["x-receipt-id"];
+    this.lastAciIdentity = lower[HEADER_ACI_IDENTITY] ?? lower["x-aci-identity"];
+    this.lastKeysetDigest = lower[HEADER_ACI_KEYSET_DIGEST] ?? lower["x-aci-keyset-digest"];
+    this.lastClassification = undefined;
+    return this.snapshot();
+  }
+
+  snapshot(): ResponseHeaderSnapshot {
+    return {
+      receiptId: this.lastReceiptId,
+      aciIdentity: this.lastAciIdentity,
+      keysetDigest: this.lastKeysetDigest,
+    };
+  }
+
+  get classification(): ReceiptClassification | undefined {
+    return this.lastClassification;
+  }
+
+  /** Stash the last request body bytes for request.received.body_hash verification. */
+  setLastRequestBody(bytes: Uint8Array): void {
+    this.lastRequestBody = bytes;
+  }
+
+  /** Stash the last response bytes for response.returned.body_hash verification. */
+  setLastResponseBytes(bytes: Uint8Array): void {
+    this.lastResponseBytes = bytes;
+  }
+
+  get lastAttestationError(): string | undefined {
+    return this._lastAttestationError;
+  }
+
+  /** Validated binding for the cached attestation, if present. */
+  get binding(): ReportVerification | undefined {
+    return this.cachedAttestation?.verification;
+  }
+
+  /** Keyset established by the cached binding, if any. */
+  get establishedKeyset(): WorkloadKeyset | undefined {
+    return this.cachedAttestation?.verification.keyset;
+  }
+
+  /** Fetch + validate the attestation report. Returns the validated artifact,
+   *  or null (with lastAttestationError set) when the fetch or binding fails. */
+  async getAttestation(apiKey: string, config: AciCloudConfig): Promise<Attested | null> {
+    const now = Date.now();
+    if (this.cachedAttestation && this.isFresh(this.cachedAttestation, now)) {
+      return this.cachedAttestation;
+    }
+
+    let lastError: string | undefined;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const nonce = newNonce();
+      const report = await fetchAttestation(apiKey, nonce, { baseUrl: config.baseUrl });
+      if (!report) return null;
+      try {
+        const verification = await bindAttestation(report, nonce);
+        if (verification) {
+          this._lastAttestationError = undefined;
+          this.cachedAttestation = { report, verification, fetchedAt: Date.now() };
+          return this.cachedAttestation;
+        }
+        lastError = "report binding failed (see console)";
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+        console.error(
+          `${LOG_PREFIX} attestation report binding failed (attempt ${attempt + 1}):`,
+          error,
+        );
+      }
+    }
+    this._lastAttestationError = lastError;
+    return null;
+  }
+
+  private isFresh(cached: Attested, now: number): boolean {
+    const staleAfterMs = keysetStaleAfterMs(cached.verification.keyset);
+    if (typeof staleAfterMs === "number") return staleAfterMs > now;
+    return now - cached.fetchedAt < ATTESTATION_FALLBACK_TTL_MS;
+  }
+
+  /** Fetch the receipt for the last response and run full verification against a
+   *  cached attestation. Stores the classification for footer rendering.
+   *
+   *  Fails closed: when `config.verify.requireAttestationMatch` is set and no
+   *  validated attestation with a matching keyset is available, the
+   *  classification is reported as mismatch/unverified rather than a silent
+   *  semantic-only pass. */
+  async classifyLastResponse(
+    apiKey: string,
+    config: AciCloudConfig,
+    _options: { requestBody?: Uint8Array; responseBytes?: Uint8Array } = {},
+  ): Promise<ReceiptClassification | null> {
+    if (!this.lastReceiptId) return null;
+    // Capture the receipt this call is for so a slower, earlier in-flight
+    // classification cannot overwrite the newer one when it finally resolves
+    // (message_end fires per response; they resolve out of order).
+    const targetReceiptId = this.lastReceiptId;
+
+    const receipt: ReceiptEnvelope | null = await fetchReceipt(apiKey, targetReceiptId, {
+      baseUrl: config.baseUrl,
+    });
+    if (!receipt) return null;
+
+    const attested = await this.getAttestation(apiKey, config);
+    const keyset = attested?.verification.keyset;
+    const digest = attested?.verification.workloadKeysetDigest;
+    const requireMatch = config.verify.requireAttestationMatch;
+
+    if (attested && keyset && digest) {
+      const classification = await classifyReceipt(receipt, keyset, digest, {
+        requestBody: this.lastRequestBody ?? _options.requestBody,
+        responseBytes: this.lastResponseBytes ?? _options.responseBytes,
+      });
+      // Only publish the classification if this is still the latest receipt.
+      if (this.lastReceiptId === targetReceiptId) {
+        this.lastClassification = classification;
+      }
+      return classification;
+    }
+
+    // No valid attestation. requireAttestationMatch means the user asked for
+    // responses to be gated on a matching attested workload — a receipt we
+    // cannot bind to one must not render "verified".
+    if (requireMatch) {
+      const blocked: ReceiptClassification = {
+        status: "unknown",
+        signatureValid: false,
+        hashesChecked: false,
+        hashesNotCheckedReason: this.lastAttestationError ?? "no valid attestation available",
+      };
+      if (this.lastReceiptId === targetReceiptId) this.lastClassification = blocked;
+      return blocked;
+    }
+
+    // Best-effort semantic classification without a binding (footers: routed /
+    // attested / mismatch — never "verified"). This mirrors the previous
+    // no-attestation fallback, minus any claim of full verification.
+    const basic: ReceiptClassification = { status: "routed", hashesChecked: false };
+    if (this.lastReceiptId === targetReceiptId) this.lastClassification = basic;
+    return basic;
+  }
+
+  reset(): void {
+    this.lastReceiptId = undefined;
+    this.lastAciIdentity = undefined;
+    this.lastKeysetDigest = undefined;
+    this.lastClassification = undefined;
+    this.cachedAttestation = undefined;
+    this._lastAttestationError = undefined;
+    this.lastRequestBody = undefined;
+    this.lastResponseBytes = undefined;
+  }
+}
+
+// Verification status text. No emoji per project conventions.
+//   signature+workload+hashes verified            -> "<id>: verified"
+//   receipt verified but signature/hash not checked -> "<id>: verified*"
+//   routed (upstream not attested)                -> "<id>: routed"
+//   signature FAILED or keyset mismatch           -> "<id>: mismatch"
+//   attestation/report pending                     -> "<id>: attested"
+//   no receipt header                              -> "<id>: (no receipt)"
+export function statusText(store: AciReceiptStore): string {
+  const classification = store.classification;
+
+  if (classification) {
+    if (isFullyVerified(classification)) return `${PROVIDER_ID}: verified`;
+    if (classification.signatureValid === false) return `${PROVIDER_ID}: mismatch`;
+    if (classification.status === "routed") return `${PROVIDER_ID}: routed`;
+    if (classification.signatureValid === true && !classification.hashesChecked) {
+      return `${PROVIDER_ID}: verified*`;
+    }
+    if (classification.status === "verified") return `${PROVIDER_ID}: verified*`;
+    return `${PROVIDER_ID}: attested`;
+  }
+
+  if (store.snapshot().receiptId || store.snapshot().aciIdentity) {
+    return `${PROVIDER_ID}: attested`;
+  }
+  return `${PROVIDER_ID}: (no receipt)`;
+}
+
+function lowerHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key.toLowerCase()] = value;
+  }
+  return out;
+}

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/verify.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/verify.ts
@@ -1,0 +1,30 @@
+// Stable import surface over the ACI verifier client.
+//
+// The provider's verification logic lives in `aci-client.ts`, which wraps the
+// repo's reference verifier `@phala/aci-verifier` (clients/verifier-ts). This
+// module re-exports the names consumers (index.ts, tests) need from ./verify
+// so the verifier wiring stays in one place. Everything resolves to the
+// reference verifier, which is conformance-tested against spec/test-vectors.md.
+
+export {
+  type AttestationReport,
+  type ReceiptEnvelope,
+  type ReportVerification,
+  type WorkloadKeyset,
+} from "@phala/aci-verifier";
+
+export {
+  attestedSpkiSha256ForHost,
+  bindAttestation,
+  canonicalRequestBytes,
+  classifyReceipt,
+  fetchAttestation,
+  fetchReceipt,
+  fetchSession,
+  isFullyVerified,
+  keysetStaleAfterMs,
+  newNonce,
+  receiptSigningKeys,
+} from "./aci-client.ts";
+
+export type { ReceiptClassification, ReceiptStatus } from "./aci-client.ts";

--- a/clients/opencode-provider/packages/opencode-provider-aci/tests/config.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/tests/config.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { loadAciCloudConfig } from "../src/config.ts";
+
+// Tests run under the neutral default profile (envPrefix "ACI", no default
+// base URL). Branded shells apply their profile before loading.
+
+test("defaults: TEE-only, auto-verify, pinning on, fail-closed", () => {
+  const config = loadAciCloudConfig({ env: {} });
+  assert.equal(config.models.isTeeOnly, true);
+  assert.equal(config.verify.autoFetchReceipt, true);
+  assert.equal(config.verify.requireAttestationMatch, false);
+  assert.equal(config.verify.failOpenOnUnpinned, false);
+  assert.equal(config.pinning.enabled, true);
+  assert.equal(config.baseUrl, "");
+});
+
+test("plugin options layer applies flat keys", () => {
+  const config = loadAciCloudConfig({
+    env: {},
+    pluginOptions: {
+      baseUrl: "https://gateway.example/v1/",
+      isTeeOnly: false,
+      failOpenOnUnpinned: true,
+      pinning: false,
+    },
+  });
+  assert.equal(config.baseUrl, "https://gateway.example/v1");
+  assert.equal(config.models.isTeeOnly, false);
+  assert.equal(config.verify.failOpenOnUnpinned, true);
+  assert.equal(config.pinning.enabled, false);
+});
+
+test("env layer beats plugin options", () => {
+  const config = loadAciCloudConfig({
+    env: { ACI_BASE_URL: "https://env.example/v1", ACI_IS_TEE_ONLY: "true" },
+    pluginOptions: { baseUrl: "https://plugin.example/v1", isTeeOnly: false },
+  });
+  assert.equal(config.baseUrl, "https://env.example/v1");
+  assert.equal(config.models.isTeeOnly, true);
+});
+
+test("runtime overrides beat env", () => {
+  const config = loadAciCloudConfig({
+    env: { ACI_BASE_URL: "https://env.example/v1", ACI_FAIL_OPEN_ON_UNPINNED: "false" },
+    overrides: {
+      baseUrl: "https://runtime.example/v1",
+      verify: { failOpenOnUnpinned: true },
+    },
+  });
+  assert.equal(config.baseUrl, "https://runtime.example/v1");
+  assert.equal(config.verify.failOpenOnUnpinned, true);
+});
+
+test("env allowlist parses comma-separated ids", () => {
+  const config = loadAciCloudConfig({
+    env: { ACI_MODEL_ALLOWLIST: "a/model, b/model ,c/model" },
+  });
+  assert.deepEqual(config.models.allowlist, ["a/model", "b/model", "c/model"]);
+});
+
+test("invalid values are ignored, never partially applied", () => {
+  const config = loadAciCloudConfig({
+    env: {},
+    pluginOptions: { isTeeOnly: "maybe", pinning: 42, baseUrl: 7 },
+  });
+  assert.equal(config.models.isTeeOnly, true);
+  assert.equal(config.pinning.enabled, true);
+  assert.equal(config.baseUrl, "");
+});

--- a/clients/opencode-provider/packages/opencode-provider-aci/tests/models.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/tests/models.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { DEFAULT_ACI_CLOUD_CONFIG } from "../src/config.ts";
+import { inferReasoning, mapAciServerModel } from "../src/models.ts";
+import type { AciServerModel } from "../src/models.ts";
+
+test("inferReasoning: qwen models are reasoning models", () => {
+  assert.equal(inferReasoning("phala/qwen3.5-27b"), true);
+});
+
+test("inferReasoning: gpt-oss models are reasoning models", () => {
+  assert.equal(inferReasoning("phala/gpt-oss-20b"), true);
+});
+
+test("inferReasoning: gemma and other non-reasoning models default to false", () => {
+  assert.equal(inferReasoning("phala/gemma-3-27b-it"), false);
+});
+
+test("inferReasoning: deepseek-r1 treated as reasoning", () => {
+  assert.equal(inferReasoning("deepseek/deepseek-r1"), true);
+});
+
+test("mapAciServerModel: drops non-TEE models when isTeeOnly is true", () => {
+  const model: AciServerModel = {
+    id: "some/plain-model",
+    name: "Plain",
+    is_tee: false,
+    context_length: 32768,
+    max_output_length: 8192,
+    pricing: { prompt: "0.00000010", completion: "0.00000020" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
+  assert.equal(mapped, null);
+});
+
+test("mapAciServerModel: keeps non-TEE models when isTeeOnly is false", () => {
+  const config = {
+    ...DEFAULT_ACI_CLOUD_CONFIG,
+    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models, isTeeOnly: false },
+  };
+  const model: AciServerModel = {
+    id: "some/plain-model",
+    name: "Plain",
+    is_tee: false,
+    context_length: 32768,
+    max_output_length: 8192,
+    pricing: { prompt: "0.00000010", completion: "0.00000020" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, config);
+  assert.ok(mapped);
+  assert.equal(mapped.name, "Plain");
+});
+
+test("mapAciServerModel: excludes embedding models", () => {
+  const model: AciServerModel = {
+    id: "qwen/qwen3-embedding-8b",
+    name: "Embedding",
+    is_tee: true,
+    context_length: 32000,
+    output_modalities: ["embeddings"],
+    input_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
+  assert.equal(mapped, null);
+});
+
+test("mapAciServerModel: converts per-token pricing to per-million", () => {
+  const model: AciServerModel = {
+    id: "phala/qwen3.5-27b",
+    name: "Qwen3.5 27B",
+    is_tee: true,
+    context_length: 262144,
+    max_output_length: 262144,
+    pricing: { prompt: "0.00000030", completion: "0.00000240" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
+  assert.ok(mapped);
+  assert.equal(mapped.cost.input, 0.3);
+  assert.equal(mapped.cost.output, 2.4);
+  assert.equal(mapped.cost.cache_read, 0);
+});
+
+test("mapAciServerModel: maps image input modality", () => {
+  const model: AciServerModel = {
+    id: "phala/qwen3-vl-30b",
+    name: "Qwen3 VL",
+    is_tee: true,
+    context_length: 128000,
+    pricing: { prompt: "0.00000020", completion: "0.00000070" },
+    input_modalities: ["text", "image"],
+    output_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
+  assert.ok(mapped);
+  assert.deepEqual(mapped.modalities.input, ["text", "image"]);
+  assert.deepEqual(mapped.modalities.output, ["text"]);
+});
+
+test("mapAciServerModel: allowlist filters out unlisted ids", () => {
+  const config = {
+    ...DEFAULT_ACI_CLOUD_CONFIG,
+    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models, allowlist: ["phala/qwen3.5-27b"] },
+  };
+  const kept: AciServerModel = {
+    id: "phala/qwen3.5-27b",
+    is_tee: true,
+    context_length: 1000,
+    pricing: { prompt: "0", completion: "0" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  const dropped: AciServerModel = {
+    id: "phala/other-model",
+    is_tee: true,
+    context_length: 1000,
+    pricing: { prompt: "0", completion: "0" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  assert.ok(mapAciServerModel(kept, config));
+  assert.equal(mapAciServerModel(dropped, config), null);
+});
+
+test("mapAciServerModel: qwen model is marked reasoning with context/output limits", () => {
+  const model: AciServerModel = {
+    id: "phala/qwen3.5-27b",
+    is_tee: true,
+    context_length: 262144,
+    max_output_length: 16384,
+    pricing: { prompt: "0", completion: "0" },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+  };
+  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
+  assert.ok(mapped);
+  assert.equal(mapped.reasoning, true);
+  assert.deepEqual(mapped.limit, { context: 262144, output: 16384 });
+});

--- a/clients/opencode-provider/packages/opencode-provider-aci/tests/pinned-fetch.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/tests/pinned-fetch.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createHash } from "node:crypto";
+
+import {
+  type CapturedExchange,
+  TlsPinManager,
+  computeSpkiSha256Hex,
+  createAciFetch,
+  hostOfInput,
+  isInferencePath,
+} from "../src/pinned-fetch.ts";
+
+const GATEWAY = "gateway.example";
+const PIN = "a".repeat(64);
+
+function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+function fakeResponse(body?: ReadableStream<Uint8Array>, headers: Record<string, string> = {}) {
+  return new Response(body ?? null, { status: 200, headers });
+}
+
+interface FakeFetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+function makeDeps(over: Partial<Parameters<typeof createAciFetch>[0]> = {}) {
+  const manager = new TlsPinManager();
+  const calls: FakeFetchCall[] = [];
+  const exchanges: CapturedExchange[] = [];
+  const baseFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return fakeResponse(streamOf([new TextEncoder().encode("data: hello\n\n")]), {
+      "x-receipt-id": "rcpt-1",
+    });
+  }) as typeof fetch;
+  const deps: Parameters<typeof createAciFetch>[0] = {
+    manager,
+    isGatewayHost: (host) => host === GATEWAY,
+    pinningEnabled: () => true,
+    failOpenOnUnpinned: () => false,
+    ensurePinned: async () => false,
+    onExchange: (x) => exchanges.push(x),
+    baseFetch,
+    ...over,
+  };
+  return { manager, calls, exchanges, deps };
+}
+
+test("non-gateway hosts pass through untouched (no tls init, no capture)", async () => {
+  const { calls, exchanges, deps } = makeDeps();
+  const fetcher = createAciFetch(deps);
+  const res = await fetcher(`https://api.other.com/v1/chat`);
+  await res.text();
+  assert.equal(calls.length, 1);
+  assert.equal((calls[0].init as Record<string, unknown> | undefined)?.tls, undefined);
+  assert.equal(exchanges.length, 0);
+});
+
+test("fail closed: no pin + failOpen off blocks before any request leaves", async () => {
+  const { calls, deps } = makeDeps();
+  const fetcher = createAciFetch(deps);
+  await assert.rejects(
+    fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" }),
+    /requires an attested TLS pin/,
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("lazy pin install: ensurePinned runs on first inference use and the pin is enforced via tls init", async () => {
+  const { manager, calls, deps } = makeDeps({
+    ensurePinned: async (host) => {
+      manager.setPin(host, PIN);
+      return true;
+    },
+  });
+  const fetcher = createAciFetch(deps);
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, {
+    method: "POST",
+    body: "{}",
+  });
+  await res.text();
+  assert.equal(calls.length, 1);
+  const tls = (calls[0].init as Record<string, unknown>)?.tls as
+    | { checkServerIdentity?: unknown; rejectUnauthorized?: boolean }
+    | undefined;
+  assert.equal(typeof tls?.checkServerIdentity, "function");
+  assert.equal(tls?.rejectUnauthorized, true);
+});
+
+test("fail open: unpinnable + failOpenOnUnpinned proceeds without tls init", async () => {
+  const { calls, deps } = makeDeps({
+    failOpenOnUnpinned: () => true,
+  });
+  const fetcher = createAciFetch(deps);
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+  await res.text();
+  assert.equal(calls.length, 1);
+  assert.equal((calls[0].init as Record<string, unknown>)?.tls, undefined);
+});
+
+test("pinning disabled: no ensurePinned, no tls init", async () => {
+  let ensureCalls = 0;
+  const { calls, deps } = makeDeps({
+    pinningEnabled: () => false,
+    ensurePinned: async () => {
+      ensureCalls++;
+      return false;
+    },
+  });
+  const fetcher = createAciFetch(deps);
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+  await res.text();
+  assert.equal(ensureCalls, 0);
+  assert.equal(calls.length, 1);
+  assert.equal((calls[0].init as Record<string, unknown>)?.tls, undefined);
+});
+
+test("ACI bootstrap endpoints stay reachable without a pin", async () => {
+  const { calls, deps } = makeDeps();
+  const fetcher = createAciFetch(deps);
+  const res = await fetcher(`https://${GATEWAY}/v1/aci/attestation?nonce=abc`);
+  await res.text();
+  assert.equal(calls.length, 1);
+});
+
+test("capture: request body, response bytes, and receipt headers reach onExchange", async () => {
+  const { exchanges, deps } = makeDeps({
+    ensurePinned: async () => true, // pin must exist for tls path; not required for capture
+  });
+  // No pin installed, failOpen off — but bootstrap paths bypass the gate; use
+  // failOpen to let this inference request through unpinned.
+  const openDeps = { ...deps, failOpenOnUnpinned: () => true };
+  const fetcher = createAciFetch(openDeps);
+  const payload = JSON.stringify({ model: "m", messages: [] });
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, {
+    method: "POST",
+    body: payload,
+  });
+  const text = await res.text();
+  assert.equal(text, "data: hello\n\n");
+  assert.equal(exchanges.length, 1);
+  const x = exchanges[0];
+  assert.equal(x.headers["x-receipt-id"], "rcpt-1");
+  assert.equal(new TextDecoder().decode(x.requestBody), payload);
+  assert.equal(new TextDecoder().decode(x.responseBytes), "data: hello\n\n");
+});
+
+test("cancelled streams never report an exchange (no partial-byte mismatch)", async () => {
+  const { exchanges, deps } = makeDeps({ failOpenOnUnpinned: () => true });
+  const hanging = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("data: partial\n\n"));
+      // never closes
+    },
+  });
+  const baseFetch = (async () => fakeResponse(hanging)) as typeof fetch;
+  const fetcher = createAciFetch({ ...deps, baseFetch });
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+  const reader = res.body!.getReader();
+  await reader.read();
+  await reader.cancel();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(exchanges.length, 0);
+});
+
+test("checkServerIdentity: matching SPKI accepts, mismatch rejects, host:port normalized", () => {
+  const manager = new TlsPinManager();
+  const pubkey = new Uint8Array([1, 2, 3, 4, 5]);
+  const spki = createHash("sha256").update(pubkey).digest("hex");
+  manager.setPin(GATEWAY, spki);
+
+  assert.equal(manager.checkServerIdentity(GATEWAY, { pubkey }), undefined);
+  // TLS callbacks report host:port for non-default ports.
+  assert.equal(manager.checkServerIdentity(`${GATEWAY}:8443`, { pubkey }), undefined);
+
+  const wrong = manager.checkServerIdentity(GATEWAY, { pubkey: new Uint8Array([9, 9]) });
+  assert.ok(wrong instanceof Error);
+  assert.match(wrong.message, /pin mismatch/);
+});
+
+test("checkServerIdentity: no pin for host defers to default TLS validation", () => {
+  const manager = new TlsPinManager();
+  assert.equal(
+    manager.checkServerIdentity("unpinned.example", { pubkey: new Uint8Array([1]) }),
+    undefined,
+  );
+});
+
+test("computeSpkiSha256Hex derives SPKI from cert raw DER (gateway-compatible)", () => {
+  // Real leaf certificate once served by inference.phala.com. The gateway's
+  // attested spki_sha256 for this cert is the openssl-verified value below;
+  // hashing cert.pubkey instead (the old behavior) produced a different,
+  // never-matching digest - the SPKI must come from the full cert DER.
+  const CERT_DER_BASE64 =
+    "MIIDlDCCAxqgAwIBAgISBb093fqYrLC2fDpObGU07PL7MAoGCCqGSM49BAMDMDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQDEwNZRTEwHhcNMjYwNjI0MDY0MTAwWhcNMjYwOTIyMDY0MDU5WjAeMRwwGgYDVQQDExNpbmZlcmVuY2UucGhhbGEuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPfiFKSLz1+UeZuPvvNE681M/nHBvHkxZozrZkRNtgppzOCLFDoitIutMRPhrp8bdFLjk7Ncr4q8u/ZOWy+pi0qOCAiEwggIdMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTto+LNWMGhCKvBfmJz0yi+VnpIkjAfBgNVHSMEGDAWgBS7IMpHC/7X5Zz5jwkqo4w3RbG82DAzBggrBgEFBQcBAQQnMCUwIwYIKwYBBQUHMAKGF2h0dHA6Ly95ZTEuaS5sZW5jci5vcmcvMB4GA1UdEQQXMBWCE2luZmVyZW5jZS5waGFsYS5jb20wEwYDVR0gBAwwCjAIBgZngQwBAgEwLwYDVR0fBCgwJjAkoCKgIIYeaHR0cDovL3llMS5jLmxlbmNyLm9yZy8xMjQuY3JsMIIBCwYKKwYBBAHWeQIEAgSB/ASB+QD3AHUAlE5Dh/rswe+B8xkkJqgYZQHH0184AgE/cmd9VTcuGdgAAAGe+JHgaAAABAMARjBEAiA14+XPYjGrDZkqR8dLCVxtHhGwl5ptxQ+muTEMxgASlwIgTIoRIBtE2g12L74hsVIO3NXrnsABXeR94B6I3ExpYQgAfgBs/lAZQ6heqRa8UtEz5NzJHvFBHH0lhCDRc4CeGBjrOgAAAZ74keP0AAgAAAUAEdzdZQQDAEcwRQIhAJV9WKFE5VtU+K9b/Oug3VDsaThlmsB6sxlpvWDCU9HaAiB24O4pNqfuTynlm3HDGNcSK7/GNdz5FBJlEfoiHNH9kTAKBggqhkjOPQQDAwNoADBlAjBatDsgLJ9tuHVePHIu7GgEXKs4iKFw2cw+EQgNHa/q3vE8KDkIpTRd+udKeii9aL0CMQC4BPJGWURCjNL5l4XYPK35Y4LCh9rOOabwjObBFiUI3rXbO0ucgdadUDOzmoBbDlA=";
+  const raw = Buffer.from(CERT_DER_BASE64, "base64");
+  assert.equal(
+    computeSpkiSha256Hex({ raw }),
+    "698c87b1ed32d3d67f23d14295fc443e91b82ad4e40482041ac1a9158c8212e2",
+  );
+});
+
+test("computeSpkiSha256Hex falls back to pubkey and rejects empty certs", () => {
+  const pubkey = new Uint8Array([7, 7, 7]);
+  assert.equal(computeSpkiSha256Hex({ pubkey }), createHash("sha256").update(pubkey).digest("hex"));
+  assert.throws(() => computeSpkiSha256Hex({}), /neither raw DER nor pubkey/);
+});
+
+test("hostOfInput + isInferencePath helpers", () => {
+  assert.equal(hostOfInput("https://GATEWAY.example/v1/models"), "gateway.example");
+  assert.equal(isInferencePath("https://x.example/v1/chat/completions"), true);
+  assert.equal(isInferencePath("https://x.example/v1/aci/receipts/1"), false);
+});
+
+test("SSE completion: cancel after [DONE] fires sse-done WITHOUT responseBytes (padding is hash-relevant)", async () => {
+  const { exchanges, deps } = makeDeps({ failOpenOnUnpinned: () => true });
+  const enc = new TextEncoder();
+  // The gateway appends keepalive padding after [DONE]; its
+  // response.returned.body_hash covers those bytes, so truncated bytes must
+  // never be delivered as verifiable responseBytes.
+  const stream = "data: chunk1\n\ndata: chunk2\n\ndata: [DONE]\n\n\n\n\n\n";
+  const split = [enc.encode(stream.slice(0, 20)), enc.encode(stream.slice(20))];
+  const baseFetch = (async () =>
+    fakeResponse(streamOf(split), { "x-receipt-id": "rcpt-9" })) as typeof fetch;
+  const fetcher = createAciFetch({ ...deps, baseFetch });
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+
+  // Simulate the AI SDK: read until the [DONE] marker arrives, then cancel
+  // instead of reading to EOF.
+  const reader = res.body!.getReader();
+  let seen = "";
+  while (!seen.includes("data: [DONE]")) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    seen += new TextDecoder().decode(value);
+  }
+  await reader.cancel();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const sseDone = exchanges.filter((x) => x.completion === "sse-done");
+  assert.equal(sseDone.length, 1);
+  assert.equal(sseDone[0].responseBytes, undefined);
+  assert.equal(sseDone[0].headers["x-receipt-id"], "rcpt-9");
+  assert.equal(
+    exchanges.filter((x) => x.completion === "eof").length,
+    0,
+    "cancel after [DONE] must not fabricate an eof exchange",
+  );
+});
+
+test("SSE completion: reading to EOF after [DONE] upgrades with full bytes (padding included)", async () => {
+  const { exchanges, deps } = makeDeps({ failOpenOnUnpinned: () => true });
+  const enc = new TextEncoder();
+  const stream = "data: chunk1\n\ndata: [DONE]\n\n\n\n\n\n";
+  const baseFetch = (async () =>
+    fakeResponse(streamOf([enc.encode(stream)]), { "x-receipt-id": "rcpt-10" })) as typeof fetch;
+  const fetcher = createAciFetch({ ...deps, baseFetch });
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+  await res.text(); // reads to EOF
+
+  const kinds = exchanges.map((x) => x.completion);
+  assert.deepEqual(kinds, ["sse-done", "eof"]);
+  const eof = exchanges[1];
+  assert.equal(new TextDecoder().decode(eof.responseBytes), stream);
+});
+
+test("SSE completion: consumer cancelling at the finish_reason frame still fires sse-done (AI SDK behavior)", async () => {
+  const { exchanges, deps } = makeDeps({ failOpenOnUnpinned: () => true });
+  const enc = new TextEncoder();
+  // The AI SDK stops reading at the finish_reason frame and cancels — the
+  // [DONE] frame never enters the tee. Completion must still fire.
+  const frames = [
+    'data: {"choices":[{"delta":{"content":"po"},"finish_reason":null}]}\n\n',
+    'data: {"choices":[{"delta":{"content":"ng"},"finish_reason":null}]}\n\n',
+    'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+    "data: [DONE]\n\n\n\n",
+  ];
+  const baseFetch = (async () =>
+    fakeResponse(streamOf(frames.map((f) => enc.encode(f))), {
+      "x-receipt-id": "rcpt-11",
+    })) as typeof fetch;
+  const fetcher = createAciFetch({ ...deps, baseFetch });
+  const res = await fetcher(`https://${GATEWAY}/v1/chat/completions`, { method: "POST" });
+
+  const reader = res.body!.getReader();
+  let seen = "";
+  while (!seen.includes('"finish_reason":"stop"')) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    seen += new TextDecoder().decode(value);
+  }
+  await reader.cancel();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const sseDone = exchanges.filter((x) => x.completion === "sse-done");
+  assert.equal(sseDone.length, 1);
+  assert.equal(sseDone[0].headers["x-receipt-id"], "rcpt-11");
+  assert.equal(sseDone[0].responseBytes, undefined);
+});

--- a/clients/opencode-provider/packages/opencode-provider-aci/tests/plugin.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/tests/plugin.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Hooks } from "@opencode-ai/plugin";
+
+import { createProvider } from "../core.ts";
+
+function mockInput() {
+  const logs: string[] = [];
+  const toasts: string[] = [];
+  const input = {
+    client: {
+      app: {
+        log: async ({ body }: { body: { message: string } }) => {
+          logs.push(body.message);
+          return {};
+        },
+      },
+      tui: {
+        showToast: async ({ body }: { body: { message: string } }) => {
+          toasts.push(body.message);
+          return {};
+        },
+      },
+    },
+    project: {},
+    directory: "/tmp",
+    worktree: "/tmp",
+    serverUrl: new URL("http://localhost:0"),
+  };
+  return { input: input as never, logs, toasts };
+}
+
+test("plugin assembles hooks and injects the provider with a custom fetch", async () => {
+  const plugin = createProvider();
+  const { input } = mockInput();
+  const hooks: Hooks = await plugin(input, {});
+
+  assert.equal(typeof hooks.config, "function");
+  assert.equal(typeof hooks.tool?.["aci_verification_status"], "object");
+  // Neutral profile has no oauth block.
+  assert.equal(hooks.auth, undefined);
+
+  const cfg: { provider?: Record<string, never> } = {};
+  await hooks.config!(cfg as never);
+
+  const provider = (cfg as Record<string, Record<string, Record<string, unknown>>>).provider.aci;
+  assert.ok(provider, "provider.aci registered");
+  assert.equal(provider.npm, "@ai-sdk/openai-compatible");
+  assert.equal(provider.name, "Private AI Gateway");
+  const options = provider.options as Record<string, unknown>;
+  assert.equal(typeof options.fetch, "function");
+  // No env key in the test environment: apiKey must be omitted so opencode
+  // fills it from the auth loader's provider.key (a stale template would
+  // shadow the logged-in credential).
+  assert.equal(options.apiKey, undefined);
+});
+
+test("config hook respects user-declared provider options and models", async () => {
+  const plugin = createProvider();
+  const { input } = mockInput();
+  const hooks = await plugin(input, {});
+
+  const cfg = {
+    provider: {
+      aci: {
+        options: { baseURL: "https://user.example/v1", headers: { "x-custom": "1" } },
+        models: { "user/model": { name: "User Model" } },
+      },
+    },
+  };
+  await hooks.config!(cfg as never);
+
+  const provider = cfg.provider.aci as unknown as {
+    options: Record<string, unknown>;
+    models: Record<string, unknown>;
+  };
+  assert.equal(provider.options.baseURL, "https://user.example/v1");
+  assert.deepEqual(provider.options.headers, { "x-custom": "1" });
+  assert.equal(typeof provider.options.fetch, "function");
+  assert.ok(provider.models["user/model"], "user model preserved");
+});
+
+test("oauth profile adds the auth hook; loader captures the credential", async () => {
+  const plugin = createProvider({
+    oauth: {
+      name: "Test Brand",
+      startDeviceFlow: async () => ({
+        deviceCode: "dc",
+        userCode: "UC-123",
+        verificationUri: "https://brand.example/device",
+        intervalSeconds: 1,
+        expiresInSeconds: 60,
+      }),
+      pollDeviceFlow: async () => ({
+        access: "minted-key",
+        refresh: "",
+        expires: Date.now() + 1e9,
+      }),
+    },
+  });
+  const { input } = mockInput();
+  const hooks = await plugin(input, {});
+
+  assert.ok(hooks.auth, "auth hook present");
+  assert.equal(hooks.auth.provider, "aci");
+  assert.equal(hooks.auth.methods.length, 2);
+
+  const loaded = await hooks.auth.loader!(
+    async () => ({ type: "oauth", access: "oauth-key" }) as never,
+    {} as never,
+  );
+  assert.deepEqual(loaded, { apiKey: "oauth-key" });
+
+  // The device-flow method maps onto authorize() -> auto callback polling.
+  const oauthMethod = hooks.auth.methods[0];
+  assert.equal(oauthMethod.type, "oauth");
+  if (oauthMethod.type !== "oauth") return;
+  const result = await oauthMethod.authorize();
+  assert.equal(result.method, "auto");
+  assert.match(result.instructions, /UC-123/);
+  if (result.method !== "auto") return;
+  const callbackResult = await result.callback();
+  assert.equal(callbackResult.type, "success");
+  if (callbackResult.type !== "success" || !("access" in callbackResult)) return;
+  assert.equal(callbackResult.access, "minted-key");
+});
+
+test("verification status tool reports pinning and receipt state", async () => {
+  const plugin = createProvider();
+  const { input } = mockInput();
+  const hooks = await plugin(input, {});
+  const statusTool = hooks.tool!["aci_verification_status"];
+  const result = await statusTool.execute({}, {} as never);
+  const report = JSON.parse(typeof result === "string" ? result : result.output);
+  assert.equal(report.provider, "aci");
+  assert.equal(typeof report.status, "string");
+  assert.ok(report.pinning);
+});

--- a/clients/opencode-provider/packages/opencode-provider-aci/tests/verify.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/tests/verify.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { generateKeyPairSync, sign as nodeSign } from "node:crypto";
+import { jcsBytes } from "@phala/aci-verifier";
+
+import {
+  type AttestationReport,
+  type ReceiptEnvelope,
+  type WorkloadKeyset,
+  attestedSpkiSha256ForHost,
+  classifyReceipt,
+  keysetStaleAfterMs,
+} from "../src/verify.ts";
+
+function ed25519Pair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const pubRaw = Buffer.from(publicKey.export({ format: "jwk" }).x as string, "base64url");
+  return { pubRaw, pubHex: pubRaw.toString("hex"), privateKey };
+}
+
+/** A keyset matching the spec §3.1 shape (flat, with not_after + TLS pins). */
+function makeKeyset(over: Partial<WorkloadKeyset> = {}): WorkloadKeyset {
+  return {
+    not_after: 2000000000,
+    receipt_signing_keys: [],
+    e2ee_public_keys: [],
+    tls_public_keys: [
+      {
+        domain: "inference.phala.com",
+        spki_sha256: "698c87b1ed32d3d67f23d14295fc443e91b82ad4e40482041ac1a9158c8212e2",
+      },
+      {
+        domain: "tee.redpill.ai",
+        spki_sha256: "11af02e1c69bb2227e9b65903010abb60fbb626930cd11b0866281bb291a352c",
+      },
+    ],
+    ...over,
+  };
+}
+
+function makeReport(keyset: WorkloadKeyset): AttestationReport {
+  return {
+    api_version: "aci/1",
+    workload_keyset_digest: "sha256:digest",
+    attestation: { tee_type: "tdx", workload_keyset: keyset, report_data: "00".repeat(32) },
+  };
+}
+
+/** A receipt envelope per §7.2/§7.3: top-level key_id + hex signature over
+ *  JCS(document minus signature). */
+function makeReceipt(over: Partial<ReceiptEnvelope> = {}): ReceiptEnvelope {
+  return {
+    api_version: "aci/1",
+    receipt_id: "rcpt-1",
+    model: "openai/gpt-oss-20b",
+    workload_keyset_digest: "sha256:digest",
+    endpoint: "/v1/chat/completions",
+    method: "POST",
+    served_at: 1700000000,
+    event_log: [],
+    key_id: "receipt-ed25519",
+    signature: "",
+    ...over,
+  };
+}
+
+async function signReceipt(receipt: ReceiptEnvelope, privateKey: Buffer): Promise<ReceiptEnvelope> {
+  // §7.2: the signature signs JCS(document minus `signature`) under Ed25519
+  // (RFC 8032 — raw message, no prehash).
+  const { signature: _sig, ...unsigned } = receipt;
+  const unsignedBytes = jcsBytes(unsigned);
+  const sig = nodeSign(null, unsignedBytes, privateKey);
+  return { ...receipt, signature: Buffer.from(sig).toString("hex") };
+}
+
+test("classifyReceipt: verified when result=verified and required=true", async () => {
+  const keyset = makeKeyset();
+  const receipt: ReceiptEnvelope = {
+    ...makeReceipt(),
+    event_log: [
+      {
+        type: "upstream.verified",
+        result: "verified",
+        required: true,
+        session_id: "as_1",
+        provider: "phala",
+        model_id: "phala/qwen3.5-27b",
+      },
+    ],
+  };
+  const c = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(c.status, "verified");
+  assert.equal(c.sessionId, "as_1");
+  assert.equal(c.provider, "phala");
+  assert.equal(c.required, true);
+  assert.equal(c.modelId, "openai/gpt-oss-20b");
+});
+
+test("classifyReceipt: routed when result=failed and required=false", async () => {
+  const keyset = makeKeyset();
+  const receipt: ReceiptEnvelope = {
+    ...makeReceipt(),
+    event_log: [
+      { type: "upstream.verified", result: "failed", required: false, provider: "openai" },
+    ],
+  };
+  const c = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(c.status, "routed");
+  assert.equal(c.required, false);
+  assert.equal(c.sessionId, undefined);
+});
+
+test("classifyReceipt: unknown when upstream.verified event is missing", async () => {
+  const keyset = makeKeyset();
+  const receipt: ReceiptEnvelope = {
+    ...makeReceipt(),
+    event_log: [{ type: "request.received" }, { type: "response.returned" }],
+  };
+  const c = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(c.status, "unknown");
+});
+
+test("classifyReceipt: signatureValid false when key_id not in keyset", async () => {
+  const keyset = makeKeyset(); // receipt_signing_keys empty
+  const receipt = makeReceipt();
+  const c = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(c.signatureValid, false);
+});
+
+test("classifyReceipt: ed25519 receipt signature validates against attested key (spec shape)", async () => {
+  const { pubHex, privateKey } = ed25519Pair();
+  const keyset = makeKeyset({
+    receipt_signing_keys: [{ key_id: "receipt-ed25519", algo: "ed25519", public_key: pubHex }],
+  });
+  const receipt = await signReceipt(
+    makeReceipt({ key_id: "receipt-ed25519" }),
+    privateKey as unknown as Buffer,
+  );
+  assert.ok(receipt.signature.length > 0, "receipt signed");
+
+  const c = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(c.signatureValid, true);
+});
+
+test("classifyReceipt: tampered receipt body invalidates the signature", async () => {
+  const { pubHex, privateKey } = ed25519Pair();
+  const keyset = makeKeyset({
+    receipt_signing_keys: [{ key_id: "receipt-ed25519", algo: "ed25519", public_key: pubHex }],
+  });
+  const signed = await signReceipt(
+    makeReceipt({ key_id: "receipt-ed25519" }),
+    privateKey as unknown as Buffer,
+  );
+  const tampered: ReceiptEnvelope = { ...signed, receipt_id: "rcpt-tampered" };
+  const c = await classifyReceipt(tampered, keyset, "sha256:digest");
+  assert.equal(c.signatureValid, false);
+});
+
+test("classifyReceipt: body hashes are checked when bytes provided; hashesChecked false otherwise", async () => {
+  const { pubHex, privateKey } = ed25519Pair();
+  const keyset = makeKeyset({
+    receipt_signing_keys: [{ key_id: "receipt-ed25519", algo: "ed25519", public_key: pubHex }],
+  });
+  const requestBytes = new TextEncoder().encode("the-request-body");
+  const receipt = await signReceipt(
+    makeReceipt({
+      key_id: "receipt-ed25519",
+      event_log: [],
+      // No body_hash events -> checks report false when bytes provided.
+    }),
+    privateKey as unknown as Buffer,
+  );
+
+  const withoutBytes = await classifyReceipt(receipt, keyset, "sha256:digest");
+  assert.equal(withoutBytes.hashesChecked, false);
+  assert.ok(withoutBytes.hashesNotCheckedReason);
+  assert.equal(withoutBytes.requestHashValid, undefined);
+  assert.equal(withoutBytes.responseHashValid, undefined);
+
+  const withBytes = await classifyReceipt(receipt, keyset, "sha256:digest", {
+    requestBody: requestBytes,
+  });
+  assert.equal(withBytes.hashesChecked, true);
+  assert.equal(withBytes.requestHashValid, false); // event absent -> no match
+});
+
+test("attestedSpkiSha256ForHost: returns the attested SPKI for a matching host", () => {
+  const keyset = makeKeyset();
+  assert.equal(
+    attestedSpkiSha256ForHost(keyset, "inference.phala.com"),
+    "698c87b1ed32d3d67f23d14295fc443e91b82ad4e40482041ac1a9158c8212e2",
+  );
+  // Case-insensitive on the host.
+  assert.equal(
+    attestedSpkiSha256ForHost(keyset, "INFERENCE.PHALA.COM"),
+    "698c87b1ed32d3d67f23d14295fc443e91b82ad4e40482041ac1a9158c8212e2",
+  );
+  // Unknown host -> undefined.
+  assert.equal(attestedSpkiSha256ForHost(keyset, "example.com"), undefined);
+});
+
+test("attestedSpkiSha256ForHost: returns undefined when no tls keys are attested", () => {
+  assert.equal(
+    attestedSpkiSha256ForHost(makeKeyset({ tls_public_keys: undefined }), "inference.phala.com"),
+    undefined,
+  );
+});
+
+test("keysetStaleAfterMs: reads not_after from the keyset (verifier-ts report freshness)", () => {
+  const keyset = makeKeyset({ not_after: 2000000000 });
+  assert.equal(keysetStaleAfterMs(keyset), 2000000000 * 1000);
+  assert.equal(keysetStaleAfterMs(undefined), undefined);
+});
+
+test("bindAttestation fails closed on a mismatched report (no throw)", async () => {
+  // bindAttestation is a provider-side wrapper around the reference verifier's
+  // verifyReportBinding; assert the reference returns ok:false (not throw) for
+  // a report whose digest is not recomputed from its own keyset.
+  const { verifyReportBinding } = await import("@phala/aci-verifier");
+  const keysetValue = makeKeyset();
+  const nonce = "a".repeat(64);
+  const bad = makeReport(keysetValue); // api_version aci/1 but digest not recomputed
+  const verification = await verifyReportBinding(bad, nonce);
+  assert.equal(verification.ok, false);
+});
+
+test("statusText: a FAILED signature renders 'mismatch', not 'verified*' (m6)", async () => {
+  const { statusText, AciReceiptStore } = await import("../src/receipt-store.ts");
+  const store = new AciReceiptStore();
+  // Simulate a classification where the signature check explicitly failed.
+  store.recordResponseHeaders({
+    "x-receipt-id": "rcpt-1",
+    "x-aci-identity": "w",
+    "x-aci-keyset-digest": "k",
+  });
+  (store as unknown as { lastClassification: Record<string, unknown> }).lastClassification = {
+    status: "unknown",
+    signatureValid: false,
+    hashesChecked: true,
+  };
+  assert.equal(statusText(store), "aci: mismatch");
+});
+
+test("statusText: verified requires hashes checked; un-checked hashes show verified* (M2)", async () => {
+  const { statusText, AciReceiptStore } = await import("../src/receipt-store.ts");
+  const store = new AciReceiptStore();
+  store.recordResponseHeaders({ "x-receipt-id": "rcpt-1" });
+  (store as unknown as { lastClassification: Record<string, unknown> }).lastClassification = {
+    status: "verified",
+    signatureValid: true,
+    hashesChecked: false,
+  };
+  assert.equal(statusText(store), "aci: verified*");
+});
+
+test("statusText: fully verified (signature + hashes) renders 'verified'", async () => {
+  const { statusText, AciReceiptStore } = await import("../src/receipt-store.ts");
+  const store = new AciReceiptStore();
+  store.recordResponseHeaders({ "x-receipt-id": "rcpt-1" });
+  (store as unknown as { lastClassification: Record<string, unknown> }).lastClassification = {
+    status: "verified",
+    signatureValid: true,
+    hashesChecked: true,
+    requestHashValid: true,
+    responseHashValid: true,
+  };
+  assert.equal(statusText(store), "aci: verified");
+});
+
+test("attestedSpkiSha256ForHost on a full report-shaped keyset is not required; keyset arg is used", () => {
+  const report = makeReport(makeKeyset());
+  // The function consumes keyset now (not a whole report). Just confirm it
+  // still digs through the TLS pins on the keyset object.
+  const keyset = report.attestation.workload_keyset as WorkloadKeyset;
+  assert.ok(attestedSpkiSha256ForHost(keyset, "inference.phala.com"));
+});
+
+test("statusText: request-only hash check renders verified*, not verified (SSE no-EOF stage)", async () => {
+  const { statusText, AciReceiptStore } = await import("../src/receipt-store.ts");
+  const store = new AciReceiptStore();
+  store.recordResponseHeaders({ "x-receipt-id": "rcpt-1" });
+  (store as unknown as { lastClassification: Record<string, unknown> }).lastClassification = {
+    status: "verified",
+    signatureValid: true,
+    requestHashValid: true,
+    responseHashValid: undefined,
+    hashesChecked: true,
+  };
+  assert.equal(statusText(store), "aci: verified*");
+});

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
@@ -1,0 +1,63 @@
+# opencode-provider-phala-cloud
+
+Phala Cloud branded [opencode](https://opencode.ai) provider plugin for
+[private-ai-gateway](https://github.com/Dstack-TEE/private-ai-gateway) (ACI):
+attested TLS (SPKI) pinning + per-response receipt verification.
+
+Thin skin over [`@phala/opencode-provider-aci`](../opencode-provider-aci) —
+all protocol logic lives in the core.
+
+## Install
+
+`opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-provider-phala-cloud"]
+}
+```
+
+## Login
+
+Device-flow login (mints a Redpill LLM virtual key; no `phak_` cloud token):
+
+```bash
+opencode auth login   # choose Phala Cloud
+```
+
+Or set an API key directly:
+
+```bash
+export PHALA_LLM_API_KEY=...
+```
+
+Then select a `phala/<model-id>` model.
+
+## Configuration
+
+Plugin options:
+
+```json
+{
+  "plugin": [["opencode-provider-phala-cloud", {
+    "isTeeOnly": true,
+    "failOpenOnUnpinned": false,
+    "pinning": true
+  }]]
+}
+```
+
+Env vars: `PHALA_BASE_URL` (aliases `PHALA_CLOUD_API_PREFIX`,
+`PHALA_CLOUD_BASE_URL`), `PHALA_IS_TEE_ONLY`, `PHALA_MODEL_ALLOWLIST`,
+`PHALA_AUTO_FETCH_RECEIPT`, `PHALA_REQUIRE_ATTESTATION_MATCH`,
+`PHALA_FAIL_OPEN_ON_UNPINNED`, `PHALA_PINNING`.
+
+Status: after each response the verification result
+(`verified` / `verified*` / `routed` / `attested` / `mismatch` + TLS pin
+state) is written to the opencode log and shown as a TUI toast. The
+`phala_verification_status` tool returns the structured status;
+`phala_settings` shows and toggles runtime settings (pinning, fail-open,
+receipt auto-verify). Set `PHALA_DEBUG=1` to write exchange/status trace
+lines to stderr (useful with `opencode run`; in headless mode the process can
+exit before the async log/toast publish lands).

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/index.ts
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/index.ts
@@ -1,0 +1,165 @@
+/**
+ * opencode-provider-phala-cloud — Phala Cloud branded distribution of the
+ * vendor-neutral private-ai-gateway (ACI) opencode provider.
+ *
+ * This package is a thin skin: it imports the core `@phala/opencode-provider-aci`
+ * and registers it with the Phala Cloud identity (provider id, endpoint, env
+ * vars, fallback catalog, OAuth device-flow login). All protocol logic —
+ * attestation, TLS SPKI pinning, receipt verification, model discovery —
+ * lives in the core.
+ *
+ * Usage:
+ *   opencode.json: { "plugin": ["opencode-provider-phala-cloud"] }
+ *   # opencode auth login (pick Phala Cloud), or set PHALA_LLM_API_KEY,
+ *   # then select model phala/<model-id>
+ */
+import {
+  type AciDeviceFlowStart,
+  type AciOAuthCredentials,
+  createProvider,
+} from "@phala/opencode-provider-aci/core";
+
+// Phala Cloud (teahouse) API base for account-level endpoints: the OAuth
+// device authorization flow and the LLM-key self lookup live here, not on the
+// inference gateway.
+const DEFAULT_CLOUD_API_URL = "https://cloud-api.phala.com";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+function getCloudApiBase(): string {
+  const value = process.env.PHALA_CLOUD_API_BASE_URL || DEFAULT_CLOUD_API_URL;
+  return value.trim().replace(/\/+$/, "") || DEFAULT_CLOUD_API_URL;
+}
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface DeviceTokenResponse {
+  access_token: string;
+  expires_in?: number | null;
+  redpill_key_id?: number | null;
+}
+
+// RFC 8628 device authorization against Phala Cloud. On approval the consume
+// step (scope "redpill:api-key") issues a Redpill LLM virtual key — no phak_
+// cloud token is created.
+async function startDeviceFlow(signal?: AbortSignal): Promise<AciDeviceFlowStart> {
+  const codeRes = await fetch(`${getCloudApiBase()}/api/v1/auth/device/code`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    // client_id stays "pi": the consume step (scope redpill:api-key) only
+    // recognizes registered CLI client ids; an unknown id passes the code
+    // step but 500s at token consume after the user approves.
+    body: JSON.stringify({ client_id: "pi", scope: "redpill:api-key" }),
+    signal,
+  });
+  if (!codeRes.ok) {
+    throw new Error(`Device authorization request failed: ${await codeRes.text()}`);
+  }
+  const code = (await codeRes.json()) as DeviceCodeResponse;
+  return {
+    deviceCode: code.device_code,
+    userCode: code.user_code,
+    verificationUri: code.verification_uri_complete ?? code.verification_uri,
+    intervalSeconds: code.interval,
+    expiresInSeconds: code.expires_in,
+  };
+}
+
+async function pollDeviceFlow(
+  start: AciDeviceFlowStart,
+  signal?: AbortSignal,
+): Promise<AciOAuthCredentials> {
+  const deadline = Date.now() + start.expiresInSeconds * 1000;
+  let token: DeviceTokenResponse | undefined;
+  // RFC 8628 §3.4: poll at the server-provided interval, and back off on
+  // slow_down. A loop without this would hammer the token endpoint.
+  let intervalMs = Math.max(Number(start.intervalSeconds) || 5, 1) * 1000;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error("Login cancelled");
+    const tokenRes = await fetch(`${getCloudApiBase()}/api/v1/auth/device/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        device_code: start.deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+      signal,
+    });
+    if (tokenRes.ok) {
+      token = (await tokenRes.json()) as DeviceTokenResponse;
+      break;
+    }
+    const raw = await tokenRes.text().catch(() => "");
+    const body = (() => {
+      try {
+        return JSON.parse(raw) as
+          | { detail?: { error?: string; error_description?: string } | string }
+          | undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+    const detail = body?.detail;
+    const errorCode = typeof detail === "object" && detail ? detail.error : undefined;
+    if (errorCode === "authorization_pending") {
+      await sleep(Math.min(intervalMs, deadline - Date.now()));
+      continue;
+    }
+    if (errorCode === "slow_down") {
+      // RFC 8628 §3.5: increase the polling interval.
+      intervalMs = Math.min(Math.max(intervalMs * 2, 5000), 30000);
+      await sleep(intervalMs);
+      continue;
+    }
+    const description =
+      (typeof detail === "object" && detail ? detail.error_description : undefined) ??
+      (typeof detail === "string" ? detail : undefined) ??
+      `HTTP ${tokenRes.status}: ${raw.slice(0, 300)}`;
+    throw new Error(`Device authorization failed: ${description}`);
+  }
+  if (!token) throw new Error("Device authorization expired");
+
+  return {
+    // Redpill LLM keys do not expire and cannot be refreshed, so `expires` is
+    // set far in the future; a dead key surfaces as a 401 and the user
+    // re-runs opencode auth login to mint a new one.
+    refresh: "",
+    access: token.access_token,
+    expires: Date.now() + 100 * 365 * 24 * 60 * 60 * 1000,
+  };
+}
+
+export default createProvider({
+  providerId: "phala",
+  label: "Phala Cloud",
+  defaultBaseUrl: "https://inference.phala.com/v1",
+  apiKeyEnv: "PHALA_LLM_API_KEY",
+  envPrefix: "PHALA",
+  logPrefix: "[phala]",
+  baseUrlAliases: ["PHALA_CLOUD_API_PREFIX", "PHALA_BASE_URL", "PHALA_CLOUD_BASE_URL"],
+  fallbackModels: [
+    {
+      id: "phala/qwen3.5-27b",
+      name: "Phala Qwen3.5 27B",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0.3, output: 2.4, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 262000,
+      maxTokens: 8192,
+    },
+  ],
+  oauth: {
+    name: "Phala Cloud",
+    startDeviceFlow,
+    pollDeviceFlow,
+  },
+});

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "opencode-provider-phala-cloud",
+  "version": "0.1.0",
+  "description": "Phala Cloud branded opencode provider for private-ai-gateway (ACI): attested TLS pinning + per-response receipt verification",
+  "keywords": [
+    "ai-provider",
+    "attestation",
+    "confidential-ai",
+    "llm",
+    "llm-provider",
+    "opencode",
+    "opencode-plugin",
+    "opencode-provider",
+    "phala",
+    "phala-cloud",
+    "tee",
+    "verifiable"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.ts",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "clean": "echo 'nothing to clean'",
+    "build": "echo 'nothing to build'"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  },
+  "dependencies": {
+    "@phala/opencode-provider-aci": "file:../opencode-provider-aci"
+  }
+}

--- a/clients/opencode-provider/tsconfig.json
+++ b/clients/opencode-provider/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "packages/*/index.ts",
+    "packages/*/src/**/*.ts",
+    "packages/*/tests/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Stacked on top of `integrate-frantic-duck` (the pi-provider monorepo). Adds `clients/opencode-provider`, an [opencode](https://opencode.ai) provider plugin monorepo with the same architecture as `clients/pi-provider`:

- **`@phala/opencode-provider-aci`** — vendor-neutral core: attested TLS (SPKI) pinning + per-response receipt verification (delegated to `@phala/aci-verifier`)
- **`opencode-provider-phala-cloud`** — thin Phala Cloud skin (provider id, endpoint, env vars, fallback catalog, RFC 8628 device-flow login)

## Key design (vs the pi provider)

The plugin injects a custom `fetch` into `@ai-sdk/openai-compatible` provider options (opencode routes all provider traffic through `options.fetch`). That one injection point replaces pi's global fetch wrapper + event hooks:

| pi provider | opencode provider |
|---|---|
| undici dispatcher wrapping globalThis.fetch | per-request `tls.checkServerIdentity` (Bun native) |
| `after_provider_response` event for receipt headers | headers read off the Response directly |
| no response bytes → caps at `verified*` | exact request/response bytes captured → honest `verified` (signature + both body hashes) |
| `/aci-settings` SettingsList TUI | no menu API exists → `{id}_settings` tool (runtime toggles) + plugin options/env |
| footer `setStatus` | log + TUI toast (deduped) + `{id}_verification_status` tool |

Stream completion is two-stage: `finish_reason`/`[DONE]` fires an sse-done exchange (signature/request-hash level → `verified*` semantics), a real EOF upgrades with complete bytes (`verified`). Truncated bytes are never hash-checked — the gateway's `response.returned.body_hash` covers post-[DONE] keepalive padding (confirmed against a live receipt).

## Notable fixes baked in

- SPKI derived from `cert.raw` via X509 export (`cert.pubkey` lacks the SPKI wrapper in both Node and Bun and never matches the attested value)
- `options.apiKey` only templated when the env key exists, so the auth loader's `provider.key` applies (a stale template shadowed the logged-in credential → gateway 401)
- device flow keeps `client_id: "pi"` (the consume step 500s on unregistered client ids)
- package entry exports only the default plugin (opencode's loader calls **every** runtime export as a plugin); library surface moved to `/core` subpath
- model discovery also reads the credential stored by `opencode auth login`

## Verification

- 53 unit/assembly tests (`node --test`), tsc / oxlint / oxfmt clean; mirrored CI workflow included
- Live E2E against `inference.phala.com`: 25-model discovery, TLS pin enforced, `phala: verified | tls-pinned` after a chat response (sse-done → eof upgrade observed with a real receipt)
- The garbled-output report was traced to the `google/gemma-4-31b-it` upstream itself (reproduced via plain curl; that session's bytes were hash-`verified`, proving the transport was intact)

## Known gaps (documented in README)

- No thinking-parameter mapping (opencode has no `compat.thinkingFormat` equivalent); `reasoning_content` still surfaces
- No proxy support for pinned connections (Bun per-request `tls` init doesn't compose with proxies)
- Login mid-session doesn't refresh the model list (discovery runs at startup)

Draft: pending review + npm publishing decisions (`file:` deps need version numbers before publish).