### PR TITLE
Normalize responses to a single canonical schema

### DIFF
--- a/src/http/app/backend.rs
+++ b/src/http/app/backend.rs
@@ -22,6 +22,7 @@ use super::error_responses::{
     e2ee_error_response, error_response, insert_str_header, internal_error_response,
     refusal_error_body,
 };
+use crate::middleware::errors::{normalize_upstream_error, surface_for_path};
 
 pub(super) struct BackendForwardInput {
     pub(super) context: GatewayRequestContext,
@@ -63,7 +64,6 @@ pub(super) async fn forward_to_backend(
             Ok(StreamingForwardResult::Stream(forward)) => {
                 let mut resp_headers = chat_response_headers(
                     &forward.receipt_id,
-                    &forward.upstream_headers,
                     "text/event-stream",
                     forward.e2ee.as_ref(),
                 );
@@ -101,22 +101,20 @@ pub(super) async fn forward_to_backend(
             }
             Ok(StreamingForwardResult::UpstreamError(forward)) => {
                 // The streaming error body is cleartext (E2EE applies to the stream,
-                // not this pre-stream error), so classify and remap it here directly.
-                match image_input_error_response(
-                    input.endpoint_path,
-                    &input.received_body,
+                // not this pre-stream error), so it is classified and remapped here
+                // directly. This used to relay the upstream's status, headers and
+                // error body verbatim, which handed the client the provider's own
+                // error vocabulary; `normalize_upstream_error` scrubs it and subsumes
+                // the image-URL remap this arm used to do on its own. (The buffered
+                // branch below still returns the upstream error body as-is on this
+                // no-middleware path — see the note there.)
+                normalize_upstream_error(
+                    surface_for_path(input.endpoint_path),
                     forward.upstream_status,
                     &forward.upstream_body,
-                ) {
-                    Some(resp) => resp,
-                    None => {
-                        let status =
-                            StatusCode::from_u16(forward.upstream_status).unwrap_or(StatusCode::OK);
-                        let resp_headers =
-                            upstream_direct_response_headers(&forward.upstream_headers);
-                        (status, resp_headers, forward.upstream_body).into_response()
-                    }
-                }
+                    &input.received_body,
+                    None,
+                )
             }
             // Both fail-closed refusals (§1.2, §5.3) carry a receipt.
             Err(err @ ServiceError::UpstreamVerification(_)) => refusal_response(
@@ -152,10 +150,12 @@ pub(super) async fn forward_to_backend(
         Ok(forward) => {
             // The service already remapped a client image-URL fetch failure to a
             // surface-correct 400 (with a matching receipt + E2EE wire body), so the
-            // buffered response is returned uniformly here.
+            // buffered response is returned uniformly here. A non-image upstream
+            // error body is returned as-is: on this no-middleware path the receipt is
+            // built over that body, so scrubbing it would have to move into the
+            // service (before the receipt), which is out of scope here.
             let resp_headers = chat_response_headers(
                 &forward.receipt.receipt_id,
-                &forward.upstream_headers,
                 "application/json",
                 forward.e2ee.as_ref(),
             );
@@ -258,8 +258,7 @@ pub(super) fn generate_request_id() -> String {
 
 pub(super) fn chat_response_headers(
     receipt_id: &str,
-    upstream_headers: &std::collections::HashMap<String, String>,
-    default_content_type: &'static str,
+    content_type: &'static str,
     e2ee: Option<&E2eeResponseInfo>,
 ) -> HeaderMap {
     let mut resp_headers = HeaderMap::new();
@@ -281,39 +280,22 @@ pub(super) fn chat_response_headers(
         }
     }
 
-    let content_type = upstream_headers
-        .get("content-type")
-        .cloned()
-        .unwrap_or_else(|| default_content_type.to_string());
-    if let Ok(value) = HeaderValue::from_str(&content_type) {
-        resp_headers.insert(axum::http::header::CONTENT_TYPE, value);
-    }
+    // Ours, not the upstream's. Relaying the upstream `content-type` leaked a
+    // small fingerprint of its own (whether it appends `; charset=utf-8`), and
+    // the caller already knows which content type this path emits.
+    resp_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_static(content_type),
+    );
     resp_headers
 }
 
-pub(super) fn upstream_direct_response_headers(
-    upstream_headers: &std::collections::HashMap<String, String>,
-) -> HeaderMap {
-    let mut resp_headers = HeaderMap::new();
-    for (name, value) in upstream_headers {
-        let lower = name.to_ascii_lowercase();
-        if matches!(
-            lower.as_str(),
-            // `x-receipt-id`: an upstream aci-service refusal carries its own
-            // receipt id, which does not resolve on this host (§7.1).
-            "connection" | "transfer-encoding" | "content-length" | "x-receipt-id"
-        ) {
-            continue;
-        }
-        let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) else {
-            continue;
-        };
-        let Ok(header_value) = HeaderValue::from_str(value) else {
-            continue;
-        };
-        resp_headers.insert(header_name, header_value);
-    }
-    resp_headers
+/// Response headers for the direct-to-upstream catalog relay. Nothing from the
+/// upstream is forwarded — see `middleware::completion::gateway_owned_headers`
+/// for why this is an allowlist rather than a denylist. The caller supplies the
+/// content type.
+pub(super) fn upstream_direct_response_headers() -> HeaderMap {
+    HeaderMap::new()
 }
 
 /// Remaining aci-service chaining hops, passed between aggregators so a config
@@ -444,7 +426,7 @@ pub(super) fn upstream_direct_response(
     upstream: crate::aci::upstream::UpstreamResponse,
     default_content_type: &'static str,
 ) -> Response {
-    let mut headers = upstream_direct_response_headers(&upstream.headers);
+    let mut headers = upstream_direct_response_headers();
     if !headers.contains_key(axum::http::header::CONTENT_TYPE) {
         headers.insert(
             axum::http::header::CONTENT_TYPE,
@@ -453,25 +435,6 @@ pub(super) fn upstream_direct_response(
     }
     let status = StatusCode::from_u16(upstream.status_code).unwrap_or(StatusCode::BAD_GATEWAY);
     (status, headers, upstream.body).into_response()
-}
-
-/// The surface-appropriate 400 when the upstream error is a client image-URL
-/// fetch failure; `None` for any other error (caller keeps verbatim passthrough).
-fn image_input_error_response(
-    endpoint_path: &str,
-    received_body: &[u8],
-    upstream_status: u16,
-    upstream_body: &[u8],
-) -> Option<Response> {
-    use crate::middleware::errors::{image_input_error_parts, parts_response, surface_for_path};
-    let (status, body) = image_input_error_parts(
-        surface_for_path(endpoint_path),
-        received_body,
-        upstream_status,
-        upstream_body,
-        None,
-    )?;
-    Some(parts_response(status, body))
 }
 
 pub(super) fn upstream_proxy_error_response(err: crate::aci::upstream::UpstreamError) -> Response {

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -256,6 +256,14 @@ pub async fn run(
         tee_only,
     } = input;
 
+    // What the client is told about who served the request. Built before
+    // `user_model` moves into the request context, and shared with the streaming
+    // transform, which needs it for every chunk.
+    let identity = Arc::new(response_transform::ResponseIdentity {
+        request_id: request_id.clone(),
+        user_model: user_model.clone(),
+    });
+
     let started = Instant::now();
     let (params, reasoning_requirements, exclude_reasoning) = if endpoint == Endpoint::ChatComplete
     {
@@ -419,28 +427,38 @@ pub async fn run(
     ) {
         Ok(shaped) => shaped,
         Err(err) => {
-            let message = format!("failed to shape provider request: {err}");
-            if should_log_failure(500) {
+            // A body we cannot shape for the chosen route is a 400, not a 500:
+            // reported as 500 it became `type: "upstream_error"` on the OpenAI
+            // surface, blaming the provider for a request the gateway itself
+            // declined to send.
+            let status = err.client_status();
+            let message = format!("cannot shape this request: {err}");
+            if should_log_failure(status) {
+                // The route id lives only here — see `TransformError::detail`.
+                let logged = match err.detail() {
+                    Some(detail) => format!("{message} ({detail})"),
+                    None => message.clone(),
+                };
                 log_generated_outcome(
                     &request_id,
                     model.unwrap_or(""),
                     "shape_error",
-                    500,
+                    status,
                     0,
                     "",
                     0,
                     started,
-                    &detail_snippet(message.as_bytes()),
+                    &detail_snippet(logged.as_bytes()),
                 );
             }
-            meter.gateway_failure(500, ErrorSource::Gateway, &message, stream);
+            meter.gateway_failure(status, ErrorSource::Gateway, &message, stream);
             let body = errors::envelope_bytes(
                 surface,
-                errors::error_type(surface, 500),
+                errors::error_type(surface, status),
                 &message,
                 Some(&request_id),
             );
-            return finalize_generated(500, body, &[], e2ee, outcome_ctx);
+            return finalize_generated(status, body, &[], e2ee, outcome_ctx);
         }
     };
     let forward_candidates: Vec<ForwardCandidate> = shaped
@@ -543,6 +561,7 @@ pub async fn run(
                 if exclude_reasoning {
                     response_transform::exclude_reasoning(&mut transformed);
                 }
+                response_transform::rewrite_identity(&mut transformed, &identity);
 
                 // Raw usage (pre-cost) goes to the report; cost is injected only
                 // into the client body's top-level usage.
@@ -604,6 +623,11 @@ pub async fn run(
                         }
                     }
                 }
+                // Last, after identity rewrite and cost injection: reduce the body
+                // to the gateway's documented output schema, so the client sees one
+                // shape and no upstream-specific field — including any we have never
+                // seen — can leak.
+                response_transform::canonicalize(&mut transformed, endpoint);
                 (
                     upstream_status,
                     serde_json::to_vec(&transformed).unwrap_or_default(),
@@ -649,8 +673,7 @@ pub async fn run(
                 Ok(finalized) => {
                     let status =
                         StatusCode::from_u16(client_status).unwrap_or(StatusCode::BAD_GATEWAY);
-                    let mut headers =
-                        response_headers(&forward.upstream_headers, "application/json");
+                    let mut headers = gateway_owned_headers("application/json");
                     insert_header(&mut headers, "x-receipt-id", &finalized.receipt.receipt_id);
                     apply_e2ee_headers(&mut headers, finalized.e2ee.as_ref(), true);
                     (status, headers, finalized.wire_body).into_response()
@@ -680,11 +703,19 @@ pub async fn run(
             }
         }
         Ok(MiddlewareForwardResult::Stream(forward)) => {
+            // Normalized, not relayed: providers spell the content type
+            // differently (`text/event-stream` vs `text/event-stream; charset=utf-8`),
+            // and that difference alone distinguishes backends. Emit only the base
+            // media type — everything before any `;` parameter — so the value is
+            // identical no matter which upstream served the stream, while a genuinely
+            // non-SSE type keeps its own base type rather than being mislabeled.
             let content_type = forward
                 .upstream_headers
                 .get("content-type")
-                .cloned()
-                .unwrap_or_else(|| "text/event-stream".to_string());
+                .map(|value| value.split(';').next().unwrap_or("").trim())
+                .filter(|base| !base.is_empty())
+                .unwrap_or("text/event-stream")
+                .to_string();
             let upstream_status = forward.upstream_status;
             let attempt_index = forward.failed_attempts.len() as u32;
             meter.failed_attempts(&forward.failed_attempts, true);
@@ -716,12 +747,12 @@ pub async fn run(
                 ms => Some(Duration::from_millis(ms)),
             };
             // Order: provider stream (drafts response.received) -> format
-            // transform (if cross-format) -> response visibility -> meter/cost ->
-            // keep-alive -> finalizer (hashes response.returned). Same-format
-            // streaming skips only the format transform. Metering sits inside the
+            // transform (if cross-format) -> response visibility -> sanitize
+            // -> meter/cost -> keep-alive -> finalizer (hashes response.returned).
+            // Same-format streaming skips only the format transform. Metering sits inside the
             // keep-alive so it only ever buffers real upstream SSE bytes; heartbeat
             // comments are injected downstream and never enter its line reassembly.
-            let response_header_map = response_headers(&forward.upstream_headers, &content_type);
+            let response_header_map = gateway_owned_headers(&content_type);
             let selected_format = candidates
                 .iter()
                 .find(|c| c.route_id == forward.selected_route)
@@ -741,8 +772,15 @@ pub async fn run(
             } else {
                 transformed
             };
-            let metered: ServiceResponseStream = Box::pin(MeterStream::new(
+            // Unconditional, unlike the two above: same-format streaming skips
+            // every other transform, and that is exactly the path that used to
+            // hand the provider's bytes to the client verbatim.
+            let sanitized: ServiceResponseStream = Box::pin(SseTransformStream::new(
                 visible,
+                StreamTransform::SanitizeResponse(identity.clone(), endpoint),
+            ));
+            let metered: ServiceResponseStream = Box::pin(MeterStream::new(
+                sanitized,
                 report,
                 errors::sse_protocol(endpoint_path),
             ));
@@ -1225,59 +1263,24 @@ fn finalize_generated(
     }
 }
 
-// Build response headers from the upstream response, dropping gateway-owned and
-// hop-by-hop headers, and forcing the content type. Provider auth/server headers
-// are not forwarded.
-fn response_headers(
-    upstream_headers: &std::collections::HashMap<String, String>,
-    content_type: &str,
-) -> HeaderMap {
+// Client response headers, built from nothing. No upstream header reaches the
+// client: which provider served a request is ours to know, and a denylist cannot
+// keep that promise because a provider can name itself in a header we have never
+// seen — for example a header that names the serving provider, or a `set-cookie`
+// that would otherwise land on our own domain.
+//
+// The caller adds what it owns on top: `x-receipt-id`, `x-e2ee-*`, and for
+// streaming `x-accel-buffering`/`cache-control`. `x-aci-*` is stamped by an outer
+// layer (`http::app::aci_headers_middleware`).
+fn gateway_owned_headers(content_type: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    for (name, value) in upstream_headers {
-        // The body we emit is always identity-encoded (re-serialized JSON or a
-        // transformed/passthrough SSE stream), so a relayed `content-encoding`
-        // would mislabel it. `content-type` is set explicitly below.
-        if is_gateway_owned(name)
-            || is_hop_by_hop(name)
-            || name.eq_ignore_ascii_case("content-type")
-            || name.eq_ignore_ascii_case("content-encoding")
-        {
-            continue;
-        }
-        if let (Ok(name), Ok(value)) = (
-            HeaderName::from_bytes(name.as_bytes()),
-            HeaderValue::from_str(value),
-        ) {
-            headers.insert(name, value);
-        }
-    }
+    // Ours, not the upstream's: the body we emit is always identity-encoded
+    // (re-serialized JSON or a transformed SSE stream), so relaying the
+    // upstream's `content-type`/`content-encoding` could mislabel it.
     if let Ok(value) = HeaderValue::from_str(content_type) {
         headers.insert(CONTENT_TYPE, value);
     }
     headers
-}
-
-fn is_gateway_owned(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    lower == "x-receipt-id"
-        || lower.starts_with("x-e2ee-")
-        || lower.starts_with("x-aci-")
-        || lower.starts_with("x-private-ai-gateway-")
-}
-
-fn is_hop_by_hop(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "connection"
-            | "keep-alive"
-            | "proxy-authenticate"
-            | "proxy-authorization"
-            | "te"
-            | "trailer"
-            | "transfer-encoding"
-            | "upgrade"
-            | "content-length"
-    )
 }
 
 fn apply_e2ee_headers(

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -135,6 +135,9 @@ pub fn rate_limit_response(
     )
 }
 
+/// The upstream's message, verbatim. Callers that classify against it (the
+/// image-URL matcher compares it to the *client's own* URL) need it unscrubbed;
+/// callers that relay it to the client must use `client_safe_error_message`.
 fn extract_error_message(body: &[u8]) -> Option<String> {
     let value: Value = serde_json::from_slice(body).ok()?;
     match value.get("error") {
@@ -145,6 +148,141 @@ fn extract_error_message(body: &[u8]) -> Option<String> {
             .map(str::to_string),
         None => None,
     }
+}
+
+/// The upstream's message, fit to hand to the client, or `None` to fall back to
+/// our own per-status text.
+fn client_safe_error_message(body: &[u8]) -> Option<String> {
+    scrub_identifying_markers(&extract_error_message(body)?)
+}
+
+/// A single error-message string made safe to relay: scrubbed by the same shape
+/// rules as the buffered path, or replaced with a generic line when nothing safe
+/// remains. Used for an in-band error on a streaming chunk, where there is no
+/// per-status text to fall back to and the message must stay non-empty.
+pub(crate) fn client_safe_error_text(message: &str) -> String {
+    scrub_identifying_markers(message)
+        .unwrap_or_else(|| "the provider returned an error".to_string())
+}
+
+/// An upstream error message, fit to relay — or `None` to fall back to our own
+/// per-status text.
+///
+/// Two stages, in order. First strip an error-code prefix by *shape*
+/// (`<400> Module.Sub.BadParam: …`), which works on providers we have never
+/// seen. Then, if what remains still carries a URL, a hostname, or an opaque id,
+/// drop the message entirely rather than try to clean it further.
+///
+/// Matched by shape, never by a maintained list of names. A bare company name in
+/// otherwise-neutral prose is therefore relayed — an accepted residual: it was
+/// a shape not seen in practice, while the shapes that were (code
+/// namespaces, hosts, headers) are all caught structurally or by the header
+/// allowlist, and a name list would have to be updated for every new upstream.
+///
+/// Biased toward dropping when a structural marker is present: a message we
+/// withhold costs the caller some detail, a message with a host or id in it can
+/// point at who served the request.
+fn scrub_identifying_markers(raw: &str) -> Option<String> {
+    let message = strip_error_code_prefix(raw).trim();
+    if message.is_empty() || looks_identifying(message) {
+        return None;
+    }
+    Some(message.to_string())
+}
+
+/// Strip a leading `<400> ` status and/or a dotted error-code identifier chain
+/// (`Module.Sub.BadParam: `). Matched by shape, never by vendor
+/// name.
+fn strip_error_code_prefix(message: &str) -> &str {
+    let mut rest = message.trim_start();
+    if let Some(after_angle) = rest.strip_prefix('<') {
+        if let Some((code, after)) = after_angle.split_once('>') {
+            if !code.is_empty() && code.chars().all(|c| c.is_ascii_digit()) {
+                rest = after.trim_start();
+            }
+        }
+    }
+    let Some((head, tail)) = rest.split_once(':') else {
+        return rest;
+    };
+    let dotted_identifier = head.contains('.')
+        && !head.contains(char::is_whitespace)
+        && head
+            .split('.')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_alphanumeric()));
+    if dotted_identifier {
+        tail.trim_start()
+    } else {
+        rest
+    }
+}
+
+/// Whether a message still carries a URL, a host, or an internal identifier —
+/// the structural shapes that point at who served a request. Names are matched by
+/// shape only; there is deliberately no list of company names to keep current.
+fn looks_identifying(message: &str) -> bool {
+    if message.contains("://") {
+        return true;
+    }
+    message
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_'))
+        // `.`/`-`/`_` are kept inside a token so a host or id stays whole, but they
+        // are also sentence punctuation: a host ending a sentence (`… api.acme.ai.`)
+        // would otherwise carry a trailing `.`, leaving an empty final label that
+        // fails every shape check below. A real host/IP/id never starts or ends with
+        // one, so trimming them is safe and closes that leak.
+        .map(|word| word.trim_matches(|c| c == '.' || c == '-' || c == '_'))
+        .any(|word| is_hostname_like(word) || is_opaque_id(word))
+}
+
+/// Top-level domains a provider's infrastructure realistically appears under.
+/// Deliberately a closed list rather than "any short alphabetic suffix": a
+/// dotted token is far more often a field path (`temperature.value`), a library
+/// (`Node.js`) or a version than a host, and treating those as identifying threw
+/// away messages the caller could have acted on. TLDs that double as common
+/// field-path or filename segments (`app`, `run`, `dev`, `cloud`, `info`, `sh`, …)
+/// are deliberately excluded for the same reason — `config.dev`/`app.run`/
+/// `entrypoint.sh` are not hosts. A host under some TLD outside this list survives
+/// — that is the accepted cost of not discarding good errors, and `://` plus the
+/// opaque-id check still catch the common shapes.
+const HOST_TLDS: &[&str] = &[
+    "com", "net", "org", "io", "ai", "cn", "eu", "uk", "de", "fr", "jp", "gg", "xyz", "local",
+    "internal",
+];
+
+/// `api.acme.ai`, `10.0.0.7` — a dotted token under a known TLD, or a dotted
+/// quad of octets.
+fn is_hostname_like(word: &str) -> bool {
+    let parts: Vec<&str> = word.split('.').collect();
+    if parts.len() < 2 || parts.iter().any(|p| p.is_empty()) {
+        return false;
+    }
+    // An IPv4 literal. A four-part version string is indistinguishable and is
+    // dropped with it; three-part versions (the common shape) are not, because
+    // they fail both this and the TLD test below.
+    if parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok()) {
+        return true;
+    }
+    let last = parts[parts.len() - 1].to_ascii_lowercase();
+    HOST_TLDS.contains(&last.as_str())
+        && parts[..parts.len() - 1]
+            .iter()
+            .all(|p| p.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'))
+}
+
+/// A request id or trace id: a UUID, or a long unbroken hex run.
+fn is_opaque_id(word: &str) -> bool {
+    let hex = |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit());
+    let groups: Vec<&str> = word.split('-').collect();
+    if groups.len() == 5
+        && [8, 4, 4, 4, 12]
+            .iter()
+            .zip(&groups)
+            .all(|(len, group)| group.len() == *len && hex(group))
+    {
+        return true;
+    }
+    word.len() >= 16 && hex(word)
 }
 
 /// The host component of an `http(s)://` URL (`https://a.example/x?y` -> `a.example`).
@@ -357,7 +495,7 @@ pub fn normalize_upstream_error_parts(
         return parts;
     }
     if is_actionable_client_error(upstream_status) {
-        if let Some(message) = extract_error_message(body) {
+        if let Some(message) = client_safe_error_message(body) {
             return (
                 upstream_status,
                 envelope_bytes(
@@ -400,6 +538,138 @@ pub fn normalize_upstream_error(
     let (status, bytes) =
         normalize_upstream_error_parts(surface, upstream_status, body, received_body, request_id);
     parts_response(status, bytes)
+}
+
+#[cfg(test)]
+mod scrub_tests {
+    use super::scrub_identifying_markers;
+
+    /// The shape captured from a provider that wraps its backend's error: a
+    /// bracketed status and a dotted code namespace, stripped to the actionable
+    /// text underneath. Works on providers never seen, because it matches shape.
+    #[test]
+    fn strips_an_error_code_prefix_and_keeps_the_actionable_text() {
+        let raw = "<400> Module.Sub.BadParam: The requested parameter combination \
+                   is not supported by this model";
+        assert_eq!(
+            scrub_identifying_markers(raw).as_deref(),
+            Some("The requested parameter combination is not supported by this model")
+        );
+    }
+
+    /// A bare dotted code with no bracketed status is the same shape.
+    #[test]
+    fn strips_a_dotted_code_without_a_bracketed_status() {
+        assert_eq!(
+            scrub_identifying_markers("InvalidParameter.Value: temperature is too large")
+                .as_deref(),
+            Some("temperature is too large")
+        );
+    }
+
+    /// A colon whose head is not a dotted code, and a non-ASCII body, are both
+    /// relayed verbatim rather than mistaken for a prefix or garbled.
+    #[test]
+    fn keeps_a_clean_message_verbatim() {
+        for message in [
+            "warning: value out of range",
+            "temperature is invalid \u{2014} must be between 0 and 1",
+            "The model does not exist or you do not have access to it.",
+            "Expected temperature to be at most 2, received 99",
+            "'temperature' must be Float",
+        ] {
+            assert_eq!(scrub_identifying_markers(message).as_deref(), Some(message));
+        }
+    }
+
+    /// A URL, a hostname, an IP, or an opaque id points at who served the
+    /// request, and is dropped by shape — no list of names involved.
+    #[test]
+    fn drops_a_message_that_still_identifies_the_upstream() {
+        for message in [
+            "upstream https://api.acme.ai/v1 returned 500",
+            "no route to inference-7.internal.acme.io",
+            "backend 10.0.0.7 refused the connection",
+            "request 136e8d8a-e1ee-94c3-90f7-3b3bd3ecbf29 failed",
+            "trace 4f9a2c1de88b0771ab34 not found",
+        ] {
+            assert_eq!(
+                scrub_identifying_markers(message),
+                None,
+                "leaked: {message}"
+            );
+        }
+    }
+
+    /// Accepted residual of dropping the name list: a bare company name in
+    /// otherwise-neutral prose is relayed. Documented as a test so the choice is
+    /// explicit — this shape has not been seen in practice, and the
+    /// shapes that were are caught above.
+    #[test]
+    fn relays_a_bare_vendor_name_in_neutral_prose() {
+        assert_eq!(
+            scrub_identifying_markers("acmecloud rejected the request").as_deref(),
+            Some("acmecloud rejected the request")
+        );
+    }
+
+    /// Stripping must not empty the message into a meaningless success.
+    #[test]
+    fn drops_a_message_that_was_only_a_code() {
+        assert_eq!(scrub_identifying_markers("<400> Internal.Algo.Bad: "), None);
+    }
+
+    /// Decimals and version-like tokens are not hostnames.
+    #[test]
+    fn does_not_mistake_numbers_for_hosts() {
+        assert_eq!(
+            scrub_identifying_markers("temperature must be between 0.0 and 2.0").as_deref(),
+            Some("temperature must be between 0.0 and 2.0")
+        );
+    }
+
+    /// A dotted token is usually a field path or a library, not a host. Treating
+    /// every one as identifying discarded messages the caller could act on, which
+    /// is the opposite of useful: these are the most actionable errors there are.
+    #[test]
+    fn keeps_messages_whose_dotted_tokens_are_not_hosts() {
+        for message in [
+            "Invalid 'temperature.value': must be a number",
+            "Node.js runtime error",
+            "invalid request.body",
+            "responseFormat.type is not supported",
+            "response_format.type is not supported",
+            "expected schema.properties.name to be a string",
+            "upgrade to version 1.2.3",
+        ] {
+            assert_eq!(
+                scrub_identifying_markers(message).as_deref(),
+                Some(message),
+                "wrongly dropped: {message}"
+            );
+        }
+    }
+
+    /// Narrowing the host rule to known TLDs must not let a real host through.
+    #[test]
+    fn still_drops_real_hosts_and_addresses() {
+        for message in [
+            "no route to inference-7.internal.acme.io",
+            "cannot connect to host files.example.com:443",
+            "backend 10.0.0.7 refused the connection",
+            "resolve failed for api.acme.ai",
+            // A host/IP/id that ends the sentence carries a trailing period.
+            "could not resolve host api.acme.ai.",
+            "connection refused by 10.0.0.7.",
+            "unknown request 136e8d8a-e1ee-94c3-90f7-3b3bd3ecbf29.",
+        ] {
+            assert_eq!(
+                scrub_identifying_markers(message),
+                None,
+                "leaked: {message}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -52,7 +52,42 @@ pub enum TransformError {
     },
     /// A transform rejected the request body (e.g. unparseable tool-call
     /// arguments). Surfaced as a gateway-attributed failure (error_source "gateway").
-    InvalidRequest(String),
+    InvalidRequest {
+        /// Returned to the client. Must never name a route, provider or upstream:
+        /// this string reaches the caller verbatim, and `route <provider>:<model>`
+        /// used to be part of it.
+        message: String,
+        /// Operator-only context — which route could not be shaped. Logged, never
+        /// returned.
+        detail: Option<String>,
+    },
+}
+
+impl TransformError {
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        TransformError::InvalidRequest {
+            message: message.into(),
+            detail: None,
+        }
+    }
+
+    /// Operator-only context, for the log line that accompanies the refusal.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            TransformError::InvalidRequest { detail, .. } => detail.as_deref(),
+            TransformError::Unsupported { .. } => None,
+        }
+    }
+
+    /// A body we cannot shape for the chosen route is the request's problem and
+    /// the caller can act on it; a route offered for an endpoint its format
+    /// cannot serve is ours.
+    pub fn client_status(&self) -> u16 {
+        match self {
+            TransformError::InvalidRequest { .. } => 400,
+            TransformError::Unsupported { .. } => 500,
+        }
+    }
 }
 
 impl std::fmt::Display for TransformError {
@@ -65,7 +100,7 @@ impl std::fmt::Display for TransformError {
                 };
                 write!(f, "{} is not supported by {format}", endpoint.label())
             }
-            TransformError::InvalidRequest(message) => write!(f, "{message}"),
+            TransformError::InvalidRequest { message, .. } => write!(f, "{message}"),
         }
     }
 }
@@ -188,9 +223,9 @@ fn candidate_params(
     if endpoint != Endpoint::ChatComplete {
         return Ok(params);
     }
-    let object = params.as_object_mut().ok_or_else(|| {
-        TransformError::InvalidRequest("request body must be a JSON object".to_string())
-    })?;
+    let object = params
+        .as_object_mut()
+        .ok_or_else(|| TransformError::invalid_request("request body must be a JSON object"))?;
     for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
         object.remove(key);
     }
@@ -204,11 +239,9 @@ fn candidate_params(
     else {
         return Ok(params);
     };
-    validate_effective(effective).map_err(|err| {
-        TransformError::InvalidRequest(format!(
-            "route {} returned invalid effective reasoning: {err}",
-            candidate.route_id
-        ))
+    validate_effective(effective).map_err(|err| TransformError::InvalidRequest {
+        message: format!("invalid effective reasoning: {err}"),
+        detail: Some(format!("route {}", candidate.route_id)),
     })?;
     sync_chat_template_reasoning(object, effective);
     let reasoning_format = candidate.reasoning_format.unwrap_or_else(|| {
@@ -288,18 +321,19 @@ fn set_chat_template_reasoning(
         .entry("chat_template_kwargs")
         .or_insert_with(|| Value::Object(Map::new()))
         .as_object_mut()
-        .ok_or_else(|| {
-            TransformError::InvalidRequest("chat_template_kwargs must be an object".to_string())
-        })?;
+        .ok_or_else(|| TransformError::invalid_request("chat_template_kwargs must be an object"))?;
     kwargs.insert(key.to_string(), Value::Bool(enabled));
     Ok(())
 }
 
+/// The route id names the provider (`<provider>:<model>`), so it goes
+/// to the log and not to the client — the caller only needs to know that the
+/// model they asked for cannot express the reasoning they requested.
 fn invalid_reasoning<T>(candidate: &RouteCandidate, message: &str) -> Result<T, TransformError> {
-    Err(TransformError::InvalidRequest(format!(
-        "route {} {message}",
-        candidate.route_id
-    )))
+    Err(TransformError::InvalidRequest {
+        message: format!("the requested model {message}"),
+        detail: Some(format!("route {}", candidate.route_id)),
+    })
 }
 
 fn reasoning_object(config: &ReasoningConfig) -> Value {
@@ -492,7 +526,7 @@ fn transform_assistant_message(msg: &Value) -> Result<Value, TransformError> {
             // request rather than forwarding a different input.
             let input = match arguments {
                 Some(s) if !s.is_empty() => serde_json::from_str(s).map_err(|e| {
-                    TransformError::InvalidRequest(format!("invalid tool call arguments: {e}"))
+                    TransformError::invalid_request(format!("invalid tool call arguments: {e}"))
                 })?,
                 _ => json!({}),
             };

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -1,10 +1,12 @@
-//! Buffered response transforms: convert an upstream provider's 2xx response
-//! body into the downstream client surface. Non-2xx responses are normalized by
-//! `errors` before reaching here, so these assume a success body. Streaming (SSE)
-//! transforms live in `stream_transform`.
+//! Response transforms that operate on a decoded 2xx body: the buffered
+//! format conversions (Anthropic <-> OpenAI, etc.), and the shape operations
+//! shared with the streaming path — `rewrite_identity` (stamp our id/model),
+//! `exclude_reasoning`, and `canonicalize` (reduce to the documented output
+//! schema and sanitize an in-band error). The streaming SSE machinery that
+//! applies these per chunk lives in `stream_transform`; non-2xx responses are
+//! normalized by `errors` before reaching here.
 //!
-//! Cost injection is a separate metering pass; these transforms only normalize
-//! the body shape (including the canonical `usage`).
+//! Cost injection is a separate metering pass.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -68,6 +70,9 @@ pub(super) fn normalize_reasoning_usage_value(usage: &mut Value) -> Option<bool>
 /// Remove reasoning traces from an OpenAI Chat Completions response while
 /// leaving usage (including `completion_tokens_details.reasoning_tokens`)
 /// untouched.
+///
+/// Must cover every field the canonical schema treats as reasoning output — the
+/// allowlist keeps them all, so any this misses would survive an opt-out.
 pub fn exclude_reasoning(body: &mut Value) {
     for choice in body
         .get_mut("choices")
@@ -77,11 +82,371 @@ pub fn exclude_reasoning(body: &mut Value) {
     {
         for container in ["message", "delta"] {
             if let Some(object) = choice.get_mut(container).and_then(Value::as_object_mut) {
-                for key in ["reasoning", "reasoning_content", "reasoning_details"] {
+                for key in [
+                    "reasoning",
+                    "reasoning_content",
+                    "reasoning_details",
+                    "thinking_blocks",
+                    "reasoning_items",
+                ] {
                     object.remove(key);
                 }
             }
         }
+    }
+}
+
+/// What the client is told about who served the request: our own request id and
+/// the model the client asked for. Carried per request because both values are
+/// per request; the streaming transform holds it behind an `Arc`.
+#[derive(Debug, Clone)]
+pub struct ResponseIdentity {
+    pub request_id: String,
+    /// `None` when the request named no model (embeddings on some surfaces), in
+    /// which case whatever the upstream reported is left alone.
+    pub user_model: Option<String>,
+}
+
+/// Rewrite the response identity — the upstream's `id` (its *format* varies
+/// between servers, so it distinguishes one backend from another) and its `model`
+/// (a server may report its own internal name where the client asked for the
+/// catalog slug) — to values the client should see.
+///
+/// This is a *value* rewrite, distinct from `canonicalize`, which drops whole
+/// fields. Two streaming shapes nest the identity one level down and are keyed off
+/// the event `type`:
+/// - `message_start`: Anthropic *streaming*. The identity is in `message`, where
+///   the `OpenaiToAnthropicMessages` conversion (which runs first) puts the
+///   upstream's values.
+/// - `response.*`: Responses API *streaming*. Lifecycle events
+///   (`response.created`/`response.completed`/…) nest the full response object —
+///   and its `id`/`model` — under `response`; delta events carry neither.
+///
+/// Everything else takes the top-level `id`/`model`: every buffered body (OpenAI
+/// chat/completion/responses, and the Anthropic message — which is
+/// `type: "message"`), and any typed event carrying identity at the top level.
+/// `rewrite_id_and_model` only *replaces* `id`/`model` where they already exist,
+/// so an event without them (an Anthropic `content_block_delta`, a Responses delta
+/// or `error` event) is untouched — and a `tool_use`/`item_id` or `content_block`
+/// id, which is content identity rather than response identity, is never touched.
+///
+/// Only ever *replaces* `id`/`model`, never adds them: an Anthropic
+/// `content_block_delta` legitimately carries neither, and inventing them would
+/// corrupt the event.
+pub fn rewrite_identity(body: &mut Value, identity: &ResponseIdentity) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    match object.get("type").and_then(Value::as_str) {
+        // Anthropic streaming: identity is in `message_start`'s `message`.
+        Some("message_start") => {
+            if let Some(message) = object.get_mut("message").and_then(Value::as_object_mut) {
+                rewrite_id_and_model(message, identity);
+            }
+        }
+        // Responses API streaming: lifecycle events nest identity in `response`.
+        Some(t) if t.starts_with("response.") => {
+            if let Some(inner) = object.get_mut("response").and_then(Value::as_object_mut) {
+                rewrite_id_and_model(inner, identity);
+            }
+        }
+        // Everything else — the buffered body (OpenAI chat/completion/responses, or
+        // the Anthropic message, which is `type: "message"`) and any typed event
+        // that carries its identity at the top level. `rewrite_id_and_model` only
+        // replaces `id`/`model` where they already exist, so an event without them
+        // (an Anthropic `content_block_delta`, a Responses delta) is left untouched.
+        _ => rewrite_id_and_model(object, identity),
+    }
+}
+
+/// Replace `id`/`model` where they already exist, on whichever object carries
+/// the response identity.
+fn rewrite_id_and_model(object: &mut serde_json::Map<String, Value>, identity: &ResponseIdentity) {
+    if object.contains_key("id") {
+        object.insert("id".to_string(), Value::String(identity.request_id.clone()));
+    }
+    if let (true, Some(model)) = (object.contains_key("model"), identity.user_model.as_ref()) {
+        object.insert("model".to_string(), Value::String(model.clone()));
+    }
+}
+
+// ── Canonical output schema (allowlist) ──────────────────────────────────────
+//
+// The client sees one shape regardless of which upstream served the request:
+// only the fields this gateway documents as its output. A denylist can only
+// remove what has been seen before and leaks anything new — an engine's next
+// nonstandard field, a provider's verification blob, a trace event. An allowlist
+// leaks nothing by construction: a field the schema does not name never reaches
+// the client, whether or not we have seen it.
+//
+// This is why `rewrite_identity` no longer strips engine fields —
+// `matched_stop` and its kind are simply not on the allowlist. Identity that is
+// a *value*, not a field (`id`/`model`), is still rewritten there; the allowlist
+// only decides which fields survive.
+//
+// Deliberately *not* included: `provider` (an aggregator that publishes which
+// backend served a request emits this; we do not) and `system_fingerprint` (its
+// whole purpose is to identify the serving backend configuration).
+
+/// Every field the OpenAI chat-completion surface emits, by level. Cross-checked
+/// against the documented OpenAI response and the common OpenAI-compatible
+/// supersets of it. Extended only by a deliberate decision to support a new field,
+/// never by what an upstream happens to send.
+///
+/// `reasoning*`/`thinking_blocks`/`reasoning_items` are reasoning extensions;
+/// `audio`/`images` are multimodal outputs; `usage.cost`/`cost_details` are
+/// injected by this gateway; `usage.reasoning_tokens` is a count some servers
+/// report at the top of `usage`. The nested `*_tokens_details` objects are kept
+/// whole so no token-breakdown sub-field is dropped.
+///
+/// `native_finish_reason` is intentionally absent: it duplicates `finish_reason`
+/// with the upstream's raw value, and the standard schemas do not list it. A
+/// catch-all "provider-specific fields" object (as some compatibility layers
+/// expose) is intentionally absent for the same reason it exists — it is exactly
+/// where an upstream's identifying fields would ride.
+const CHAT_TOP: &[&str] = &[
+    "id",
+    "object",
+    "created",
+    "model",
+    "choices",
+    "usage",
+    "service_tier",
+    // A streaming chunk may carry an in-band error (top level and per choice). It
+    // must survive canonicalization: the client
+    // needs to see the error, and the downstream metering stage detects a failed
+    // 200 stream by this field — dropping it would meter a failure as success.
+    "error",
+];
+const CHAT_CHOICE: &[&str] = &[
+    "index",
+    "message",
+    "delta",
+    "finish_reason",
+    "logprobs",
+    "error",
+];
+const CHAT_MESSAGE: &[&str] = &[
+    "role",
+    "content",
+    "name",
+    "refusal",
+    "tool_calls",
+    "function_call",
+    "annotations",
+    "audio",
+    "images",
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "thinking_blocks",
+    "reasoning_items",
+];
+const CHAT_USAGE: &[&str] = &[
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "prompt_tokens_details",
+    "completion_tokens_details",
+    "reasoning_tokens",
+    "server_tool_use",
+    "server_tool_use_details",
+    "cost",
+    "cost_details",
+];
+/// The standard OpenAI error object. Its interior must be filtered like every
+/// other level: some upstreams nest `error.metadata.provider_name` and
+/// `error.metadata.raw` (the raw upstream error, often a host/URL) inside it, and
+/// keeping the whole object would relay exactly the upstream identity the rest of
+/// this removes. The buffered error path rebuilds a fresh object for the same
+/// reason; this keeps only these fields and scrubs the message.
+const CHAT_ERROR: &[&str] = &["message", "type", "param", "code"];
+
+/// The legacy `/v1/completions` (text completion) surface. OpenAI-standard and
+/// small; cross-checked against the documented text-completion response.
+/// Reuses `CHAT_USAGE`/`CHAT_ERROR` (identical shapes). `system_fingerprint` and
+/// `provider` are dropped for the same reason as on the chat surface.
+const COMPLETION_TOP: &[&str] = &[
+    "id", "object", "created", "model", "choices", "usage", "error",
+];
+const COMPLETION_CHOICE: &[&str] = &["text", "index", "logprobs", "finish_reason", "error"];
+
+/// The `/v1/responses` (Responses API) surface. A larger shape that echoes request
+/// parameters back and carries client-supplied `metadata`; the field set is the
+/// documented Responses API response object. `output[]` items are content and left
+/// intact. `system_fingerprint`/`provider` and any other unlisted upstream field
+/// are dropped. `usage` has its own shape.
+const RESPONSES_TOP: &[&str] = &[
+    "id",
+    "created_at",
+    "error",
+    "incomplete_details",
+    "instructions",
+    "metadata",
+    "model",
+    "object",
+    "output",
+    "parallel_tool_calls",
+    "temperature",
+    "tool_choice",
+    "tools",
+    "top_p",
+    "max_output_tokens",
+    "previous_response_id",
+    "reasoning",
+    "status",
+    "text",
+    "truncation",
+    "usage",
+    "user",
+    "store",
+    // A real, non-identifying OpenAI field (`auto`/`default`/`flex`); kept for
+    // parity with `CHAT_TOP`.
+    "service_tier",
+];
+const RESPONSES_USAGE: &[&str] = &[
+    "input_tokens",
+    "input_tokens_details",
+    "output_tokens",
+    "output_tokens_details",
+    "total_tokens",
+    "cost",
+    "cost_details",
+];
+
+/// Reduce a response to the gateway's documented output schema for `endpoint`,
+/// dropping every field the schema does not name. Runs last, after
+/// `rewrite_identity` and cost injection, on both a buffered body and a single
+/// streaming chunk.
+///
+/// Covers the three OpenAI-compatible surfaces (chat completions, legacy
+/// completions, responses). The Anthropic Messages surface and embeddings are not
+/// canonicalized here — Messages has its own shape handled by the format
+/// conversion, and embeddings are not yet scoped.
+pub fn canonicalize(body: &mut Value, endpoint: Endpoint) {
+    match endpoint {
+        Endpoint::ChatComplete => canonicalize_chat_completion(body),
+        Endpoint::Complete => canonicalize_text_completion(body),
+        Endpoint::CreateModelResponse => canonicalize_responses(body),
+        Endpoint::Embed | Endpoint::Messages => {}
+    }
+}
+
+fn canonicalize_text_completion(body: &mut Value) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    retain_allowed(object, COMPLETION_TOP);
+    if let Some(usage) = object.get_mut("usage").and_then(Value::as_object_mut) {
+        retain_allowed(usage, CHAT_USAGE);
+    }
+    sanitize_error(object.get_mut("error"));
+    for choice in object
+        .get_mut("choices")
+        .and_then(Value::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        if let Some(choice) = choice.as_object_mut() {
+            retain_allowed(choice, COMPLETION_CHOICE);
+            sanitize_error(choice.get_mut("error"));
+        }
+    }
+}
+
+/// The Responses API is the one surface whose streaming events do *not* share
+/// the final object's shape: a stream is a sequence of typed envelopes
+/// (`{"type":"response.output_text.delta","delta":…}`,
+/// `{"type":"response.completed","response":{…}}`, `{"type":"error",…}`), while
+/// the buffered body *is* the response object (`{"object":"response",…}`, no
+/// top-level `type`). Applying the final-object allowlist to an event envelope
+/// would empty it and destroy the stream — and, because metering keys on the
+/// envelope's `type`/`response.status`/`error`, misreport a successful stream as
+/// failed. So dispatch on the envelope `type`:
+/// - No `type`: the buffered response object — canonicalize it directly.
+/// - `response.*` lifecycle: the full object is nested under `response` — that is
+///   the only identity-bearing part; canonicalize it and leave the envelope's
+///   control fields (`type`, `sequence_number`, …) untouched.
+/// - Any other typed event (deltas, item/part events, `error`): a control/content
+///   envelope carrying no response object — pass through verbatim.
+fn canonicalize_responses(body: &mut Value) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    match object.get("type").and_then(Value::as_str) {
+        Some(t) if t.starts_with("response.") => {
+            if let Some(inner) = object.get_mut("response").and_then(Value::as_object_mut) {
+                canonicalize_responses_object(inner);
+            }
+        }
+        Some(_) => {}
+        None => canonicalize_responses_object(object),
+    }
+}
+
+fn canonicalize_responses_object(object: &mut serde_json::Map<String, Value>) {
+    retain_allowed(object, RESPONSES_TOP);
+    if let Some(usage) = object.get_mut("usage").and_then(Value::as_object_mut) {
+        retain_allowed(usage, RESPONSES_USAGE);
+    }
+    // `output[]` items are content (message/reasoning/function_call, …) and left
+    // intact; the identifying fields ride at the top level, dropped above.
+    sanitize_error(object.get_mut("error"));
+}
+
+fn retain_allowed(object: &mut serde_json::Map<String, Value>, allowed: &[&str]) {
+    object.retain(|key, _| allowed.contains(&key.as_str()));
+}
+
+fn canonicalize_chat_completion(body: &mut Value) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    retain_allowed(object, CHAT_TOP);
+    if let Some(usage) = object.get_mut("usage").and_then(Value::as_object_mut) {
+        retain_allowed(usage, CHAT_USAGE);
+    }
+    // The allowlist keeps the `error` field (so the client sees an in-band error
+    // and metering classifies the stream), but the error object's interior is
+    // upstream-controlled — filter it to the standard fields and scrub its
+    // message, so no `metadata.provider_name`/`raw` or unknown sub-field leaks.
+    sanitize_error(object.get_mut("error"));
+    for choice in object
+        .get_mut("choices")
+        .and_then(Value::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        let Some(choice) = choice.as_object_mut() else {
+            continue;
+        };
+        retain_allowed(choice, CHAT_CHOICE);
+        sanitize_error(choice.get_mut("error"));
+        // A buffered choice carries `message`; a streaming choice carries `delta`.
+        for container in ["message", "delta"] {
+            if let Some(part) = choice.get_mut(container).and_then(Value::as_object_mut) {
+                retain_allowed(part, CHAT_MESSAGE);
+            }
+        }
+    }
+}
+
+/// Make an in-band error client-safe. An object error is filtered to the standard
+/// fields (dropping `metadata` and any other upstream-controlled sub-field) and
+/// its message scrubbed; a bare-string error is scrubbed. Both shapes match what
+/// the buffered path accepts; any other shape is left untouched.
+fn sanitize_error(error: Option<&mut Value>) {
+    match error {
+        Some(Value::String(text)) => {
+            *text = crate::middleware::errors::client_safe_error_text(text);
+        }
+        Some(Value::Object(object)) => {
+            retain_allowed(object, CHAT_ERROR);
+            if let Some(Value::String(message)) = object.get_mut("message") {
+                *message = crate::middleware::errors::client_safe_error_text(message);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -307,6 +672,467 @@ fn openai_to_anthropic_messages(response: Value) -> Value {
         "stop_sequence": Value::Null,
         "usage": usage,
     })
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn identity() -> ResponseIdentity {
+        ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: Some("acme/model-a".to_string()),
+        }
+    }
+
+    /// The two steps together, as the buffered path runs them: identity rewrite
+    /// then canonicalize. The upstream id/model become ours, and the engine field
+    /// `matched_stop` is gone — dropped by the allowlist, not named anywhere.
+    #[test]
+    fn rewrites_identity_and_canonicalizes_a_chat_completion() {
+        let mut body = json!({
+            "id": "7bdaaade50304502b0fe7e66e9a4bec2",
+            "object": "chat.completion",
+            "model": "vendor-model-int",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "hi" },
+                "finish_reason": "stop",
+                "matched_stop": 424242
+            }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1 }
+        });
+        rewrite_identity(&mut body, &identity());
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert_eq!(body["id"], "req_ours");
+        assert_eq!(body["model"], "acme/model-a");
+        assert!(body["choices"][0].get("matched_stop").is_none());
+        // Everything on the allowlist is left alone.
+        assert_eq!(body["choices"][0]["finish_reason"], "stop");
+        assert_eq!(body["choices"][0]["message"]["content"], "hi");
+        assert_eq!(body["usage"]["completion_tokens"], 1);
+    }
+
+    /// `rewrite_identity` alone is a value rewrite only — it no longer drops
+    /// fields, so an engine field survives it and is left to `canonicalize`.
+    #[test]
+    fn identity_rewrite_does_not_drop_fields() {
+        let mut body = json!({
+            "id": "x",
+            "choices": [{ "index": 0, "matched_stop": 424242 }]
+        });
+        rewrite_identity(&mut body, &identity());
+        assert_eq!(body["id"], "req_ours");
+        assert_eq!(body["choices"][0]["matched_stop"], 424242);
+    }
+
+    /// The trap: Anthropic Messages carries a top-level `stop_reason` that is
+    /// part of its contract. The identity rewrite never touches it, and the
+    /// Messages surface is not canonicalized against the chat-completion schema.
+    #[test]
+    fn keeps_the_anthropic_top_level_stop_reason() {
+        let mut body = json!({
+            "id": "msg_upstream",
+            "type": "message",
+            "model": "claude-x",
+            "stop_reason": "end_turn",
+            "content": [{ "type": "text", "text": "hi" }]
+        });
+        rewrite_identity(&mut body, &identity());
+        canonicalize(&mut body, Endpoint::Messages);
+        assert_eq!(body["stop_reason"], "end_turn");
+        assert_eq!(body["id"], "req_ours");
+    }
+
+    /// A choice-level `stop_reason` (an engine's, not the Anthropic contract's)
+    /// is dropped by the chat-completion allowlist.
+    #[test]
+    fn canonicalize_drops_a_choice_level_stop_reason() {
+        let mut body = json!({
+            "id": "x",
+            "choices": [{ "index": 0, "finish_reason": "stop", "stop_reason": 424242 }]
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert!(body["choices"][0].get("stop_reason").is_none());
+        assert_eq!(body["choices"][0]["finish_reason"], "stop");
+    }
+
+    /// The allowlist drops fields never seen before — a provider verification
+    /// blob, a trace, an engine field — without naming them, and keeps `usage.cost`
+    /// (injected by us) and a streaming `delta`.
+    #[test]
+    fn canonicalize_drops_unknown_fields_and_keeps_the_contract() {
+        let mut body = json!({
+            "id": "x",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "provider": "SomeProvider",
+            "system_fingerprint": "fp_backend_1",
+            "vendor_verification": { "sig": "x" },
+            "x_vendor_trace": "x",
+            "choices": [{
+                "index": 0,
+                "delta": { "role": "assistant", "content": "hi", "vendor_ext": 1 },
+                "finish_reason": null,
+                "matched_stop": 1
+            }],
+            "usage": { "completion_tokens": 2, "cost": 0.01, "reasoning_tokens": 1, "vendor_meta": 9 }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        let top: Vec<&String> = body.as_object().unwrap().keys().collect();
+        assert!(
+            !top.iter().any(|k| [
+                "provider",
+                "system_fingerprint",
+                "vendor_verification",
+                "x_vendor_trace"
+            ]
+            .contains(&k.as_str())),
+            "leaked: {top:?}"
+        );
+        assert!(body["choices"][0].get("matched_stop").is_none());
+        assert!(body["choices"][0]["delta"].get("vendor_ext").is_none());
+        assert!(body["usage"].get("vendor_meta").is_none());
+        // Contract fields survive.
+        assert_eq!(body["choices"][0]["delta"]["content"], "hi");
+        assert_eq!(body["usage"]["cost"], 0.01);
+        assert_eq!(body["usage"]["reasoning_tokens"], 1);
+    }
+
+    /// Multimodal and reasoning output fields must survive — dropping them would
+    /// break audio, image, and thinking-block responses. Locks the allowlist
+    /// against a too-narrow trim.
+    #[test]
+    fn canonicalize_keeps_multimodal_and_reasoning_output() {
+        let mut body = json!({
+            "id": "x",
+            "object": "chat.completion",
+            "service_tier": "default",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "audio": { "id": "a", "data": "…" },
+                    "images": [{ "type": "image_url", "image_url": { "url": "…" } }],
+                    "reasoning": "…",
+                    "thinking_blocks": [{ "type": "thinking", "thinking": "…" }],
+                    "reasoning_items": [{ "type": "reasoning" }],
+                    "name": "assistant-1"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": { "completion_tokens": 1, "server_tool_use": { "web_search": 1 } }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert_eq!(body["service_tier"], "default");
+        let msg = &body["choices"][0]["message"];
+        for field in [
+            "audio",
+            "images",
+            "reasoning",
+            "thinking_blocks",
+            "reasoning_items",
+            "name",
+        ] {
+            assert!(msg.get(field).is_some(), "dropped message.{field}");
+        }
+        assert!(body["usage"].get("server_tool_use").is_some());
+    }
+
+    /// An in-band error frame on a chat-completion stream must survive
+    /// canonicalization, or the client loses the error and the downstream meter
+    /// (which keys on top-level `error`) records a failed stream as a success. A
+    /// clean message is kept verbatim.
+    #[test]
+    fn canonicalize_keeps_an_in_band_stream_error() {
+        let mut body = json!({
+            "id": "x",
+            "object": "chat.completion.chunk",
+            "error": { "message": "context length exceeded", "code": 400 }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert_eq!(body["error"]["message"], "context length exceeded");
+        assert_eq!(body["error"]["code"], 400);
+    }
+
+    /// The error object's interior is filtered like every other level: the message
+    /// is scrubbed, standard fields (`code`) are kept, and upstream-identifying
+    /// sub-fields — `metadata.provider_name`, `metadata.raw` — are dropped, not
+    /// just the message. Checked top-level and per choice.
+    #[test]
+    fn canonicalize_scrubs_an_identifying_in_band_error() {
+        let mut body = json!({
+            "id": "x",
+            "object": "chat.completion.chunk",
+            "error": {
+                "message": "backend 10.0.0.7 refused the connection",
+                "code": 502,
+                "metadata": { "provider_name": "SomeProvider", "raw": "upstream https://api.acme.ai 502" }
+            },
+            "choices": [{
+                "index": 0,
+                "error": { "message": "no route to inference-7.internal.acme.io", "metadata": { "provider_name": "X" } }
+            }]
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert_eq!(body["error"]["message"], "the provider returned an error");
+        assert_eq!(body["error"]["code"], 502); // standard field kept
+        assert!(
+            body["error"].get("metadata").is_none(),
+            "leaked error.metadata"
+        );
+        assert_eq!(
+            body["choices"][0]["error"]["message"],
+            "the provider returned an error"
+        );
+        assert!(body["choices"][0]["error"].get("metadata").is_none());
+    }
+
+    /// Some providers send a bare-string `error` rather than an object; it is
+    /// scrubbed too, matching what the buffered error path accepts.
+    #[test]
+    fn canonicalize_scrubs_a_bare_string_error() {
+        let mut body = json!({
+            "id": "x",
+            "error": "cannot connect to host files.example.com:443"
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete);
+        assert_eq!(body["error"], "the provider returned an error");
+    }
+
+    /// Opting out of reasoning must drop every reasoning field the allowlist
+    /// keeps — including `thinking_blocks` and `reasoning_items`, which an earlier
+    /// version of `exclude_reasoning` missed while canonicalize kept them.
+    #[test]
+    fn exclude_reasoning_covers_every_allowlisted_reasoning_field() {
+        let mut body = json!({
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "hi",
+                    "reasoning": "…",
+                    "reasoning_content": "…",
+                    "reasoning_details": [{}],
+                    "thinking_blocks": [{ "type": "thinking" }],
+                    "reasoning_items": [{}]
+                }
+            }]
+        });
+        exclude_reasoning(&mut body);
+        let msg = body["choices"][0]["message"].as_object().unwrap();
+        for field in [
+            "reasoning",
+            "reasoning_content",
+            "reasoning_details",
+            "thinking_blocks",
+            "reasoning_items",
+        ] {
+            assert!(!msg.contains_key(field), "leaked {field} after opt-out");
+        }
+        assert_eq!(msg["content"], "hi");
+    }
+
+    /// A surface without a defined schema (Anthropic Messages, embeddings) is
+    /// passed through untouched.
+    #[test]
+    fn canonicalize_is_a_noop_for_unschematized_surfaces() {
+        let original = json!({ "id": "x", "anything": true, "choices": [] });
+        for endpoint in [Endpoint::Messages, Endpoint::Embed] {
+            let mut body = original.clone();
+            canonicalize(&mut body, endpoint);
+            assert_eq!(body, original, "mutated for {endpoint:?}");
+        }
+    }
+
+    /// Legacy `/v1/completions`: engine and identity fields are dropped, the
+    /// OpenAI-standard text choice survives.
+    #[test]
+    fn canonicalize_text_completion() {
+        let mut body = json!({
+            "id": "x",
+            "object": "text_completion",
+            "created": 1,
+            "model": "m",
+            "system_fingerprint": "fp_backend",
+            "provider": "SomeProvider",
+            "choices": [{
+                "text": "hello",
+                "index": 0,
+                "finish_reason": "stop",
+                "logprobs": null,
+                "matched_stop": 1
+            }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1, "cost": 0.01 }
+        });
+        canonicalize(&mut body, Endpoint::Complete);
+        assert!(body.get("system_fingerprint").is_none());
+        assert!(body.get("provider").is_none());
+        assert!(body["choices"][0].get("matched_stop").is_none());
+        assert_eq!(body["choices"][0]["text"], "hello");
+        assert_eq!(body["usage"]["cost"], 0.01);
+    }
+
+    /// `/v1/responses`: identity/unknown top-level fields are dropped, but the
+    /// request-echo params, client `metadata`, and `output[]` content survive, and
+    /// the Responses-shaped `usage` (`input_tokens`/`output_tokens`) is kept.
+    #[test]
+    fn canonicalize_responses() {
+        let mut body = json!({
+            "id": "resp_x",
+            "object": "response",
+            "created_at": 1,
+            "model": "m",
+            "system_fingerprint": "fp_backend",
+            "provider": "SomeProvider",
+            "status": "completed",
+            "metadata": { "client_tag": "abc" },
+            "temperature": 0.7,
+            "tools": [{ "type": "function" }],
+            "previous_response_id": "resp_prev",
+            "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "hi" }] }],
+            "usage": { "input_tokens": 3, "output_tokens": 2, "total_tokens": 5, "cost": 0.02 }
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse);
+        // Dropped: upstream identity and unknowns.
+        assert!(body.get("system_fingerprint").is_none());
+        assert!(body.get("provider").is_none());
+        // Kept: request-echo, client metadata, output content, responses usage.
+        assert_eq!(body["metadata"]["client_tag"], "abc");
+        assert_eq!(body["temperature"], 0.7);
+        assert_eq!(body["previous_response_id"], "resp_prev");
+        assert_eq!(body["output"][0]["content"][0]["text"], "hi");
+        assert_eq!(body["usage"]["input_tokens"], 3);
+        assert_eq!(body["usage"]["cost"], 0.02);
+    }
+
+    /// `/v1/responses` streaming: a lifecycle event carries the response object
+    /// nested under `response`. Its identity is rewritten and its interior
+    /// canonicalized, while the envelope's own control fields (`type`,
+    /// `sequence_number`) — which metering keys on — are left intact.
+    #[test]
+    fn canonicalize_responses_lifecycle_event() {
+        let mut body = json!({
+            "type": "response.completed",
+            "sequence_number": 42,
+            "response": {
+                "id": "resp_upstream",
+                "object": "response",
+                "model": "upstream-internal",
+                "system_fingerprint": "fp_backend",
+                "provider": "SomeProvider",
+                "status": "completed",
+                "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "hi" }] }],
+                "usage": { "input_tokens": 3, "output_tokens": 2 }
+            }
+        });
+        rewrite_identity(&mut body, &identity());
+        canonicalize(&mut body, Endpoint::CreateModelResponse);
+        // Envelope control fields survive untouched (metering depends on them).
+        assert_eq!(body["type"], "response.completed");
+        assert_eq!(body["sequence_number"], 42);
+        // Nested object: identity rewritten, upstream markers dropped, content kept.
+        assert_eq!(body["response"]["id"], "req_ours");
+        assert_eq!(body["response"]["model"], "acme/model-a");
+        assert!(body["response"].get("system_fingerprint").is_none());
+        assert!(body["response"].get("provider").is_none());
+        assert_eq!(body["response"]["status"], "completed");
+        assert_eq!(body["response"]["output"][0]["content"][0]["text"], "hi");
+    }
+
+    /// `/v1/responses` streaming: a delta and a typed `error` event are not the
+    /// response object; applying the final-object allowlist would empty them.
+    /// They must pass through verbatim so the client sees content and errors and
+    /// metering can classify the stream.
+    #[test]
+    fn canonicalize_responses_passes_through_non_object_events() {
+        for event in [
+            json!({
+                "type": "response.output_text.delta",
+                "item_id": "msg_1",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": "hi",
+                "sequence_number": 3
+            }),
+            json!({
+                "type": "error",
+                "code": "server_error",
+                "message": "boom",
+                "sequence_number": 9
+            }),
+        ] {
+            let mut body = event.clone();
+            rewrite_identity(&mut body, &identity());
+            canonicalize(&mut body, Endpoint::CreateModelResponse);
+            assert_eq!(body, event, "envelope was mutated: {event}");
+        }
+    }
+
+    /// Anthropic streaming events carry neither field; inventing them would
+    /// corrupt the event.
+    #[test]
+    fn never_adds_id_or_model_to_an_event_that_has_neither() {
+        let mut body = json!({ "type": "content_block_delta", "index": 0 });
+        rewrite_identity(&mut body, &identity());
+        assert_eq!(body, json!({ "type": "content_block_delta", "index": 0 }));
+    }
+
+    /// Anthropic streaming hides the response identity one level down, in the
+    /// `message` of a `message_start` event — where the format conversion put the
+    /// upstream's own id and internal model name. The top-level-only rewrite
+    /// missed it, leaking both to a `/v1/messages` client of an OpenAI upstream.
+    #[test]
+    fn rewrites_the_nested_identity_of_an_anthropic_message_start() {
+        let mut body = json!({
+            "type": "message_start",
+            "message": {
+                "id": "chatcmpl-7bdaaade5030",
+                "type": "message",
+                "role": "assistant",
+                "model": "vendor-model-int",
+                "content": [],
+            },
+        });
+        rewrite_identity(&mut body, &identity());
+        assert_eq!(body["message"]["id"], "req_ours");
+        assert_eq!(body["message"]["model"], "acme/model-a");
+        // The rest of the event is untouched.
+        assert_eq!(body["message"]["role"], "assistant");
+    }
+
+    /// A `tool_use` id is content identity, not response identity: the
+    /// message_start branch must not reach into other events and rewrite it.
+    #[test]
+    fn leaves_a_tool_use_id_in_a_content_block_alone() {
+        let mut body = json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": { "type": "tool_use", "id": "toolu_abc", "name": "f" },
+        });
+        let before = body.clone();
+        rewrite_identity(&mut body, &identity());
+        assert_eq!(body, before);
+    }
+
+    /// No requested model (some embedding surfaces) leaves the upstream's alone
+    /// rather than blanking it.
+    #[test]
+    fn leaves_model_alone_when_the_request_named_none() {
+        let mut body = json!({ "id": "x", "model": "whatever" });
+        rewrite_identity(
+            &mut body,
+            &ResponseIdentity {
+                request_id: "req_ours".to_string(),
+                user_model: None,
+            },
+        );
+        assert_eq!(body["model"], "whatever");
+        assert_eq!(body["id"], "req_ours");
+    }
 }
 
 #[cfg(test)]

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -3,12 +3,14 @@
 //! state across events (a per-stream transform state).
 //!
 //! Three provider conversions are supported. Same-format streaming reaches this
-//! module only when response reasoning must be excluded. Cost injection, TTFT,
-//! and outcome are a separate metering pass downstream (`sse`).
+//! module too: every stream is sanitized here (identity rewrite + canonicalize,
+//! per chunk), and reasoning is excluded when the client opts out. Cost
+//! injection, TTFT, and outcome are a separate metering pass downstream (`sse`).
 
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use axum::body::Bytes;
@@ -21,6 +23,7 @@ use crate::aggregator::service::{ServiceError, ServiceResponseStream};
 use super::request_transform::Endpoint;
 use super::response_transform::{
     self, i64_field, map_finish_reason, now_millis, now_secs, transform_finish_reason,
+    ResponseIdentity,
 };
 use super::sse::MAX_SSE_LINE_BYTES;
 use super::types::ProviderFormat;
@@ -28,19 +31,27 @@ use super::types::ProviderFormat;
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
 /// Which streaming transform applies.
-#[derive(Debug, Clone, Copy)]
+///
+/// `Clone` rather than `Copy`: `SanitizeResponse` carries per-request values
+/// (our request id, the client's model name), which no unit variant can.
+#[derive(Debug, Clone)]
 pub enum StreamTransform {
     AnthropicToOpenaiChat,
     OpenaiToAnthropicMessages,
     AnthropicCompleteToOpenai,
     ExcludeReasoning,
+    /// Applied to every stream, including same-format passthrough, which is the
+    /// one path that previously relayed provider bytes verbatim. Carries the
+    /// endpoint so each chunk is canonicalized to that surface's output schema.
+    SanitizeResponse(Arc<ResponseIdentity>, Endpoint),
 }
 
 impl StreamTransform {
-    fn provider(self) -> &'static str {
+    fn provider(&self) -> &'static str {
         match self {
             StreamTransform::OpenaiToAnthropicMessages => "openai",
             StreamTransform::ExcludeReasoning => "openai",
+            StreamTransform::SanitizeResponse(_, _) => "openai",
             _ => "anthropic",
         }
     }
@@ -53,13 +64,25 @@ impl StreamTransform {
     // aborts dispatch — covers `: PROCESSING` heartbeats, ignored fields, and
     // name-only or empty-`data:` keep-alives).
     fn apply(
-        self,
+        &self,
         event: &str,
         fallback_id: &str,
         state: &mut StreamState,
     ) -> Result<Option<String>, ()> {
-        if matches!(self, StreamTransform::ExcludeReasoning) {
-            return exclude_reasoning_event(event).map(Some);
+        match self {
+            StreamTransform::ExcludeReasoning => {
+                return Ok(Some(edit_event_body(
+                    event,
+                    response_transform::exclude_reasoning,
+                )))
+            }
+            StreamTransform::SanitizeResponse(identity, endpoint) => {
+                return Ok(Some(edit_event_body(event, |body| {
+                    response_transform::rewrite_identity(body, identity);
+                    response_transform::canonicalize(body, *endpoint);
+                })))
+            }
+            _ => {}
         }
         let event = parse_event(event);
         match self {
@@ -70,7 +93,9 @@ impl StreamTransform {
                 openai_to_anthropic_messages_stream(&event, fallback_id, state)
             }
             StreamTransform::AnthropicCompleteToOpenai => anthropic_complete_stream(&event),
-            StreamTransform::ExcludeReasoning => unreachable!(),
+            StreamTransform::ExcludeReasoning | StreamTransform::SanitizeResponse(_, _) => {
+                unreachable!("handled above")
+            }
         }
     }
 }
@@ -771,22 +796,38 @@ fn replace_data_fields(event: &str, replacement: &str) -> String {
     output
 }
 
-fn exclude_reasoning_event(event: &str) -> Result<String, ()> {
+/// Apply an in-place body edit to one SSE event, leaving the framing alone.
+///
+/// Shared by the two same-format transforms (reasoning exclusion and response
+/// sanitization): both parse the payload, edit it, and re-emit only if it changed.
+/// Keep-alives, empty payloads and `[DONE]` pass through untouched.
+///
+/// Never fails the stream. Both callers are cleanup passes layered on top of a
+/// response that is already the client's surface — unlike a format conversion,
+/// which must parse every frame to produce valid output, an edit that cannot
+/// parse a frame has nothing to remove and passes it through verbatim. This is
+/// deliberately more tolerant than the conversions: sanitization is applied to
+/// every stream including same-format passthrough, which historically forwarded
+/// bytes without parsing at all, so a single non-JSON frame must not turn a stream
+/// that used to succeed into a failure.
+fn edit_event_body(event: &str, edit: impl FnOnce(&mut Value)) -> String {
     let parsed = parse_event(event);
     let Some(payload) = parsed.data.as_deref() else {
-        return Ok(framed_event(event));
+        return framed_event(event);
     };
     let payload = payload.trim();
     if payload.is_empty() || payload == "[DONE]" {
-        return Ok(framed_event(event));
+        return framed_event(event);
     }
-    let mut body: Value = serde_json::from_str(payload).map_err(|_| ())?;
+    let Ok(mut body) = serde_json::from_str::<Value>(payload) else {
+        return framed_event(event);
+    };
     let original = body.clone();
-    response_transform::exclude_reasoning(&mut body);
+    edit(&mut body);
     if body == original {
-        Ok(framed_event(event))
+        framed_event(event)
     } else {
-        Ok(replace_data_fields(event, &json_str(&body)))
+        replace_data_fields(event, &json_str(&body))
     }
 }
 
@@ -1164,6 +1205,47 @@ mod tests {
         assert!(collected[0].is_err(), "and not a clean EOF");
     }
 
+    /// The full production pipeline for a `/v1/messages` client of an OpenAI
+    /// upstream: the format conversion runs first and nests the upstream id and
+    /// model inside a `message_start`, then the identity rewrite runs. End to end,
+    /// the client must see neither. This is the stacked-transform case a
+    /// single-layer unit test cannot cover.
+    #[tokio::test]
+    async fn anthropic_stream_pipeline_hides_upstream_id_and_model() {
+        let upstream = "data: {\"id\":\"chatcmpl-7bdaaade5030\",\"model\":\"vendor-model-int\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}\n\n";
+        let events: Vec<Result<Bytes, ServiceError>> = vec![
+            Ok(Bytes::from(upstream)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let converted = Box::pin(SseTransformStream::new(
+            inner,
+            StreamTransform::OpenaiToAnthropicMessages,
+        ));
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: Some("acme/model-a".to_string()),
+        });
+        // Messages surface: canonicalize no-ops for an unschematized surface, so
+        // the anthropic events are left intact and only id/model are rewritten.
+        let sanitized = SseTransformStream::new(
+            converted,
+            StreamTransform::SanitizeResponse(identity, Endpoint::Messages),
+        );
+        let collected: Vec<Result<Bytes, ServiceError>> = sanitized.collect().await;
+
+        let wire: String = collected
+            .into_iter()
+            .map(|c| String::from_utf8(c.unwrap().to_vec()).unwrap())
+            .collect();
+        assert!(wire.contains("message_start"), "sanity: {wire}");
+        assert!(!wire.contains("chatcmpl-7bdaaade5030"), "leaked id: {wire}");
+        assert!(!wire.contains("vendor-model-int"), "leaked model: {wire}");
+        assert!(wire.contains("req_ours"), "{wire}");
+        assert!(wire.contains("acme/model-a"), "{wire}");
+        assert!(wire.contains("\"text\":\"hi\""), "content survived: {wire}");
+    }
+
     // Replay a fixture's input events through the transform (fixed fallback id),
     // collecting emitted data objects with `created` stripped (and a `__done`
     // sentinel for `[DONE]`), to compare against the Node-generated output.
@@ -1369,10 +1451,10 @@ mod tests {
 
     #[test]
     fn reasoning_exclusion_preserves_non_data_sse_fields() {
-        let output = exclude_reasoning_event(
+        let output = edit_event_body(
             "event: chunk\nid: 7\nretry: 100\n: keep\n{\"choices\":[{\"delta\":{\"content\":\"answer\",\"reasoning\":\"hidden\"}}],\"usage\":{\"completion_tokens_details\":{\"reasoning_tokens\":3}}}",
-        )
-        .unwrap();
+            response_transform::exclude_reasoning,
+        );
         assert!(output.contains("event: chunk\n"), "{output}");
         assert!(output.contains("id: 7\n"), "{output}");
         assert!(output.contains("retry: 100\n"), "{output}");
@@ -1380,6 +1462,80 @@ mod tests {
         assert!(output.contains("\"content\":\"answer\""), "{output}");
         assert!(output.contains("\"reasoning_tokens\":3"), "{output}");
         assert!(!output.contains("hidden"), "{output}");
+    }
+
+    /// The same-format streaming path is the one that used to hand provider
+    /// bytes to the client untouched, so the rewrite is verified on an event, not
+    /// only on a buffered body.
+    #[test]
+    fn identity_rewrites_a_streamed_chunk() {
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: Some("acme/model-a".to_string()),
+        });
+        let mut state = StreamState::default();
+        let output = StreamTransform::SanitizeResponse(identity, Endpoint::ChatComplete)
+            .apply(
+                "data: {\"id\":\"b4fa5a1dc59c4b41\",\"model\":\"vendor-model-int\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"matched_stop\":424242}]}",
+                "fb",
+                &mut state,
+            )
+            .unwrap()
+            .unwrap();
+        assert!(output.contains("req_ours"), "{output}");
+        assert!(output.contains("acme/model-a"), "{output}");
+        assert!(!output.contains("matched_stop"), "{output}");
+        assert!(!output.contains("vendor-model-int"), "{output}");
+        assert!(output.contains("\"content\":\"hi\""), "{output}");
+    }
+
+    /// A same-format passthrough stream historically forwarded bytes without
+    /// parsing, so a lone non-JSON `data:` frame reached the client and the
+    /// stream still succeeded. Sanitization runs on every stream now, so it must
+    /// be no stricter: a frame it cannot parse is passed through, never rejected
+    /// (which `emit` would turn into a failed, truncated stream).
+    #[test]
+    fn identity_passes_through_an_unparseable_frame() {
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: None,
+        });
+        let mut state = StreamState::default();
+        let result = StreamTransform::SanitizeResponse(identity, Endpoint::ChatComplete).apply(
+            "data: : upstream keep-alive text, not json",
+            "fb",
+            &mut state,
+        );
+        assert!(
+            result.is_ok(),
+            "an unparseable frame must not fail the stream"
+        );
+        assert!(result
+            .unwrap()
+            .unwrap()
+            .contains("upstream keep-alive text"));
+    }
+
+    /// `[DONE]` and keep-alives carry no JSON; sanitization must leave them intact
+    /// or the client sees a truncated stream.
+    #[test]
+    fn identity_passes_through_terminators_and_keepalives() {
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: None,
+        });
+        let transform = StreamTransform::SanitizeResponse(identity, Endpoint::ChatComplete);
+        let mut state = StreamState::default();
+        for event in ["data: [DONE]", ": PROCESSING", "data: "] {
+            let output = transform
+                .apply(event, "fb", &mut state)
+                .unwrap_or_else(|_| panic!("rejected {event}"))
+                .unwrap();
+            assert!(
+                output.starts_with(event.split('\n').next().unwrap()),
+                "{output}"
+            );
+        }
     }
 
     #[test]

--- a/tests/aci_service_surface.rs
+++ b/tests/aci_service_surface.rs
@@ -1537,7 +1537,6 @@ async fn streaming_chat_completion_upstream_error_is_returned_without_sse_or_rec
 
     assert_eq!(resp.status, StatusCode::BAD_REQUEST);
     assert_eq!(header(&resp.headers, "content-type"), "application/json");
-    assert_eq!(header(&resp.headers, "x-upstream-error"), "true");
     assert!(resp.headers.get("x-receipt-id").is_none());
     assert!(resp.headers.get("x-e2ee-applied").is_none());
     assert!(resp.headers.get("x-accel-buffering").is_none());
@@ -1545,6 +1544,9 @@ async fn streaming_chat_completion_upstream_error_is_returned_without_sse_or_rec
     assert!(resp.headers.get("connection").is_none());
     assert!(resp.headers.get("transfer-encoding").is_none());
     assert_ne!(resp.headers.get("content-length").unwrap(), "999");
+    // No upstream header reaches the client. This arm used to relay them, which
+    // would let a header that names the serving provider reach the caller.
+    assert!(resp.headers.get("x-upstream-error").is_none());
 
     let response_data = json_body(&resp);
     assert_eq!(
@@ -2129,8 +2131,7 @@ async fn a_chat_stream_missing_done_is_completed_inside_the_receipt() {
 // An Anthropic stream that closes cleanly without `message_stop` has finished,
 // so it is completed and signed — but the gateway appends nothing: fabricating
 // a `message_stop` would assert an end the upstream never sent. The client gets
-// exactly what the upstream sent, then EOF, as litellm's Anthropic passthrough
-// also does.
+// exactly what the upstream sent, then EOF.
 #[tokio::test]
 async fn an_anthropic_stream_missing_message_stop_is_completed_without_a_tail() {
     let h = harness_with_upstream(RecordingUpstream::with_stream_chunks(vec![

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -40,6 +40,9 @@ use common::{event_from_request, StaticKeyProvider, StubQuoter};
 struct MockUpstream {
     status: u16,
     body: Vec<u8>,
+    /// Headers an upstream may add on top of `content-type` — the kind the
+    /// allowlist must drop so none of them can reach a client.
+    extra_headers: Vec<(&'static str, &'static str)>,
 }
 
 #[async_trait]
@@ -53,6 +56,9 @@ impl UpstreamBackend for MockUpstream {
     async fn forward(&self, _req: UpstreamRequest) -> Result<UpstreamResponse, UpstreamError> {
         let mut headers = HashMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
+        for (name, value) in &self.extra_headers {
+            headers.insert(name.to_string(), value.to_string());
+        }
         Ok(UpstreamResponse {
             status_code: self.status,
             body: self.body.clone(),
@@ -255,11 +261,23 @@ fn build_service_failing_verify() -> Arc<AciService> {
 }
 
 fn build_service_with_upstream(status: u16, body: Vec<u8>) -> Arc<AciService> {
+    build_service_with_upstream_headers(status, body, Vec::new())
+}
+
+fn build_service_with_upstream_headers(
+    status: u16,
+    body: Vec<u8>,
+    extra_headers: Vec<(&'static str, &'static str)>,
+) -> Arc<AciService> {
     Arc::new(
         AciService::new_with_upstream_verifier(
             Arc::new(StaticKeyProvider::default()),
             Arc::new(StubQuoter::default()),
-            Arc::new(MockUpstream { status, body }),
+            Arc::new(MockUpstream {
+                status,
+                body,
+                extra_headers,
+            }),
             Arc::new(OkVerifier),
             Arc::new(InMemoryReceiptStore::default()),
             AciServiceConfig::for_test(),
@@ -420,6 +438,102 @@ async fn response_parts(response: axum::response::Response) -> (u16, axum::http:
     (status, headers, body)
 }
 
+/// The shape of headers an upstream sends that identify it: one names the
+/// serving provider outright, one names its edge, one is a set-cookie that would
+/// otherwise land on our own domain. Synthetic values — the test proves the
+/// allowlist drops arbitrary upstream headers, not any specific provider.
+const LEAKY_UPSTREAM_HEADERS: &[(&str, &str)] = &[
+    ("x-acme-serving", "acme"),
+    ("server", "acme-edge/1.0"),
+    ("inference-id", "29abc41a-c5c0-56d7-818a-c56c8c0fb272"),
+    ("x-request-id", "fa57b5a8-4967-4e5c-9ab8-103a9feeeb14"),
+    ("alt-svc", r#"h3=":8443"; ma=86400"#),
+    ("x-vendor-call-gateway", "true"),
+    ("set-cookie", "edge_sess=0893731c1786104409;path=/"),
+];
+
+fn assert_no_upstream_headers(headers: &axum::http::HeaderMap) {
+    for (name, _) in LEAKY_UPSTREAM_HEADERS {
+        assert!(
+            headers.get(*name).is_none(),
+            "{name} reached the client; response headers must be an allowlist"
+        );
+    }
+}
+
+async fn raw_body(response: axum::response::Response) -> (axum::http::HeaderMap, String) {
+    let headers = response.headers().clone();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (headers, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[tokio::test]
+async fn buffered_success_hides_which_upstream_served_it() {
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{ "routeId": "acme:model-a", "format": "openai" }],
+            "pricing": { "inputCostPerToken": "0", "outputCostPerToken": "0" }
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    // An engine-served body: `matched_stop` is the engine's own field, the id
+    // is its own format, and `model` is the upstream's internal name.
+    let service = build_service_with_upstream_headers(
+        200,
+        br#"{"id":"7bdaaade50304502b0fe7e66e9a4bec2","object":"chat.completion","model":"vendor-model-int","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop","matched_stop":424242}],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#.to_vec(),
+        LEAKY_UPSTREAM_HEADERS.to_vec(),
+    );
+
+    let (status, headers, body) =
+        response_parts(mw.handle_completion(&service, chat_input()).await).await;
+    assert_eq!(status, 200);
+    assert_no_upstream_headers(&headers);
+    assert_eq!(body["id"], json!("req-1"));
+    assert_eq!(body["model"], json!("gpt-test"));
+    assert!(body["choices"][0].get("matched_stop").is_none());
+    // The parts that are the client's answer are untouched.
+    assert_eq!(body["choices"][0]["message"]["content"], json!("hi"));
+    assert_eq!(body["choices"][0]["finish_reason"], json!("stop"));
+    assert_eq!(body["usage"]["completion_tokens"], json!(1));
+}
+
+#[tokio::test]
+async fn streamed_success_hides_which_upstream_served_it() {
+    // Same-format streaming is the path that relayed provider bytes verbatim,
+    // so it gets its own end-to-end check rather than only a unit test.
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{ "routeId": "acme:model-a", "format": "openai" }],
+            "pricing": { "inputCostPerToken": "0", "outputCostPerToken": "0" }
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let service = build_service_with_upstream_headers(
+        200,
+        b"data: {\"id\":\"b4fa5a1dc59c4b41\",\"model\":\"vendor-model-int\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"matched_stop\":424242}]}\n\ndata: [DONE]\n\n".to_vec(),
+        LEAKY_UPSTREAM_HEADERS.to_vec(),
+    );
+    let mut input = chat_input();
+    input.stream = true;
+
+    let (headers, body) = raw_body(mw.handle_completion(&service, input).await).await;
+    assert_no_upstream_headers(&headers);
+    assert!(!body.contains("matched_stop"), "{body}");
+    assert!(!body.contains("vendor-model-int"), "{body}");
+    assert!(!body.contains("b4fa5a1dc59c4b41"), "{body}");
+    assert!(body.contains("req-1"), "{body}");
+    assert!(body.contains("gpt-test"), "{body}");
+    // Framing and content survive intact.
+    assert!(body.contains(r#""content":"hi""#), "{body}");
+    assert!(body.contains("data: [DONE]"), "{body}");
+}
+
 #[tokio::test]
 async fn denial_returns_forbidden_envelope() {
     let control_url = spawn_control(200, json!({ "allow": false })).await;
@@ -504,11 +618,14 @@ async fn allow_forwards_and_finalizes_receipt() {
         headers.get("x-receipt-id").is_some(),
         "buffered success must carry a receipt id"
     );
-    assert_eq!(body["id"], json!("chat-1"));
+    // Our request id, not the upstream's `chat-1`: the shape of a provider's id
+    // identifies its backend (`chatcmpl-<uuid>`, bare 32-hex, timestamp-prefixed
+    // each belong to a different one), so it is replaced rather than relayed.
+    assert_eq!(body["id"], json!("req-1"));
 }
 
 #[tokio::test]
-async fn control_override_reconciles_openrouter_reasoning_before_forwarding() {
+async fn control_override_reconciles_reasoning_before_forwarding() {
     let control_url = spawn_control(
         200,
         json!({


### PR DESCRIPTION
## Why

The same request served by different upstreams came back in different shapes. Response headers varied by backend (a serving-stack header on every request, alongside `server`, `inference-id`, `x-request-id`, `alt-svc`, and a `set-cookie` that could land on our own domain), and the body carried whatever the serving stack emitted — an inference engine's own nonstandard fields, the upstream's `id` (whose format differs between backends), and the upstream's internal `model` name instead of the catalog slug the client asked for.

A unified gateway should return one consistent, documented response shape regardless of which upstream served the request — the way an aggregator presents heterogeneous providers behind one stable API. This change normalizes headers, body, and errors to that single contract.

## What

**Response headers — denylist to allowlist.** Three functions built the client response headers; two by denylist, which cannot hold, since a backend can name itself in a header we have never listed (`set-cookie` was on no list at all). They now build from a fixed set, which is what the third already did — so the header shape is identical no matter which upstream served the request.

**Response body — a canonical output schema (allowlist).** After the response is transformed to the client's surface, its `id`/`model` are rewritten, and cost is injected, the body is reduced to exactly the fields the gateway documents. A field the schema does not name never reaches the client — including one we have never seen (an engine's next nonstandard field, a backend verification blob, a trace event). This is the difference from a denylist, which can only remove what has already been observed. `id` is rewritten to our request id and `model` to the requested catalog slug (value rewrites, kept separate from the field allowlist). `system_fingerprint`, a backend-specific `provider` field, and engine fields identify one particular serving configuration and are not part of the contract, so they are not emitted.

The schema is defined per surface, cross-checked against the documented OpenAI response objects and their common compatibility supersets:

- **Chat completions** — `id`/`object`/`created`/`model`/`choices`/`usage`/`service_tier`, with the message, delta, usage, and error objects each filtered to their own documented fields.
- **Legacy completions** (`/v1/completions`) — the text-completion object and its `text`/`index`/`logprobs`/`finish_reason` choices.
- **Responses** (`/v1/responses`) — the Responses object: request-echo parameters, client `metadata`, `output[]` content, and the Responses-shaped `usage`.

Applied on both the buffered and streaming paths. The Responses API is the one surface whose streaming events are typed envelopes (`response.created`/`response.output_text.delta`/…) rather than the final object repeated, so normalization there is envelope-aware: a lifecycle event's nested response object is normalized in place while the event's own control fields are left intact, and delta/error events pass through untouched — the client's stream and the gateway's own metering both depend on those frames surviving.

**Upstream 4xx messages — scrub by shape, never by a list of names.** A code prefix is stripped by shape (`<400> Module.Sub.BadParam: …`), and if what remains carries a URL, a hostname, or an opaque id the message is dropped for our own per-status text. There is deliberately no maintained list of vendor names — the reduction is purely structural. Extraction stays raw for the image-URL classifier, which matches against the client's own URL.

**Our own errors stopped naming the route.** A request we could not shape returned the internal route id to the client; it now goes only to the log. That failure also reported 500, which types as `upstream_error` and blamed the provider for a request the gateway itself declined to send — a body we cannot shape is the caller's problem (400), while a route offered for an endpoint its format cannot serve stays ours (500).

**Streaming pre-error path.** The pre-stream upstream error was returned verbatim (status, headers, body); it now goes through the same normalization as the buffered path.

## Scope

The direct-to-backend path (used when the gateway runs without the control-plane middleware) is deliberately left as-is for the response body — normalizing it there is out of scope for this change. Its response headers are tightened to the same fixed allowlist, and its streaming pre-error is scrubbed like the middleware path; a non-streaming upstream error body on this path is still returned as-is, because the receipt is built over that body in the service layer, so scrubbing it belongs there — a follow-up. The Anthropic Messages surface and embeddings are not reduced against a chat schema — Messages has its own contract handled by the format conversion, and embeddings are not yet scoped.

## Tests

- Header allowlist verified end to end on both buffered and streaming paths, using synthetic upstream headers.
- Canonical schema per surface: drops engine fields, a `provider` field, `system_fingerprint`, and unknown backend/trace fields it has never seen, while keeping the contract (content, `usage.cost`, `reasoning_tokens`, streaming `delta`); the identity rewrite and canonicalize together on the buffered path; the nested `message_start` identity through the full two-transform streaming pipeline; a `tool_use` id left untouched.
- Buffered completions and responses each keep their documented fields and drop backend markers.
- Responses streaming: a lifecycle event's nested object is normalized and its identity rewritten while the envelope's control fields survive; a delta and a typed `error` event pass through byte-for-byte.
- Error scrubbing by shape: a code prefix stripped, a clean message kept, a message with a host/URL/opaque-id dropped (including one ending a sentence, trailing period and all), and a bare name in neutral prose relayed.
- A malformed SSE frame passes through sanitization instead of failing the stream.

`cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

## Verify after deploy

Send a completion pinned to a specific provider and confirm the response is exactly the documented shape: identical headers regardless of upstream, no field outside the canonical schema, an `id` equal to our request id, and a `model` equal to the requested catalog slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
