### PR TITLE
Log the kind an in-band error suppression withholds

### DIFF
--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -459,22 +459,33 @@ pub(crate) fn is_upstream_capacity_signal(status: u16, body: &[u8]) -> bool {
             .any(|w| w == UPSTREAM_CAPACITY_MARKER)
 }
 
-/// Field values and prose a provider uses to say *this gateway's* account with
-/// it is out of quota or credit. Kept small and extended from what upstreams
-/// are actually seen to send; failing to recognize one only leaves today's
-/// behaviour, so the list is safe to grow lazily.
+/// Kind values a provider *declares* for "this gateway's account with me is out
+/// of quota or credit". A declared kind is provider-authored — request content
+/// cannot reach `code`/`type` — so unlike the prose table below this one may
+/// drive everything, including the recorded status. Each entry names where it
+/// was seen; failing to recognize one only leaves today's behaviour, so the
+/// list is safe to grow lazily from observed traffic.
 const QUOTA_EXHAUSTED_KINDS: &[&str] = &[
+    // OpenAI-compatible surfaces: quota / credit exhausted (both observed in
+    // the wild; the second is a compatible provider's spelling).
     "insufficient_quota",
     "credit_balance_exhausted",
-    "billing_error",
+    // OpenAI-compatible surfaces: billing not set up or deactivated — arrives
+    // as a 429, the masking this classifier exists to undo.
     "billing_not_active",
+    // The Anthropic surface's own 402 vocabulary; an upstream speaking that
+    // surface declares account trouble with it.
+    "billing_error",
 ];
 /// Prose markers for providers that report this only in the message, under a
-/// kind they also use for ordinary request faults. Deliberately narrow: an
-/// upstream 4xx often quotes the caller's own input back, so a marker loose
-/// enough to appear in a prompt would let a caller drive this classification.
-/// Each of these is a whole provider-authored clause, not a word that could
-/// ride in quoted content.
+/// kind they also use for ordinary request faults. Weaker evidence than a
+/// declared kind — an upstream 4xx often quotes the caller's own input back,
+/// so a prompt can plant one of these in `error.message`. Two consequences,
+/// both deliberate: each entry is a whole provider-authored clause rather than
+/// a word that could ride in quoted content, and a prose match may only
+/// suppress what the caller is shown — never drive the recorded status or
+/// anything else acted on beyond the response (see
+/// [`declares_quota_exhausted`]).
 const QUOTA_EXHAUSTED_PROSE: &[&str] = &[
     "credit balance is too low",
     "exceeded your current quota",

--- a/src/middleware/response_transform.rs
+++ b/src/middleware/response_transform.rs
@@ -330,6 +330,25 @@ fn is_relayable_error(error: &serde_json::Map<String, Value>) -> bool {
     !is_quota_exhausted_error(error) && is_relayable_kind(effective_error_kind(error))
 }
 
+/// One structured line when an upstream error kind is withheld, so the relay
+/// allowlist is observable in production: a kind that keeps appearing here
+/// either belongs on the allowlist or confirms its suppression. Kind words are
+/// provider vocabulary — logged sanitized and capped like finish reasons, with
+/// no message content alongside.
+fn note_suppressed_kind(kind: Option<&Value>) {
+    let Some(kind) = kind else { return };
+    let kind = match kind {
+        Value::String(kind) => super::completion::sanitize_reason(kind),
+        Value::Number(status) => status.to_string(),
+        _ => return,
+    };
+    tracing::info!(
+        target: "request_outcome",
+        suppressed_kind = %kind,
+        "in-band error kind suppressed"
+    );
+}
+
 /// The status a suppressed in-band error folds to.
 ///
 /// An account refusal is ours whatever kind the provider filed it under, so it
@@ -623,6 +642,7 @@ fn canonicalize_messages(body: &mut Value, request_id: Option<&str>) {
             client_error_message(error.and_then(|error| error.get("message"))),
         )
     } else {
+        note_suppressed_kind(kind);
         let status = error.map_or(502, |error| suppressed_status_for(error, error.get("type")));
         (
             error_type(Surface::Anthropic, status).to_string(),
@@ -737,6 +757,7 @@ fn sanitize_responses_error_event(object: &mut serde_json::Map<String, Value>) {
         let param = client_error_param(field("param"));
         responses_error_event(code, &message, param.as_deref(), sequence_number)
     } else {
+        note_suppressed_kind(kind);
         let status = if quota_exhausted {
             map_upstream_status(402)
         } else {
@@ -799,6 +820,7 @@ fn sanitize_responses_error_field(error: Option<&mut Value>) {
                 let message = client_error_message(object.get("message"));
                 (code, message)
             } else {
+                note_suppressed_kind(kind);
                 let status = suppressed_status_for(object, object.get("type"));
                 (
                     responses_gateway_code(status).to_string(),
@@ -882,6 +904,7 @@ fn sanitize_error(error: Option<&mut Value>) {
         return;
     };
     if !is_relayable_error(object) {
+        note_suppressed_kind(effective_error_kind(object));
         let status = suppressed_status_for(object, object.get("type"));
         *error = chat_gateway_error(status);
         return;


### PR DESCRIPTION
The relay allowlist and the account-kind table are judgments about what
upstreams send; only traffic can validate them. On the streaming path a
suppression previously left no trace at any log level — the sanitize stage
rebuilds the event before metering sees it — so a mistaken table entry would
first surface as a caller's report.

One structured `request_outcome` line at each of the four suppression points,
carrying only the withheld kind: provider vocabulary, sanitized and capped like
finish reasons, no message content. Also pins each account-kind entry's
provenance in its comment and states the two tables' asymmetry (a declared kind
may drive everything; a prose marker may only suppress what the caller is
shown).

Comment + logging only — no behavioural change; full suite, clippy, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)