### PR TITLE
Retain evidence in Chutes sessions

### DIFF
--- a/docs/reviews/aci-spec-conformance-gaps.md
+++ b/docs/reviews/aci-spec-conformance-gaps.md
@@ -36,36 +36,21 @@ item.
    silently. Sessions do better: the JSONL store survives restarts and
    extends retention per citing receipt (§8 retention rule).
 
-4. **Chutes per-instance sessions carry no §8.2 evidence.** The Chutes
-   verifier's raw evidence is fleet-wide and nonce-bound, so sealing it into
-   each per-instance session would mint a new session id for every
-   verification round and every fleet change. The implementation instead
-   seals per-instance sessions with an empty `evidence` object
-   (`record_attested_upstream_session`), keeping them content-addressed on
-   per-instance facts only. Consequence: the §9.2 deep-audit step fails
-   closed on Chutes-cited sessions (`aci` CLI upstream-2; verifier-ts
-   `checkSessionEvidence`) — a §9.2(4) deep audit is impossible for Chutes
-   even once built (see the §9.2 audits item below), while receipt
-   verification and the §9.1/§9.3 checks are unaffected. The
-   session store still accepts these records (its §8.2 check rejects only
-   evidence whose `data` does not hash to `digest`). Candidate work item:
-   have the provider verifier emit each instance's own evidence slice.
-
-5. **Streaming upstream errors carry no receipt.** A streaming request whose
+4. **Streaming upstream errors carry no receipt.** A streaming request whose
    upstream answers non-200 is returned as a buffered error without a
    receipt (inherited dstack-vllm-proxy behavior,
    `forward_chat_completion_stream_request`), while the buffered path issues
    a receipt for the same upstream error status. Arguably outside §1.4(5) —
    no inference completed — but the coverage is asymmetric.
 
-6. **§5.3 membership is best-effort for multi-instance backends.** The
+5. **§5.3 membership is best-effort for multi-instance backends.** The
    pinned-session gate runs before forwarding against the channel's current
    session ids. A Chutes-style backend fronts many instances behind one
    route, and the serving instance is known only after the response, so a
    non-listed instance can serve when a sibling instance was listed. The
    receipt's cited id exposes this to the client's §9.3(6) check.
 
-7. **The E2EE v2 replay cache is per process.** The
+6. **The E2EE v2 replay cache is per process.** The
    [v2 protocol](../../spec/e2ee-v2.md#7-key-selection-validation-and-replay-protection)
    requires rejection of a repeated
    `(client_public_key, service_public_key, nonce)` tuple inside the acceptance
@@ -74,7 +59,7 @@ item.
    same captured request once unless the deployment provides affinity or a
    shared replay store.
 
-8. **Session validity is advertised far longer than a session can actually
+7. **Session validity is advertised far longer than a session can actually
     serve.** `expires_at` is set to `now + receipt_ttl_seconds` (default
     3600), but each verification round mints a fresh nonce, so the evidence
     digest — part of the channel fingerprint — changes every
@@ -85,7 +70,7 @@ item.
     it. Fix direction: end a session's validity period when a re-verification
     supersedes it, so "current" means current.
 
-9. **A channel with several bindings is split into one session per
+8. **A channel with several bindings is split into one session per
     binding.** `record_attested_upstream_session` seals a session per entry
     in `channel_bindings`. For a Chutes-style backend that is correct (one
     session per instance), but an `aci-service` upstream publishing several
@@ -96,7 +81,7 @@ item.
     fails its own §9.3(6) check. Fix direction: group bindings of one channel
     into one session, keyed on what makes a channel distinct.
 
-10. **Session retention can lapse before the receipts citing it.** Session
+9. **Session retention can lapse before the receipts citing it.** Session
     `retention_until` is fixed at seal time — stream start — while the
     receipt's expiry is computed at stream end, so for a long stream the
     session can be evicted while its citing receipt is still served. §8
@@ -104,7 +89,7 @@ item.
     window on the buffered paths, stream-duration window on the streaming
     ones.
 
-11. **A verified, served request can be recorded as `result: "failed"`.**
+10. **A verified, served request can be recorded as `result: "failed"`.**
     `cite_served_session` matches a reported served instance only against
     sealed sessions carrying an `instance_key`. An external verifier that
     returns an `e2ee_public_key_sha256` binding without `key_id` (optional in
@@ -113,7 +98,7 @@ item.
     verified and served. Unreachable with the bundled bridges, which always
     set `key_id`.
 
-12. **The Chutes backend adds a member to the forwarded body after
+11. **The Chutes backend adds a member to the forwarded body after
     hashing.** `request.forwarded` hashes `prepared.request.body`, and
     `build_chutes_e2ee_request` then inserts `e2e_response_pk` into that JSON
     before encrypting and sending. The JSON the upstream parses therefore
@@ -121,7 +106,7 @@ item.
     encryption as a channel-binding detail outside client-facing E2EE
     extensions, but this is a body member, not encryption framing.
 
-13. **TLS keys are attested without custody evidence.** The keyset publishes
+12. **TLS keys are attested without custody evidence.** The keyset publishes
     the SPKI of a mounted certificate whose private key lives in the external
     TLS terminator, not the workload, and no `key_custody` entry covers the
     TLS role — so no verifier policy can check §3.3 custody for it, and a
@@ -130,20 +115,20 @@ item.
     supported mechanism that does not depend on this. Fix direction: terminate
     TLS in the workload, or publish custody evidence for the terminator.
 
-14. **The dstack custody policy checks only the receipt key.**
+13. **The dstack custody policy checks only the receipt key.**
     `verify_dstack_kms_receipt_custody` matches the `receipt` role against
     `receipt_signing_keys`; the `e2ee-secp256k1` and `e2ee-x25519` custody
     entries are never matched against `e2ee_public_keys`, and TLS is not
     covered. §3.3 requires a policy to specify custody for the receipt, E2EE
     and TLS keys.
 
-15. **No plausibility bound on `not_after`.** §3.1 says a verifier SHOULD
+14. **No plausibility bound on `not_after`.** §3.1 says a verifier SHOULD
     reject an implausibly distant expiry; no verifier here does, and the
     service accepts any configured lifetime. §3.4's automatic expiry is the
     only revocation that needs no coordination, so an absurd `not_after`
     nullifies it.
 
-16. **The `aci-service` upstream verifier trusts `image_digest`
+15. **The `aci-service` upstream verifier trusts `image_digest`
     uncorroborated.** Its policy accepts an upstream when the attested
     app id is allowlisted **or** the report's `source_provenance.image_digest`
     is (`AciServiceVerifierPolicy::accepts_measured`). The first path is
@@ -162,7 +147,7 @@ item.
     the anchor must stay measured. Fix direction: anchor `image_digest` to the
     verified compose, or drop it as a policy anchor.
 
-17. **The §9.2 session audits stop short of evidence appraisal.** Both
+16. **The §9.2 session audits stop short of evidence appraisal.** Both
     verifiers prove the cited session hashes to its id, the validity window
     holds, and the evidence data hashes to its digest — §9.2(1)-(2). The
     `aci` CLI also appraises the typed claims against a caller policy
@@ -174,7 +159,7 @@ item.
 
 ## Stale surroundings
 
-18. **The live E2E scripts predate the simplified protocol.** Parts of
+17. **The live E2E scripts predate the simplified protocol.** Parts of
    `scripts/live_e2e/` (e.g. `cases/embeddings.py`, `cases/lifecycle.py`)
    still assert removed mechanism (transparency events), and
    `scripts/phala_multi_upstream_smoke.sh` /
@@ -184,14 +169,14 @@ item.
    scripts need the same pass, and the public deployment serves the
    previous build until redeployed.
 
-19. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
+18. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
    test vectors byte-for-byte, but the workflow triggers only on
    `clients/verifier-ts/**`, so an edit to `spec/test-vectors.md` alone does
    not rerun them (Rust CI catches drift via `tests/spec_vectors.rs`).
 
 ## Beyond-spec surfaces (intentional, keep honest)
 
-20. **Legacy dstack-vllm-proxy compatibility** (the Appendix B non-ACI-surfaces rule).
+19. **Legacy dstack-vllm-proxy compatibility** (the Appendix B non-ACI-surfaces rule).
     `/v1/attestation/report` (separate report-data layout, injected
     `signing_address` / `intel_quote` / `nvidia_payload`), `/v1/signature/{id}`,
     and the `X-Signing-Algo` E2EE mode serve pre-ACI clients. The shared k256

--- a/scripts/live_e2e/chutes_session_smoke.py
+++ b/scripts/live_e2e/chutes_session_smoke.py
@@ -6,7 +6,7 @@ each with its own E2EE key), sends a request, and asserts:
 
   1. the attested-session list has one session per *verified instance*, each
      bound to that instance's E2EE key (`e2ee_public_key_sha256` with a `key_id`),
-     not one bundled session, and
+     not one bundled session, and each full session retains valid evidence, and
   2. the request's receipt cites one of those per-instance sessions — i.e. the
      session of the instance that actually served — so the chain receipt ->
      instance session -> that instance's claims holds.
@@ -20,6 +20,8 @@ Usage (from scripts/, with CHUTES_API_KEY in the environment):
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import os
 import signal
@@ -59,6 +61,29 @@ def instance_binding(session: dict) -> dict | None:
         if binding.get("type") == "e2ee_public_key_sha256" and binding.get("key_id"):
             return binding
     return None
+
+
+def get_session(session_id: str) -> dict | None:
+    r = requests.get(f"{BASE}/v1/aci/sessions/{session_id}", timeout=30)
+    if r.status_code != 200:
+        return None
+    if hashlib.sha256(r.content).hexdigest() != session_id:
+        return None
+    return r.json()
+
+
+def evidence_digest_matches_data(session: dict) -> bool:
+    evidence = session.get("evidence") or {}
+    digest = evidence.get("digest")
+    data_uri = evidence.get("data")
+    if not isinstance(digest, str) or not isinstance(data_uri, str):
+        return False
+    try:
+        encoded = data_uri.split(";base64,", 1)[1]
+        decoded = base64.b64decode(encoded, validate=True)
+    except (IndexError, ValueError):
+        return False
+    return digest == f"sha256:{hashlib.sha256(decoded).hexdigest()}"
 
 
 def send_request() -> tuple[int, str | None]:
@@ -163,13 +188,19 @@ def main() -> int:
                 print("FAIL: no attested sessions recorded for Chutes")
                 return 1
 
-            # 1. Every Chutes session is a single per-instance E2EE channel.
+            # 1. Every Chutes session is a single per-instance E2EE channel and
+            #    retains the verifier input required for a deep audit.
             key_ids: list[str] = []
             for s in sessions:
                 binding = instance_binding(s)
                 if binding is None:
                     print(f"FAIL: session {s.get('session_id')} is not a per-instance E2EE channel: "
                           f"{s.get('channel_binding')}")
+                    return 1
+                session_id = s.get("session_id")
+                full_session = get_session(session_id) if isinstance(session_id, str) else None
+                if full_session is None or not evidence_digest_matches_data(full_session):
+                    print(f"FAIL: session {session_id} has missing or invalid evidence")
                     return 1
                 key_ids.append(binding["key_id"])
             if len(set(key_ids)) != len(key_ids):

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -71,8 +71,8 @@ pub(super) fn chutes_instance_id<'a>(
 }
 
 /// Typed claims for one Chutes instance: the verifier's facts for that instance
-/// only, so its session is content-addressed on its own data and survives fleet
-/// churn (a sibling instance joining or failing does not change it).
+/// only, so the claim slice is not changed by a sibling joining or failing. The
+/// session separately retains the verification round's raw evidence.
 pub(super) fn per_instance_session_claims(
     event: &UpstreamVerifiedEvent,
     instance_id: &str,
@@ -91,12 +91,13 @@ pub(super) fn per_instance_session_claims(
 }
 
 /// One instance's slice of the Chutes `provider_claims` — that instance's own
-/// attestation facts, so its session binds its CPU and GPU evidence while staying
+/// attestation facts, so its claims bind its CPU and GPU results while staying
 /// stable under fleet churn. Everything fleet-shaped is dropped (the lists, the
 /// per-instance maps, and the *fleet-aggregate* GPU scalars — `all`/`any` over
 /// instances). What is kept is per-instance and nonce-free: the matched CPU
 /// measurement profile, this instance's TCB status, and this instance's GPU
-/// verification outcome (verified / arch). The raw nonce-bound quotes stay out.
+/// verification outcome (verified / arch). Raw nonce-bound quotes stay out of
+/// the claim slice and remain available through the session evidence.
 fn per_instance_provider_claims(full: Option<&Value>, instance_id: &str) -> Value {
     let mut pc = serde_json::Map::new();
     let Some(Value::Object(map)) = full else {
@@ -779,8 +780,8 @@ mod claim_mapping_tests {
             c1.extra.get("gpu_verified").and_then(Value::as_bool),
             Some(true)
         );
-        // Fleet-wide fields are dropped, so the slice (and the session content id)
-        // does not change when a sibling instance does (per-instance idempotency).
+        // Fleet-wide fields are dropped, so the claim slice does not change when
+        // a sibling instance does. The session id also commits to raw evidence.
         assert!(!c1.extra.contains_key("verified_instance_ids"));
         assert!(!c1.extra.contains_key("instance_tcb_statuses"));
         assert!(!c1.extra.contains_key("instance_measurements"));

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -699,18 +699,15 @@ impl AciService {
                 Some(instance_id) => per_instance_session_claims(event, instance_id),
                 None => session_claims_for_event(event),
             };
-            // A per-instance (Chutes) binding excludes the shared, nonce-bound raw
-            // evidence so re-verifying the same instance is a no-op; a single
-            // channel keeps the event's evidence.
-            let evidence = if instance.is_some() {
-                EvidenceRef::default()
-            } else {
-                event
-                    .evidence
-                    .as_ref()
-                    .map(EvidenceRef::from_value)
-                    .unwrap_or_default()
-            };
+            // Every session retains the verifier input required for a deep audit.
+            // Chutes currently emits one shared, nonce-bound evidence bundle for
+            // all verified instances, so each per-instance session carries that
+            // bundle and a fresh verification round produces a fresh session id.
+            let evidence = event
+                .evidence
+                .as_ref()
+                .map(EvidenceRef::from_value)
+                .unwrap_or_default();
             let session_id = self.seal_attested_session(
                 event,
                 identity.clone(),

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -303,6 +303,44 @@ async fn verified_upstream_binding_creates_attested_session() {
 }
 
 #[tokio::test]
+async fn chutes_per_instance_sessions_retain_verifier_evidence() {
+    let (service, _) = make_service(b"{}");
+    let evidence_bytes = br#"{"fixture":"chutes"}"#;
+    let evidence_digest = private_ai_gateway::aci::digest::sha256_hex(evidence_bytes);
+    let evidence_data = "data:application/json;base64,eyJmaXh0dXJlIjoiY2h1dGVzIn0=".to_string();
+    let event = UpstreamVerifiedEvent {
+        provider_type: Some("chutes".to_string()),
+        url_origin: Some("https://llm.chutes.ai".to_string()),
+        verifier_id: "private-ai-verifier/chutes/v1".to_string(),
+        evidence: Some(serde_json::json!({
+            "digest": evidence_digest,
+            "data": evidence_data,
+        })),
+        channel_bindings: ["instance-a", "instance-b"]
+            .into_iter()
+            .map(|instance_id| ChannelBinding::E2eePublicKeySha256 {
+                provider: "chutes".to_string(),
+                key_id: Some(instance_id.to_string()),
+                algorithm: "chutes-ml-kem-768".to_string(),
+                public_key_sha256: "aa".repeat(32),
+            })
+            .collect(),
+        ..verified_event("chutes", "model-tee")
+    };
+
+    service.record_session(&event);
+
+    let sessions = service.list_attested_sessions(Some("chutes"));
+    assert_eq!(sessions.len(), 2, "one session per Chutes instance");
+    for session in sessions {
+        let evidence = &session.document().evidence;
+        assert_eq!(evidence.digest.as_deref(), Some(evidence_digest.as_str()));
+        assert_eq!(evidence.data_uri.as_deref(), Some(evidence_data.as_str()));
+        assert!(evidence.digest_matches_data());
+    }
+}
+
+#[tokio::test]
 async fn verified_upstream_binding_fails_without_persisted_session() {
     let (svc, received) = make_service_raw(br#"{"id":"chat-xyz","model":"x"}"#);
     let svc = svc.with_session_store(Arc::new(FailingSessionStore));


### PR DESCRIPTION
## Summary

Chutes verification already returns valid attestation evidence, but the session producer discarded it when creating per-instance sessions. That left `evidence: {}` and caused deep audits to reject otherwise valid sessions.

This keeps the verifier evidence in every Chutes instance session. A fresh nonce-bound verification now creates a fresh content-addressed session, which is the honest behavior.

Also adds a two-instance regression test and removes the resolved conformance gap.

## Checks

- `cargo test --test service`
- `cargo test per_instance_claims_pick_the_instance_and_drop_fleet_data`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Live `zai-org/GLM-5.1-TEE` smoke against Chutes: 14 per-instance sessions; every full session was content-addressed correctly and carried hash-matching evidence; the completion receipt cited the serving instance
