### PR TITLE
Support native chat-template reasoning switches

### DIFF
--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -251,7 +251,9 @@ fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &Rea
     let Some(Value::Object(kwargs)) = object.get_mut("chat_template_kwargs") else {
         return;
     };
-    let enabled = reasoning_enabled(reasoning);
+    let Some(enabled) = reasoning_enabled(reasoning) else {
+        return;
+    };
     for key in ["thinking", "enable_thinking"] {
         if let Some(value) = kwargs.get_mut(key) {
             *value = Value::Bool(enabled);
@@ -259,13 +261,15 @@ fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &Rea
     }
 }
 
-fn reasoning_enabled(reasoning: &ReasoningConfig) -> bool {
-    reasoning.enabled.unwrap_or_else(|| {
-        reasoning.max_tokens.is_some()
-            || reasoning
+fn reasoning_enabled(reasoning: &ReasoningConfig) -> Option<bool> {
+    reasoning
+        .enabled
+        .or_else(|| {
+            reasoning
                 .effort
-                .is_some_and(|effort| effort != ReasoningEffort::None)
-    })
+                .map(|effort| effort != ReasoningEffort::None)
+        })
+        .or(reasoning.max_tokens.map(|_| true))
 }
 
 fn set_chat_template_reasoning(
@@ -277,6 +281,9 @@ fn set_chat_template_reasoning(
     if reasoning.max_tokens.is_some() {
         return invalid_reasoning(candidate, "cannot represent max_tokens");
     }
+    let Some(enabled) = reasoning_enabled(reasoning) else {
+        return invalid_reasoning(candidate, "reasoning configuration is empty");
+    };
     let kwargs = object
         .entry("chat_template_kwargs")
         .or_insert_with(|| Value::Object(Map::new()))
@@ -284,7 +291,7 @@ fn set_chat_template_reasoning(
         .ok_or_else(|| {
             TransformError::InvalidRequest("chat_template_kwargs must be an object".to_string())
         })?;
-    kwargs.insert(key.to_string(), Value::Bool(reasoning_enabled(reasoning)));
+    kwargs.insert(key.to_string(), Value::Bool(enabled));
     Ok(())
 }
 

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -236,6 +236,12 @@ fn candidate_params(
                 Value::String(effort.as_str().to_string()),
             );
         }
+        (ProviderFormat::Openai, ReasoningFormat::ChatTemplateThinking) => {
+            set_chat_template_reasoning(object, effective, candidate, "thinking")?;
+        }
+        (ProviderFormat::Openai, ReasoningFormat::ChatTemplateEnableThinking) => {
+            set_chat_template_reasoning(object, effective, candidate, "enable_thinking")?;
+        }
         (ProviderFormat::Anthropic, _) => return invalid_reasoning(candidate, "has no adapter"),
     }
     Ok(params)
@@ -245,17 +251,41 @@ fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &Rea
     let Some(Value::Object(kwargs)) = object.get_mut("chat_template_kwargs") else {
         return;
     };
-    let enabled = reasoning.enabled.unwrap_or_else(|| {
-        reasoning.max_tokens.is_some()
-            || reasoning
-                .effort
-                .is_some_and(|effort| effort != ReasoningEffort::None)
-    });
+    let enabled = reasoning_enabled(reasoning);
     for key in ["thinking", "enable_thinking"] {
         if let Some(value) = kwargs.get_mut(key) {
             *value = Value::Bool(enabled);
         }
     }
+}
+
+fn reasoning_enabled(reasoning: &ReasoningConfig) -> bool {
+    reasoning.enabled.unwrap_or_else(|| {
+        reasoning.max_tokens.is_some()
+            || reasoning
+                .effort
+                .is_some_and(|effort| effort != ReasoningEffort::None)
+    })
+}
+
+fn set_chat_template_reasoning(
+    object: &mut Map<String, Value>,
+    reasoning: &ReasoningConfig,
+    candidate: &RouteCandidate,
+    key: &str,
+) -> Result<(), TransformError> {
+    if reasoning.max_tokens.is_some() {
+        return invalid_reasoning(candidate, "cannot represent max_tokens");
+    }
+    let kwargs = object
+        .entry("chat_template_kwargs")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| {
+            TransformError::InvalidRequest("chat_template_kwargs must be an object".to_string())
+        })?;
+    kwargs.insert(key.to_string(), Value::Bool(reasoning_enabled(reasoning)));
+    Ok(())
 }
 
 fn invalid_reasoning<T>(candidate: &RouteCandidate, message: &str) -> Result<T, TransformError> {
@@ -1405,6 +1435,41 @@ mod tests {
             assert_eq!(kwargs["thinking"], expected);
             assert_eq!(kwargs["enable_thinking"], expected);
             assert_eq!(kwargs["tokenize"], false);
+        }
+    }
+
+    #[test]
+    fn chat_template_reasoning_format_inserts_native_switch() {
+        for (format, key) in [
+            ("chat_template_thinking", "thinking"),
+            ("chat_template_enable_thinking", "enable_thinking"),
+        ] {
+            let request = json!({
+                "model": "m",
+                "messages": [],
+                "reasoning_effort": "none"
+            });
+            let (params, requested, _) =
+                crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+            let candidate: RouteCandidate = serde_json::from_value(json!({
+                "routeId": "self-hosted:m",
+                "format": "openai",
+                "engine": "vllm",
+                "reasoningFormat": format
+            }))
+            .unwrap();
+
+            let bodies = build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                &[candidate],
+                requested.as_ref(),
+            )
+            .unwrap();
+            let body = &bodies[0].1;
+            assert_eq!(body["chat_template_kwargs"][key], false);
+            assert!(body.get("reasoning_effort").is_none());
+            assert!(body.get("reasoning").is_none());
         }
     }
 

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -39,6 +39,10 @@ pub enum ReasoningFormat {
     ReasoningEffort,
     #[serde(rename = "reasoning")]
     Reasoning,
+    #[serde(rename = "chat_template_thinking")]
+    ChatTemplateThinking,
+    #[serde(rename = "chat_template_enable_thinking")]
+    ChatTemplateEnableThinking,
 }
 
 /// Canonical public/control reasoning effort.

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -552,6 +552,40 @@ async fn control_override_reconciles_openrouter_reasoning_before_forwarding() {
 }
 
 #[tokio::test]
+async fn control_selects_native_kimi_reasoning_switch() {
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{
+                "routeId": "chutes:moonshotai/kimi-k2.6",
+                "format": "openai",
+                "engine": "vllm",
+                "reasoningFormat": "chat_template_thinking"
+            }]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let (service, _, forwarded) = build_sequenced_service(vec![200]);
+    let mut input = chat_input();
+    input.params = json!({
+        "model": "moonshotai/kimi-k2.6",
+        "messages": [{ "role": "user", "content": "Return JSON" }],
+        "reasoning_effort": "none",
+        "response_format": { "type": "json_object" },
+        "max_tokens": 64
+    });
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    let body: Value = serde_json::from_slice(&forwarded.lock().unwrap()[0]).unwrap();
+    assert_eq!(body["chat_template_kwargs"], json!({ "thinking": false }));
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning").is_none());
+}
+
+#[tokio::test]
 async fn buffered_success_transforms_injects_cost_and_meters() {
     // Anthropic upstream over /v1/chat/completions: response is transformed to the
     // OpenAI shape, cost is injected into the client body, and the metering report


### PR DESCRIPTION
## Summary

- add explicit chat-template reasoning dialects for `thinking` and `enable_thinking`
- encode canonical reasoning as a native boolean under `chat_template_kwargs`
- avoid sending incompatible root `reasoning` or `reasoning_effort` fields for those routes

## Root cause

Kimi K2.6 on Chutes rejects the gateway's inferred root `reasoning_effort` parameter with HTTP 400. Its native chat template instead accepts `chat_template_kwargs.thinking`. Engine inference cannot choose this model-specific dialect reliably.

The control plane can now select the exact dialect per deployment. The gateway preserves the existing canonical reasoning precedence and rejects token budgets that a boolean switch cannot represent.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- focused middleware integration test verifies a Kimi route forwards only `chat_template_kwargs.thinking: false`

Production activation depends on the matching control-plane change and per-deployment configuration.
