### PR TITLE
Read a chat-template thinking switch as reasoning intent

### DIFF
--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -14,10 +14,21 @@ endpoints below).
   (empty list = anonymous allowed). Reasoning-aware routing is optional and this
   minimal example does not implement it. A candidate can return
   `effectiveReasoning` to override the normalized request. Candidates can set
-  `reasoningFormat` to `"reasoning_effort"` or `"reasoning"` to select the
+  `reasoningFormat` to `"reasoning_effort"`, `"reasoning"`,
+  `"chat_template_thinking"` or `"chat_template_enable_thinking"` to select the
   upstream parameter dialect explicitly. When omitted, the gateway preserves
   its legacy behavior: managed routes use nested `reasoning`, while SGLang and
   vLLM routes use `reasoning_effort`.
+
+  Declaring a dialect also opts the route into reading a caller's
+  `chat_template_kwargs` thinking switch. Some callers can only express "no
+  thinking" that way, and left untranslated the switch reaches the upstream as
+  an opaque key that only a real vLLM/SGLang server acts on — a vendor API
+  behind the same route ignores it and keeps thinking. On a route that declares
+  a dialect, a switch set to `false` is re-encoded in that dialect. An explicit
+  `reasoning`/`reasoning_effort` still wins, and a switch set to `true` is never
+  translated: encoding "on" would have to invent an effort the caller did not
+  ask for.
 - `POST /consult/post` — accepts the usage report and drops it (no billing).
 
 No database; configuration only.

--- a/examples/control-plane/src/config.ts
+++ b/examples/control-plane/src/config.ts
@@ -17,8 +17,15 @@ export interface RouteCandidate {
   format: Format;
   /** Self-hosted serving engine (sglang/vllm); absent for managed APIs. */
   engine?: 'sglang' | 'vllm';
-  /** Explicit upstream reasoning parameter dialect. */
-  reasoningFormat?: 'reasoning_effort' | 'reasoning';
+  /**
+   * Explicit upstream reasoning parameter dialect. Also opts the route into
+   * reading a `chat_template_kwargs` thinking switch as reasoning intent.
+   */
+  reasoningFormat?:
+    | 'reasoning_effort'
+    | 'reasoning'
+    | 'chat_template_thinking'
+    | 'chat_template_enable_thinking';
 }
 
 export interface ModelEntry {

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -224,6 +224,8 @@ fn candidate_params(
         return Ok(params);
     }
     // Read request context before the mutable borrow below.
+    let derived = chat_template_reasoning_intent(&params, candidate, requested_reasoning);
+    let requested_reasoning = requested_reasoning.or(derived.as_ref());
     let effective = resolve_effective_reasoning(candidate, &params, requested_reasoning);
     let object = params
         .as_object_mut()
@@ -327,6 +329,65 @@ fn resolve_effective_reasoning(
         // Normal chat: caller's reasoning.
         requested.cloned()
     }
+}
+
+/// Read a switched-off `chat_template_kwargs` thinking flag as a request to
+/// disable reasoning.
+///
+/// The flag is the vLLM chat-template idiom, and for some callers it is the
+/// only way to say "no thinking" at all: a client whose model catalog exposes
+/// no `none` reasoning effort has nothing else to send, so it sets
+/// `{"thinking": false, "enable_thinking": false}` and no `reasoning` field.
+/// Left untranslated that is an opaque body key. It survives to the upstream
+/// only for self-hosted engines (see the passthrough allowlist), and only a
+/// real vLLM/SGLang server acts on it — a managed API behind the same route
+/// receives it and ignores it, so the model keeps thinking and the caller is
+/// silently not honoured. Reading it here turns the switch into ordinary
+/// reasoning intent, so it is subject to policy and gets encoded in whatever
+/// dialect the route actually speaks.
+///
+/// Three deliberate limits:
+///
+/// - An explicit `reasoning`/`reasoning_effort` always wins. It is the standard
+///   field and the more precise statement of intent; the switch only fills the
+///   silence.
+/// - Only `false` is read. Encoding "on" would have to invent an effort
+///   (`enabled: true` maps to `medium`), which is a stronger claim than the
+///   caller made and would change what a working request asks for.
+/// - Only OpenAI-format routes that declare a `reasoning_format` take part. A
+///   route whose dialect nobody configured cannot be assumed to want a
+///   synthesized parameter, and the Anthropic surface treats any reasoning as a
+///   hard error. Since this intent is inferred rather than stated, it must
+///   never be the reason a request fails: where it cannot be encoded, it is
+///   simply not derived, and the switch stays the passthrough it is today.
+fn chat_template_reasoning_intent(
+    params: &Value,
+    candidate: &RouteCandidate,
+    requested: Option<&ReasoningConfig>,
+) -> Option<ReasoningConfig> {
+    if requested.is_some()
+        || candidate.format != ProviderFormat::Openai
+        || candidate.reasoning_format.is_none()
+    {
+        return None;
+    }
+    let kwargs = params.get("chat_template_kwargs")?.as_object()?;
+    let mut disabled = false;
+    for key in ["thinking", "enable_thinking"] {
+        match kwargs.get(key).and_then(Value::as_bool) {
+            // Any switch left on ends the derivation, which covers both rules
+            // above at once: a plain "on" is never translated, and a caller who
+            // sets the two aliases against each other has stated no intent to
+            // read, so the body is left alone rather than a side picked.
+            Some(true) => return None,
+            Some(false) => disabled = true,
+            None => {}
+        }
+    }
+    disabled.then(|| ReasoningConfig {
+        enabled: Some(false),
+        ..Default::default()
+    })
 }
 
 fn sync_chat_template_reasoning(object: &mut Map<String, Value>, reasoning: &ReasoningConfig) {
@@ -1513,6 +1574,180 @@ mod tests {
             assert_eq!(kwargs["thinking"], expected);
             assert_eq!(kwargs["enable_thinking"], expected);
             assert_eq!(kwargs["tokenize"], false);
+        }
+    }
+
+    /// The case that motivated `chat_template_reasoning_intent`: a caller
+    /// disables thinking the only way its catalog lets it, and the route is a
+    /// managed API that ignores the switch. Before, nothing was encoded and the
+    /// upstream kept thinking; now the switch is re-expressed in the dialect
+    /// the route declared.
+    #[test]
+    fn chat_template_switch_off_is_read_as_reasoning_intent() {
+        for reasoning_format in ["reasoning_effort", "reasoning"] {
+            let request = json!({
+                "model": "m",
+                "messages": [],
+                "max_tokens": 65536,
+                "chat_template_kwargs": { "thinking": false, "enable_thinking": false }
+            });
+            let (params, requested, _) =
+                crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+            assert!(requested.is_none(), "the switch is not a reasoning field");
+            let candidate: RouteCandidate = serde_json::from_value(json!({
+                "routeId": "managed:m",
+                "format": "openai",
+                "engine": "sglang",
+                "reasoningFormat": reasoning_format,
+            }))
+            .unwrap();
+
+            let bodies = build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                &[candidate],
+                requested.as_ref(),
+            )
+            .unwrap();
+            let body = &bodies[0].1;
+            if reasoning_format == "reasoning_effort" {
+                assert_eq!(body["reasoning_effort"], "none");
+            } else {
+                assert_eq!(body["reasoning"]["enabled"], false);
+            }
+            // The switch still rides along for an upstream that does honor it.
+            assert_eq!(body["chat_template_kwargs"]["thinking"], false);
+        }
+    }
+
+    /// Most requests that hit this also carry `tools`, which is a separate
+    /// branch of `resolve_effective_reasoning` — the derived intent has to
+    /// survive it. Above the policy threshold it is what disables reasoning; at
+    /// or below, the threshold already forces `none` and the two agree.
+    #[test]
+    fn chat_template_switch_survives_the_tools_branch() {
+        for (max_tokens, tool_choice) in [
+            (65536, json!("none")),
+            (65536, json!("auto")),
+            (65536, json!("required")),
+            (
+                65536,
+                json!({ "type": "function", "function": { "name": "get_current_weather" } }),
+            ),
+            (256, json!("auto")),
+        ] {
+            let request = json!({
+                "model": "m",
+                "messages": [],
+                "max_tokens": max_tokens,
+                "tools": [{
+                    "type": "function",
+                    "function": { "name": "get_current_weather", "parameters": {} }
+                }],
+                "tool_choice": tool_choice,
+                "chat_template_kwargs": { "thinking": false, "enable_thinking": false }
+            });
+            let (params, requested, _) =
+                crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+            let candidate: RouteCandidate = serde_json::from_value(json!({
+                "routeId": "managed:m",
+                "format": "openai",
+                "engine": "sglang",
+                "reasoningFormat": "reasoning_effort",
+                "reasoningPolicy": { "threshold": 2048 }
+            }))
+            .unwrap();
+
+            let bodies = build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                &[candidate],
+                requested.as_ref(),
+            )
+            .unwrap();
+            let body = &bodies[0].1;
+            assert_eq!(
+                body["reasoning_effort"], "none",
+                "max_tokens {max_tokens}, tool_choice {tool_choice}"
+            );
+            // The tool call itself must be untouched by the reasoning shaping.
+            assert_eq!(body["tool_choice"], tool_choice);
+            assert!(body["tools"].is_array());
+        }
+    }
+
+    /// The three limits the derivation deliberately keeps: an explicit
+    /// reasoning field wins, "on" is never synthesized, and a route that
+    /// declares no dialect is left exactly as it is today — the last one is
+    /// what keeps the Anthropic surface (where any reasoning is a hard error)
+    /// and managed OpenAI routes from newly rejecting a request that works.
+    #[test]
+    fn chat_template_switch_is_not_read_outside_its_limits() {
+        let candidate = |format: &str, reasoning_format: Option<&str>| -> RouteCandidate {
+            let mut fields = json!({
+                "routeId": "managed:m",
+                "format": format,
+                "engine": "sglang",
+            });
+            if let Some(dialect) = reasoning_format {
+                fields["reasoningFormat"] = dialect.into();
+            }
+            serde_json::from_value(fields).unwrap()
+        };
+        let base =
+            |kwargs: Value| json!({ "model": "m", "messages": [], "chat_template_kwargs": kwargs });
+
+        // Explicit reasoning wins over the switch.
+        let mut request = base(json!({ "thinking": false }));
+        request["reasoning_effort"] = "high".into();
+        let (params, requested, _) =
+            crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+        let bodies = build_candidates(
+            &params,
+            Endpoint::ChatComplete,
+            &[candidate("openai", Some("reasoning_effort"))],
+            requested.as_ref(),
+        )
+        .unwrap();
+        assert_eq!(bodies[0].1["reasoning_effort"], "high");
+
+        // Nothing is synthesized for a switch that is on, for a contradictory
+        // pair, for a route that declares no dialect, or for the Anthropic
+        // surface — the last two would otherwise be a shape the upstream
+        // rejects and an outright 400, from an intent nobody stated.
+        let off = json!({ "thinking": false, "enable_thinking": false });
+        for (kwargs, format, dialect) in [
+            (
+                json!({ "thinking": true, "enable_thinking": true }),
+                "openai",
+                Some("reasoning_effort"),
+            ),
+            (
+                json!({ "thinking": true, "enable_thinking": false }),
+                "openai",
+                Some("reasoning_effort"),
+            ),
+            (off.clone(), "openai", None),
+            (off.clone(), "anthropic", Some("reasoning_effort")),
+        ] {
+            let request = base(kwargs.clone());
+            let (params, requested, _) =
+                crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+            let bodies = build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                &[candidate(format, dialect)],
+                requested.as_ref(),
+            )
+            .expect("a derived intent must never be the reason a request fails");
+            let body = &bodies[0].1;
+            assert!(
+                body.get("reasoning_effort").is_none() && body.get("reasoning").is_none(),
+                "{kwargs} on {format}/{dialect:?} should stay a passthrough, got {body}"
+            );
+            if format == "openai" {
+                assert_eq!(body["chat_template_kwargs"], kwargs);
+            }
         }
     }
 

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -704,6 +704,87 @@ async fn control_selects_native_kimi_reasoning_switch() {
     assert!(body.get("reasoning").is_none());
 }
 
+/// End to end for the shape that exposed the gap: a caller whose only way to
+/// say "no thinking" is the chat-template switch, and a route whose upstream
+/// ignores it. The switch has to reach that upstream as the dialect the route
+/// declared.
+#[tokio::test]
+async fn chat_template_switch_reaches_a_managed_route_as_its_own_dialect() {
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{
+                "routeId": "vendor:acme/model-a",
+                "format": "openai",
+                "engine": "sglang",
+                "reasoningFormat": "reasoning_effort",
+                "reasoningPolicy": { "threshold": 2048 }
+            }]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let (service, _, forwarded) = build_sequenced_service(vec![200]);
+    let mut input = chat_input();
+    input.params = json!({
+        "model": "acme/model-a",
+        "messages": [{ "role": "user", "content": "How many apples?" }],
+        "max_tokens": 65536,
+        "temperature": 1,
+        "top_p": 0.95,
+        "chat_template_kwargs": { "thinking": false, "enable_thinking": false }
+    });
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    let body: Value = serde_json::from_slice(&forwarded.lock().unwrap()[0]).unwrap();
+    assert_eq!(body["reasoning_effort"], "none");
+    // Still forwarded for an upstream that does act on it.
+    assert_eq!(
+        body["chat_template_kwargs"],
+        json!({ "thinking": false, "enable_thinking": false })
+    );
+}
+
+/// A route that declares no dialect keeps today's behavior exactly: the switch
+/// is a passthrough and nothing is synthesized. This is what keeps the change
+/// off the managed surfaces, where an invented reasoning parameter would be
+/// rejected rather than ignored.
+#[tokio::test]
+async fn chat_template_switch_stays_a_passthrough_without_a_declared_dialect() {
+    let control_url = spawn_control(
+        200,
+        json!({
+            "allow": true,
+            "candidates": [{
+                "routeId": "self-hosted:acme/model-a",
+                "format": "openai",
+                "engine": "vllm"
+            }]
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let (service, _, forwarded) = build_sequenced_service(vec![200]);
+    let mut input = chat_input();
+    input.params = json!({
+        "model": "acme/model-a",
+        "messages": [{ "role": "user", "content": "How many apples?" }],
+        "chat_template_kwargs": { "thinking": false, "enable_thinking": false }
+    });
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, input).await).await;
+    assert_eq!(status, 200);
+    let body: Value = serde_json::from_slice(&forwarded.lock().unwrap()[0]).unwrap();
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning").is_none());
+    assert_eq!(
+        body["chat_template_kwargs"],
+        json!({ "thinking": false, "enable_thinking": false })
+    );
+}
+
 #[tokio::test]
 async fn buffered_success_transforms_injects_cost_and_meters() {
     // Anthropic upstream over /v1/chat/completions: response is transformed to the


### PR DESCRIPTION
## The gap

A caller that can only express "no thinking" through the vLLM chat-template idiom is not heard:

```json
{ "chat_template_kwargs": { "thinking": false, "enable_thinking": false } }
```

with no `reasoning` field. A client whose model catalog exposes no `none` reasoning effort has nothing else to send.

`normalize_chat_request` reads only `reasoning`, `reasoning_effort` and `include_reasoning`, so `requested_reasoning` is `None`, `resolve_effective_reasoning` yields `None`, and `candidate_params` returns early at the `let Some(effective) = effective else` guard without encoding anything.

The switch then travels on as an opaque body key. It reaches the upstream only for self-hosted engines — it is in the `engine.is_some()` passthrough list — and only a real vLLM/SGLang server acts on it. A managed API behind such a route receives it and ignores it, so the model keeps thinking and the caller is silently not honoured.

The asymmetry is the tell: `sync_chat_template_reasoning` already writes *into* `chat_template_kwargs` to reconcile it with an effective reasoning, but nothing ever read intent back *out* of it.

## Measured

Against a managed upstream, with the disable switch set: 300–600 reasoning tokens on every request that asked for none, while a self-hosted route serving the same model correctly returned zero.

Re-sent to that same managed backend as `reasoning_effort: "none"`, reasoning tokens go to zero. With `tools` present it holds for every `tool_choice` variant (`none` / `auto` / `required` / pinned function), and the tool call itself is unaffected — still one call, still `finish_reason: tool_calls`.

## The change

`chat_template_reasoning_intent` derives the intent from the switch, and `candidate_params` folds it in ahead of `resolve_effective_reasoning`. From there the existing path does the work: deployment policy still applies, and the dialect the route declares decides the wire form.

Three limits keep it from touching anything that works today:

- **An explicit `reasoning`/`reasoning_effort` wins.** It is the standard field and the more precise statement of intent; the switch only fills the silence.
- **Only `false` is read.** Encoding "on" would have to invent an effort — `enabled: true` maps to `medium` — which is a stronger claim than the caller made.
- **Only OpenAI-format routes that declare a `reasoning_format` take part.** An inferred intent must never be the reason a request fails, and the Anthropic arm rejects any reasoning outright. Where the intent cannot be encoded it is simply not derived, and the switch stays the passthrough it is today.

The switch is never removed from the body, so routes whose upstream does honour it are unchanged.

## Tests

Three unit tests and two integration tests:

- both dialects encode the derived intent (`reasoning_effort: "none"` / `reasoning: {enabled: false}`)
- it survives the `tools` branch across all four `tool_choice` shapes, both sides of the policy threshold, with `tools`/`tool_choice` untouched
- each of the three limits, including an Anthropic route that declares a dialect — removing the format guard makes this one fail with `the requested model has no adapter`, which is exactly the regression it exists to catch
- end to end through the middleware, against a mock control plane, for both a route that declares a dialect and one that does not

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test --all-targets` are clean.

## Also

`examples/control-plane` advertised only two of the four `ReasoningFormat` variants — corrected, and the README now documents what declaring a dialect opts a route into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)