### PR TITLE
Retain Chutes evidence without session churn

### DIFF
--- a/docs/attested-session-system.md
+++ b/docs/attested-session-system.md
@@ -26,6 +26,14 @@ process-owned store. The session's validity period reuses
 `receipt_ttl_seconds`, and retention extends per citing receipt, satisfying
 the §8 rule that a session outlives every receipt citing it.
 
+The session id and the store's local reuse fingerprint serve different
+purposes. The session id commits to the complete immutable record, including
+its establishing evidence. For a Chutes instance, the reuse fingerprint omits
+the nonce-bound fleet evidence digest but still includes the instance binding
+and per-instance claims. An unchanged instance therefore keeps its existing
+session and original evidence; a changed binding or claim creates a new
+session. Other providers include the evidence digest in the reuse fingerprint.
+
 Full trace:
 
 ```

--- a/docs/reviews/aci-spec-conformance-gaps.md
+++ b/docs/reviews/aci-spec-conformance-gaps.md
@@ -3,7 +3,7 @@
 Where this implementation currently falls short of, or diverges from,
 [the ACI Spec](../../spec/aci.md). The spec is authoritative; these are
 implementation compromises, not spec changes. Each item is a candidate work
-item.
+item. Item numbers are stable identifiers, so resolved gaps leave holes.
 
 ## Verifier coverage
 
@@ -36,40 +36,6 @@ item.
    silently. Sessions do better: the JSONL store survives restarts and
    extends retention per citing receipt (§8 retention rule).
 
-4. **Chutes per-instance sessions carry no §8.2 evidence.** The Chutes
-   verifier's raw evidence is fleet-wide and nonce-bound, so sealing it into
-   each per-instance session would mint a new session id for every
-   verification round and every fleet change. The implementation instead
-   seals per-instance sessions with an empty `evidence` object
-   (`record_attested_upstream_session`), keeping them content-addressed on
-   per-instance facts only. Consequence: the §9.2 deep-audit step fails
-   closed on Chutes-cited sessions (`aci` CLI upstream-2; verifier-ts
-   `checkSessionEvidence`) — a §9.2(4) deep audit is impossible for Chutes
-   even once built (see the §9.2 audits item below), while receipt
-   verification and the §9.1/§9.3 checks are unaffected. The
-   session store still accepts these records (its §8.2 check rejects only
-   evidence whose `data` does not hash to `digest`).
-
-   Sealing the evidence in was tried and reverted. The predicted new session
-   id per round is what happens, and it compounds: each round appends a fresh
-   record per instance instead of resolving to the existing one, and each
-   record now carries the fleet-wide bundle, so the log grows without bound
-   relative to the live set. Startup replays that log into the index, so a
-   long enough gap since the last compaction exhausts memory before the
-   process serves a request — and because the kill lands during startup, it
-   repeats on every restart with no path back except moving the file aside.
-
-   So the fix has to keep the evidence *out* of what the session id commits
-   to. Emitting a per-instance evidence slice, the work item below, removes
-   the fleet-wide half but not the nonce-bound half, so on its own it still
-   mints a new id per round. Retaining the evidence under its own digest and
-   linking sessions to it out of band addresses both, and retains every
-   round's evidence rather than only the latest. Either way, two properties
-   the store depends on need stating explicitly, because nothing currently
-   enforces them: a session's identity must not commit to anything that
-   changes per verification round, and replay must stay proportional to the
-   live set rather than to everything appended since the last compaction.
-
 5. **Streaming upstream errors carry no receipt.** A streaming request whose
    upstream answers non-200 is returned as a buffered error without a
    receipt (inherited dstack-vllm-proxy behavior,
@@ -95,14 +61,13 @@ item.
 
 8. **Session validity is advertised far longer than a session can actually
     serve.** `expires_at` is set to `now + receipt_ttl_seconds` (default
-    3600), but each verification round mints a fresh nonce, so the evidence
-    digest — part of the channel fingerprint — changes every
-    `verifier_cache_seconds` (default 300) and a new session supersedes the
-    old one. The list endpoint keeps advertising the superseded session as
-    current until its `expires_at`, so a client that verified and pinned it
-    (§5.3) is refused `session_not_accepted` while the service still lists
-    it. Fix direction: end a session's validity period when a re-verification
-    supersedes it, so "current" means current.
+    3600). For providers other than Chutes, a nonce-bound evidence digest is
+    part of the channel fingerprint, so the default proactive refresh every
+    240 seconds can supersede the old session while the list endpoint still
+    advertises it as current until `expires_at`. A client that pinned it
+    (§5.3) is then refused `session_not_accepted`. Fix direction: end a
+    session's validity period when a re-verification supersedes it, so
+    "current" means current.
 
 9. **A channel with several bindings is split into one session per
     binding.** `record_attested_upstream_session` seals a session per entry

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -84,6 +84,8 @@ pub(super) fn attested_route_eligible(is_tee: Option<bool>) -> bool {
 /// Local key over a channel's verified material — the dedup handle the hot
 /// path uses to find "the current session for this channel" without sealing a
 /// new document per request. Never served; carries no protocol meaning.
+const CHUTES_EVIDENCE_FINGERPRINT_V1: &str = "chutes-establishing-evidence-v1";
+
 #[derive(Serialize)]
 struct ChannelMaterial<'a> {
     upstream_name: &'a str,
@@ -92,7 +94,7 @@ struct ChannelMaterial<'a> {
     identity: &'a Option<WorkloadIdentityRef>,
     channel_binding: &'a [ChannelBinding],
     claims: &'a SessionClaims,
-    evidence_digest: &'a Option<String>,
+    evidence_digest: Option<&'a str>,
 }
 
 impl ChannelMaterial<'_> {
@@ -822,6 +824,18 @@ impl AciService {
         now: u64,
         expires_at: u64,
     ) -> Result<String, ServiceError> {
+        // Chutes evidence is nonce-bound, so a fresh verification changes its
+        // digest even when this instance's binding and claims are unchanged.
+        // Keep the establishing evidence in the sealed document, but reuse the
+        // live session until its material changes or its validity ends.
+        let is_chutes_instance = channel_bindings
+            .first()
+            .is_some_and(|binding| chutes_instance_id(event, binding).is_some());
+        let fingerprint_evidence_digest = if is_chutes_instance {
+            Some(CHUTES_EVIDENCE_FINGERPRINT_V1)
+        } else {
+            evidence.digest.as_deref()
+        };
         let fingerprint = ChannelMaterial {
             upstream_name: &event.upstream_name,
             endpoint: &event.url_origin,
@@ -829,7 +843,7 @@ impl AciService {
             identity: &identity,
             channel_binding: &channel_bindings,
             claims: &claims,
-            evidence_digest: &evidence.digest,
+            evidence_digest: fingerprint_evidence_digest,
         }
         .fingerprint()
         .map_err(|err| ServiceError::SessionStore(format!("channel fingerprint: {err}")))?;

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 mod common;
 
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use private_ai_gateway::aci::receipt::{ChannelBinding, UpstreamVerifiedEvent, VerificationResult};
 use private_ai_gateway::aci::types::{ServiceCapabilities, SourceProvenance};
 use private_ai_gateway::aci::upstream::{
@@ -492,6 +493,52 @@ async fn attested_session_id_changes_when_verification_material_changes() {
     assert_eq!(
         second_session.document().evidence.digest.as_deref(),
         Some(second_digest.as_str())
+    );
+}
+
+#[test]
+fn chutes_nonce_refresh_reuses_evidenceful_sessions() {
+    let (service, _) = make_service(b"{}");
+    let event = |round: usize, key: &str| {
+        let evidence = format!("chutes-round-{round}");
+        UpstreamVerifiedEvent {
+            provider_type: Some("chutes".to_string()),
+            url_origin: Some("https://llm.chutes.ai".to_string()),
+            verifier_id: "private-ai-verifier/chutes/v1".to_string(),
+            evidence: Some(serde_json::json!({
+                "digest": private_ai_gateway::aci::digest::sha256_hex(evidence.as_bytes()),
+                "data": format!("data:text/plain;base64,{}", BASE64.encode(&evidence)),
+            })),
+            channel_bindings: vec![ChannelBinding::E2eePublicKeySha256 {
+                provider: "chutes".to_string(),
+                key_id: Some("inst-a".to_string()),
+                algorithm: "chutes-ml-kem-768".to_string(),
+                public_key_sha256: key.repeat(32),
+            }],
+            provider_claims: Some(serde_json::json!({})),
+            ..verified_event("chutes", "model-tee")
+        }
+    };
+
+    service.record_session(&event(0, "aa"));
+    let initial_id = service.list_attested_sessions(Some("chutes"))[0]
+        .session_id()
+        .to_string();
+    service.record_session(&event(1, "aa"));
+    let sessions = service.list_attested_sessions(Some("chutes"));
+    assert_eq!(
+        sessions.len(),
+        1,
+        "nonce-only refresh must reuse the session"
+    );
+    assert_eq!(sessions[0].session_id(), initial_id);
+    assert!(sessions[0].document().evidence.digest_matches_data());
+
+    service.record_session(&event(1, "bb"));
+    assert_eq!(
+        service.list_attested_sessions(Some("chutes")).len(),
+        2,
+        "a changed instance binding must create a new session"
     );
 }
 


### PR DESCRIPTION
## Summary

- retain the full establishing evidence in each Chutes session
- reuse the session across nonce-only verification refreshes
- still rotate when the instance binding, claims, or validity period changes

This restores deep-audit evidence without bringing back the unbounded log growth from #142. The stable marker is only a local dedup key; the public session ID still commits to the full evidence document.

## Checks

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- local JSONL simulation: 14 instances stayed at 14 records across 100 fresh-evidence rounds; rotating one binding produced the expected 15th record