### PR TITLE
fix: stop downgrading reasoning effort for self-hosted engines

### DIFF
--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -1109,22 +1109,6 @@ fn oai_user_from_metadata(params: &Value) -> Result<Option<Value>, TransformErro
         .cloned())
 }
 
-// ── Engine reasoning-effort remap ────────────────────────────────────────────
-
-fn map_sglang_reasoning_effort(params: &Value) -> Result<Option<Value>, TransformError> {
-    Ok(match params.get("reasoning_effort") {
-        Some(Value::String(effort)) => {
-            let mapped = match effort.as_str() {
-                "minimal" => "low",
-                "xhigh" => "max",
-                other => other,
-            };
-            Some(Value::String(mapped.to_string()))
-        }
-        other => other.cloned(),
-    })
-}
-
 // ── Config tables ────────────────────────────────────────────────────────────
 
 fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
@@ -1172,22 +1156,15 @@ fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
         p!("frequency_penalty", with_min(-2), with_max(2)),
         p!("logprobs", with_default(json!(false))),
     ]);
-    if let Some(engine) = engine {
+    // Self-hosted engines take the full canonical effort vocabulary, so the
+    // effort value rides the shared pass-through above unchanged.
+    if engine.is_some() {
         config.extend(pass!(
             "top_k",
             "min_p",
             "repetition_penalty",
             "chat_template_kwargs",
         ));
-        if engine == Engine::Sglang {
-            *config
-                .iter_mut()
-                .find(|config| config.input == "reasoning_effort")
-                .unwrap() = p!(
-                "reasoning_effort",
-                with_transform(map_sglang_reasoning_effort)
-            );
-        }
     }
     config
 }
@@ -1474,7 +1451,7 @@ mod tests {
         assert_eq!(bodies.len(), 3);
         assert_eq!(bodies[0].1["reasoning"]["effort"], "high");
         assert!(bodies[0].1.get("reasoning_effort").is_none());
-        assert_eq!(bodies[1].1["reasoning_effort"], "low");
+        assert_eq!(bodies[1].1["reasoning_effort"], "minimal");
         assert!(bodies[1].1.get("reasoning").is_none());
         // Candidate c has no policy — falls back to caller's requested reasoning.
         assert_eq!(bodies[2].1["reasoning"]["effort"], "medium");

--- a/tests/fixtures/transform_golden.json
+++ b/tests/fixtures/transform_golden.json
@@ -97,7 +97,7 @@
     "output": {
       "model": "m",
       "messages": [],
-      "reasoning_effort": "low",
+      "reasoning_effort": "minimal",
       "top_k": 5,
       "min_p": 0.1
     }
@@ -115,7 +115,7 @@
     "output": {
       "model": "m",
       "messages": [],
-      "reasoning_effort": "max"
+      "reasoning_effort": "xhigh"
     }
   },
   {


### PR DESCRIPTION
## What

Remove the sglang `reasoning_effort` remap (`minimal→low`, `xhigh→max`) so the caller's effort tier reaches self-hosted upstreams unchanged.

## Why

[#29](https://github.com/Dstack-TEE/private-ai-gateway/pull/29) added the remap for a concrete reason, quoting its own description:

> **never normalized** `reasoning_effort`, so OpenAI-only values (`minimal`, `xhigh`) hit sglang's stricter vocabulary and 4xx'd

That premise no longer holds. The engine's request schema now declares the full canonical vocabulary:

```python
ReasoningEffortTier = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
```

plus a fractional `[0.0, 0.99]` form for finer control. With every tier accepted upstream, the remap is pure loss — `xhigh` and `max` are *different* tiers, so a caller asking for `xhigh` has been silently served `max`.

## How

- Delete `map_sglang_reasoning_effort`. The effort value now rides the shared pass-through like any other parameter.
- Delete the `engine == Engine::Sglang` branch in `openai_chat_complete_config`. The remap was the only thing separating sglang from vllm in request shaping, so the branch collapses and the binding narrows to `engine.is_some()`.
- `engine` keeps its two remaining jobs: admitting the native sampling params (`top_k`, `min_p`, `repetition_penalty`, `chat_template_kwargs`) and selecting the `reasoning_effort` dialect default. The control-plane contract is untouched.

## Behavior

| engine | before | after |
|---|---|---|
| sglang | `xhigh` → `max`, `minimal` → `low` | passthrough |
| vllm | passthrough | passthrough (unchanged) |
| none (managed API) | passthrough | passthrough (unchanged) |

Since self-hosted openai-format deployments default to `engine=sglang`, this affects most first-party nodes.

## Risk

This assumes the self-hosted fleet runs an engine build new enough to take the wider vocabulary. A node left on the older five-tier schema will answer 4xx to `xhigh`/`minimal` instead of quietly downgrading them. Worth one `xhigh` request against a node before rolling out.

## Test

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass. Updated the two golden fixtures (`openai_chat_sglang_reasoning_minimal`, `openai_chat_sglang_reasoning_xhigh`) and the `build_candidates` unit assertion to expect passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)