### PR TITLE
Make the session log survivable: revert the Chutes evidence retention, replay only what is live

### DIFF
--- a/docs/reviews/aci-spec-conformance-gaps.md
+++ b/docs/reviews/aci-spec-conformance-gaps.md
@@ -36,21 +36,55 @@ item.
    silently. Sessions do better: the JSONL store survives restarts and
    extends retention per citing receipt (§8 retention rule).
 
-4. **Streaming upstream errors carry no receipt.** A streaming request whose
+4. **Chutes per-instance sessions carry no §8.2 evidence.** The Chutes
+   verifier's raw evidence is fleet-wide and nonce-bound, so sealing it into
+   each per-instance session would mint a new session id for every
+   verification round and every fleet change. The implementation instead
+   seals per-instance sessions with an empty `evidence` object
+   (`record_attested_upstream_session`), keeping them content-addressed on
+   per-instance facts only. Consequence: the §9.2 deep-audit step fails
+   closed on Chutes-cited sessions (`aci` CLI upstream-2; verifier-ts
+   `checkSessionEvidence`) — a §9.2(4) deep audit is impossible for Chutes
+   even once built (see the §9.2 audits item below), while receipt
+   verification and the §9.1/§9.3 checks are unaffected. The
+   session store still accepts these records (its §8.2 check rejects only
+   evidence whose `data` does not hash to `digest`).
+
+   Sealing the evidence in was tried and reverted. The predicted new session
+   id per round is what happens, and it compounds: each round appends a fresh
+   record per instance instead of resolving to the existing one, and each
+   record now carries the fleet-wide bundle, so the log grows without bound
+   relative to the live set. Startup replays that log into the index, so a
+   long enough gap since the last compaction exhausts memory before the
+   process serves a request — and because the kill lands during startup, it
+   repeats on every restart with no path back except moving the file aside.
+
+   So the fix has to keep the evidence *out* of what the session id commits
+   to. Emitting a per-instance evidence slice, the work item below, removes
+   the fleet-wide half but not the nonce-bound half, so on its own it still
+   mints a new id per round. Retaining the evidence under its own digest and
+   linking sessions to it out of band addresses both, and retains every
+   round's evidence rather than only the latest. Either way, two properties
+   the store depends on need stating explicitly, because nothing currently
+   enforces them: a session's identity must not commit to anything that
+   changes per verification round, and replay must stay proportional to the
+   live set rather than to everything appended since the last compaction.
+
+5. **Streaming upstream errors carry no receipt.** A streaming request whose
    upstream answers non-200 is returned as a buffered error without a
    receipt (inherited dstack-vllm-proxy behavior,
    `forward_chat_completion_stream_request`), while the buffered path issues
    a receipt for the same upstream error status. Arguably outside §1.4(5) —
    no inference completed — but the coverage is asymmetric.
 
-5. **§5.3 membership is best-effort for multi-instance backends.** The
+6. **§5.3 membership is best-effort for multi-instance backends.** The
    pinned-session gate runs before forwarding against the channel's current
    session ids. A Chutes-style backend fronts many instances behind one
    route, and the serving instance is known only after the response, so a
    non-listed instance can serve when a sibling instance was listed. The
    receipt's cited id exposes this to the client's §9.3(6) check.
 
-6. **The E2EE v2 replay cache is per process.** The
+7. **The E2EE v2 replay cache is per process.** The
    [v2 protocol](../../spec/e2ee-v2.md#7-key-selection-validation-and-replay-protection)
    requires rejection of a repeated
    `(client_public_key, service_public_key, nonce)` tuple inside the acceptance
@@ -59,7 +93,7 @@ item.
    same captured request once unless the deployment provides affinity or a
    shared replay store.
 
-7. **Session validity is advertised far longer than a session can actually
+8. **Session validity is advertised far longer than a session can actually
     serve.** `expires_at` is set to `now + receipt_ttl_seconds` (default
     3600), but each verification round mints a fresh nonce, so the evidence
     digest — part of the channel fingerprint — changes every
@@ -70,7 +104,7 @@ item.
     it. Fix direction: end a session's validity period when a re-verification
     supersedes it, so "current" means current.
 
-8. **A channel with several bindings is split into one session per
+9. **A channel with several bindings is split into one session per
     binding.** `record_attested_upstream_session` seals a session per entry
     in `channel_bindings`. For a Chutes-style backend that is correct (one
     session per instance), but an `aci-service` upstream publishing several
@@ -81,7 +115,7 @@ item.
     fails its own §9.3(6) check. Fix direction: group bindings of one channel
     into one session, keyed on what makes a channel distinct.
 
-9. **Session retention can lapse before the receipts citing it.** Session
+10. **Session retention can lapse before the receipts citing it.** Session
     `retention_until` is fixed at seal time — stream start — while the
     receipt's expiry is computed at stream end, so for a long stream the
     session can be evicted while its citing receipt is still served. §8
@@ -89,7 +123,7 @@ item.
     window on the buffered paths, stream-duration window on the streaming
     ones.
 
-10. **A verified, served request can be recorded as `result: "failed"`.**
+11. **A verified, served request can be recorded as `result: "failed"`.**
     `cite_served_session` matches a reported served instance only against
     sealed sessions carrying an `instance_key`. An external verifier that
     returns an `e2ee_public_key_sha256` binding without `key_id` (optional in
@@ -98,7 +132,7 @@ item.
     verified and served. Unreachable with the bundled bridges, which always
     set `key_id`.
 
-11. **The Chutes backend adds a member to the forwarded body after
+12. **The Chutes backend adds a member to the forwarded body after
     hashing.** `request.forwarded` hashes `prepared.request.body`, and
     `build_chutes_e2ee_request` then inserts `e2e_response_pk` into that JSON
     before encrypting and sending. The JSON the upstream parses therefore
@@ -106,7 +140,7 @@ item.
     encryption as a channel-binding detail outside client-facing E2EE
     extensions, but this is a body member, not encryption framing.
 
-12. **TLS keys are attested without custody evidence.** The keyset publishes
+13. **TLS keys are attested without custody evidence.** The keyset publishes
     the SPKI of a mounted certificate whose private key lives in the external
     TLS terminator, not the workload, and no `key_custody` entry covers the
     TLS role — so no verifier policy can check §3.3 custody for it, and a
@@ -115,20 +149,20 @@ item.
     supported mechanism that does not depend on this. Fix direction: terminate
     TLS in the workload, or publish custody evidence for the terminator.
 
-13. **The dstack custody policy checks only the receipt key.**
+14. **The dstack custody policy checks only the receipt key.**
     `verify_dstack_kms_receipt_custody` matches the `receipt` role against
     `receipt_signing_keys`; the `e2ee-secp256k1` and `e2ee-x25519` custody
     entries are never matched against `e2ee_public_keys`, and TLS is not
     covered. §3.3 requires a policy to specify custody for the receipt, E2EE
     and TLS keys.
 
-14. **No plausibility bound on `not_after`.** §3.1 says a verifier SHOULD
+15. **No plausibility bound on `not_after`.** §3.1 says a verifier SHOULD
     reject an implausibly distant expiry; no verifier here does, and the
     service accepts any configured lifetime. §3.4's automatic expiry is the
     only revocation that needs no coordination, so an absurd `not_after`
     nullifies it.
 
-15. **The `aci-service` upstream verifier trusts `image_digest`
+16. **The `aci-service` upstream verifier trusts `image_digest`
     uncorroborated.** Its policy accepts an upstream when the attested
     app id is allowlisted **or** the report's `source_provenance.image_digest`
     is (`AciServiceVerifierPolicy::accepts_measured`). The first path is
@@ -147,7 +181,7 @@ item.
     the anchor must stay measured. Fix direction: anchor `image_digest` to the
     verified compose, or drop it as a policy anchor.
 
-16. **The §9.2 session audits stop short of evidence appraisal.** Both
+17. **The §9.2 session audits stop short of evidence appraisal.** Both
     verifiers prove the cited session hashes to its id, the validity window
     holds, and the evidence data hashes to its digest — §9.2(1)-(2). The
     `aci` CLI also appraises the typed claims against a caller policy
@@ -159,7 +193,7 @@ item.
 
 ## Stale surroundings
 
-17. **The live E2E scripts predate the simplified protocol.** Parts of
+18. **The live E2E scripts predate the simplified protocol.** Parts of
    `scripts/live_e2e/` (e.g. `cases/embeddings.py`, `cases/lifecycle.py`)
    still assert removed mechanism (transparency events), and
    `scripts/phala_multi_upstream_smoke.sh` /
@@ -169,14 +203,14 @@ item.
    scripts need the same pass, and the public deployment serves the
    previous build until redeployed.
 
-18. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
+19. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
    test vectors byte-for-byte, but the workflow triggers only on
    `clients/verifier-ts/**`, so an edit to `spec/test-vectors.md` alone does
    not rerun them (Rust CI catches drift via `tests/spec_vectors.rs`).
 
 ## Beyond-spec surfaces (intentional, keep honest)
 
-19. **Legacy dstack-vllm-proxy compatibility** (the Appendix B non-ACI-surfaces rule).
+20. **Legacy dstack-vllm-proxy compatibility** (the Appendix B non-ACI-surfaces rule).
     `/v1/attestation/report` (separate report-data layout, injected
     `signing_address` / `intel_quote` / `nvidia_payload`), `/v1/signature/{id}`,
     and the `X-Signing-Algo` E2EE mode serve pre-ACI clients. The shared k256

--- a/scripts/live_e2e/chutes_session_smoke.py
+++ b/scripts/live_e2e/chutes_session_smoke.py
@@ -6,7 +6,7 @@ each with its own E2EE key), sends a request, and asserts:
 
   1. the attested-session list has one session per *verified instance*, each
      bound to that instance's E2EE key (`e2ee_public_key_sha256` with a `key_id`),
-     not one bundled session, and each full session retains valid evidence, and
+     not one bundled session, and
   2. the request's receipt cites one of those per-instance sessions — i.e. the
      session of the instance that actually served — so the chain receipt ->
      instance session -> that instance's claims holds.
@@ -20,8 +20,6 @@ Usage (from scripts/, with CHUTES_API_KEY in the environment):
 """
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
 import os
 import signal
@@ -61,29 +59,6 @@ def instance_binding(session: dict) -> dict | None:
         if binding.get("type") == "e2ee_public_key_sha256" and binding.get("key_id"):
             return binding
     return None
-
-
-def get_session(session_id: str) -> dict | None:
-    r = requests.get(f"{BASE}/v1/aci/sessions/{session_id}", timeout=30)
-    if r.status_code != 200:
-        return None
-    if hashlib.sha256(r.content).hexdigest() != session_id:
-        return None
-    return r.json()
-
-
-def evidence_digest_matches_data(session: dict) -> bool:
-    evidence = session.get("evidence") or {}
-    digest = evidence.get("digest")
-    data_uri = evidence.get("data")
-    if not isinstance(digest, str) or not isinstance(data_uri, str):
-        return False
-    try:
-        encoded = data_uri.split(";base64,", 1)[1]
-        decoded = base64.b64decode(encoded, validate=True)
-    except (IndexError, ValueError):
-        return False
-    return digest == f"sha256:{hashlib.sha256(decoded).hexdigest()}"
 
 
 def send_request() -> tuple[int, str | None]:
@@ -188,19 +163,13 @@ def main() -> int:
                 print("FAIL: no attested sessions recorded for Chutes")
                 return 1
 
-            # 1. Every Chutes session is a single per-instance E2EE channel and
-            #    retains the verifier input required for a deep audit.
+            # 1. Every Chutes session is a single per-instance E2EE channel.
             key_ids: list[str] = []
             for s in sessions:
                 binding = instance_binding(s)
                 if binding is None:
                     print(f"FAIL: session {s.get('session_id')} is not a per-instance E2EE channel: "
                           f"{s.get('channel_binding')}")
-                    return 1
-                session_id = s.get("session_id")
-                full_session = get_session(session_id) if isinstance(session_id, str) else None
-                if full_session is None or not evidence_digest_matches_data(full_session):
-                    print(f"FAIL: session {session_id} has missing or invalid evidence")
                     return 1
                 key_ids.append(binding["key_id"])
             if len(set(key_ids)) != len(key_ids):

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -71,8 +71,8 @@ pub(super) fn chutes_instance_id<'a>(
 }
 
 /// Typed claims for one Chutes instance: the verifier's facts for that instance
-/// only, so the claim slice is not changed by a sibling joining or failing. The
-/// session separately retains the verification round's raw evidence.
+/// only, so its session is content-addressed on its own data and survives fleet
+/// churn (a sibling instance joining or failing does not change it).
 pub(super) fn per_instance_session_claims(
     event: &UpstreamVerifiedEvent,
     instance_id: &str,
@@ -91,13 +91,12 @@ pub(super) fn per_instance_session_claims(
 }
 
 /// One instance's slice of the Chutes `provider_claims` — that instance's own
-/// attestation facts, so its claims bind its CPU and GPU results while staying
+/// attestation facts, so its session binds its CPU and GPU evidence while staying
 /// stable under fleet churn. Everything fleet-shaped is dropped (the lists, the
 /// per-instance maps, and the *fleet-aggregate* GPU scalars — `all`/`any` over
 /// instances). What is kept is per-instance and nonce-free: the matched CPU
 /// measurement profile, this instance's TCB status, and this instance's GPU
-/// verification outcome (verified / arch). Raw nonce-bound quotes stay out of
-/// the claim slice and remain available through the session evidence.
+/// verification outcome (verified / arch). The raw nonce-bound quotes stay out.
 fn per_instance_provider_claims(full: Option<&Value>, instance_id: &str) -> Value {
     let mut pc = serde_json::Map::new();
     let Some(Value::Object(map)) = full else {
@@ -780,8 +779,8 @@ mod claim_mapping_tests {
             c1.extra.get("gpu_verified").and_then(Value::as_bool),
             Some(true)
         );
-        // Fleet-wide fields are dropped, so the claim slice does not change when
-        // a sibling instance does. The session id also commits to raw evidence.
+        // Fleet-wide fields are dropped, so the slice (and the session content id)
+        // does not change when a sibling instance does (per-instance idempotency).
         assert!(!c1.extra.contains_key("verified_instance_ids"));
         assert!(!c1.extra.contains_key("instance_tcb_statuses"));
         assert!(!c1.extra.contains_key("instance_measurements"));

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -699,15 +699,18 @@ impl AciService {
                 Some(instance_id) => per_instance_session_claims(event, instance_id),
                 None => session_claims_for_event(event),
             };
-            // Every session retains the verifier input required for a deep audit.
-            // Chutes currently emits one shared, nonce-bound evidence bundle for
-            // all verified instances, so each per-instance session carries that
-            // bundle and a fresh verification round produces a fresh session id.
-            let evidence = event
-                .evidence
-                .as_ref()
-                .map(EvidenceRef::from_value)
-                .unwrap_or_default();
+            // A per-instance (Chutes) binding excludes the shared, nonce-bound raw
+            // evidence so re-verifying the same instance is a no-op; a single
+            // channel keeps the event's evidence.
+            let evidence = if instance.is_some() {
+                EvidenceRef::default()
+            } else {
+                event
+                    .evidence
+                    .as_ref()
+                    .map(EvidenceRef::from_value)
+                    .unwrap_or_default()
+            };
             let session_id = self.seal_attested_session(
                 event,
                 identity.clone(),

--- a/src/aggregator/session_store.rs
+++ b/src/aggregator/session_store.rs
@@ -272,7 +272,16 @@ impl JsonlSessionStore {
     /// Takes an advisory exclusive lock on `<path>.lock` *before* reading the
     /// log, so only one process ever writes it — failing with
     /// [`io::ErrorKind::WouldBlock`] if another holds the lock.
-    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+    ///
+    /// `now` drops records whose retention already lapsed instead of loading
+    /// them. They would be evicted by the first `compact` anyway, so this only
+    /// changes when the work happens — but it decides whether startup is
+    /// proportional to the *live* set or to everything appended since the last
+    /// compaction, which for a busy log is the difference between booting and
+    /// exhausting memory before serving a request. Taken as a parameter rather
+    /// than read from the clock so the store stays deterministic, like
+    /// `compact`.
+    pub fn open(path: impl AsRef<Path>, now: u64) -> io::Result<Self> {
         let path: PathBuf = path.as_ref().to_path_buf();
 
         // Single-writer lock first, before we read or write the log.
@@ -309,6 +318,11 @@ impl JsonlSessionStore {
                 };
                 next_seq = next_seq.max(seq_after);
                 if record.record_type != RECORD_TYPE_SESSION {
+                    continue;
+                }
+                // Ahead of the decode: a lapsed record costs a base64 decode, a
+                // parse and a digest hash before eviction would drop it.
+                if record.retention_until <= now {
                     continue;
                 }
                 let Ok(bytes) = BASE64.decode(record.payload_b64.as_bytes()) else {
@@ -546,7 +560,7 @@ mod tests {
     /// so the retry belongs only in the test harness.
     fn open_store(path: &Path) -> JsonlSessionStore {
         for _ in 0..200 {
-            match JsonlSessionStore::open(path) {
+            match JsonlSessionStore::open(path, 0) {
                 Ok(store) => return store,
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -579,6 +593,58 @@ mod tests {
             evidence: EvidenceRef::default(),
         })
         .unwrap()
+    }
+
+    /// Replay must be proportional to the live set, not to everything appended
+    /// since the last compaction. A lapsed record is dropped before it is
+    /// decoded, parsed and hashed — the work that made a busy log expensive to
+    /// boot from — and never reaches the index.
+    #[test]
+    fn replay_drops_lapsed_records_before_loading_them() {
+        let path = temp_path();
+        {
+            let store = open_store(&path);
+            let live = session("live", 0, 9_000);
+            let lapsed = session("lapsed", 0, 1_000);
+            store.put_session("fp-live", live, 9_000, 0).unwrap();
+            store.put_session("fp-lapsed", lapsed, 1_000, 0).unwrap();
+        }
+        assert_eq!(count_lines(&path), 2, "both records are on disk");
+
+        // Reopened past the lapsed record's deadline but before the live one's.
+        let reopened = JsonlSessionStore::open(&path, 5_000).unwrap();
+        let index = reopened.index.lock().unwrap();
+        assert_eq!(
+            index.by_id.len(),
+            1,
+            "only the live record is resident after replay"
+        );
+        assert!(
+            index.by_fingerprint.contains_key("fp-live"),
+            "the live record survives"
+        );
+        assert!(
+            !index.by_fingerprint.contains_key("fp-lapsed"),
+            "the lapsed record was never inserted"
+        );
+    }
+
+    /// The filter is a scheduling change, not a policy one: `now = 0` keeps
+    /// everything, so a caller that does not care still replays the whole log.
+    #[test]
+    fn replay_keeps_everything_when_nothing_has_lapsed() {
+        let path = temp_path();
+        {
+            let store = open_store(&path);
+            store
+                .put_session("fp-a", session("a", 0, 9_000), 9_000, 0)
+                .unwrap();
+            store
+                .put_session("fp-b", session("b", 0, 1_000), 1_000, 0)
+                .unwrap();
+        }
+        let reopened = JsonlSessionStore::open(&path, 0).unwrap();
+        assert_eq!(reopened.index.lock().unwrap().by_id.len(), 2);
     }
 
     #[test]
@@ -744,7 +810,7 @@ mod tests {
         let path = temp_path();
         let first = open_store(&path);
 
-        let blocked = JsonlSessionStore::open(&path);
+        let blocked = JsonlSessionStore::open(&path, 0);
         assert!(
             matches!(&blocked, Err(e) if e.kind() == io::ErrorKind::WouldBlock),
             "a second open must fail while the first holds the lock"

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,12 +450,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config,
         Arc::new(SystemClock),
     )?;
-    let session_store = Arc::new(JsonlSessionStore::open(&session_log_path).map_err(|err| {
-        invalid_input(format!(
-            "failed to open gateway session log {}: {err}",
-            session_log_path.display()
-        ))
-    })?);
+    let session_store = Arc::new(
+        JsonlSessionStore::open(&session_log_path, SystemClock.now_secs()).map_err(|err| {
+            invalid_input(format!(
+                "failed to open gateway session log {}: {err}",
+                session_log_path.display()
+            ))
+        })?,
+    );
     tracing::info!(session_log = %session_log_path.display(), "persisting attested sessions to JSONL log");
     // Reclaim the duplicate/expired lines accumulated while the process was down
     // before serving, then keep the file bounded on a periodic cadence.

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -303,44 +303,6 @@ async fn verified_upstream_binding_creates_attested_session() {
 }
 
 #[tokio::test]
-async fn chutes_per_instance_sessions_retain_verifier_evidence() {
-    let (service, _) = make_service(b"{}");
-    let evidence_bytes = br#"{"fixture":"chutes"}"#;
-    let evidence_digest = private_ai_gateway::aci::digest::sha256_hex(evidence_bytes);
-    let evidence_data = "data:application/json;base64,eyJmaXh0dXJlIjoiY2h1dGVzIn0=".to_string();
-    let event = UpstreamVerifiedEvent {
-        provider_type: Some("chutes".to_string()),
-        url_origin: Some("https://llm.chutes.ai".to_string()),
-        verifier_id: "private-ai-verifier/chutes/v1".to_string(),
-        evidence: Some(serde_json::json!({
-            "digest": evidence_digest,
-            "data": evidence_data,
-        })),
-        channel_bindings: ["instance-a", "instance-b"]
-            .into_iter()
-            .map(|instance_id| ChannelBinding::E2eePublicKeySha256 {
-                provider: "chutes".to_string(),
-                key_id: Some(instance_id.to_string()),
-                algorithm: "chutes-ml-kem-768".to_string(),
-                public_key_sha256: "aa".repeat(32),
-            })
-            .collect(),
-        ..verified_event("chutes", "model-tee")
-    };
-
-    service.record_session(&event);
-
-    let sessions = service.list_attested_sessions(Some("chutes"));
-    assert_eq!(sessions.len(), 2, "one session per Chutes instance");
-    for session in sessions {
-        let evidence = &session.document().evidence;
-        assert_eq!(evidence.digest.as_deref(), Some(evidence_digest.as_str()));
-        assert_eq!(evidence.data_uri.as_deref(), Some(evidence_data.as_str()));
-        assert!(evidence.digest_matches_data());
-    }
-}
-
-#[tokio::test]
 async fn verified_upstream_binding_fails_without_persisted_session() {
     let (svc, received) = make_service_raw(br#"{"id":"chat-xyz","model":"x"}"#);
     let svc = svc.with_session_store(Arc::new(FailingSessionStore));


### PR DESCRIPTION
Two commits, both from the same failure. Reviewable independently.

## What happened

`#142` sealed the Chutes verifier's evidence into each per-instance session. That evidence is fleet-wide and nonce-bound, so the session id changes every verification round: re-verifying an instance stops resolving to the existing session and appends another record instead, each one now carrying the whole fleet bundle. The log grows without bound relative to the live set.

On its own that is a capacity problem. What made it an outage is the replay — startup rebuilds the index from the entire log, so past a certain size the process exhausts memory *before serving a request*. The kill lands during startup, so it repeats on every restart, and there is no way out except moving the file aside by hand.

The gap entry `#142` deleted had already ruled the change out, and named this exact mechanism:

> The Chutes verifier's raw evidence is fleet-wide and nonce-bound, so sealing it into each per-instance session **would mint a new session id for every verification round** and every fleet change.

## 1. `Replay the session log proportionally to its live set`

Independent of the above, and the reason a large log is unrecoverable rather than merely large.

Replay loads every record, including ones whose retention already lapsed — which the first compaction drops seconds later. Their only effect is the cost of getting there: a base64 decode, a parse and a digest hash each, all paid before the process serves anything.

So startup is proportional to everything appended since the last compaction, not to what is still live, and the two diverge without limit: compaction bounds the record *count*, nothing bounds how much is appended between runs.

The fix skips lapsed records ahead of the decode. It is a scheduling change, not a policy one — those records were going to be evicted regardless. `now` is a parameter rather than a clock read, so the store stays deterministic, matching `compact`.

Two tests: a lapsed record never reaches the index, and `now = 0` still replays everything (the filter does not change what the store retains, only when). Mutation-checked — removing the condition fails the first.

## 2. `Revert "Retain evidence in Chutes sessions (#142)"`

A plain revert, plus the gap entry restored with what the attempt taught.

The §9.2 deep-audit gap it was closing is real, so the entry goes back rather than the feature staying in, and it now records the shape a fix needs: **the evidence has to stay out of what the session id commits to.** The per-instance evidence slice already listed as a work item removes the fleet-wide half but not the nonce-bound half, so it does not get there on its own. Retaining evidence under its own digest and linking sessions to it out of band does — and keeps every round's evidence rather than the latest only.

Two invariants the store depends on but does not enforce are now stated there: a session's identity must not commit to anything that changes per verification round, and replay must stay proportional to the live set.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` (529), `python3 -m compileall scripts` all clean.

`main` is not currently deployable without this — a fresh deploy hits the crash loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)