### PR TITLE
Move reasoning decision logic to the gateway

### DIFF
--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -25,7 +25,7 @@ use crate::aggregator::service::{
     ServiceError, ServiceResponseStream, UpstreamVerificationError,
 };
 
-use super::control::{ControlClient, GenerationConstraints};
+use super::control::ControlClient;
 use super::errors::{self, Surface};
 use super::reasoning;
 use super::request_transform::{build_candidates, Endpoint};
@@ -324,24 +324,9 @@ pub async fn run(
     // Forward the routing block verbatim; the control plane validates it. Parsing
     // it here would silently drop a caller's restrictions on a malformed field.
     let provider = params.get("provider");
-    let structured_output = endpoint == Endpoint::ChatComplete
-        && params
-            .get("response_format")
-            .is_some_and(|value| !value.is_null());
-    let output_token_limit = output_token_limit(endpoint, &params);
 
     let consult = control
-        .consult_pre(
-            model,
-            api_key_hash.as_deref(),
-            provider,
-            reasoning_requirements.as_ref(),
-            GenerationConstraints {
-                structured_output,
-                output_token_limit,
-            },
-            tee_only,
-        )
+        .consult_pre(model, api_key_hash.as_deref(), provider, tee_only)
         .await;
 
     let meter = Meter {
@@ -1316,18 +1301,6 @@ fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) {
     }
 }
 
-fn output_token_limit(endpoint: Endpoint, params: &Value) -> Option<u64> {
-    match endpoint {
-        Endpoint::ChatComplete => params
-            .get("max_completion_tokens")
-            .and_then(Value::as_u64)
-            .or_else(|| params.get("max_tokens").and_then(Value::as_u64)),
-        Endpoint::Complete | Endpoint::Messages => params.get("max_tokens").and_then(Value::as_u64),
-        Endpoint::CreateModelResponse => params.get("max_output_tokens").and_then(Value::as_u64),
-        Endpoint::Embed => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1365,39 +1338,5 @@ mod tests {
         // class — must trip the anomaly.
         assert!(finish_reasons_anomalous(["upstream_error"]));
         assert!(finish_reasons_anomalous(["stop", "weird_provider_reason"]));
-    }
-
-    #[test]
-    fn normalizes_output_token_limit_across_api_surfaces() {
-        let cases = [
-            (Endpoint::ChatComplete, r#"{"max_tokens":128}"#, Some(128)),
-            (
-                Endpoint::ChatComplete,
-                r#"{"max_tokens":128,"max_completion_tokens":64}"#,
-                Some(64),
-            ),
-            (
-                Endpoint::ChatComplete,
-                r#"{"max_tokens":64,"max_completion_tokens":null}"#,
-                Some(64),
-            ),
-            (
-                Endpoint::ChatComplete,
-                r#"{"max_tokens":64,"max_completion_tokens":"invalid"}"#,
-                Some(64),
-            ),
-            (Endpoint::Complete, r#"{"max_tokens":48}"#, Some(48)),
-            (Endpoint::Messages, r#"{"max_tokens":32}"#, Some(32)),
-            (
-                Endpoint::CreateModelResponse,
-                r#"{"max_output_tokens":16}"#,
-                Some(16),
-            ),
-            (Endpoint::Embed, r#"{"max_tokens":8}"#, None),
-        ];
-        for (endpoint, params, expected) in cases {
-            let params = serde_json::from_str(params).unwrap();
-            assert_eq!(output_token_limit(endpoint, &params), expected);
-        }
     }
 }

--- a/src/middleware/control.rs
+++ b/src/middleware/control.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use super::config::MiddlewareConfig;
-use super::types::{PostReport, PreConsult, ReasoningConfig};
+use super::types::{PostReport, PreConsult};
 
 const DEFAULT_CONTROL_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_CONTROL_POST_TIMEOUT_MS: u64 = 10_000;
@@ -44,15 +44,6 @@ impl std::error::Error for ControlError {}
 pub struct CatalogResponse {
     pub status: u16,
     pub body: Vec<u8>,
-}
-
-#[derive(Default, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct GenerationConstraints {
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub(super) structured_output: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) output_token_limit: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -139,8 +130,7 @@ impl ControlClient {
     }
 
     /// Pre-request consult:
-    /// `{ apiKeyHash?, model?, provider?, reasoning?, structuredOutput?, outputTokenLimit? }`
-    /// -> decision.
+    /// `{ apiKeyHash?, model?, provider? }` -> decision.
     /// Fails closed — any non-200, invalid JSON, timeout, or transport error
     /// returns a 503 denial.
     pub(super) async fn consult_pre(
@@ -148,8 +138,6 @@ impl ControlClient {
         model: Option<&str>,
         api_key_hash: Option<&str>,
         provider: Option<&Value>,
-        reasoning: Option<&ReasoningConfig>,
-        constraints: GenerationConstraints,
         tee_only: bool,
     ) -> PreConsult {
         #[derive(Serialize)]
@@ -163,11 +151,6 @@ impl ControlClient {
             // block must not silently drop the caller's routing restrictions).
             #[serde(skip_serializing_if = "Option::is_none")]
             provider: Option<&'a Value>,
-            // Canonical route-relevant controls only. Response visibility stays local.
-            #[serde(skip_serializing_if = "Option::is_none")]
-            reasoning: Option<&'a ReasoningConfig>,
-            #[serde(flatten)]
-            constraints: GenerationConstraints,
             // TEE-only host: the control plane 404s a non-TEE model. Only sent
             // when set so the metadata-minimal payload is unchanged off these hosts.
             #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -178,8 +161,6 @@ impl ControlClient {
             api_key_hash,
             model,
             provider,
-            reasoning,
-            constraints,
             tee: tee_only,
         };
         let build = || {
@@ -313,37 +294,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn generation_constraints_pin_the_wire_names() {
-        assert_eq!(
-            serde_json::to_value(GenerationConstraints::default()).unwrap(),
-            serde_json::json!({})
-        );
-        let constraints = GenerationConstraints {
-            structured_output: true,
-            output_token_limit: Some(128),
-        };
-        assert_eq!(
-            serde_json::to_value(constraints).unwrap(),
-            serde_json::json!({ "structuredOutput": true, "outputTokenLimit": 128 })
-        );
-    }
-
     #[tokio::test]
     async fn consult_pre_fails_closed_on_transport_error() {
         // Port 1 is unroutable in practice; the request fails fast within the
         // configured timeout and must deny.
         let client = ControlClient::new(&config("http://127.0.0.1:1")).unwrap();
-        let consult = client
-            .consult_pre(
-                Some("m"),
-                None,
-                None,
-                None,
-                GenerationConstraints::default(),
-                false,
-            )
-            .await;
+        let consult = client.consult_pre(Some("m"), None, None, false).await;
         assert!(!consult.allow);
         assert_eq!(consult.status, Some(503));
         assert_eq!(

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -223,27 +223,22 @@ fn candidate_params(
     if endpoint != Endpoint::ChatComplete {
         return Ok(params);
     }
+    // Read request context before the mutable borrow below.
+    let effective = resolve_effective_reasoning(candidate, &params, requested_reasoning);
     let object = params
         .as_object_mut()
         .ok_or_else(|| TransformError::invalid_request("request body must be a JSON object"))?;
     for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
         object.remove(key);
     }
-    // The control plane's route-specific resolution is authoritative. Fall back
-    // to caller intent only when control did not resolve it. Absence remains
-    // absence: provider and engine labels do not imply reasoning capability.
-    let Some(effective) = candidate
-        .effective_reasoning
-        .as_ref()
-        .or(requested_reasoning)
-    else {
+    let Some(effective) = effective else {
         return Ok(params);
     };
-    validate_effective(effective).map_err(|err| TransformError::InvalidRequest {
+    validate_effective(&effective).map_err(|err| TransformError::InvalidRequest {
         message: format!("invalid effective reasoning: {err}"),
         detail: Some(format!("route {}", candidate.route_id)),
     })?;
-    sync_chat_template_reasoning(object, effective);
+    sync_chat_template_reasoning(object, &effective);
     let reasoning_format = candidate.reasoning_format.unwrap_or_else(|| {
         if candidate.engine.is_some() {
             ReasoningFormat::ReasoningEffort
@@ -253,7 +248,7 @@ fn candidate_params(
     });
     match (candidate.format, reasoning_format) {
         (ProviderFormat::Openai, ReasoningFormat::Reasoning) => {
-            object.insert("reasoning".to_string(), reasoning_object(effective));
+            object.insert("reasoning".to_string(), reasoning_object(&effective));
         }
         (ProviderFormat::Openai, ReasoningFormat::ReasoningEffort) => {
             if effective.max_tokens.is_some() {
@@ -270,14 +265,68 @@ fn candidate_params(
             );
         }
         (ProviderFormat::Openai, ReasoningFormat::ChatTemplateThinking) => {
-            set_chat_template_reasoning(object, effective, candidate, "thinking")?;
+            set_chat_template_reasoning(object, &effective, candidate, "thinking")?;
         }
         (ProviderFormat::Openai, ReasoningFormat::ChatTemplateEnableThinking) => {
-            set_chat_template_reasoning(object, effective, candidate, "enable_thinking")?;
+            set_chat_template_reasoning(object, &effective, candidate, "enable_thinking")?;
         }
         (ProviderFormat::Anthropic, _) => return invalid_reasoning(candidate, "has no adapter"),
     }
     Ok(params)
+}
+
+/// Compute the effective reasoning config from the deployment's policy and the
+/// request context. Three cases:
+///
+/// 1. `response_format` present, no `tools`: structured output. Apply override
+///    or default (always from policy — the caller's reasoning is ignored
+///    because OR injects a default that cannot be distinguished from intent).
+///
+/// 2. `tools` present (with or without `response_format`): tool calls. Apply
+///    threshold only — disable reasoning when max_tokens is small enough that
+///    reasoning might eat the budget. Above the threshold, keep the caller's
+///    reasoning. Tool call JSON is small, but complex prompts can produce
+///    hundreds of reasoning tokens, so the threshold protects small budgets.
+///
+/// 3. Neither: normal chat. Keep the caller's reasoning.
+fn resolve_effective_reasoning(
+    candidate: &RouteCandidate,
+    params: &Value,
+    requested: Option<&ReasoningConfig>,
+) -> Option<ReasoningConfig> {
+    let policy = candidate.reasoning_policy.as_ref();
+    let has_rf = params.get("response_format").is_some_and(|v| !v.is_null());
+    let has_tools = params.get("tools").is_some_and(|v| !v.is_null());
+    let max_tokens = params
+        .get("max_completion_tokens")
+        .and_then(Value::as_u64)
+        .or_else(|| params.get("max_tokens").and_then(Value::as_u64));
+
+    if has_rf && !has_tools {
+        // Structured output: override or default (always from policy when
+        // configured — the caller's reasoning is ignored because OR injects a
+        // default that cannot be distinguished from intent). Fall back to
+        // caller when no policy is configured.
+        policy
+            .and_then(|p| p.override_policy.clone().or(p.default_policy.clone()))
+            .or(requested.cloned())
+    } else if has_tools {
+        // Tools: threshold only. Disable below threshold, keep caller above.
+        if let Some(p) = policy {
+            if let (Some(threshold), Some(mt)) = (p.threshold, max_tokens) {
+                if mt <= threshold {
+                    return Some(ReasoningConfig {
+                        effort: Some(ReasoningEffort::None),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+        requested.cloned()
+    } else {
+        // Normal chat: caller's reasoning.
+        requested.cloned()
+    }
 }
 
 fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &ReasoningConfig) {
@@ -1306,7 +1355,7 @@ fn anthropic_messages_config() -> ProviderConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::middleware::types::{Engine, ProviderFormat, RouteCandidate};
+    use crate::middleware::types::{Engine, ProviderFormat, ReasoningPolicy, RouteCandidate};
 
     fn chat(format: ProviderFormat, params: Value, engine: Option<Engine>) -> Value {
         transform_to_provider_request(format, &params, Endpoint::ChatComplete, engine).unwrap()
@@ -1378,7 +1427,7 @@ mod tests {
 
     #[test]
     fn build_candidates_uses_effective_or_requested_reasoning() {
-        let params = json!({ "model": "m", "messages": [{ "role": "user", "content": "hi" }], "max_tokens": 8 });
+        let params = json!({ "model": "m", "messages": [{ "role": "user", "content": "hi" }], "max_tokens": 8, "response_format": { "type": "json_object" } });
         let reasoning = |effort| {
             Some(ReasoningConfig {
                 effort: Some(effort),
@@ -1391,21 +1440,27 @@ mod tests {
                 format: ProviderFormat::Openai,
                 engine: None,
                 reasoning_format: Some(ReasoningFormat::Reasoning),
-                effective_reasoning: reasoning(ReasoningEffort::High),
+                reasoning_policy: Some(ReasoningPolicy {
+                    override_policy: reasoning(ReasoningEffort::High),
+                    ..Default::default()
+                }),
             },
             RouteCandidate {
                 route_id: "openai:b".into(),
                 format: ProviderFormat::Openai,
                 engine: Some(Engine::Sglang),
                 reasoning_format: None,
-                effective_reasoning: reasoning(ReasoningEffort::Minimal),
+                reasoning_policy: Some(ReasoningPolicy {
+                    override_policy: reasoning(ReasoningEffort::Minimal),
+                    ..Default::default()
+                }),
             },
             RouteCandidate {
                 route_id: "openai:c".into(),
                 format: ProviderFormat::Openai,
                 engine: None,
                 reasoning_format: None,
-                effective_reasoning: None,
+                reasoning_policy: None,
             },
         ];
         let requested = reasoning(ReasoningEffort::Medium).unwrap();
@@ -1421,6 +1476,7 @@ mod tests {
         assert!(bodies[0].1.get("reasoning_effort").is_none());
         assert_eq!(bodies[1].1["reasoning_effort"], "low");
         assert!(bodies[1].1.get("reasoning").is_none());
+        // Candidate c has no policy — falls back to caller's requested reasoning.
         assert_eq!(bodies[2].1["reasoning"]["effort"], "medium");
         assert!(bodies[2].1.get("reasoning_effort").is_none());
     }
@@ -1451,6 +1507,7 @@ mod tests {
             let params = json!({
                 "model": "m",
                 "messages": [],
+                "response_format": { "type": "json_object" },
                 "chat_template_kwargs": {
                     "thinking": original,
                     "enable_thinking": original,
@@ -1462,7 +1519,10 @@ mod tests {
                 format: ProviderFormat::Openai,
                 engine: Some(engine),
                 reasoning_format: None,
-                effective_reasoning: controlled.map(reasoning),
+                reasoning_policy: controlled.map(|c| ReasoningPolicy {
+                    override_policy: Some(reasoning(c)),
+                    ..Default::default()
+                }),
             };
 
             let bodies = build_candidates(
@@ -1488,25 +1548,24 @@ mod tests {
             let request = json!({
                 "model": "m",
                 "messages": [],
+                "response_format": { "type": "json_object" },
                 "reasoning_effort": "none"
             });
-            let (params, requested, _) =
+            let (params, _requested, _) =
                 crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
             let candidate: RouteCandidate = serde_json::from_value(json!({
                 "routeId": "self-hosted:m",
                 "format": "openai",
                 "engine": "vllm",
-                "reasoningFormat": format
+                "reasoningFormat": format,
+                "reasoningPolicy": {
+                    "override": { "effort": "none" }
+                }
             }))
             .unwrap();
 
-            let bodies = build_candidates(
-                &params,
-                Endpoint::ChatComplete,
-                &[candidate],
-                requested.as_ref(),
-            )
-            .unwrap();
+            let bodies =
+                build_candidates(&params, Endpoint::ChatComplete, &[candidate], None).unwrap();
             let body = &bodies[0].1;
             assert_eq!(body["chat_template_kwargs"][key], false);
             assert!(body.get("reasoning_effort").is_none());
@@ -1605,14 +1664,14 @@ mod tests {
                 format: ProviderFormat::Openai,
                 engine: None,
                 reasoning_format: None,
-                effective_reasoning: None,
+                reasoning_policy: None,
             },
             RouteCandidate {
                 route_id: "anthropic:m".into(),
                 format: ProviderFormat::Anthropic,
                 engine: None,
                 reasoning_format: None,
-                effective_reasoning: None,
+                reasoning_policy: None,
             },
         ];
         let bodies = build_candidates(&params, Endpoint::ChatComplete, &candidates, None).unwrap();

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -93,6 +93,21 @@ pub enum SpendMode {
     SubscriptionOverflow,
 }
 
+/// Deployment-level reasoning policy, read from config by the control plane
+/// and passed to the gateway verbatim. The gateway owns the decision logic —
+/// it has the request context (response_format, tools, max_tokens) needed to
+/// choose which field applies.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReasoningPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "override")]
+    pub override_policy: Option<ReasoningConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "default")]
+    pub default_policy: Option<ReasoningConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold: Option<u64>,
+}
+
 /// One ordered failover candidate: a backend route id plus the upstream format.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -110,9 +125,9 @@ pub struct RouteCandidate {
     /// self-hosted engines use `reasoning_effort`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_format: Option<ReasoningFormat>,
-    /// Request-specific setting selected after capability filtering.
+    /// Raw reasoning policy from deployment config; the gateway decides.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effective_reasoning: Option<ReasoningConfig>,
+    pub reasoning_policy: Option<ReasoningPolicy>,
 }
 
 /// Provider routing block, forwarded verbatim to the control plane.

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -635,7 +635,9 @@ async fn control_override_reconciles_reasoning_before_forwarding() {
                 "format": "openai",
                 "engine": "sglang",
                 "reasoningFormat": "reasoning_effort",
-                "effectiveReasoning": { "effort": "none" }
+                "reasoningPolicy": {
+                    "override": { "effort": "none" }
+                }
             }]
         }),
     )


### PR DESCRIPTION
The gateway now decides effective reasoning locally using the deployment's raw policy from control plus the request context. Three cases:
1. `response_format` only (no tools): apply override or default (always disable)
2. `tools` present: threshold only (disable below N, keep above)
3. Neither: caller's reasoning

**Removes:**
- `GenerationConstraints` struct + `output_token_limit()` function + tests
- `structured_output` computation and `reasoning`/`constraints` params from `consult_pre`
- `effective_reasoning` field on `RouteCandidate`

**Adds:**
- `ReasoningPolicy` struct, `resolve_effective_reasoning()` function
- `reasoning_policy` field on `RouteCandidate`

This fixes the tool call error spike (override no longer fires when tools present) and protects small max_tokens from reasoning eating the budget.

Net: −84 lines vs deployed version