### PR TITLE
Inject continuous usage options for streaming requests

### DIFF
--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -184,7 +184,7 @@ pub fn transform_to_provider_request(
     engine: Option<Engine>,
 ) -> Result<Value, TransformError> {
     let mut params = params.clone();
-    inject_stream_options(&mut params);
+    inject_stream_options(&mut params, endpoint);
     let config = select_config(format, endpoint, engine)?;
     transform_using_provider_config(&config, &params)
 }
@@ -448,17 +448,11 @@ fn set_nested_property(obj: &mut Value, path: &str, value: Value) {
         .insert(parts[parts.len() - 1].to_string(), value);
 }
 
-// Mutate `params` to request usage on streaming: only
-// when `stream === true` and `stream_options.include_usage` is not already true.
-fn inject_stream_options(params: &mut Value) {
-    if params.get("stream") != Some(&Value::Bool(true)) {
+fn inject_stream_options(params: &mut Value, endpoint: Endpoint) {
+    if !matches!(endpoint, Endpoint::ChatComplete | Endpoint::Complete) {
         return;
     }
-    let already = params
-        .get("stream_options")
-        .and_then(|so| so.get("include_usage"))
-        == Some(&Value::Bool(true));
-    if already {
+    if params.get("stream") != Some(&Value::Bool(true)) {
         return;
     }
     if let Some(obj) = params.as_object_mut() {
@@ -472,6 +466,14 @@ fn inject_stream_options(params: &mut Value) {
             .as_object_mut()
             .unwrap()
             .insert("include_usage".to_string(), Value::Bool(true));
+        stream_options
+            .as_object_mut()
+            .unwrap()
+            .insert("continuous_usage_stats".to_string(), Value::Bool(true));
+        obj.insert("continuous_usage_stats".to_string(), Value::Bool(true));
+        if endpoint == Endpoint::Complete {
+            obj.insert("include_usage".to_string(), Value::Bool(true));
+        }
     }
 }
 
@@ -1091,6 +1093,7 @@ fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
         "response_format",
         "top_logprobs",
         "stream_options",
+        "continuous_usage_stats",
         "service_tier",
         "parallel_tool_calls",
         "max_completion_tokens",
@@ -1146,6 +1149,8 @@ fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
 fn openai_complete_config() -> ProviderConfig {
     let mut config = pass!(
         "stream_options",
+        "include_usage",
+        "continuous_usage_stats",
         "stop",
         "best_of",
         "logit_bias",
@@ -1349,7 +1354,11 @@ mod tests {
             json!({ "model": "m", "messages": [], "stream": true }),
             None,
         );
-        assert_eq!(chat_out["stream_options"], json!({ "include_usage": true }));
+        assert_eq!(
+            chat_out["stream_options"],
+            json!({ "include_usage": true, "continuous_usage_stats": true })
+        );
+        assert_eq!(chat_out["continuous_usage_stats"], json!(true));
 
         // Legacy /v1/completions must also carry include_usage to upstream, or
         // usage-only streaming providers (e.g. vLLM) never emit a usage chunk
@@ -1363,7 +1372,28 @@ mod tests {
         .unwrap();
         assert_eq!(
             complete_out["stream_options"],
-            json!({ "include_usage": true })
+            json!({ "include_usage": true, "continuous_usage_stats": true })
+        );
+        assert_eq!(complete_out["include_usage"], json!(true));
+        assert_eq!(complete_out["continuous_usage_stats"], json!(true));
+
+        let existing_include_usage = chat(
+            ProviderFormat::Openai,
+            json!({
+                "model": "m",
+                "messages": [],
+                "stream": true,
+                "stream_options": { "include_usage": true }
+            }),
+            None,
+        );
+        assert_eq!(
+            existing_include_usage["stream_options"],
+            json!({ "include_usage": true, "continuous_usage_stats": true })
+        );
+        assert_eq!(
+            existing_include_usage["continuous_usage_stats"],
+            json!(true)
         );
 
         let responses = transform_to_provider_request(
@@ -1374,6 +1404,7 @@ mod tests {
         )
         .unwrap();
         assert!(responses.get("stream_options").is_none());
+        assert!(responses.get("continuous_usage_stats").is_none());
     }
 
     #[test]

--- a/tests/fixtures/transform_golden.json
+++ b/tests/fixtures/transform_golden.json
@@ -62,8 +62,10 @@
       "messages": [],
       "stream": true,
       "stream_options": {
-        "include_usage": true
-      }
+        "include_usage": true,
+        "continuous_usage_stats": true
+      },
+      "continuous_usage_stats": true
     }
   },
   {


### PR DESCRIPTION
## Summary

This PR keeps streaming usage normalization in Private AI Gateway's request transform layer so downstream routers can stay transparent.

- inject `stream_options.include_usage=true` and `stream_options.continuous_usage_stats=true` for streaming `/v1/chat/completions`
- inject the same fields plus top-level `include_usage=true` for streaming `/v1/completions`
- leave `/v1/responses` untouched
- update the transform golden fixture

## Why

A router sitting behind PAG should not rewrite or rebuild request bodies just to make usage reporting work. The gateway request transform is the right layer to normalize these provider-facing JSON fields before the request reaches a transparent router.

## Tests

Builder Ubuntu container:

- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib stream_options_injected_for_chat_but_not_responses`
- `cargo test --test transform rust_request_transforms_match_node_fixtures`

Latest builder log: `/persistent/router-aci-phala-direct-r1/builder-test-20260811-origin-main132.log`