### PR TITLE
Rebuild in-band stream errors per client surface

### DIFF
--- a/src/aggregator/service/middleware.rs
+++ b/src/aggregator/service/middleware.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::aci::receipt::{ReceiptBuilder, UpstreamVerifiedEvent};
 use crate::aci::upstream::{UpstreamError, UpstreamRequest, UpstreamResponse};
 use crate::aggregator::metrics::{RequestMode, StreamErrorKind};
-use crate::middleware::errors::is_upstream_capacity_signal;
+use crate::middleware::errors::{is_upstream_capacity_signal, recorded_attempt_status};
 use crate::sse_framing::SseFramingObserver;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -505,6 +505,8 @@ impl AciService {
                         // any capacity signal: the walk exit decides whether to replay the
                         // capacity rejections or commit the retained answer.
                         let is_capacity = is_upstream_capacity_signal(status, &upstream_body);
+                        // Read before the body moves into `retained`.
+                        let attempt_status = recorded_attempt_status(status, &upstream_body);
                         let last_may_retry = (is_capacity || !capacity_indices.is_empty())
                             && capacity_retry_eligible(
                                 capacity_retry_done,
@@ -526,7 +528,7 @@ impl AciService {
                                 route_id: route_id.clone(),
                                 attempt_slot: failed_attempts.len(),
                             });
-                            failed_attempts.push((route_id.clone(), status));
+                            failed_attempts.push((route_id.clone(), attempt_status));
                             continue;
                         }
                         self.metrics
@@ -651,6 +653,8 @@ impl AciService {
                 // any capacity signal: the walk exit decides whether to replay the
                 // capacity rejections or commit the retained answer.
                 let is_capacity = is_upstream_capacity_signal(status, &upstream_response.body);
+                // Read before `upstream_response` moves into `retained`.
+                let attempt_status = recorded_attempt_status(status, &upstream_response.body);
                 let last_may_retry = (is_capacity || !capacity_indices.is_empty())
                     && capacity_retry_eligible(
                         capacity_retry_done,
@@ -674,7 +678,7 @@ impl AciService {
                         }),
                         attempt_slot: failed_attempts.len(),
                     });
-                    failed_attempts.push((route_id.clone(), status));
+                    failed_attempts.push((route_id.clone(), attempt_status));
                     continue;
                 }
 

--- a/src/error_payload.rs
+++ b/src/error_payload.rs
@@ -24,6 +24,7 @@ pub fn error_type(surface: Surface, status: u16) -> &'static str {
             402 => "billing_error",
             403 => "permission_error",
             404 => "not_found_error",
+            413 => "request_too_large",
             429 => "rate_limit_error",
             504 => "timeout_error",
             s if s >= 500 => "api_error",
@@ -34,6 +35,9 @@ pub fn error_type(surface: Surface, status: u16) -> &'static str {
             402 => "insufficient_quota",
             403 => "permission_error",
             404 => "not_found_error",
+            // No 413 arm: `request_too_large` is the Anthropic surface's word,
+            // and this surface has none — an oversized request is an invalid
+            // one here, which the fallthrough already says.
             429 => "rate_limit_error",
             503 => "service_unavailable",
             504 => "timeout_error",

--- a/src/error_payload.rs
+++ b/src/error_payload.rs
@@ -44,9 +44,17 @@ pub fn error_type(surface: Surface, status: u16) -> &'static str {
 }
 
 /// Generic sanitized message for a non-actionable upstream status.
+///
+/// The 4xx arms matter as much as the 5xx ones: they are what a caller reads
+/// when their own request was rejected but the provider's wording could not be
+/// relayed, and the generic upstream line would send them to retry a request
+/// that cannot succeed.
 pub fn upstream_message(upstream_status: u16) -> &'static str {
     match upstream_status {
+        400 | 422 => "The request was rejected as invalid",
         401..=403 => "The upstream provider is currently unavailable",
+        404 => "The requested model or resource was not found",
+        413 => "The request is too large",
         429 => "Rate limit exceeded. Please retry after some time.",
         503 => "The model is currently unavailable. Please try again later.",
         504 => "The upstream provider timed out",

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -643,7 +643,7 @@ pub async fn run(
                     );
                 }
                 meter.success(
-                    reported_status(mapped, upstream_status),
+                    reported_status(mapped, upstream_status, &forward.upstream_body),
                     attempt_index,
                     Some(&forward.selected_route),
                     None,
@@ -903,7 +903,11 @@ pub async fn run(
             }
             meter.failed_attempts(&forward.failed_attempts, true);
             meter.upstream_error(
-                reported_status(status, forward.error.upstream_status),
+                reported_status(
+                    status,
+                    forward.error.upstream_status,
+                    &forward.error.upstream_body,
+                ),
                 attempt_index,
                 &forward.selected_route,
             );
@@ -1092,7 +1096,16 @@ fn truncate(text: &str, max_chars: usize) -> String {
 // client-facing status when it is client-attributable (4xx) — a remapped
 // image-fetch failure must not count against the provider's health — otherwise
 // the raw upstream status, preserving the provider's real code in the logs.
-fn reported_status(mapped: u16, upstream_status: u16) -> u16 {
+fn reported_status(mapped: u16, upstream_status: u16, upstream_body: &[u8]) -> u16 {
+    // A provider refusing because our account with it is unpaid records as
+    // 402, whatever status it chose to say that under. The record then names
+    // the condition rather than the wording: a provider that reports this as a
+    // 429 and one that reports it as a literal 402 are the same row, and the
+    // 429 it may have arrived as does not stand for load it is not carrying.
+    let recorded = errors::recorded_attempt_status(upstream_status, upstream_body);
+    if recorded != upstream_status {
+        return recorded;
+    }
     if (400..500).contains(&mapped) {
         mapped
     } else {

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -612,7 +612,11 @@ pub async fn run(
                 // to the gateway's documented output schema, so the client sees one
                 // shape and no upstream-specific field — including any we have never
                 // seen — can leak.
-                response_transform::canonicalize(&mut transformed, endpoint);
+                response_transform::canonicalize(
+                    &mut transformed,
+                    endpoint,
+                    Some(request_id.as_str()),
+                );
                 (
                     upstream_status,
                     serde_json::to_vec(&transformed).unwrap_or_default(),

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -19,7 +19,10 @@ use serde_json::{json, Value};
 // Re-exported so call sites keep importing client-facing error shapes from one
 // place; the definitions are shared because the service layer builds them too.
 pub use crate::error_payload::{error_type, upstream_message, Surface};
-pub use crate::sse_protocol::{sse_protocol, stream_error_tail, SseProtocol};
+pub use crate::sse_protocol::{
+    chat_gateway_error, responses_error_event, responses_gateway_code, sse_protocol,
+    stream_error_tail, SseProtocol,
+};
 
 use crate::error_payload::envelope;
 
@@ -220,7 +223,9 @@ fn strip_error_code_prefix(message: &str) -> &str {
 /// Whether a message still carries a URL, a host, or an internal identifier —
 /// the structural shapes that point at who served a request. Names are matched by
 /// shape only; there is deliberately no list of company names to keep current.
-fn looks_identifying(message: &str) -> bool {
+/// `pub(crate)`: `response_transform` applies the same check to an error's
+/// `param` value, where the fallback is null rather than a generic line.
+pub(crate) fn looks_identifying(message: &str) -> bool {
     if message.contains("://") {
         return true;
     }

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -30,7 +30,12 @@ use crate::error_payload::envelope;
 /// across surfaces; only the envelope and `error.type` are surface-aware.
 pub fn map_upstream_status(status: u16) -> u16 {
     match status {
-        400 | 404 | 422 => status,
+        // 413 sits with the other request-fault statuses: an oversized request
+        // is the caller's to fix, and flattening it to 502 would both invite a
+        // retry that cannot succeed and contradict the relay path above, which
+        // returns it unflattened whenever the provider's message survives
+        // scrubbing.
+        400 | 404 | 413 | 422 => status,
         429 => 429,
         503 => 503,
         504 => 504,
@@ -454,6 +459,147 @@ pub(crate) fn is_upstream_capacity_signal(status: u16, body: &[u8]) -> bool {
             .any(|w| w == UPSTREAM_CAPACITY_MARKER)
 }
 
+/// Field values and prose a provider uses to say *this gateway's* account with
+/// it is out of quota or credit. Kept small and extended from what upstreams
+/// are actually seen to send; failing to recognize one only leaves today's
+/// behaviour, so the list is safe to grow lazily.
+const QUOTA_EXHAUSTED_KINDS: &[&str] = &[
+    "insufficient_quota",
+    "credit_balance_exhausted",
+    "billing_error",
+    "billing_not_active",
+];
+/// Prose markers for providers that report this only in the message, under a
+/// kind they also use for ordinary request faults. Deliberately narrow: an
+/// upstream 4xx often quotes the caller's own input back, so a marker loose
+/// enough to appear in a prompt would let a caller drive this classification.
+/// Each of these is a whole provider-authored clause, not a word that could
+/// ride in quoted content.
+const QUOTA_EXHAUSTED_PROSE: &[&str] = &[
+    "credit balance is too low",
+    "exceeded your current quota",
+    "no credits remaining",
+];
+
+/// Whether an upstream refusal says the provider is unpaid rather than busy.
+///
+/// The distinction exists only in the response body — the same 429 carries both
+/// "you are going too fast" and "your account is out of credit", and a provider
+/// may report the latter under 400 instead. Nothing downstream can recover it:
+/// the body stops here, and what reaches the usage record is this gateway's own
+/// generic text. So it is classified here or not at all.
+pub(crate) fn is_quota_exhausted_signal(status: u16, body: &[u8]) -> bool {
+    if !(400..500).contains(&status) {
+        return false;
+    }
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return false;
+    };
+    value
+        .get("error")
+        .unwrap_or(&value)
+        .as_object()
+        .is_some_and(is_quota_exhausted_error)
+}
+
+/// The same classification against an error object already in hand — the shape
+/// an in-band error takes inside a 200 stream, where there is no status to
+/// consult. Both paths must agree: a provider that reports this condition
+/// under a kind the relay allowlist recognizes (some do, reusing the same
+/// `invalid_request_error` they use for real request faults) would otherwise
+/// be suppressed on one path and relayed verbatim on the other.
+pub(crate) fn is_quota_exhausted_error(error: &serde_json::Map<String, Value>) -> bool {
+    declared_kind_is_quota_exhausted(error)
+        || error
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_ascii_lowercase)
+            .is_some_and(|message| {
+                QUOTA_EXHAUSTED_PROSE
+                    .iter()
+                    .any(|marker| message.contains(marker))
+            })
+}
+
+/// The account signal as the provider *stated* it, in a kind field it chose —
+/// no prose. Only this may drive anything acted on beyond the response itself.
+///
+/// An upstream 4xx often quotes the caller's own input back, so a prompt can
+/// put a prose marker into `error.message`. Withholding a message on that
+/// basis costs a caller some detail; letting it reclassify the attempt would
+/// hand a caller a lever over how this route is judged, which no request
+/// should have.
+pub(crate) fn declares_quota_exhausted(status: u16, body: &[u8]) -> bool {
+    if !(400..500).contains(&status) {
+        return false;
+    }
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return false;
+    };
+    value
+        .get("error")
+        .unwrap_or(&value)
+        .as_object()
+        .is_some_and(declared_kind_is_quota_exhausted)
+}
+
+/// The status an upstream attempt is recorded under.
+///
+/// A provider refusing because our account with it is unpaid records as 402
+/// whatever status it chose to say that under, so the row names the condition
+/// rather than the wording. Every recorded attempt goes through this, not just
+/// the one whose answer was committed: an unpaid route is usually *not* the
+/// committed one — the walk fails over past it — and recording that attempt
+/// under its raw status would leave the condition invisible exactly where it
+/// matters most, on a model with more than one route.
+pub(crate) fn recorded_attempt_status(status: u16, body: &[u8]) -> u16 {
+    if declares_quota_exhausted(status, body) {
+        402
+    } else {
+        status
+    }
+}
+
+fn declared_kind_is_quota_exhausted(error: &serde_json::Map<String, Value>) -> bool {
+    ["code", "type"].into_iter().any(|key| {
+        error
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|kind| QUOTA_EXHAUSTED_KINDS.contains(&kind))
+    })
+}
+
+/// The client-facing parts for an upstream that refused because it is unpaid.
+///
+/// Two things have to happen here, and neither can happen anywhere else. The
+/// client must not be told to retry: a 429's "retry after some time" promises a
+/// recovery that will not come, and relaying the provider's own wording (which
+/// a 4xx otherwise earns) would tell the caller *their* balance is empty when
+/// it is this gateway's. So it takes the status an upstream 402 already takes —
+/// 502 — with the generic unavailable line. The usage record then follows the
+/// same reclassification, which is what moves it out of the neutral rate-limit
+/// bucket it would otherwise sit in.
+fn quota_exhausted_error_parts(
+    surface: Surface,
+    upstream_status: u16,
+    upstream_body: &[u8],
+    request_id: Option<&str>,
+) -> Option<(u16, Vec<u8>)> {
+    if !is_quota_exhausted_signal(upstream_status, upstream_body) {
+        return None;
+    }
+    let status = map_upstream_status(402);
+    Some((
+        status,
+        envelope_bytes(
+            surface,
+            error_type(surface, status),
+            upstream_message(402),
+            request_id,
+        ),
+    ))
+}
+
 fn capacity_error_parts(
     surface: Surface,
     upstream_status: u16,
@@ -493,6 +639,13 @@ pub fn normalize_upstream_error_parts(
     if let Some(parts) =
         image_input_error_parts(surface, received_body, upstream_status, body, request_id)
     {
+        return parts;
+    }
+    // A provider refusing because it is unpaid is not rate-limiting us, and the
+    // refusal is not the caller's to act on. Checked before both the capacity
+    // remap and the actionable-4xx relay, which would otherwise hand the caller
+    // a retry promise or the provider's own account wording.
+    if let Some(parts) = quota_exhausted_error_parts(surface, upstream_status, body, request_id) {
         return parts;
     }
     // A provider signalling it is out of capacity is busy, not broken: 429, not 5xx.
@@ -680,6 +833,48 @@ mod scrub_tests {
 #[cfg(test)]
 mod tests {
     use super::is_upstream_capacity_signal;
+
+    /// The same 429 carries both "slow down" and "your account is unpaid", and
+    /// some providers report the latter under 400. Only the unpaid one is
+    /// reclassified — to the status an upstream 402 already takes, with our own
+    /// wording, so the caller is neither promised a retry nor told their own
+    /// balance is empty.
+    #[test]
+    fn an_unpaid_provider_is_reclassified_away_from_rate_limiting() {
+        let unpaid = [
+            (429, br#"{"error":{"code":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details."}}"#.to_vec()),
+            (400, br#"{"error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the API."}}"#.to_vec()),
+        ];
+        for (status, body) in unpaid {
+            let (mapped, envelope) =
+                normalize_upstream_error_parts(Surface::Openai, status, &body, b"{}", None);
+            assert_eq!(mapped, 502, "status {status}");
+            let value: Value = serde_json::from_slice(&envelope).unwrap();
+            assert_eq!(value["error"]["type"], "upstream_error");
+            assert_eq!(
+                value["error"]["message"],
+                "The upstream provider is currently unavailable"
+            );
+            let wire = String::from_utf8(envelope).unwrap();
+            assert!(!wire.contains("quota"), "leaked account wording: {wire}");
+            assert!(!wire.contains("credit"), "leaked account wording: {wire}");
+        }
+
+        // A plain rate limit is untouched: still a 429, still retryable.
+        let (mapped, envelope) = normalize_upstream_error_parts(
+            Surface::Openai,
+            429,
+            br#"{"error":{"code":"rate_limit_exceeded","message":"Too many requests"}}"#,
+            b"{}",
+            None,
+        );
+        assert_eq!(mapped, 429);
+        let value: Value = serde_json::from_slice(&envelope).unwrap();
+        assert_eq!(
+            value["error"]["message"],
+            "Rate limit exceeded. Please retry after some time."
+        );
+    }
 
     #[test]
     fn capacity_signal_is_429_or_the_marked_5xx_body() {

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -12,8 +12,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
+use super::errors::{
+    chat_gateway_error, client_safe_error_text, error_type, is_actionable_client_error,
+    looks_identifying, map_upstream_status, responses_error_event, responses_gateway_code,
+    upstream_message, Surface,
+};
 use super::request_transform::Endpoint;
 use super::types::ProviderFormat;
+use crate::error_payload::envelope;
 
 const STRICT_OPENAI_COMPLIANCE: bool = true;
 
@@ -254,17 +260,236 @@ const CHAT_USAGE: &[&str] = &[
     "cost",
     "cost_details",
 ];
-/// The standard OpenAI error object. Its interior must be filtered like every
-/// other level: some upstreams nest `error.metadata.provider_name` and
-/// `error.metadata.raw` (the raw upstream error, often a host/URL) inside it, and
-/// keeping the whole object would relay exactly the upstream identity the rest of
-/// this removes. The buffered error path rebuilds a fresh object for the same
-/// reason; this keeps only these fields and scrubs the message.
-const CHAT_ERROR: &[&str] = &["message", "type", "param", "code"];
+// ── In-band error kinds (allowlist) ──────────────────────────────────────────
+//
+// An upstream error's `type`/`code` is a claim about whose problem it is, and
+// the answer is not always the caller's: an account- or credential-level kind
+// (`insufficient_quota`, `authentication_error`) describes the gateway's own
+// standing with the upstream, and relaying it misattributes the failure to the
+// caller. The HTTP layer draws the same line by status
+// (`is_actionable_client_error`); an in-band error carries no status, so it is
+// drawn over kinds — as an allowlist, for the same reason the field schema is
+// one: a denylist relays every kind not seen before.
+//
+// A kind is relayed only when the caller can act on it: fix the request, or
+// retry. Everything else folds into the gateway's own vocabulary via
+// `suppressed_error_status`. One table for both surfaces; they barely overlap
+// and a stray value from the other surface is harmless.
+
+/// In-band error kinds a client can act on, and so worth relaying.
+const RELAYABLE_ERROR_KINDS: &[&str] = &[
+    // Malformed, unsupported, or aimed at something that is not there.
+    "invalid_request_error",
+    "not_found_error",
+    "model_not_found",
+    "invalid_value",
+    "invalid_type",
+    "unsupported_value",
+    "unsupported_parameter",
+    "missing_required_parameter",
+    "unknown_parameter",
+    // Does not fit the model.
+    "context_length_exceeded",
+    "string_above_max_length",
+    "request_too_large",
+    // The request's own content was refused or could not be read.
+    "invalid_prompt",
+    "content_filter",
+    "content_policy_violation",
+    "invalid_image",
+    "invalid_image_format",
+    "invalid_image_url",
+    "invalid_base64_image",
+    "invalid_image_mode",
+    "image_parse_error",
+    "image_too_large",
+    "image_too_small",
+    "image_file_too_large",
+    "image_file_not_found",
+    "image_content_policy_violation",
+    "empty_image_file",
+    "unsupported_image_media_type",
+    "failed_to_download_image",
+    // Not the caller's fault, but retryable — and it names the service's
+    // load, not an account.
+    "overloaded_error",
+    "vector_store_timeout",
+];
+
+/// Whether an in-band error's kind is safe to relay. A string kind takes the
+/// allowlist. A numeric kind is an HTTP status by another name and takes the
+/// HTTP rule verbatim, so the in-band and buffered paths cannot disagree about
+/// the same status. An absent or null kind claims nothing about whose fault it
+/// is, and leaves the scrubbed message as the only thing relayed.
+fn is_relayable_kind(kind: Option<&Value>) -> bool {
+    match kind {
+        None | Some(Value::Null) => true,
+        Some(Value::String(kind)) => RELAYABLE_ERROR_KINDS.contains(&kind.as_str()),
+        Some(kind @ Value::Number(_)) => {
+            numeric_status(kind).is_some_and(is_actionable_client_error)
+        }
+        _ => false,
+    }
+}
+
+/// A numeric kind read as an HTTP status.
+fn numeric_status(kind: &Value) -> Option<u16> {
+    kind.as_u64().and_then(|status| u16::try_from(status).ok())
+}
+
+/// The message to send: the upstream's string scrubbed, or the generic line
+/// when there is none — a structured or missing message still owes the client
+/// one.
+fn client_error_message(message: Option<&Value>) -> String {
+    message
+        .and_then(Value::as_str)
+        .map_or_else(|| upstream_message(502).to_string(), client_safe_error_text)
+}
+
+/// The kind that decides relay-or-suppress for an error object: a specific
+/// `code` outranks the often-generic `type` — upstreams pair a precise code
+/// (`invalid_image`) with a catch-all type (`server_error`), and judging both
+/// would suppress exactly the errors the allowlist exists to relay.
+fn effective_error_kind(object: &serde_json::Map<String, Value>) -> Option<&Value> {
+    object
+        .get("code")
+        .filter(|code| !code.is_null())
+        .or_else(|| object.get("type"))
+}
+
+/// The `param` value to send: a string naming the request parameter at fault,
+/// per the surface contracts. A structured value or an identifying string
+/// (URL, host, opaque id) becomes null rather than reach the client.
+fn client_error_param(param: Option<&Value>) -> Option<String> {
+    let text = param?.as_str()?;
+    (!looks_identifying(text)).then(|| text.to_string())
+}
+
+/// The chat `type` for a relayable effective kind whose own `type` slot did
+/// not provide one: a `*_error` kind already names the class of failure
+/// (`overloaded_error`, `not_found_error`); a granular code names a request
+/// problem; a numeric status maps through the surface vocabulary; no kind at
+/// all is the generic upstream type, as the bare-string wrap.
+fn chat_error_type(kind: Option<&Value>) -> String {
+    match kind {
+        Some(Value::String(kind)) if kind.ends_with("_error") => kind.clone(),
+        Some(Value::String(_)) => error_type(Surface::Openai, 400).to_string(),
+        Some(kind @ Value::Number(_)) => {
+            error_type(Surface::Openai, numeric_status(kind).unwrap_or(502)).to_string()
+        }
+        _ => error_type(Surface::Openai, 502).to_string(),
+    }
+}
+
+/// The HTTP status a relayable kind corresponds to. The chat surface renders
+/// it as the numeric `code`; the other surfaces map it into their own type
+/// vocabulary via `error_type`.
+fn kind_http_status(kind: Option<&Value>) -> u16 {
+    match kind {
+        Some(kind @ Value::Number(_)) => numeric_status(kind).unwrap_or(400),
+        Some(Value::String(kind)) => match kind.as_str() {
+            "not_found_error" | "model_not_found" => 404,
+            "request_too_large" => 413,
+            "overloaded_error" => 503,
+            "vector_store_timeout" => 504,
+            _ => 400,
+        },
+        _ => 400,
+    }
+}
+
+/// The subset of the relayable kinds that is official Responses `code`
+/// vocabulary. A relayable kind from another surface's vocabulary
+/// (`overloaded_error`, `context_length_exceeded`) is not — it renders as
+/// null/generic, the relayed message carrying the detail.
+const RESPONSES_ERROR_CODES: &[&str] = &[
+    "invalid_prompt",
+    "vector_store_timeout",
+    "invalid_image",
+    "invalid_image_format",
+    "invalid_base64_image",
+    "invalid_image_url",
+    "invalid_image_mode",
+    "image_parse_error",
+    "image_too_large",
+    "image_too_small",
+    "image_file_too_large",
+    "image_file_not_found",
+    "image_content_policy_violation",
+    "empty_image_file",
+    "unsupported_image_media_type",
+    "failed_to_download_image",
+];
+
+fn responses_error_code(kind: Option<&Value>) -> Option<&str> {
+    kind.and_then(Value::as_str)
+        .filter(|kind| RESPONSES_ERROR_CODES.contains(kind))
+}
+
+/// The subset of the relayable kinds that is official Anthropic error-type
+/// vocabulary; anything else maps through its status (`vector_store_timeout`
+/// → `timeout_error`, a granular image code → `invalid_request_error`).
+const ANTHROPIC_ERROR_TYPES: &[&str] = &[
+    "invalid_request_error",
+    "not_found_error",
+    "request_too_large",
+    "overloaded_error",
+];
+
+fn messages_error_type(kind: Option<&Value>) -> String {
+    match kind {
+        None => error_type(Surface::Anthropic, 502).to_string(),
+        Some(Value::String(kind)) if ANTHROPIC_ERROR_TYPES.contains(&kind.as_str()) => kind.clone(),
+        _ => error_type(Surface::Anthropic, kind_http_status(kind)).to_string(),
+    }
+}
+
+/// The status a suppressed error folds to, given the kind that decided the
+/// suppression and the `type` slot as a fallback classifier.
+///
+/// The allowlist will never be complete: an upstream can coin a granular code
+/// this gateway has not seen, and suppressing it is the safe default. But
+/// folding it to 502 also *reclassifies* it — it tells the client the provider
+/// broke and the request is worth retrying, when a `type` the allowlist does
+/// recognize already said the request itself is at fault. That turns a caller's
+/// permanently-invalid request into a retry loop. So when the effective kind
+/// decides nothing (the 502 default) and the `type` slot names a class this
+/// gateway knows, that class decides the status instead. Only the status
+/// changes: the kind and the message stay the gateway's own either way, so no
+/// upstream vocabulary or prose rides along.
+fn suppressed_status(kind: Option<&Value>, error_type_slot: Option<&Value>) -> u16 {
+    match suppressed_error_status(kind) {
+        502 => match error_type_slot {
+            Some(slot) if is_relayable_kind(Some(slot)) => kind_http_status(Some(slot)),
+            _ => 502,
+        },
+        decided => decided,
+    }
+}
+
+/// The status a suppressed kind folds to, mirroring the statuses
+/// `map_upstream_status` preserves: rate-limit → 429, unavailable → 503,
+/// timeout → 504, everything else → 502. Retry semantics survive, but in the
+/// gateway's own words. Takes the single *effective* kind, never both slots —
+/// a first-match-wins order over two slots would depend on argument order.
+fn suppressed_error_status(kind: Option<&Value>) -> u16 {
+    match kind {
+        Some(Value::String(kind)) => match kind.as_str() {
+            "rate_limit_error" | "rate_limit_exceeded" => 429,
+            "timeout_error" => 504,
+            _ => 502,
+        },
+        // A numeric kind takes the HTTP mapping itself; the actionable
+        // statuses it preserves never reach here (they are relayable).
+        Some(kind @ Value::Number(_)) => map_upstream_status(numeric_status(kind).unwrap_or(502)),
+        _ => 502,
+    }
+}
 
 /// The legacy `/v1/completions` (text completion) surface. OpenAI-standard and
 /// small; cross-checked against the documented text-completion response.
-/// Reuses `CHAT_USAGE`/`CHAT_ERROR` (identical shapes). `system_fingerprint` and
+/// Reuses `CHAT_USAGE` and the chat `sanitize_error` (identical shapes).
+/// `system_fingerprint` and
 /// `provider` are dropped for the same reason as on the chat surface.
 const COMPLETION_TOP: &[&str] = &[
     "id", "object", "created", "model", "choices", "usage", "error",
@@ -320,15 +545,54 @@ const RESPONSES_USAGE: &[&str] = &[
 /// streaming chunk.
 ///
 /// Covers the three OpenAI-compatible surfaces (chat completions, legacy
-/// completions, responses). The Anthropic Messages surface and embeddings are not
-/// canonicalized here — Messages has its own shape handled by the format
-/// conversion, and embeddings are not yet scoped.
-pub fn canonicalize(body: &mut Value, endpoint: Endpoint) {
+/// completions, responses). The Anthropic Messages surface has no output
+/// allowlist — its shape is the format conversion's business — but its in-band
+/// `error` event is normalized; embeddings are not yet scoped.
+/// `request_id` is the gateway's own id, stamped into a rebuilt Messages error
+/// event — the gateway's error tail carries it, and a rebuilt upstream error
+/// must be indistinguishable from it (and stay correlatable with the receipt).
+pub fn canonicalize(body: &mut Value, endpoint: Endpoint, request_id: Option<&str>) {
     match endpoint {
         Endpoint::ChatComplete => canonicalize_chat_completion(body),
         Endpoint::Complete => canonicalize_text_completion(body),
         Endpoint::CreateModelResponse => canonicalize_responses(body),
-        Endpoint::Embed | Endpoint::Messages => {}
+        Endpoint::Messages => canonicalize_messages(body, request_id),
+        Endpoint::Embed => {}
+    }
+}
+
+/// The Messages surface is left as the upstream (or the format conversion)
+/// shaped it, except for the in-band `error` event, which carries
+/// upstream-controlled kind and prose. It is rebuilt in the shape
+/// `stream_error_tail` emits for this protocol, dropping everything beside
+/// `type`/`message` by construction; the rebuilt event keeps `type: "error"`
+/// and a non-null `error` member, which the meter and the framing observer
+/// classify a failed stream by.
+fn canonicalize_messages(body: &mut Value, request_id: Option<&str>) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    if object.get("type").and_then(Value::as_str) != Some("error") {
+        return;
+    }
+    let error = object.get("error");
+    let kind = error
+        .and_then(|error| error.get("type"))
+        .filter(|kind| !kind.is_null());
+    let (kind, message) = if is_relayable_kind(kind) {
+        (
+            messages_error_type(kind),
+            client_error_message(error.and_then(|error| error.get("message"))),
+        )
+    } else {
+        let status = suppressed_error_status(kind);
+        (
+            error_type(Surface::Anthropic, status).to_string(),
+            upstream_message(status).to_string(),
+        )
+    };
+    if let Value::Object(event) = envelope(Surface::Anthropic, &kind, &message, request_id) {
+        *object = event;
     }
 }
 
@@ -367,13 +631,22 @@ fn canonicalize_text_completion(body: &mut Value) {
 /// - `response.*` lifecycle: the full object is nested under `response` — that is
 ///   the only identity-bearing part; canonicalize it and leave the envelope's
 ///   control fields (`type`, `sequence_number`, …) untouched.
-/// - Any other typed event (deltas, item/part events, `error`): a control/content
-///   envelope carrying no response object — pass through verbatim.
+/// - `error`: the one non-lifecycle envelope carrying upstream-controlled
+///   prose and kind — rebuilt as the gateway's own error event.
+/// - Any other typed event (deltas, item/part events): a control/content
+///   envelope carrying no response object and nothing upstream-authored beyond
+///   content — pass through verbatim. There is no schema to filter an envelope
+///   against, and applying the final-object allowlist would empty it.
 fn canonicalize_responses(body: &mut Value) {
     let Some(object) = body.as_object_mut() else {
         return;
     };
     match object.get("type").and_then(Value::as_str) {
+        // `response.error` must be matched before the lifecycle prefix: it
+        // carries the error at the top level with no `response` member, so the
+        // lifecycle arm would pass it through verbatim. Rebuilt as the
+        // canonical `error` event, which metering also classifies by.
+        Some("error" | "response.error") => sanitize_responses_error_event(object),
         Some(t) if t.starts_with("response.") => {
             if let Some(inner) = object.get_mut("response").and_then(Value::as_object_mut) {
                 canonicalize_responses_object(inner);
@@ -384,6 +657,57 @@ fn canonicalize_responses(body: &mut Value) {
     }
 }
 
+/// Rebuild a Responses in-band `error` event as the gateway's own.
+///
+/// This is the one non-`response.*` event with a gateway-side canonical shape:
+/// `stream_error_tail` already emits it when the gateway ends a broken
+/// Responses stream itself, and a client should not be able to tell the two
+/// apart. Two upstream shapes arrive — the documented flat event, and an
+/// `error` object nested under the envelope — and both collapse into that one
+/// shape. `sequence_number` is preserved: the protocol numbers its events, and
+/// the framing observer continues that numbering when it appends a tail of its
+/// own. The rebuilt event keeps `type: "error"`, which the meter and the
+/// framing observer classify a failed stream by.
+fn sanitize_responses_error_event(object: &mut serde_json::Map<String, Value>) {
+    let nested = object.get("error");
+    // Prefer the nested object's fields over the envelope's. The kind is the
+    // `code`, falling back to the nested `type`; the top-level `type` is the
+    // event name (`error`), never the kind.
+    let field = |key: &str| {
+        nested
+            .and_then(|error| error.get(key))
+            .or_else(|| object.get(key))
+    };
+    let kind = field("code")
+        .filter(|code| !code.is_null())
+        .or_else(|| nested.and_then(|error| error.get("type")));
+    let sequence_number = object
+        .get("sequence_number")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let event = if is_relayable_kind(kind) {
+        let message = client_error_message(field("message"));
+        // `code` and `param` are `string | null` on this event. Only the
+        // surface's own code vocabulary is kept; any other kind — numeric, or
+        // another surface's word — nulls out, the relayed message carrying the
+        // detail. `param` survives only as a safe parameter name.
+        let code = responses_error_code(kind);
+        let param = client_error_param(field("param"));
+        responses_error_event(code, &message, param.as_deref(), sequence_number)
+    } else {
+        let status = suppressed_status(kind, nested.and_then(|error| error.get("type")));
+        responses_error_event(
+            Some(responses_gateway_code(status)),
+            upstream_message(status),
+            None,
+            sequence_number,
+        )
+    };
+    if let Value::Object(event) = event {
+        *object = event;
+    }
+}
+
 fn canonicalize_responses_object(object: &mut serde_json::Map<String, Value>) {
     retain_allowed(object, RESPONSES_TOP);
     if let Some(usage) = object.get_mut("usage").and_then(Value::as_object_mut) {
@@ -391,7 +715,55 @@ fn canonicalize_responses_object(object: &mut serde_json::Map<String, Value>) {
     }
     // `output[]` items are content (message/reasoning/function_call, …) and left
     // intact; the identifying fields ride at the top level, dropped above.
-    sanitize_error(object.get_mut("error"));
+    sanitize_responses_error_field(object.get_mut("error"));
+}
+
+/// The response object's `error` field is `{code, message}` — string code,
+/// string message — or null. Anything non-null is *rebuilt* into exactly that
+/// shape, never filtered in place: filtering would let a relayable-but-bare
+/// error keep no code, a numeric code stay numeric, or a non-string `message`
+/// bypass the text scrub. Same relay policy as `sanitize_error`: a relayable
+/// kind keeps its name and its scrubbed message; a suppressed kind becomes the
+/// gateway's own vocabulary; no kind at all relays the scrubbed message under
+/// the generic code.
+fn sanitize_responses_error_field(error: Option<&mut Value>) {
+    let Some(error) = error else { return };
+    let (code, message) = match &*error {
+        // A null error is the healthy value; there is nothing to rebuild.
+        Value::Null => return,
+        // A bare-string error (some providers send one) becomes the object.
+        Value::String(text) => (
+            responses_gateway_code(502).to_string(),
+            client_safe_error_text(text),
+        ),
+        Value::Object(object) => {
+            let kind = effective_error_kind(object);
+            if is_relayable_kind(kind) {
+                // Only the surface's own code vocabulary is kept; any other
+                // kind gets the generic code, with the scrubbed message still
+                // carrying the detail.
+                let code = responses_error_code(kind)
+                    .unwrap_or_else(|| responses_gateway_code(502))
+                    .to_string();
+                let message = client_error_message(object.get("message"));
+                (code, message)
+            } else {
+                let status = suppressed_status(kind, object.get("type"));
+                (
+                    responses_gateway_code(status).to_string(),
+                    upstream_message(status).to_string(),
+                )
+            }
+        }
+        // Any other non-null shape (an array, a number, a boolean) claims
+        // nothing parseable and its interior is upstream-controlled — fold it
+        // rather than relay it.
+        _ => (
+            responses_gateway_code(502).to_string(),
+            upstream_message(502).to_string(),
+        ),
+    };
+    *error = json!({ "code": code, "message": message });
 }
 
 fn retain_allowed(object: &mut serde_json::Map<String, Value>, allowed: &[&str]) {
@@ -431,23 +803,65 @@ fn canonicalize_chat_completion(body: &mut Value) {
     }
 }
 
-/// Make an in-band error client-safe. An object error is filtered to the standard
-/// fields (dropping `metadata` and any other upstream-controlled sub-field) and
-/// its message scrubbed; a bare-string error is scrubbed. Both shapes match what
-/// the buffered path accepts; any other shape is left untouched.
+/// Make an in-band error client-safe. An object whose kind is not relayable is
+/// replaced wholesale by the gateway's own error — scrubbing is not enough,
+/// because an account-status message carries no structural marker for the
+/// scrubber to catch. A relayable object is *rebuilt* as the full
+/// `{message, type, param, code}` object (a client indexing those keys must
+/// never miss one) with its message scrubbed; a bare-string error becomes the
+/// same object; any other non-null shape folds into the generic error.
 fn sanitize_error(error: Option<&mut Value>) {
-    match error {
-        Some(Value::String(text)) => {
-            *text = crate::middleware::errors::client_safe_error_text(text);
-        }
-        Some(Value::Object(object)) => {
-            retain_allowed(object, CHAT_ERROR);
-            if let Some(Value::String(message)) = object.get_mut("message") {
-                *message = crate::middleware::errors::client_safe_error_text(message);
-            }
-        }
-        _ => {}
+    let Some(error) = error else { return };
+    if error.is_null() {
+        return;
     }
+    // A bare-string error (some providers send one) becomes the standard
+    // object — a client parsing that shape must never meet a string.
+    if let Value::String(text) = error {
+        let mut generic = chat_gateway_error(502);
+        generic["message"] = Value::String(client_safe_error_text(text));
+        *error = generic;
+        return;
+    }
+    let Some(object) = error.as_object() else {
+        // Any other non-null shape (an array, a number, a boolean) claims
+        // nothing parseable and its interior is upstream-controlled — fold it
+        // rather than relay it.
+        *error = chat_gateway_error(502);
+        return;
+    };
+    if !is_relayable_kind(effective_error_kind(object)) {
+        let status = suppressed_status(effective_error_kind(object), object.get("type"));
+        *error = chat_gateway_error(status);
+        return;
+    }
+    // Relayable: rebuild rather than filter, so every key is present. `code`
+    // is always the numeric status on this surface — aggregator-style clients
+    // classify retries by it, and a vocabulary string would degrade to a
+    // generic 500 in their parsers. It renders from the same effective kind
+    // the relay decision used, whichever slot carried it; only a kindless
+    // error claims no status and keeps a null code.
+    let code = match effective_error_kind(object).filter(|kind| !kind.is_null()) {
+        Some(kind) => json!(kind_http_status(Some(kind))),
+        None => Value::Null,
+    };
+    let error_kind = match object.get("type").and_then(Value::as_str) {
+        Some(kind) if RELAYABLE_ERROR_KINDS.contains(&kind) => kind.to_string(),
+        _ => chat_error_type(effective_error_kind(object)),
+    };
+    let message = match object.get("message") {
+        Some(Value::String(text)) => client_safe_error_text(text),
+        // A structured value is an upstream detail carrier, not a message, and
+        // a null or absent one still owes the client a message.
+        _ => client_safe_error_text(""),
+    };
+    let param = client_error_param(object.get("param"));
+    *error = json!({
+        "message": message,
+        "type": error_kind,
+        "param": param,
+        "code": code,
+    });
 }
 
 pub(super) fn now_secs() -> u64 {
@@ -704,7 +1118,7 @@ mod identity_tests {
             "usage": { "prompt_tokens": 1, "completion_tokens": 1 }
         });
         rewrite_identity(&mut body, &identity());
-        canonicalize(&mut body, Endpoint::ChatComplete);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
         assert_eq!(body["id"], "req_ours");
         assert_eq!(body["model"], "acme/model-a");
         assert!(body["choices"][0].get("matched_stop").is_none());
@@ -740,7 +1154,7 @@ mod identity_tests {
             "content": [{ "type": "text", "text": "hi" }]
         });
         rewrite_identity(&mut body, &identity());
-        canonicalize(&mut body, Endpoint::Messages);
+        canonicalize(&mut body, Endpoint::Messages, None);
         assert_eq!(body["stop_reason"], "end_turn");
         assert_eq!(body["id"], "req_ours");
     }
@@ -753,7 +1167,7 @@ mod identity_tests {
             "id": "x",
             "choices": [{ "index": 0, "finish_reason": "stop", "stop_reason": 424242 }]
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
         assert!(body["choices"][0].get("stop_reason").is_none());
         assert_eq!(body["choices"][0]["finish_reason"], "stop");
     }
@@ -780,7 +1194,7 @@ mod identity_tests {
             }],
             "usage": { "completion_tokens": 2, "cost": 0.01, "reasoning_tokens": 1, "vendor_meta": 9 }
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
         let top: Vec<&String> = body.as_object().unwrap().keys().collect();
         assert!(
             !top.iter().any(|k| [
@@ -826,7 +1240,7 @@ mod identity_tests {
             }],
             "usage": { "completion_tokens": 1, "server_tool_use": { "web_search": 1 } }
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
         assert_eq!(body["service_tier"], "default");
         let msg = &body["choices"][0]["message"];
         for field in [
@@ -845,7 +1259,9 @@ mod identity_tests {
     /// An in-band error frame on a chat-completion stream must survive
     /// canonicalization, or the client loses the error and the downstream meter
     /// (which keys on top-level `error`) records a failed stream as a success. A
-    /// clean message is kept verbatim.
+    /// clean message is kept verbatim, and the rebuilt object always carries
+    /// the full `{message, type, param, code}` shape — a numeric code stays a
+    /// number, which retry-classifying clients depend on.
     #[test]
     fn canonicalize_keeps_an_in_band_stream_error() {
         let mut body = json!({
@@ -853,9 +1269,16 @@ mod identity_tests {
             "object": "chat.completion.chunk",
             "error": { "message": "context length exceeded", "code": 400 }
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
-        assert_eq!(body["error"]["message"], "context length exceeded");
-        assert_eq!(body["error"]["code"], 400);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(
+            body["error"],
+            json!({
+                "message": "context length exceeded",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": 400
+            })
+        );
     }
 
     /// The error object's interior is filtered like every other level: the message
@@ -869,7 +1292,7 @@ mod identity_tests {
             "object": "chat.completion.chunk",
             "error": {
                 "message": "backend 10.0.0.7 refused the connection",
-                "code": 502,
+                "code": 400,
                 "metadata": { "provider_name": "SomeProvider", "raw": "upstream https://api.acme.ai 502" }
             },
             "choices": [{
@@ -877,9 +1300,10 @@ mod identity_tests {
                 "error": { "message": "no route to inference-7.internal.acme.io", "metadata": { "provider_name": "X" } }
             }]
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
         assert_eq!(body["error"]["message"], "the provider returned an error");
-        assert_eq!(body["error"]["code"], 502); // standard field kept
+        assert_eq!(body["error"]["code"], 400); // standard field kept
+
         assert!(
             body["error"].get("metadata").is_none(),
             "leaked error.metadata"
@@ -892,15 +1316,25 @@ mod identity_tests {
     }
 
     /// Some providers send a bare-string `error` rather than an object; it is
-    /// scrubbed too, matching what the buffered error path accepts.
+    /// scrubbed and wrapped into the standard error object — the surface
+    /// contract is `{message, type, param, code}` and a client parsing that
+    /// shape must never meet a string.
     #[test]
     fn canonicalize_scrubs_a_bare_string_error() {
         let mut body = json!({
             "id": "x",
             "error": "cannot connect to host files.example.com:443"
         });
-        canonicalize(&mut body, Endpoint::ChatComplete);
-        assert_eq!(body["error"], "the provider returned an error");
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(
+            body["error"],
+            json!({
+                "message": "the provider returned an error",
+                "type": "upstream_error",
+                "code": 502,
+                "param": null
+            })
+        );
     }
 
     /// Opting out of reasoning must drop every reasoning field the allowlist
@@ -937,13 +1371,14 @@ mod identity_tests {
     }
 
     /// A surface without a defined schema (Anthropic Messages, embeddings) is
-    /// passed through untouched.
+    /// passed through untouched — for Messages the in-band `error` event is the
+    /// one exception, covered separately.
     #[test]
     fn canonicalize_is_a_noop_for_unschematized_surfaces() {
         let original = json!({ "id": "x", "anything": true, "choices": [] });
         for endpoint in [Endpoint::Messages, Endpoint::Embed] {
             let mut body = original.clone();
-            canonicalize(&mut body, endpoint);
+            canonicalize(&mut body, endpoint, None);
             assert_eq!(body, original, "mutated for {endpoint:?}");
         }
     }
@@ -968,7 +1403,7 @@ mod identity_tests {
             }],
             "usage": { "prompt_tokens": 1, "completion_tokens": 1, "cost": 0.01 }
         });
-        canonicalize(&mut body, Endpoint::Complete);
+        canonicalize(&mut body, Endpoint::Complete, None);
         assert!(body.get("system_fingerprint").is_none());
         assert!(body.get("provider").is_none());
         assert!(body["choices"][0].get("matched_stop").is_none());
@@ -994,12 +1429,19 @@ mod identity_tests {
             "tools": [{ "type": "function" }],
             "previous_response_id": "resp_prev",
             "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "hi" }] }],
+            "error": { "code": "server_error", "message": "backend https://api.acme.ai fell over" },
             "usage": { "input_tokens": 3, "output_tokens": 2, "total_tokens": 5, "cost": 0.02 }
         });
-        canonicalize(&mut body, Endpoint::CreateModelResponse);
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
         // Dropped: upstream identity and unknowns.
         assert!(body.get("system_fingerprint").is_none());
         assert!(body.get("provider").is_none());
+        // A suppressed error keeps the response object's `{code, message}` shape —
+        // no chat-style `type`/`param` — in the gateway's own vocabulary.
+        assert_eq!(
+            body["error"],
+            json!({ "code": "server_error", "message": "The upstream provider returned an error" })
+        );
         // Kept: request-echo, client metadata, output content, responses usage.
         assert_eq!(body["metadata"]["client_tag"], "abc");
         assert_eq!(body["temperature"], 0.7);
@@ -1007,6 +1449,30 @@ mod identity_tests {
         assert_eq!(body["output"][0]["content"][0]["text"], "hi");
         assert_eq!(body["usage"]["input_tokens"], 3);
         assert_eq!(body["usage"]["cost"], 0.02);
+
+        // A bare-string error is wrapped into the `{code, message}` shape, not
+        // left a string.
+        let mut body = json!({
+            "object": "response",
+            "error": "backend at https://api.acme.ai timed out"
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(
+            body["error"],
+            json!({ "code": "server_error", "message": "the provider returned an error" })
+        );
+
+        // A malformed error (an array — any non-null shape that is neither
+        // object nor string) folds instead of passing through.
+        let mut body = json!({
+            "object": "response",
+            "error": [{ "provider": "SomeProvider", "raw": "https://api.acme.ai 502" }]
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(
+            body["error"],
+            json!({ "code": "server_error", "message": "The upstream provider returned an error" })
+        );
     }
 
     /// `/v1/responses` streaming: a lifecycle event carries the response object
@@ -1030,7 +1496,7 @@ mod identity_tests {
             }
         });
         rewrite_identity(&mut body, &identity());
-        canonicalize(&mut body, Endpoint::CreateModelResponse);
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
         // Envelope control fields survive untouched (metering depends on them).
         assert_eq!(body["type"], "response.completed");
         assert_eq!(body["sequence_number"], 42);
@@ -1043,33 +1509,312 @@ mod identity_tests {
         assert_eq!(body["response"]["output"][0]["content"][0]["text"], "hi");
     }
 
-    /// `/v1/responses` streaming: a delta and a typed `error` event are not the
-    /// response object; applying the final-object allowlist would empty them.
-    /// They must pass through verbatim so the client sees content and errors and
-    /// metering can classify the stream.
+    /// `/v1/responses` streaming: a typed event that carries no response object
+    /// is not the response object; applying the final-object allowlist would
+    /// empty it. It must pass through verbatim so the client sees content and
+    /// metering can classify the stream. The `error` event is the one
+    /// exception — it is the only envelope carrying upstream-controlled prose,
+    /// and the gateway defines its shape (covered separately).
     #[test]
-    fn canonicalize_responses_passes_through_non_object_events() {
-        for event in [
+    fn canonicalize_responses_passes_through_an_unknown_typed_event() {
+        let event = json!({
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hi",
+            "sequence_number": 3
+        });
+        let mut body = event.clone();
+        rewrite_identity(&mut body, &identity());
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body, event, "envelope was mutated: {event}");
+    }
+
+    /// `/v1/responses` streaming: an in-band `error` event is rebuilt as the
+    /// gateway's own. A kind naming our account with the upstream (the nested
+    /// shape one provider sends) folds into the generic upstream error — the
+    /// message would survive the scrubber's shape checks yet still leak who
+    /// served the request and blame the caller's quota for ours. An actionable
+    /// kind (the documented flat shape) is relayed. `sequence_number` survives
+    /// either way; the framing observer continues the numbering from it.
+    #[test]
+    fn canonicalize_responses_rebuilds_an_in_band_error() {
+        let mut body = json!({
+            "type": "error",
+            "sequence_number": 2,
+            "error": {
+                "type": "insufficient_quota",
+                "code": "credit_balance_exhausted",
+                "message": "You have no credits remaining. Add credits at https://console.acme.ai/billing.",
+                "param": null
+            }
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["code"], "server_error");
+        assert_eq!(body["message"], "The upstream provider returned an error");
+        assert_eq!(body["sequence_number"], 2);
+        assert!(body.get("error").is_none(), "nested error object survived");
+        assert!(!body.to_string().contains("console.acme.ai"));
+
+        // A relayable kind from another surface's vocabulary is not a Responses
+        // code: it nulls out, the relayed message carrying the detail. An
+        // official code (`invalid_image`, asserted in the param cases below)
+        // is kept.
+        let mut body = json!({
+            "type": "error",
+            "code": "context_length_exceeded",
+            "message": "input exceeds the model context window",
+            "param": "input",
+            "sequence_number": 7
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["code"], Value::Null);
+        assert_eq!(body["message"], "input exceeds the model context window");
+        assert_eq!(body["param"], "input");
+        assert_eq!(body["sequence_number"], 7);
+
+        // `code` and `param` are `string | null` on the wire: a numeric code
+        // has no official rendering and nulls out (the message carries the
+        // detail), and `param` nulls out when structured — or when it is an
+        // identifying string.
+        let mut body = json!({
+            "type": "error",
+            "code": 400,
+            "message": "bad request",
+            "param": { "raw": "https://api.acme.ai", "provider": "SomeProvider" },
+            "sequence_number": 3
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["code"], Value::Null);
+        assert_eq!(body["message"], "bad request");
+        assert_eq!(body["param"], Value::Null);
+        assert_eq!(body["sequence_number"], 3);
+
+        // A suppressed rate limit renders the surface's own official code, not
+        // a chat/HTTP type word.
+        let mut body = json!({
+            "type": "error",
+            "code": "rate_limit_exceeded",
+            "message": "acme tier exhausted",
+            "sequence_number": 6
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["code"], "rate_limit_exceeded");
+        assert_eq!(
+            body["message"],
+            "Rate limit exceeded. Please retry after some time."
+        );
+
+        let mut body = json!({
+            "type": "error",
+            "code": "invalid_image",
+            "message": "bad image",
+            "param": "https://api.acme.ai/internal",
+            "sequence_number": 5
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["code"], "invalid_image");
+        assert_eq!(body["param"], Value::Null);
+
+        // An error framed as `response.error` (error object at the top level,
+        // no `response` member) must not fall into the lifecycle passthrough;
+        // it is rebuilt as the canonical `error` event.
+        let mut body = json!({
+            "type": "response.error",
+            "sequence_number": 4,
+            "error": { "type": "insufficient_quota", "code": "credit_balance_exhausted", "message": "no credits" }
+        });
+        canonicalize(&mut body, Endpoint::CreateModelResponse, None);
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["code"], "server_error");
+        assert_eq!(body["message"], "The upstream provider returned an error");
+        assert_eq!(body["sequence_number"], 4);
+    }
+
+    /// A chat in-band error whose kind names our account with the upstream is
+    /// replaced by the gateway's own error object — but `error` stays non-null,
+    /// or metering would record the failed stream as a success. A rate-limit
+    /// kind keeps its retry semantics in our vocabulary, as the HTTP layer does
+    /// for an upstream 429.
+    #[test]
+    fn canonicalize_collapses_a_chat_error_that_names_our_account() {
+        let mut body = json!({
+            "id": "x",
+            "object": "chat.completion.chunk",
+            "error": {
+                "type": "insufficient_quota",
+                "code": "credit_balance_exhausted",
+                "message": "You have no credits remaining."
+            }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "upstream_error");
+        assert_eq!(body["error"]["code"], 502); // numeric: retry classifiers read it
+        assert_eq!(
+            body["error"]["message"],
+            "The upstream provider returned an error"
+        );
+
+        let mut body = json!({
+            "error": { "type": "rate_limit_error", "message": "acme tier exhausted, upgrade your plan" }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "rate_limit_error");
+        assert_eq!(body["error"]["code"], 429);
+        assert_eq!(
+            body["error"]["message"],
+            "Rate limit exceeded. Please retry after some time."
+        );
+
+        // A precise code outranks a generic type: relayed on the code (as its
+        // numeric status on this surface), with the non-relayable type
+        // replaced — and always the full four-field object.
+        let mut body = json!({
+            "error": { "type": "server_error", "code": "invalid_image", "message": "image could not be decoded" }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(
+            body["error"],
             json!({
-                "type": "response.output_text.delta",
-                "item_id": "msg_1",
-                "output_index": 0,
-                "content_index": 0,
-                "delta": "hi",
-                "sequence_number": 3
-            }),
+                "message": "image could not be decoded",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": 400
+            })
+        );
+
+        // A numeric 503 keeps its status semantics instead of folding to 502,
+        // as `map_upstream_status` does on the HTTP path.
+        let mut body = json!({
+            "error": { "code": 503, "message": "acme scheduler drained" }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "service_unavailable");
+        assert_eq!(body["error"]["code"], 503);
+        assert_eq!(
+            body["error"]["message"],
+            "The model is currently unavailable. Please try again later."
+        );
+
+        // The `type` and the numeric code derive from the effective kind,
+        // whichever slot carried it: a `*_error` kind keeps naming its own
+        // class of failure and must not be relabeled a request error, and a
+        // type-only kind still yields its status.
+        for (slot, kind, expect_type, expect_code) in [
+            ("code", "overloaded_error", "overloaded_error", 503),
+            ("code", "not_found_error", "not_found_error", 404),
+            ("type", "overloaded_error", "overloaded_error", 503),
+            ("type", "not_found_error", "not_found_error", 404),
+        ] {
+            let mut body = json!({ "error": { slot: kind, "message": "m" } });
+            canonicalize(&mut body, Endpoint::ChatComplete, None);
+            assert_eq!(body["error"]["type"], expect_type, "{slot}:{kind}");
+            assert_eq!(body["error"]["code"], expect_code, "{slot}:{kind}");
+        }
+
+        // An unrecognized code beside a `type` the allowlist does know keeps
+        // that type's classification: the error is still fully rebuilt in our
+        // own words, but the client is not told to retry a request that is
+        // permanently invalid.
+        let mut body = json!({
+            "error": { "type": "invalid_request_error", "code": "string_below_min_length",
+                       "message": "messages[0].content is too short" }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], 400);
+        assert_eq!(
+            body["error"]["message"],
+            "The request was rejected as invalid"
+        );
+
+        // A malformed error (neither object nor string) folds instead of
+        // passing through — but stays non-null for metering.
+        let mut body = json!({
+            "error": [{ "provider": "SomeProvider", "raw": "https://api.acme.ai 502" }]
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "upstream_error");
+        assert_eq!(
+            body["error"]["message"],
+            "The upstream provider returned an error"
+        );
+
+        // A relayed error with a null message still gets a string message and
+        // the full shape.
+        let mut body = json!({
+            "error": { "code": "invalid_image", "message": null }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(
+            body["error"],
+            json!({
+                "message": "the provider returned an error",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": 400
+            })
+        );
+
+        // `param` survives only as a safe parameter name: a structured value
+        // and an identifying string both null out, a plain name is kept.
+        for (param, expect) in [
+            (
+                json!({ "provider": "SomeProvider", "raw": "https://api.acme.ai/internal" }),
+                Value::Null,
+            ),
+            (json!("https://api.acme.ai/internal"), Value::Null),
+            (json!("input"), json!("input")),
+        ] {
+            let mut body = json!({
+                "error": { "code": "invalid_image", "message": "bad image", "param": param }
+            });
+            canonicalize(&mut body, Endpoint::ChatComplete, None);
+            assert_eq!(body["error"]["param"], expect);
+            assert_eq!(body["error"]["code"], 400);
+        }
+    }
+
+    /// A Messages in-band `error` event is rebuilt in the tail's shape: an
+    /// account-naming kind folds into `api_error` with the generic message,
+    /// while an actionable kind keeps its type and its scrubbed message.
+    #[test]
+    fn canonicalize_messages_rebuilds_an_in_band_error_event() {
+        let mut body = json!({
+            "type": "error",
+            "error": { "type": "billing_error", "message": "credit balance too low, top up your account" },
+            "request_id": "req_upstream"
+        });
+        canonicalize(&mut body, Endpoint::Messages, Some("req_ours"));
+        assert_eq!(
+            body,
             json!({
                 "type": "error",
-                "code": "server_error",
-                "message": "boom",
-                "sequence_number": 9
-            }),
-        ] {
-            let mut body = event.clone();
-            rewrite_identity(&mut body, &identity());
-            canonicalize(&mut body, Endpoint::CreateModelResponse);
-            assert_eq!(body, event, "envelope was mutated: {event}");
-        }
+                "error": { "type": "api_error", "message": "The upstream provider returned an error" },
+                // The gateway's own id, as on the gateway's error tail — the
+                // upstream's is gone with the rest of the event.
+                "request_id": "req_ours"
+            })
+        );
+
+        let mut body = json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "message": "max_tokens is required" }
+        });
+        canonicalize(&mut body, Endpoint::Messages, None);
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["message"], "max_tokens is required");
+
+        // A relayable kind from another surface's vocabulary maps into this
+        // surface's own types.
+        let mut body = json!({
+            "type": "error",
+            "error": { "type": "vector_store_timeout", "message": "m" }
+        });
+        canonicalize(&mut body, Endpoint::Messages, None);
+        assert_eq!(body["error"]["type"], "timeout_error");
     }
 
     /// Anthropic streaming events carry neither field; inventing them would

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -14,8 +14,8 @@ use serde_json::{json, Value};
 
 use super::errors::{
     chat_gateway_error, client_safe_error_text, error_type, is_actionable_client_error,
-    looks_identifying, map_upstream_status, responses_error_event, responses_gateway_code,
-    upstream_message, Surface,
+    is_quota_exhausted_error, looks_identifying, map_upstream_status, responses_error_event,
+    responses_gateway_code, upstream_message, Surface,
 };
 use super::request_transform::Endpoint;
 use super::types::ProviderFormat;
@@ -316,6 +316,37 @@ const RELAYABLE_ERROR_KINDS: &[&str] = &[
     "vector_store_timeout",
 ];
 
+/// Whether an in-band error may be relayed at all.
+///
+/// The kind decides it, except when the error body says the provider is
+/// refusing because our account with it is unpaid. Some providers report that
+/// under a kind this allowlist recognizes — the same `invalid_request_error`
+/// they use for real request faults — and its message names a balance rather
+/// than a host, so the identifying-marker scrub has nothing to catch and would
+/// relay it verbatim. The HTTP path classifies the identical body; both must
+/// reach the same answer or one provider error is suppressed on one path and
+/// leaked on the other.
+fn is_relayable_error(error: &serde_json::Map<String, Value>) -> bool {
+    !is_quota_exhausted_error(error) && is_relayable_kind(effective_error_kind(error))
+}
+
+/// The status a suppressed in-band error folds to.
+///
+/// An account refusal is ours whatever kind the provider filed it under, so it
+/// takes the status an upstream 402 takes, directly. Deferring to
+/// `suppressed_status` would let the `type` slot's fallback reclassify it — a
+/// provider that files this under `invalid_request_error` would have the
+/// caller told their request was invalid, when no request could have succeeded.
+fn suppressed_status_for(
+    object: &serde_json::Map<String, Value>,
+    type_slot: Option<&Value>,
+) -> u16 {
+    if is_quota_exhausted_error(object) {
+        return map_upstream_status(402);
+    }
+    suppressed_status(effective_error_kind(object), type_slot)
+}
+
 /// Whether an in-band error's kind is safe to relay. A string kind takes the
 /// allowlist. A numeric kind is an HTTP status by another name and takes the
 /// HTTP rule verbatim, so the in-band and buffered paths cannot disagree about
@@ -437,7 +468,8 @@ const ANTHROPIC_ERROR_TYPES: &[&str] = &[
 ];
 
 fn messages_error_type(kind: Option<&Value>) -> String {
-    match kind {
+    // An explicit `"type": null` claims nothing, exactly as an absent one does.
+    match kind.filter(|kind| !kind.is_null()) {
         None => error_type(Surface::Anthropic, 502).to_string(),
         Some(Value::String(kind)) if ANTHROPIC_ERROR_TYPES.contains(&kind.as_str()) => kind.clone(),
         _ => error_type(Surface::Anthropic, kind_http_status(kind)).to_string(),
@@ -459,7 +491,10 @@ fn messages_error_type(kind: Option<&Value>) -> String {
 /// upstream vocabulary or prose rides along.
 fn suppressed_status(kind: Option<&Value>, error_type_slot: Option<&Value>) -> u16 {
     match suppressed_error_status(kind) {
-        502 => match error_type_slot {
+        // An explicit `"type": null` claims nothing, exactly as an absent one
+        // does; without the filter it reaches the relayable test, which passes
+        // a null kind, and lands on the request-fault default.
+        502 => match error_type_slot.filter(|slot| !slot.is_null()) {
             Some(slot) if is_relayable_kind(Some(slot)) => kind_http_status(Some(slot)),
             _ => 502,
         },
@@ -575,17 +610,20 @@ fn canonicalize_messages(body: &mut Value, request_id: Option<&str>) {
     if object.get("type").and_then(Value::as_str) != Some("error") {
         return;
     }
-    let error = object.get("error");
-    let kind = error
-        .and_then(|error| error.get("type"))
-        .filter(|kind| !kind.is_null());
-    let (kind, message) = if is_relayable_kind(kind) {
+    // The same kind resolution and the same suppressed-status rules as every
+    // other surface: read code-first, and let the account check outrank the
+    // kind. Reading the `type` slot alone would relay an unpaid provider as a
+    // rate limit here while the other paths call it an upstream error, and
+    // would file a caller's invalid request under a retryable provider fault.
+    let error = object.get("error").and_then(Value::as_object);
+    let kind = error.and_then(effective_error_kind);
+    let (kind, message) = if error.is_some_and(is_relayable_error) {
         (
             messages_error_type(kind),
             client_error_message(error.and_then(|error| error.get("message"))),
         )
     } else {
-        let status = suppressed_error_status(kind);
+        let status = error.map_or(502, |error| suppressed_status_for(error, error.get("type")));
         (
             error_type(Surface::Anthropic, status).to_string(),
             upstream_message(status).to_string(),
@@ -681,21 +719,29 @@ fn sanitize_responses_error_event(object: &mut serde_json::Map<String, Value>) {
     let kind = field("code")
         .filter(|code| !code.is_null())
         .or_else(|| nested.and_then(|error| error.get("type")));
-    let sequence_number = object
-        .get("sequence_number")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let event = if is_relayable_kind(kind) {
+    let sequence_number = object.get("sequence_number").and_then(Value::as_u64);
+    // The account check reads whichever object carries the error's own fields:
+    // the nested one when the provider wrapped it, the envelope otherwise.
+    let carrier = nested.and_then(Value::as_object).unwrap_or(&*object);
+    let quota_exhausted = is_quota_exhausted_error(carrier);
+    let event = if !quota_exhausted && is_relayable_kind(kind) {
         let message = client_error_message(field("message"));
         // `code` and `param` are `string | null` on this event. Only the
         // surface's own code vocabulary is kept; any other kind — numeric, or
         // another surface's word — nulls out, the relayed message carrying the
         // detail. `param` survives only as a safe parameter name.
-        let code = responses_error_code(kind);
+        // Same fallback as the buffered sibling, so the two agree on a kind
+        // this surface's enum does not name.
+        let code = responses_error_code(kind)
+            .or_else(|| kind.map(|_| responses_gateway_code(kind_http_status(kind))));
         let param = client_error_param(field("param"));
         responses_error_event(code, &message, param.as_deref(), sequence_number)
     } else {
-        let status = suppressed_status(kind, nested.and_then(|error| error.get("type")));
+        let status = if quota_exhausted {
+            map_upstream_status(402)
+        } else {
+            suppressed_status(kind, nested.and_then(|error| error.get("type")))
+        };
         responses_error_event(
             Some(responses_gateway_code(status)),
             upstream_message(status),
@@ -738,17 +784,22 @@ fn sanitize_responses_error_field(error: Option<&mut Value>) {
         ),
         Value::Object(object) => {
             let kind = effective_error_kind(object);
-            if is_relayable_kind(kind) {
+            if !is_quota_exhausted_error(object) && is_relayable_kind(kind) {
                 // Only the surface's own code vocabulary is kept; any other
                 // kind gets the generic code, with the scrubbed message still
                 // carrying the detail.
+                // A relayable kind outside this surface's enum still has a
+                // status; render the gateway code for *that*, not the generic
+                // server error — `server_error` beside "the request was
+                // rejected as invalid" tells the client to retry a request
+                // that cannot succeed.
                 let code = responses_error_code(kind)
-                    .unwrap_or_else(|| responses_gateway_code(502))
+                    .unwrap_or_else(|| responses_gateway_code(kind_http_status(kind)))
                     .to_string();
                 let message = client_error_message(object.get("message"));
                 (code, message)
             } else {
-                let status = suppressed_status(kind, object.get("type"));
+                let status = suppressed_status_for(object, object.get("type"));
                 (
                     responses_gateway_code(status).to_string(),
                     upstream_message(status).to_string(),
@@ -830,8 +881,8 @@ fn sanitize_error(error: Option<&mut Value>) {
         *error = chat_gateway_error(502);
         return;
     };
-    if !is_relayable_kind(effective_error_kind(object)) {
-        let status = suppressed_status(effective_error_kind(object), object.get("type"));
+    if !is_relayable_error(object) {
+        let status = suppressed_status_for(object, object.get("type"));
         *error = chat_gateway_error(status);
         return;
     }
@@ -1559,9 +1610,11 @@ mod identity_tests {
         assert!(!body.to_string().contains("console.acme.ai"));
 
         // A relayable kind from another surface's vocabulary is not a Responses
-        // code: it nulls out, the relayed message carrying the detail. An
-        // official code (`invalid_image`, asserted in the param cases below)
-        // is kept.
+        // code, but it still has a status: it renders as the enum value for
+        // that status, so the one machine-readable field agrees with the
+        // relayed message instead of calling a request fault a server error.
+        // An official code (`invalid_image`, asserted in the param cases below)
+        // is kept as-is.
         let mut body = json!({
             "type": "error",
             "code": "context_length_exceeded",
@@ -1570,15 +1623,15 @@ mod identity_tests {
             "sequence_number": 7
         });
         canonicalize(&mut body, Endpoint::CreateModelResponse, None);
-        assert_eq!(body["code"], Value::Null);
+        assert_eq!(body["code"], "invalid_prompt");
         assert_eq!(body["message"], "input exceeds the model context window");
         assert_eq!(body["param"], "input");
         assert_eq!(body["sequence_number"], 7);
 
-        // `code` and `param` are `string | null` on the wire: a numeric code
-        // has no official rendering and nulls out (the message carries the
-        // detail), and `param` nulls out when structured — or when it is an
-        // identifying string.
+        // `code` and `param` are `string | null` on the wire: a numeric code is
+        // never relayed as a number, it renders as the enum value for the
+        // status it names, and `param` nulls out when structured — or when it
+        // is an identifying string.
         let mut body = json!({
             "type": "error",
             "code": 400,
@@ -1587,7 +1640,7 @@ mod identity_tests {
             "sequence_number": 3
         });
         canonicalize(&mut body, Endpoint::CreateModelResponse, None);
-        assert_eq!(body["code"], Value::Null);
+        assert_eq!(body["code"], "invalid_prompt");
         assert_eq!(body["message"], "bad request");
         assert_eq!(body["param"], Value::Null);
         assert_eq!(body["sequence_number"], 3);
@@ -1702,10 +1755,10 @@ mod identity_tests {
         // whichever slot carried it: a `*_error` kind keeps naming its own
         // class of failure and must not be relabeled a request error, and a
         // type-only kind still yields its status.
+        // One kind per slot covers both axes: that the slot does not matter,
+        // and that the status comes from the kind rather than a fixed default.
         for (slot, kind, expect_type, expect_code) in [
             ("code", "overloaded_error", "overloaded_error", 503),
-            ("code", "not_found_error", "not_found_error", 404),
-            ("type", "overloaded_error", "overloaded_error", 503),
             ("type", "not_found_error", "not_found_error", 404),
         ] {
             let mut body = json!({ "error": { slot: kind, "message": "m" } });
@@ -1730,6 +1783,23 @@ mod identity_tests {
             "The request was rejected as invalid"
         );
 
+        // An account refusal reported under a kind the allowlist recognizes is
+        // still suppressed: its message names a balance rather than a host, so
+        // the identifying-marker scrub has nothing to catch and would relay it
+        // verbatim — telling the caller their own balance is empty. The HTTP
+        // path classifies the identical body, and the two must agree.
+        let mut body = json!({
+            "error": { "type": "invalid_request_error",
+                       "message": "Your credit balance is too low to access the API, please go to Plans & Billing." }
+        });
+        canonicalize(&mut body, Endpoint::ChatComplete, None);
+        assert_eq!(body["error"]["type"], "upstream_error");
+        assert_eq!(
+            body["error"]["message"],
+            "The upstream provider returned an error"
+        );
+        assert!(!body.to_string().contains("credit balance"));
+
         // A malformed error (neither object nor string) folds instead of
         // passing through — but stays non-null for metering.
         let mut body = json!({
@@ -1742,21 +1812,14 @@ mod identity_tests {
             "The upstream provider returned an error"
         );
 
-        // A relayed error with a null message still gets a string message and
-        // the full shape.
+        // A null message still yields a string one (the shape itself is pinned
+        // by the case above, which builds through the same path).
         let mut body = json!({
             "error": { "code": "invalid_image", "message": null }
         });
         canonicalize(&mut body, Endpoint::ChatComplete, None);
-        assert_eq!(
-            body["error"],
-            json!({
-                "message": "the provider returned an error",
-                "type": "invalid_request_error",
-                "param": null,
-                "code": 400
-            })
-        );
+        assert_eq!(body["error"]["message"], "the provider returned an error");
+        assert_eq!(body["error"]["code"], 400);
 
         // `param` survives only as a safe parameter name: a structured value
         // and an identifying string both null out, a plain name is kept.
@@ -1815,6 +1878,29 @@ mod identity_tests {
         });
         canonicalize(&mut body, Endpoint::Messages, None);
         assert_eq!(body["error"]["type"], "timeout_error");
+
+        // This surface reaches the same verdict as the others on the same
+        // body: an account refusal filed under a rate-limit kind is not a rate
+        // limit, and a caller's invalid request is not a provider fault.
+        let mut body = json!({
+            "type": "error",
+            "error": { "type": "rate_limit_error",
+                       "message": "Your credit balance is too low to access the API." }
+        });
+        canonicalize(&mut body, Endpoint::Messages, None);
+        assert_eq!(body["error"]["type"], "api_error");
+        assert_eq!(
+            body["error"]["message"],
+            "The upstream provider returned an error"
+        );
+
+        let mut body = json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "code": "string_below_min_length",
+                       "message": "messages[0].content is too short" }
+        });
+        canonicalize(&mut body, Endpoint::Messages, None);
+        assert_eq!(body["error"]["type"], "invalid_request_error");
     }
 
     /// Anthropic streaming events carry neither field; inventing them would

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -79,7 +79,11 @@ impl StreamTransform {
             StreamTransform::SanitizeResponse(identity, endpoint) => {
                 return Ok(Some(edit_event_body(event, |body| {
                     response_transform::rewrite_identity(body, identity);
-                    response_transform::canonicalize(body, *endpoint);
+                    response_transform::canonicalize(
+                        body,
+                        *endpoint,
+                        Some(identity.request_id.as_str()),
+                    );
                 })))
             }
             _ => {}
@@ -235,14 +239,20 @@ fn anthropic_chat_chunk(
 
     if parsed.get("type").and_then(Value::as_str) == Some("error") {
         if let Some(error) = parsed.get("error") {
+            // The error rides in the chunk's `error` member, as it does on the
+            // same-format path: that is the member a client detects a failed
+            // 200 stream by, and the sanitize stage rebuilds its interior into
+            // this surface's vocabulary. Putting the upstream's error type in
+            // `finish_reason` instead left the client no error to find and
+            // relayed a word this surface does not use.
             let body = json!({
                 "id": fallback_id,
                 "object": "chat.completion.chunk",
                 "created": now_secs(),
                 "model": "",
-                "provider": "anthropic",
+                "error": error.clone(),
                 "choices": [{
-                    "finish_reason": error.get("type").cloned().unwrap_or(Value::Null),
+                    "finish_reason": "stop",
                     "delta": { "content": "" },
                 }],
             });
@@ -759,7 +769,7 @@ fn framed_event(event: &str) -> String {
     output
 }
 
-fn replace_data_fields(event: &str, replacement: &str) -> String {
+fn replace_data_fields(event: &str, replacement: &str, event_name: Option<&str>) -> String {
     let has_data_field = event.lines().any(|line| {
         line.trim_end_matches('\r')
             .split_once(':')
@@ -787,6 +797,14 @@ fn replace_data_fields(event: &str, replacement: &str) -> String {
                 output.push('\n');
                 replaced = true;
             }
+        } else if event_name.is_some()
+            && line
+                .split_once(':')
+                .is_some_and(|(field, _)| field == "event")
+        {
+            output.push_str("event: ");
+            output.push_str(event_name.unwrap_or_default());
+            output.push('\n');
         } else {
             output.push_str(line);
             output.push('\n');
@@ -825,10 +843,19 @@ fn edit_event_body(event: &str, edit: impl FnOnce(&mut Value)) -> String {
     let original = body.clone();
     edit(&mut body);
     if body == original {
-        framed_event(event)
-    } else {
-        replace_data_fields(event, &json_str(&body))
+        return framed_event(event);
     }
+    // An edit that renames the payload's `type` (the `response.error` →
+    // canonical `error` rebuild) must rename the SSE event field with it — a
+    // client subscribing by event name would otherwise never see it.
+    let renamed = match (
+        original.get("type").and_then(Value::as_str),
+        body.get("type").and_then(Value::as_str),
+    ) {
+        (Some(old), Some(new)) if old != new => Some(new.to_string()),
+        _ => None,
+    };
+    replace_data_fields(event, &json_str(&body), renamed.as_deref())
 }
 
 /// Splits the provider byte stream into SSE events and applies a stateful
@@ -1226,8 +1253,9 @@ mod tests {
             request_id: "req_ours".to_string(),
             user_model: Some("acme/model-a".to_string()),
         });
-        // Messages surface: canonicalize no-ops for an unschematized surface, so
-        // the anthropic events are left intact and only id/model are rewritten.
+        // Messages surface: canonicalize touches only an in-band `error` event
+        // on this unschematized surface, so the anthropic events here are left
+        // intact and only id/model are rewritten.
         let sanitized = SseTransformStream::new(
             converted,
             StreamTransform::SanitizeResponse(identity, Endpoint::Messages),
@@ -1244,6 +1272,39 @@ mod tests {
         assert!(wire.contains("req_ours"), "{wire}");
         assert!(wire.contains("acme/model-a"), "{wire}");
         assert!(wire.contains("\"text\":\"hi\""), "content survived: {wire}");
+    }
+
+    /// A `response.error`-framed upstream error through the sanitize stage: the
+    /// payload is rebuilt as the canonical `error` event, and the SSE `event:`
+    /// field must be renamed with it — a client subscribing by event name would
+    /// otherwise never see the error the payload now claims to be.
+    #[tokio::test]
+    async fn sanitize_renames_the_sse_event_with_the_rebuilt_payload() {
+        let upstream = concat!(
+            "event: response.error\n",
+            "data: {\"type\":\"response.error\",\"sequence_number\":2,\"error\":{\"type\":\"insufficient_quota\",\"code\":\"credit_balance_exhausted\",\"message\":\"no credits, top up at https://console.acme.ai/billing\"}}\n\n",
+        );
+        let events: Vec<Result<Bytes, ServiceError>> = vec![Ok(Bytes::from(upstream))];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: Some("acme/model-a".to_string()),
+        });
+        let sanitized = SseTransformStream::new(
+            inner,
+            StreamTransform::SanitizeResponse(identity, Endpoint::CreateModelResponse),
+        );
+        let collected: Vec<Result<Bytes, ServiceError>> = sanitized.collect().await;
+        let wire: String = collected
+            .into_iter()
+            .map(|c| String::from_utf8(c.unwrap().to_vec()).unwrap())
+            .collect();
+        assert!(wire.contains("event: error\n"), "{wire}");
+        assert!(!wire.contains("response.error"), "{wire}");
+        assert!(wire.contains("\"type\":\"error\""), "{wire}");
+        assert!(wire.contains("\"sequence_number\":2"), "{wire}");
+        assert!(!wire.contains("credit_balance_exhausted"), "{wire}");
+        assert!(!wire.contains("console.acme.ai"), "{wire}");
     }
 
     // Replay a fixture's input events through the transform (fixed fallback id),
@@ -1339,6 +1400,40 @@ mod tests {
         let error = out.iter().find(|e| e["type"] == json!("error")).unwrap();
         assert_eq!(error["error"]["type"], json!("overloaded_error"));
         assert!(!out.iter().any(|e| e["type"] == json!("message_stop")));
+    }
+
+    /// An Anthropic upstream's error on the chat surface must reach the client
+    /// as this surface's own in-band error — the `error` member a client
+    /// detects a failed 200 stream by — not as the upstream's error type in
+    /// `finish_reason`, which left nothing to detect and named a vocabulary
+    /// this surface does not use. Run through the production pair
+    /// (convert, then sanitize), since the rebuild happens in the second stage.
+    #[tokio::test]
+    async fn anthropic_stream_error_reaches_the_chat_client_as_an_error_member() {
+        let upstream = "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"billing_error\",\"message\":\"credit balance too low\"}}\n\n";
+        let events: Vec<Result<Bytes, ServiceError>> = vec![Ok(Bytes::from(upstream))];
+        let inner: ServiceResponseStream = Box::pin(futures_util::stream::iter(events));
+        let converted = Box::pin(SseTransformStream::new(
+            inner,
+            StreamTransform::AnthropicToOpenaiChat,
+        ));
+        let identity = Arc::new(ResponseIdentity {
+            request_id: "req_ours".to_string(),
+            user_model: Some("acme/model-a".to_string()),
+        });
+        let sanitized = SseTransformStream::new(
+            converted,
+            StreamTransform::SanitizeResponse(identity, Endpoint::ChatComplete),
+        );
+        let collected: Vec<Result<Bytes, ServiceError>> = sanitized.collect().await;
+        let wire: String = collected
+            .into_iter()
+            .map(|c| String::from_utf8(c.unwrap().to_vec()).unwrap())
+            .collect();
+        assert!(wire.contains("\"error\""), "no error member: {wire}");
+        assert!(!wire.contains("billing_error"), "leaked kind: {wire}");
+        assert!(!wire.contains("credit balance"), "leaked message: {wire}");
+        assert!(wire.contains("data: [DONE]"), "{wire}");
     }
 
     #[tokio::test]

--- a/src/middleware/stream_transform.rs
+++ b/src/middleware/stream_transform.rs
@@ -251,8 +251,12 @@ fn anthropic_chat_chunk(
                 "created": now_secs(),
                 "model": "",
                 "error": error.clone(),
+                // No finish reason: the stream did not finish, it failed, and
+                // `stop` would tell a client reading only this field that a
+                // truncated response completed normally. The `error` member
+                // above is what says what happened.
                 "choices": [{
-                    "finish_reason": "stop",
+                    "finish_reason": Value::Null,
                     "delta": { "content": "" },
                 }],
             });

--- a/src/sse_protocol.rs
+++ b/src/sse_protocol.rs
@@ -51,6 +51,59 @@ pub fn stream_success_terminator(protocol: SseProtocol) -> Option<&'static str> 
     }
 }
 
+/// The chat error object the gateway emits for a failure it will not attribute
+/// to the caller. One definition for its two producers: the tail this module
+/// appends to a stream that broke, and the rebuild of an upstream's own
+/// in-band error in `response_transform` — a client must not be able to tell
+/// the two apart, which a differing `code` or field order would give away.
+///
+/// `code` is the numeric status, unlike the HTTP error envelope's string-or-
+/// null: this object rides inside a 200 stream, where consumers read `code` as
+/// the status the failed chunk stands for.
+pub fn chat_gateway_error(status: u16) -> Value {
+    json!({
+        "message": upstream_message(status),
+        "type": error_type(Surface::Openai, status),
+        "code": status,
+        "param": Value::Null,
+    })
+}
+
+/// The Responses `code` the gateway emits for a failure it will not attribute
+/// to the caller: the surface's own official `rate_limit_exceeded` for a rate
+/// limit, its official generic otherwise. Both are in the documented code
+/// enum — a word from another surface's vocabulary would fail a strict
+/// client's validation of it.
+pub fn responses_gateway_code(status: u16) -> &'static str {
+    match status {
+        429 => "rate_limit_exceeded",
+        _ => "server_error",
+    }
+}
+
+/// The Responses in-stream error event. One definition for its two producers:
+/// the tail this module appends to a stream that broke, and the rebuild of an
+/// upstream's own in-band error in `response_transform` — a client should not
+/// be able to tell the two apart.
+///
+/// `code` and `param` are `string | null` on the wire; the parameter types
+/// enforce that, so no caller can smuggle a numeric code or a structured
+/// `param` into the event.
+pub fn responses_error_event(
+    code: Option<&str>,
+    message: &str,
+    param: Option<&str>,
+    sequence_number: u64,
+) -> Value {
+    json!({
+        "type": "error",
+        "code": code,
+        "message": message,
+        "param": param,
+        "sequence_number": sequence_number,
+    })
+}
+
 /// SSE bytes that end a broken response stream visibly to the client.
 ///
 /// A broken stream is ended gracefully rather than failed — a body `Err` would
@@ -85,23 +138,21 @@ pub fn stream_error_tail(
         SseProtocol::OpenaiResponses => {
             // The protocol numbers its events, so the error continues the
             // sequence rather than restarting it. A caller with no view of the
-            // stream has none to continue from.
-            let body = json!({
-                "type": "error",
-                "code": Value::Null,
-                "message": message,
-                "param": Value::Null,
-                "sequence_number": last_sequence_number.map_or(0, |last| last.saturating_add(1)),
-            });
+            // stream has none to continue from. The code is the one the
+            // gateway emits for any unattributed failure: a null here would
+            // let a client tell a gateway-detected break from an
+            // upstream-reported error, which are deliberately
+            // indistinguishable.
+            let body = responses_error_event(
+                Some(responses_gateway_code(502)),
+                message,
+                None,
+                last_sequence_number.map_or(0, |last| last.saturating_add(1)),
+            );
             format!("\n\nevent: error\ndata: {}\n\n", json_str(&body))
         }
         SseProtocol::OpenaiChat => {
-            let body = envelope(
-                Surface::Openai,
-                error_type(Surface::Openai, 502),
-                message,
-                request_id,
-            );
+            let body = json!({ "error": chat_gateway_error(502) });
             format!("\n\ndata: {}\n\ndata: [DONE]\n\n", json_str(&body))
         }
     }

--- a/src/sse_protocol.rs
+++ b/src/sse_protocol.rs
@@ -77,6 +77,12 @@ pub fn chat_gateway_error(status: u16) -> Value {
 pub fn responses_gateway_code(status: u16) -> &'static str {
     match status {
         429 => "rate_limit_exceeded",
+        // A request fault must not render as a server error: `code` is the only
+        // machine-readable field on this event, and `server_error` beside "the
+        // request was rejected as invalid" tells the client to retry something
+        // that cannot succeed. `invalid_prompt` is the enum's request-fault
+        // value. Statuses with no enum value (404) keep the generic.
+        400 | 413 | 422 => "invalid_prompt",
         _ => "server_error",
     }
 }
@@ -93,15 +99,21 @@ pub fn responses_error_event(
     code: Option<&str>,
     message: &str,
     param: Option<&str>,
-    sequence_number: u64,
+    sequence_number: Option<u64>,
 ) -> Value {
-    json!({
+    let mut event = json!({
         "type": "error",
         "code": code,
         "message": message,
         "param": param,
-        "sequence_number": sequence_number,
-    })
+    });
+    // Only when the upstream numbered its events. Inventing a 0 mid-stream
+    // would break the monotonic sequence a client tracks, and claim a position
+    // the protocol never gave this event.
+    if let Some(sequence_number) = sequence_number {
+        event["sequence_number"] = json!(sequence_number);
+    }
+    event
 }
 
 /// SSE bytes that end a broken response stream visibly to the client.
@@ -147,7 +159,7 @@ pub fn stream_error_tail(
                 Some(responses_gateway_code(502)),
                 message,
                 None,
-                last_sequence_number.map_or(0, |last| last.saturating_add(1)),
+                Some(last_sequence_number.map_or(0, |last| last.saturating_add(1))),
             );
             format!("\n\nevent: error\ndata: {}\n\n", json_str(&body))
         }


### PR DESCRIPTION
A 200 stream whose upstream reports an error mid-flight could hand the client
that error verbatim, and an upstream refusing because its account is unpaid was
relayed to the caller as a rate limit — a retry promise for a condition retrying
cannot resolve.

## What changed

**In-band errors are rebuilt, not filtered.** Four paths escaped the response
sanitizer: the Responses `error` event and its `response.error` framing, the
Messages surface, the chat error object's own `type`/`code`, and the
Anthropic-to-OpenAI conversion — which put the upstream's error type in
`finish_reason` and emitted no `error` member at all, leaving the client nothing
to detect a failed stream by.

One shared policy decides whether an upstream's kind may be relayed: an
allowlist of kinds a caller can act on, read code-first because upstreams pair a
precise code with a catch-all type. A kind naming the gateway's own account with
the provider is never relayed — it tells the caller something false about
themselves, and scrubbing cannot catch it, since account-status prose carries no
host or id for the shape rules to find.

Each surface then renders that decision in its own vocabulary: the chat error
carries the numeric status consumers of a 200 stream classify retries by, the
Responses error only its documented code enum, the Messages error only its own
types. `param` survives only as a safe parameter name; `message` is always a
string.

**Gateway-generated and upstream-reported errors are indistinguishable.** Both
are built by one function per protocol, so a client cannot tell them apart by
code, key order, or a missing `request_id` — the same property this gateway
already keeps for headers, ids and model names.

**An unpaid provider is reclassified where the body is still in hand.** The
distinction between "throttled" and "unpaid" exists only in the response body,
which stops at this layer. The client gets the status an upstream 402 already
takes; the attempt is recorded as 402 whatever status the provider chose to
report it under. Not restricted to 429: a provider reporting the same condition
under 400 earns the actionable-4xx relay, which would hand the caller the
provider's own account wording verbatim.

## Behaviour on successful requests

Unchanged, byte for byte — the changed code only runs when there is an error.
The Node-comparison golden fixtures for normal streams and buffered responses
pass untouched.

## Verification

- Full suite green (27 test binaries), `clippy --all-targets -D warnings`, `fmt`
- Wire-level replay through the production stream pipeline: the reported error
  event in, a rebuilt event out, framing and event numbering preserved
- Cross-surface tests pin all four paths to the same verdict on the same body

## Known residuals

- The relay allowlist is a bet on what upstreams send; a kind outside it loses
  its granular code and message, but no longer misclassifies a permanently
  invalid request as a retryable upstream failure. Suppression is not logged, so
  calibrating the list needs a data source that does not exist yet.
- A relayed chat error's granular string code (`context_length_exceeded`) is not
  machine-readable any more — the numeric status took that slot; the detail
  survives in the relayed message.
- The same-format chat path still relays an upstream `finish_reason`
  unnormalized. Fixing it needs the meter given a failure signal it does not
  currently have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)