### PR TITLE
Record the upstream's own words on a failed attempt

### DIFF
--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -595,6 +595,7 @@ pub async fn run(
                     attempt_index,
                     Some(&forward.selected_route),
                     raw_usage,
+                    None,
                 );
                 meter.failed_attempts(&forward.failed_attempts, false);
 
@@ -647,6 +648,7 @@ pub async fn run(
                     attempt_index,
                     Some(&forward.selected_route),
                     None,
+                    errors::client_safe_error_message(&forward.upstream_body),
                 );
                 meter.failed_attempts(&forward.failed_attempts, false);
                 (mapped, body)
@@ -910,6 +912,7 @@ pub async fn run(
                 ),
                 attempt_index,
                 &forward.selected_route,
+                errors::client_safe_error_message(&forward.error.upstream_body),
             );
             finalize_generated(status, body, &[], e2ee, outcome_ctx)
         }
@@ -1012,28 +1015,42 @@ impl Meter<'_> {
         }
     }
 
+    // `error_message` carries the upstream's own words when the attempt failed,
+    // already scrubbed to what a client may see. `error_source` stays unset:
+    // the control plane reads any value there as "one of our components broke",
+    // which would misattribute a provider's failure and take it out of that
+    // provider's health signal entirely.
     fn success(
         &self,
         status: u16,
         attempt_index: u32,
         selected_route_id: Option<&str>,
         usage: Option<Value>,
+        error_message: Option<String>,
     ) {
         self.spawn(PostReport {
             status,
             attempt_index: Some(attempt_index),
             selected_route_id: selected_route_id.map(str::to_string),
             usage,
+            error_message,
             ..self.base()
         });
     }
 
-    fn upstream_error(&self, status: u16, attempt_index: u32, selected_route_id: &str) {
+    fn upstream_error(
+        &self,
+        status: u16,
+        attempt_index: u32,
+        selected_route_id: &str,
+        error_message: Option<String>,
+    ) {
         self.spawn(PostReport {
             status,
             is_streaming: Some(true),
             attempt_index: Some(attempt_index),
             selected_route_id: Some(selected_route_id.to_string()),
+            error_message,
             ..self.base()
         });
     }

--- a/src/middleware/errors.rs
+++ b/src/middleware/errors.rs
@@ -160,7 +160,11 @@ fn extract_error_message(body: &[u8]) -> Option<String> {
 
 /// The upstream's message, fit to hand to the client, or `None` to fall back to
 /// our own per-status text.
-fn client_safe_error_message(body: &[u8]) -> Option<String> {
+///
+/// `pub(crate)` so the usage record can carry it too: what is safe to show a
+/// caller is safe to store, and a status code alone leaves no way to ask why a
+/// route started failing.
+pub(crate) fn client_safe_error_message(body: &[u8]) -> Option<String> {
     scrub_identifying_markers(&extract_error_message(body)?)
 }
 


### PR DESCRIPTION
`error_message` is written only when one of our own components fails; an
upstream's failure records a status code and nothing else. A route that starts
failing can be seen failing but not asked *why* — the provider's explanation
reaches the client, scrubbed, and is then dropped.

Concretely: a backend recently answered 404 to ~190k requests over a week. The
rows show `404` and an empty message, so the reason it was objecting is not
recoverable from the record at all.

## Change

Carry the scrubbed message into the usage record on the two paths that hold the
body — the buffered and streaming upstream-error terminals. It is the identical
string handed to the client, so it has already been through the identifying-
marker scrub: what is safe to show is safe to store.

`error_source` is deliberately **not** set. Any value there reads as "one of our
components broke", which would pull a provider's failure out of that provider's
own health signal.

## Known gap

Attempts abandoned mid-walk (failed over past) still record a status alone —
route and status travel through the walk as a pair, and widening that touches
the forwarding path throughout rather than its edges. The terminal attempt is
where a single-candidate failure lands, which is the shape the 404 case took.

Full suite, clippy, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)