### PR TITLE
Rebuild the docs and add a verifiable `aci curl` quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends shellcheck
 
+      - name: Check aci installer
+        run: |
+          sh -n install-aci.sh
+          sh -n tests/install_aci.sh
+          shellcheck install-aci.sh tests/install_aci.sh
+          sh tests/install_aci.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release-aci.yml
+++ b/.github/workflows/release-aci.yml
@@ -1,0 +1,112 @@
+name: Release aci
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-aci-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create draft release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -eu
+          if gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft >release-state 2>/dev/null; then
+            test "$(cat release-state)" = "true" || {
+              echo "release $RELEASE_TAG is already published" >&2
+              exit 1
+            }
+          else
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --draft \
+              --generate-notes \
+              --title "aci $RELEASE_TAG"
+          fi
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - runner: macos-15
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl toolchain
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Build and check binary
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -eu
+          cargo build --release --locked --bin aci --target "$TARGET"
+          binary="target/$TARGET/release/aci"
+          strip "$binary"
+          expected="aci ${RELEASE_TAG#v}"
+          actual="$($binary --version)"
+          test "$actual" = "$expected" || {
+            echo "tag/package version mismatch: expected '$expected', got '$actual'" >&2
+            exit 1
+          }
+
+      - name: Upload binary and checksum
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -eu
+          asset="aci-$TARGET"
+          cp "target/$TARGET/release/aci" "$asset"
+          if command -v sha256sum >/dev/null 2>&1; then
+            digest="$(sha256sum "$asset" | awk '{print $1}')"
+          else
+            digest="$(shasum -a 256 "$asset" | awk '{print $1}')"
+          fi
+          printf '%s  %s\n' "$digest" "$asset" >"$asset.sha256"
+          gh release upload "$RELEASE_TAG" "$asset" "$asset.sha256" --clobber
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Publish draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Install:
 - Rust stable with `rustfmt` and `clippy`;
 - Python 3.12;
 - [uv](https://docs.astral.sh/uv/);
-- Node.js 20 when changing the TypeScript verifier.
+- Node.js 24, npm, and Bun 1.4 when changing the TypeScript clients.
 
 From the repository root:
 
@@ -31,13 +31,19 @@ cargo test --all-targets
 python3 -m compileall scripts
 ```
 
-When `clients/verifier-ts/` or an ACI construction changes:
+When anything under `clients/` changes, or when a shared ACI construction
+changes, run the unified client workspace checks from the repository root:
 
 ```sh
-cd clients/verifier-ts
-npm ci
-npm run build
-npm test
+npm --prefix clients ci
+npm --prefix clients run build
+npm --prefix clients run check
+npm --prefix clients test
+npm --prefix clients run test:bun
+npm --prefix clients run lint
+npm --prefix clients run format:check
+npm --prefix clients run lint:packages
+bash clients/package-smoke.sh
 ```
 
 Live-provider tests consume credentials and quota, so they are not part of credential-free CI. Use [Run the live end-to-end suite](docs/live-e2e-test-suite.md) for provider adapter, attestation, and forwarding changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+Private AI Gateway is a security-sensitive reference implementation. Changes to routing, canonical JSON, attestation, key custody, receipt signing, E2EE, or channel binding need tests that show both the accepted case and the tampered or rejected case.
+
+## Development setup
+
+Install:
+
+- Rust stable with `rustfmt` and `clippy`;
+- Python 3.12;
+- [uv](https://docs.astral.sh/uv/);
+- Node.js 20 when changing the TypeScript verifier.
+
+From the repository root:
+
+```sh
+uv sync --locked
+cargo build --all-targets
+```
+
+A running gateway also needs a dstack SDK endpoint. See [Local development](docs/getting-started.md) for the socket and startup flow.
+
+## Required checks
+
+Run the main CI checks before opening a change:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+python3 -m compileall scripts
+```
+
+When `clients/verifier-ts/` or an ACI construction changes:
+
+```sh
+cd clients/verifier-ts
+npm ci
+npm run build
+npm test
+```
+
+Live-provider tests consume credentials and quota, so they are not part of credential-free CI. Use [Run the live end-to-end suite](docs/live-e2e-test-suite.md) for provider adapter, attestation, and forwarding changes.
+
+## Change requirements
+
+### ACI wire or cryptography
+
+Update the specification, implementation, and test vectors together when a change affects:
+
+- JCS input or field names;
+- workload-keyset, report-data, session, or receipt digests;
+- signature payloads or algorithms;
+- E2EE keys, AAD, nonces, or encrypted field paths;
+- receipt events, session claims, or evidence encoding;
+- keyset expiry and rotation behavior.
+
+Do not add a compatibility shortcut to the canonical `/v1/aci/*` artifacts. Keep legacy behavior on the explicitly documented legacy routes and test the two surfaces separately.
+
+### Provider verification
+
+A provider verifier must return an enforceable channel binding. A successful evidence check without transport enforcement is not an accepted integration.
+
+For a new or changed provider:
+
+1. Apply [Provider audit criteria](docs/providers/audit-criteria.md).
+2. Add negative tests for changed nonce, quote, binding, measurement, or pin as applicable.
+3. Keep supplemental evidence separate from mandatory gates.
+4. Map claims to `asserted`, `refuted`, or `unknown` without upgrading missing evidence.
+5. Update the provider's living `verification.md` page.
+6. Run the relevant hermetic and live tests.
+
+Preserve a dated `review.md` as an audit record. Add a supersession note when the implementation changes rather than rewriting what the audit observed.
+
+### Configuration and APIs
+
+Unknown JSON fields are rejected deliberately. A new setting requires:
+
+- a typed field and validation;
+- a documented default and zero or empty-value behavior;
+- redaction when it can contain a secret;
+- serialization and replacement tests;
+- an update to [Configuration reference](docs/configuration-reference.md).
+
+A route or wire-behavior change requires an update to [HTTP API reference](docs/api-reference.md). Middleware request or response changes also require [Control-plane contract](docs/control-plane-contract.md) updates.
+
+## Documentation standard
+
+Living documentation must describe the current code, not an intended design.
+
+- Put setup and learning sequences in tutorials.
+- Put runnable tasks in how-to guides.
+- Put fields, defaults, routes, and schemas in references.
+- Put trust boundaries and design reasoning in explanations.
+- Label point-in-time observations with a date and reviewed revision.
+- Use canonical `/v1/aci/*` routes in new examples.
+- State the condition that makes a security property fail closed.
+- Call out what a verifier does not prove.
+- Use repository-relative commands and links.
+- Remove placeholders and private workstation paths.
+
+Start at the [Documentation index](docs/README.md). After changing Markdown, check local links and search for stale source paths or renamed fields.
+
+## Commit scope
+
+Keep generated output, local `.env` files, provider credentials, live evidence, and temporary state out of commits. Do not update provider pins from an unreviewed first observation. Explain security-relevant behavior changes in the commit or pull-request description, including the new failure behavior and tests that cover it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ path = "src/lib.rs"
 name = "private-ai-gateway"
 path = "src/main.rs"
 
+[[bin]]
+name = "aci"
+path = "src/bin/aci/main.rs"
+
 [dependencies]
 # Canonical-JSON, types, and serialization.
 serde = { version = "1", features = ["derive"] }
@@ -83,6 +87,7 @@ clap = { version = "4", default-features = false, features = ["derive", "std", "
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 serde_json = "1"
+tempfile = "3"
 
 [lints.rust]
 unused_must_use = "deny"

--- a/README.md
+++ b/README.md
@@ -3,19 +3,72 @@
 Private inference you can verify.
 
 Private AI Gateway sits between your app and AI providers. Keep the OpenAI or
-Anthropic API shape you already use. When a request needs private inference,
-the gateway verifies the confidential-computing backend before it sends your
-prompt. If verification passes, your app gets the normal model response plus
-`x-receipt-id`, which points to a signed receipt for the request.
+Anthropic API shape you already use. The gateway verifies confidential
+workloads and binds each network hop to their attested keys before your prompt
+leaves the protected path.
 
 This repo contains the Rust reference implementation of
 [Attested Confidential Inference (ACI)](spec/aci.md). Use it to test ACI or
-build your own gateway and provider integrations. It's a developer preview that
-you run yourself. This project doesn't host an API.
+build your own gateway and provider integrations. It is a developer preview.
 
-Start with the [ACI quickstart](docs/quickstart.md) to verify a live deployment
-with the `aci` CLI, or read the [ACI specification](spec/aci.md) for the trust
-model and wire protocol.
+## Try a private inference request
+
+Install the `aci` CLI on Linux or macOS:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/Dstack-TEE/private-ai-gateway/main/install-aci.sh \
+  | sh
+```
+
+Then use the Chat Completions API you already know. Replace `YOUR_API_KEY` and
+`MODEL_ID` with values from your provider:
+
+```bash
+~/.local/bin/aci curl https://api.redpill.ai/v1/chat/completions -- \
+  --fail-with-body \
+  --no-buffer \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "content-type: application/json" \
+  --data-binary '{
+    "model": "MODEL_ID",
+    "messages": [{"role": "user", "content": "Why is this request private?"}],
+    "stream": true,
+    "provider": {"aci_verified": true}
+  }'
+```
+
+Before curl sends the body, `aci` verifies a fresh hardware quote, the measured
+gateway workload, and the TLS key it reached. It then pins curl to that exact
+key. The transcript appears on stderr while the normal API response streams on
+stdout. Abridged verification output:
+
+```text
+PASS  id-1  hardware quote verifies and binds report_data
+PASS  id-4  measured workload provenance connects to public source
+PASS  id-6  the TLS channel is bound to the attested keyset
+VERIFIED (5 pass, 1 skipped: custody policy not implemented)
+PINNED      curl -> attested TLS key
+```
+
+The `provider.aci_verified` field handles the next hop. It tells the verified
+gateway code to refuse the request unless the selected model backend passes its
+own attestation and channel-binding checks. When your policy accepts the
+measured gateway and provider workloads, plaintext stays inside those attested
+workloads. The model processes it there. Under the TEE threat model, the model
+operator and cloud host cannot inspect the protected memory that holds it.
+
+The full transcript reports every skipped policy check. The current CLI does
+not yet evaluate private-key custody, and `aci curl` does not verify the
+response receipt. Use [`aci send`](docs/quickstart.md#verify-one-inference-end-to-end)
+or [`aci serve`](docs/quickstart.md#use-it-as-a-local-endpoint) for receipt
+verification, and read the [verification guide](docs/attested-confidential-inference.md)
+before sending sensitive data.
+
+This repo contains the implementation and verifier. It does not issue Redpill
+API credentials or operate the example service. Continue with the
+[ACI quickstart](docs/quickstart.md) for the full verification path, or read the
+[ACI specification](spec/aci.md) for the trust model and wire protocol.
 
 ## Why this exists
 
@@ -225,7 +278,7 @@ curl --fail --silent --show-error \
 Check the captured files with the `aci` CLI:
 
 ```bash
-cargo run --bin aci -- audit \
+aci audit \
   --report report.json \
   --receipt receipt.json \
   --nonce "$NONCE" \
@@ -290,7 +343,7 @@ same one-hour retention window unless the binary configuration changes in code.
 | Path | Contents |
 | --- | --- |
 | `src/aci/` | ACI wire types, canonicalization, receipts, E2EE, upstream transports, and verifiers |
-| `src/bin/aci/` | `aci` verifier, audit, session, send, and local proxy commands |
+| `src/bin/aci/` | `aci` verifier, audit, session, curl, send, and local proxy commands |
 | `src/aggregator/` | request service, routing state, receipts, sessions, and metrics |
 | `src/http/` | Axum routes and HTTP response handling |
 | `src/middleware/` | in-process control-plane client, transforms, failover, pricing, and SSE handling |

--- a/README.md
+++ b/README.md
@@ -1,599 +1,308 @@
 # Private AI Gateway
 
-Private AI Gateway is an OpenAI-compatible gateway for **Attested Confidential
-Inference (ACI)**. It publishes dstack workload attestation for the gateway,
-verifies configured private-inference upstreams before forwarding prompts, and
-signs per-request receipts.
+Private inference you can verify.
 
-A relying party evaluates three artifacts before accepting a response: the
-gateway attestation report, the provider verification event for the selected
-route, and the signed receipt that binds the response to the gateway identity.
+Private AI Gateway sits between your app and AI providers. Keep the OpenAI or
+Anthropic API shape you already use. When a request needs private inference,
+the gateway verifies the confidential-computing backend before it sends your
+prompt. If verification passes, your app gets the normal model response plus
+`x-receipt-id`, which points to a signed receipt for the request.
 
-This repository is the reference implementation of the
-[ACI Spec](spec/aci.md) (earlier draft discussion in
-[`Dstack-TEE/dstack#694`](https://github.com/Dstack-TEE/dstack/pull/694)). It is
-also the workload that
-[`git-launcher`](https://github.com/Dstack-TEE/dstack-examples/tree/main/git-launcher)
-can fetch, build, and run inside a dstack v2 application VM.
+This repo contains the Rust reference implementation of
+[Attested Confidential Inference (ACI)](spec/aci.md). Use it to test ACI or
+build your own gateway and provider integrations. It's a developer preview that
+you run yourself. This project doesn't host an API.
 
-Start here:
+Start with the [ACI quickstart](docs/quickstart.md) to verify a live deployment
+with the `aci` CLI, or read the [ACI specification](spec/aci.md) for the trust
+model and wire protocol.
 
-- [ACI quickstart](docs/quickstart.md) — verify a live deployment with the
-  `aci` CLI, then use it as a local OpenAI-compatible endpoint.
-- [ACI spec](spec/aci.md) — the protocol: trust model, artifacts, checks.
-- [ACI client architecture](clients/architecture.md) — the framework-neutral
-  client product, existing versus new components, release policy, and coding
-  agent integration boundary.
-- [Coding agent integrations](clients/coding-agents.md) — native Pi and
-  OpenCode installation, login, model selection, and ACI inspection.
+## Why this exists
 
-## Audience
+HTTPS protects your connection to a domain. It can't tell you which program is
+handling your prompt, whether that program runs in protected hardware, or
+whether a gateway sent the prompt to a different backend.
 
-- Security auditors should start with the claim, limits, request flow, and
-  auditor checklist.
-- New users and agent developers should start with the short mental model and
-  local smoke path before reading provider-specific details.
+ACI lets you check those details. It connects the gateway's attested keyset, the
+provider's attestation, the channel used for forwarding, and the request and
+response hashes in one verifiable trail.
 
-## Security Claim
+The gateway and model still need plaintext to do their jobs. Private inference
+makes the workloads that see that plaintext verifiable. The optional E2EE v2
+compatibility extension also hides supported inference fields from
+infrastructure between your app and the gateway workload.
 
-When the gateway is correctly deployed in dstack with reviewed code, reviewed
-runtime config, and supported provider adapters, a relying party can verify
-these facts:
+## Add one field
 
-1. **Gateway identity**: the gateway is a specific workload running in a genuine
-   TEE, with reported source provenance and a stable workload keyset.
-2. **Client channel binding**: the user-facing TLS SPKI, when configured, or
-   E2EE public keys are published in the attested keyset, so a client can bind
-   an API session to the verified workload identity.
-3. **Upstream verification**: before a prompt is forwarded, the backend verifies
-   the selected upstream provider and gets an enforceable channel binding, such
-   as a TLS SPKI or provider E2EE key.
-4. **Fail-closed forwarding**: if verification is required and the gateway
-   cannot verify the upstream or enforce the verified binding, it does not send
-   the prompt.
-5. **Per-request evidence**: every provider-backed inference response carries
-   `x-receipt-id`. The signed receipt records the user-visible request hash, the
-   selected provider route, upstream verification, provider-facing request hash,
-   and response hash.
-
-### Limits
-
-- It does not make an arbitrary upstream provider private. A provider is only
-  acceptable when its adapter can verify a provider-specific identity and
-  enforce the request channel binding.
-- It does not hide plaintext from gateway middleware. Middleware is optional,
-  but if enabled it sees plaintext after downstream E2EE termination and must be
-  part of the same attested deployment and audit boundary.
-- It does not provide durable public transparency yet. Receipts are currently
-  kept in memory with a configurable TTL; public transparency log integration is
-  not implemented.
-- It does not make a local developer run equivalent to an attested production
-  deployment. The production claim depends on dstack attestation, dstack KMS,
-  pinned source provenance, and reviewed runtime policy.
-
-## How A Request Is Protected
-
-```mermaid
-%%{init: {"flowchart": {"nodeSpacing": 40, "rankSpacing": 70}}}%%
-flowchart LR
-  user["User<br/>OpenAI SDK"]
-  upstream["Upstream<br/>providers"]
-
-  subgraph gateway["Private AI Gateway"]
-    frontend["Frontend"]
-    middleware["Optional<br/>middleware"]
-    backend["Backend"]
-
-    frontend -->|"in-process"| middleware
-    middleware -->|"target"| backend
-    frontend -->|"direct"| backend
-  end
-
-  user <-->|"attested session"| frontend
-  backend <-->|"attested session"| upstream
-```
-
-1. The user verifies `GET /v1/aci/attestation?nonce=<fresh nonce>` and accepts
-   the gateway workload keyset.
-2. The user sends an OpenAI-compatible request over ordinary TLS or the E2EE
-   v2 compatibility extension.
-3. The frontend records the user-facing request and downstream E2EE state.
-4. Optional middleware may handle auth, billing, routing, cache-aware logic, or
-   rewrites. Middleware does not create verification facts.
-5. The backend validates the target route, verifies or refreshes the upstream
-   lease, enforces the verified channel binding, and forwards the provider
-   request.
-6. The response returns through the same path. The frontend signs the receipt
-   after it has observed the final user-visible response.
-
-## Auditor Checklist
-
-Use this checklist before treating a deployment as private inference.
-
-| Check | Evidence |
-| --- | --- |
-| Gateway identity is real | `GET /v1/aci/attestation?nonce=<fresh nonce>` proves the TEE quote and the attested keyset digest bound into it. For dstack, first use the [dstack verification path](docs/providers/phala-direct/verification.md#how-the-os-image-is-classified) to reproduce the boot measurements and bind `os_image_hash`, then use `--require-production-os` to appraise that hash. The ACI clients replay RTMR3 and can pin `compose-hash`, but do not reconstruct MRTD/RTMR0-2. Exact source-build acceptance remains verifier policy. |
-| Keys are bound to the workload | The keyset in the report lists receipt-signing, E2EE, and optional TLS SPKI keys. The quote binds the digest of the keyset itself; there is no separate identity key or endorsement. |
-| Client session is bound | For direct TLS, verify the server certificate SPKI matches the attested keyset. For an E2EE extension, verify its service key from the keyset. |
-| Upstream is verified | Receipt event `upstream.verified` must be `verified` for the provider and canonical model id. |
-| Channel binding is enforceable | The upstream verification event must include a binding the backend can enforce on the actual request path. |
-| Upstream session is auditable | `upstream.verified.session_id`, when present, points to `GET /v1/aci/sessions/{session_id}`. The id is the SHA-256 of the exact served session document bytes, so the fetched record is provably the one the receipt cited. |
-| Middleware is in boundary | If middleware is enabled, audit its source/config and confirm it runs inside the same attested deployment. |
-| Response is bound | Verify the receipt signature under the attested receipt key and compare the response hash in `response.returned`. |
-| Provider is admissible | Review the provider's `docs/providers/<provider>/review.md` against `docs/providers/audit-criteria.md`. |
-
-Provider verification and transport binding are backend responsibilities.
-Middleware and user-controlled headers can select routes, but they do not create
-verification facts.
-
-## What New Users Should Know
-
-You can talk to the gateway with normal OpenAI-compatible clients. The
-additional ACI artifacts are:
-
-- `GET /v1/aci/attestation?nonce=<n>`: proves which gateway workload you are
-  talking to.
-- `x-receipt-id`: returned on provider-backed inference responses.
-- `GET /v1/aci/receipts/{id}`: fetches the signed receipt by chat id or receipt id.
-- `GET /v1/aci/sessions/{session_id}`: fetches an attested-session audit
-  record referenced by a receipt.
-- Optional [E2EE v2 compatibility headers](spec/e2ee-v2.md): encrypt
-  content-bearing request and response fields to an attested key when the
-  client wants application-level encryption in addition to TLS. V2 is enabled
-  by default, is supported through at least February 10, 2027, and is planned
-  to be replaced by E2EE v3.
-
-Useful terms:
-
-- **TEE**: trusted execution environment. In this project, the gateway relies on
-  dstack/TDX evidence to prove where the workload is running.
-- **E2EE**: field-level end-to-end encryption between a client and the verified
-  gateway workload, used when TLS alone is not enough for the client.
-- **Workload keyset**: the attested document listing the gateway's
-  receipt-signing, E2EE, and TLS keys. The TEE quote binds its digest, making
-  the keyset the unit of workload identity.
-- **dstack KMS**: the dstack key-release service used by this implementation to
-  obtain stable workload keys inside an approved TEE workload.
-- **TDX quote / DCAP**: Intel TDX attestation evidence and the verification
-  path used for dstack and ACI service upstream reports.
-- **Receipt**: a signed per-request event log that binds the observed request,
-  provider route, upstream verification result, and returned response.
-- **SPKI digest**: a SHA-256 digest of a TLS public key used as channel-binding
-  evidence when a verifier or attested keyset supplies it.
-
-## Evidence Encoding
-
-ACI evidence objects are byte-preserving:
+Your app doesn't need a new SDK. Add `provider.aci_verified` to any supported
+request that must use a verified provider:
 
 ```json
 {
-  "digest": "sha256:<sha256-of-decoded-data-bytes>",
-  "data": "data:<content-type>;base64,<exact-bytes>"
+  "model": "public-model-id",
+  "messages": [
+    {"role": "user", "content": "Explain remote attestation in one sentence."}
+  ],
+  "provider": {
+    "aci_verified": true
+  }
 }
 ```
 
-The gateway computes `digest` over the bytes obtained by decoding the data URI,
-not over a parsed JSON value. When a verifier needs to preserve multiple
-upstream responses, `data` may be a `multipart/mixed` data URI whose parts carry
-their original content type, source URL, and body bytes.
+With that flag set:
 
-Do not infer provider semantics from the generic evidence wrapper. Provider
-meaning belongs to the provider verifier and the provider review document. The
-gateway enforces only the generic verifier result and channel binding.
+- verification or channel-binding failure stops the request before the provider
+  receives your prompt
+- a successful response includes `x-receipt-id`, which points to a signed
+  receipt covering the request, response, route, and verification result
 
-## Project Status
+The receipt stores hashes, not your prompt or response body. When the provider
+returns an enforceable binding, the receipt also links to an immutable session
+record with the provider's claims and evidence.
 
-`0.1.0` is a developer preview. The request path is implemented, but production
-release still depends on provider strict-release review, durable operational
-storage decisions, and production compose wiring for a concrete middleware
-container.
+## Where your data goes
 
-| Area | Status |
-| --- | --- |
-| Workload keyset, quote-bound keyset digest, attestation report | Implemented |
-| Signed receipts | Implemented |
-| Chat/completions, streaming, embeddings, `/v1/models` | Implemented; embeddings are buffered |
-| Downstream E2EE v2 compatibility extension and legacy vLLM E2EE | Implemented for chat/completions/embeddings; streaming E2EE for chat/completions |
-| Runtime upstream config file and admin API | Implemented |
-| Gateway-owned Prometheus metrics | Implemented |
-| Provider adapters | Implemented for Tinfoil, NEAR AI, Chutes, SecretAI, PhalaDirect, ACI service, and generic OpenAI-compatible upstreams |
-| Attested-session audit records | Implemented for upstream sessions; downstream sessions pending TLS/domain work |
-| Middleware framework | Implemented over HTTP on Unix domain sockets |
-| Receipt store | In-memory; receipt TTL is configurable. The gateway never stores request bodies (receipts hold hashes, not content). |
-| Public transparency log | Not implemented |
-
-The binary has no ephemeral-key or stub-quote startup mode. It loads
-receipt-signing and E2EE keys from dstack KMS through the Rust `dstack-sdk`,
-and it uses the same SDK for TDX quotes.
-
-## Quick Start For New Users
-
-This repository expects a dstack SDK endpoint. By default the gateway uses
-`/var/run/dstack.sock`. For local development, set `dstack_endpoint` in the
-gateway config to a forwarded dstack socket.
-
-Prerequisites:
-
-- Rust stable toolchain.
-- A reachable dstack SDK endpoint.
-- `docker compose`, `curl`, `jq`, `cargo`, `sha256sum`, and `awk` for the local
-  multi-upstream smoke test.
-
-Run checks:
-
-```bash
-cargo test
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
+```mermaid
+flowchart LR
+    client[Your app] -->|inference request| gateway[Attested gateway workload]
+    gateway -->|channel bound to verified key| provider[Verified provider workload]
+    provider -->|model response| gateway
+    gateway -->|response and receipt ID| client
+    gateway -.->|auth, routing, usage, and status metadata| control[Optional control plane]
 ```
 
-Start an identity-only gateway:
+Two workloads see plaintext: the attested gateway workload and the verified
+provider workload that runs the model. The optional E2EE v2 compatibility
+extension keeps supported prompt fields encrypted until they reach the gateway
+workload. The provider binding stops an ACI-required request from using a
+channel that doesn't match the verified provider key.
+
+The optional control plane stays out of the inference-content path. The gateway
+doesn't send it prompt or response bodies, raw bearer tokens, or provider
+credentials. It gets the bearer-token hash, requested model, routing options,
+and the metadata needed for auth, pricing, and usage reporting. The routing
+object is forwarded as-is, so don't put prompts or secrets in it. The
+[control-plane contract](docs/control-plane-contract.md) lists every field.
+
+## How the proof works
+
+A trusted execution environment (TEE) is a hardware-isolated place to run code.
+This gateway uses Intel TDX through dstack. ACI builds a verification chain on
+top of it:
+
+1. The gateway publishes a nonce-bound attestation report whose hardware quote
+   binds the workload keyset digest. The nonce prevents an old report from
+   passing as a fresh one.
+2. A provider adapter checks the selected backend's evidence before the prompt
+   leaves the gateway.
+3. The gateway takes the provider key from that evidence and requires the real
+   forwarding channel to use it.
+4. After the response, the gateway signs a receipt containing request and
+   response hashes, the route, and the verification result.
+5. For a deeper audit, the receipt can link to a content-addressed session with
+   the full provider evidence.
+
+You still decide what counts as trusted: hardware roots, measurements, workload
+source, provider adapters, and claims. The reference `aci` CLI and TypeScript
+client verify the quote and report-binding chain; their default policy still
+leaves some appraisal decisions, including private-key custody and exact
+source-build acceptance, to the relying party. Read the
+[verification and security guide](docs/attested-confidential-inference.md)
+before sending sensitive data.
+
+> [!IMPORTANT]
+> Private inference is opt-in. Configuring a TEE provider does not make every
+> request fail closed. Set `provider.aci_verified: true`, pass a non-empty
+> `provider.aci_session_ids` allowlist, or use a hostname listed in
+> `middleware.tee_only_domains`. Without one of these constraints, the gateway
+> may still forward after verification fails and record the failure in the
+> receipt.
+
+## Pick a routing mode
+
+The gateway has two routing modes:
+
+- Direct mode maps the public model ID through `upstreams.json` and sends the
+  request to one configured upstream.
+- Middleware mode asks an external control plane to authorize the request,
+  price it, and return an ordered route list. Request handling stays in the
+  gateway's Rust process. The control plane receives metadata, not inference
+  content or provider credentials.
+
+## API coverage
+
+Current API coverage:
+
+- OpenAI Chat Completions, legacy Completions, Embeddings, and Responses create
+- Anthropic Messages
+- buffered and SSE responses where the selected surface supports streaming
+- the ACI E2EE v2 compatibility extension for Chat Completions, Completions,
+  and Embeddings
+- canonical attestation, receipt, session, metrics, and admin APIs
+- legacy dstack-vllm-proxy attestation and signature aliases
+
+The [HTTP API reference](docs/api-reference.md) lists every route, mode-specific
+behavior, authentication rule, and size limit.
+
+## Run it locally
+
+The production binary has no generated-key or fake-quote mode. A local run
+still needs a reachable dstack SDK endpoint. If the process is outside a dstack
+CVM, first [forward and verify a dev CVM socket](docs/getting-started.md#connect-to-the-dstack-sdk).
+
+### Prerequisites
+
+- Rust stable
+- Python 3.12 and [uv](https://docs.astral.sh/uv/)
+- a reachable dstack SDK endpoint
+
+The smoke suites need extra tools. See the [testing guide](docs/live-e2e-test-suite.md)
+before running them.
+
+### Start the gateway
+
+Install the Python environment used by the provider verifiers:
+
+```bash
+uv sync --locked
+```
+
+Create a static gateway config:
 
 ```bash
 mkdir -p /tmp/private-ai-gateway-state
-printf '[]\n' >/tmp/private-ai-gateway-upstreams.seed.json
-cat >/tmp/private-ai-gateway.config.json <<EOF
+
+cat >/tmp/private-ai-gateway.config.json <<'JSON'
 {
+  "bind": "127.0.0.1:8086",
   "state_dir": "/tmp/private-ai-gateway-state",
-  "upstream_config_seed_path": "/tmp/private-ai-gateway-upstreams.seed.json",
   "dstack_endpoint": "unix:/tmp/aci-dstack-sock-dev.dstack.sock"
 }
-EOF
+JSON
+```
 
+Start the service:
+
+```bash
 PRIVATE_AI_GATEWAY_CONFIG_PATH=/tmp/private-ai-gateway.config.json \
-cargo run --release --bin private-ai-gateway
+  cargo run --release --locked --bin private-ai-gateway
 ```
 
-This starts the gateway and proves the identity surface, but it intentionally
-does not configure inference routes.
-
-In another terminal:
+The gateway starts with no inference routes when
+`/tmp/private-ai-gateway-state/upstreams.json` is absent or empty. In another
+terminal, confirm the process and fetch a nonce-bound canonical report:
 
 ```bash
-curl -sS http://127.0.0.1:8086/
-curl -sS "http://127.0.0.1:8086/v1/aci/attestation?nonce=$(openssl rand -hex 32)"
+curl --fail --silent --show-error http://127.0.0.1:8086/health
+
+NONCE="$(openssl rand -hex 32)"
+curl --fail --silent --show-error \
+  "http://127.0.0.1:8086/v1/aci/attestation?nonce=$NONCE" \
+  -o report.json
 ```
 
-To exercise actual inference behavior without provider API keys, run the local
-multi-upstream smoke test:
+`/health` should return `{"status":"ok"}`. A successful report contains
+`api_version: "aci/1"`, a `workload_keyset_digest`, and the plain
+`attestation.workload_keyset` object bound by the quote.
+
+For local inference without provider credentials, run the
+[multi-upstream smoke test](docs/live-e2e-test-suite.md#run-the-local-multi-upstream-smoke-test).
+For a real provider, continue with the
+[configuration reference](docs/configuration-reference.md#upstream-configuration).
+
+## Verify the response
+
+Save the response body exactly as received and read `x-receipt-id` from the
+headers. Fetch the receipt with the same bearer token you used for inference:
 
 ```bash
-DSTACK_SOCK=/tmp/aci-dstack-sock-dev.dstack.sock \
-scripts/local_multi_upstream_smoke.sh
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer $API_KEY" \
+  "$GATEWAY_URL/v1/aci/receipts/$RECEIPT_ID" \
+  -o receipt.json
 ```
 
-The smoke test runs two mocked upstream ACI services plus one gateway, all using
-the forwarded dstack socket. It asserts model routing, receipts, upstream
-verification events, and metrics.
-
-## Verify A Response
-
-A relying party verifies the gateway identity first, then verifies that a
-receipt was signed by a key listed in the attested keyset.
-
-1. Fetch `GET /v1/aci/attestation?nonce=<fresh nonce>`.
-2. Send the inference request and save the response body plus the
-   `x-receipt-id` response header.
-3. Fetch `GET /v1/aci/receipts/{id}` with that receipt id.
-4. Verify the attestation report, keyset, receipt signature, response hash, and
-   `upstream.verified` event.
-
-Use the helper script when the gateway is reachable:
-
-```bash
-uv run python scripts/live_e2e/user_verify.py \
-  --base-url http://127.0.0.1:8086 \
-  --chat-id "$RECEIPT_ID" \
-  --nonce "$NONCE"
-```
-
-The script's `--chat-id` argument accepts either a chat id or a receipt id. To
-verify already captured artifacts, run the `aci` CLI offline:
+Check the captured files with the `aci` CLI:
 
 ```bash
 cargo run --bin aci -- audit \
   --report report.json \
   --receipt receipt.json \
-  --nonce "$NONCE"
+  --nonce "$NONCE" \
+  --response-body response.json
 ```
 
-[docs/quickstart.md](docs/quickstart.md) is the full walkthrough against a
-live deployment.
+This runs the same quote, binding-chain, receipt, body-hash, and session checks
+as the live client. Review skipped checks in the transcript and apply your own
+source provenance, key-custody, key-expiry, and provider policy. The
+[verification guide](docs/attested-confidential-inference.md) covers the full
+flow.
 
-## Configure Upstreams
+Browser clients can use
+[`@phala/aci-verifier`](clients/verifier-ts/README.md) for service, quote,
+report-binding, receipt, body-hash, and session verification. Node and Bun apps
+can import `connectAci()` from `@phala/aci-verifier/runtime` to get an
+instance-scoped, attested SPKI-pinned fetch transport. See the
+[client architecture](clients/architecture.md) and
+[coding-agent guide](clients/coding-agents.md) for framework integrations.
 
-The gateway owns one mutable state directory. Set `state_dir` in the static
-gateway config; if omitted, the default is `/var/lib/private-ai-gateway`.
-The active upstream config is always `upstreams.json` inside that directory.
+## Docs
 
-A missing, empty, or whitespace-only file is valid and means no upstreams are
-configured yet. Inference routes require a JSON array with at least one
-upstream:
+Start at the [documentation index](docs/README.md). The main paths are:
 
-```json
-[
-  {
-    "name": "tinfoil-glm51",
-    "provider": "tinfoil",
-    "base_url": "https://inference.tinfoil.sh",
-    "models": {
-      "glm51-tinfoil": "glm-5-1"
-    },
-    "bearer_token": "<tinfoil-api-key>"
-  }
-]
-```
-
-`models` maps public model ids to provider-facing upstream model ids. In
-no-middleware mode, the public model id is also the target route id. Private
-Chutes deployments that use Basic authentication and the attested E2EE transport
-are documented in [Private Chutes configuration](docs/providers/chutes/configuration.md).
-
-For other scoped private OpenAI-compatible endpoints that require Basic
-authentication, keep the credential in `bearer_token` and set
-`"basic_auth": true`. The flag defaults to `false`, which uses Bearer
-authentication.
-
-In middleware mode, middleware selects a backend target route of this form:
-
-```text
-<upstream name>:<public model id in upstream config>
-```
-
-Supported `provider` values:
-
-| Provider | Use |
+| Goal | Document |
 | --- | --- |
-| `openai-compatible` | Generic OpenAI-compatible upstream with no provider-owned verifier. |
-| `aci-service` | Upstream ACI service that exposes ACI attestation and dstack/DCAP evidence. |
-| `tinfoil` | Tinfoil provider adapter using provider-owned verification through `private-ai-verifier`. |
-| `near-ai` | NEAR AI gateway adapter with TLS binding from the provider report. |
-| `chutes` | Chutes adapter with provider E2EE key verification and encrypted `/e2e/invoke` transport. |
-| `secret-ai` | Direct SecretAI SecretVM adapter with CPU/GPU verification, measured production workload reporting, optional workload pinning, and enforced inference TLS SPKI. See [docs/providers/secret-ai/verification.md](docs/providers/secret-ai/verification.md). |
-| `phala-direct` | Direct Phala dstack-vllm-proxy endpoint (one per model) with TLS SPKI binding from the version-2 attestation report. See [docs/providers/phala-direct/verification.md](docs/providers/phala-direct/verification.md). |
+| Understand the trust model and verify artifacts | [ACI verification and security model](docs/attested-confidential-inference.md) |
+| Run the gateway locally | [Local development](docs/getting-started.md) |
+| Configure the gateway, middleware, or an upstream | [Configuration reference](docs/configuration-reference.md) |
+| Integrate an HTTP client | [HTTP API reference](docs/api-reference.md) |
+| Use the verified TypeScript transport | [ACI client architecture](clients/architecture.md) |
+| Use ACI from Pi | [Pi provider extension](clients/pi-provider/README.md) |
+| Implement a control plane | [Control-plane contract](docs/control-plane-contract.md) |
+| Deploy with dstack git-launcher | [Deployment guide](deploy/README.md) |
+| Review provider verification | [Provider index](docs/providers/README.md) |
+| Run tests and live provider checks | [Testing guide](docs/live-e2e-test-suite.md) |
+| Implement the protocol | [ACI specification](spec/README.md) |
+| Contribute a change | [Contributing guide](CONTRIBUTING.md) |
 
-ACI service verification policy is set on the upstream entry with
-`accepted_subjects`, `accepted_image_digests`,
-`accepted_dstack_kms_root_public_keys`, and `pccs_url`.
+## Security boundaries
 
-Tinfoil, NEAR AI, Chutes, SecretAI, and PhalaDirect use the Python provider
-verifier bridge. Set `PRIVATE_AI_VERIFIER_DIR` only when you need to override
-the bridge's vendored `confidential_verifier` package with an external checkout.
+Keep these limits in mind before treating a deployment as private:
 
-For one-command Compose deployments, set `upstream_config_seed_path` in the
-static gateway config to a read-only seed file. The gateway validates and
-copies the seed to `<state_dir>/upstreams.json` only when the active config is
-missing or empty. An existing admin-updated config is never overwritten.
+- A generic OpenAI-compatible route stays a normal TLS route. It becomes
+  confidential only when an implemented provider adapter can verify it and bind
+  the forwarding channel.
+- Requests without an ACI constraint may continue after verification fails.
+- The attested gateway workload sees plaintext. The external control plane gets
+  routing and usage metadata, but not prompt or response bodies.
+- Receipts live in memory for one hour and disappear on restart. They store body
+  hashes, not the request or response itself.
+- Reported source or image metadata still needs a verifier policy. Reporting a
+  value doesn't mean your deployment has approved it.
+- A local process using a forwarded dev socket has the remote CVM's identity and
+  measurements. It is not equivalent to a reviewed production deployment.
 
-When `admin_token` is set in the gateway config, operators can inspect and
-replace the live config:
+Attested-session records are stored in `<state_dir>/sessions.jsonl` and use the
+same one-hour retention window unless the binary configuration changes in code.
 
-```bash
-curl -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
-  http://127.0.0.1:8086/v1/admin/upstreams
+## Repository layout
 
-curl -X PUT \
-  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
-  -H "content-type: application/json" \
-  --data-binary @upstreams.json \
-  http://127.0.0.1:8086/v1/admin/upstreams
-```
-
-The admin view redacts bearer tokens and returns the active `config_digest`.
-If no admin token is configured, the admin endpoint returns `404`.
-
-## Deploy With Git Launcher
-
-The recommended dstack deployment path uses `git-launcher`:
-
-1. `git-launcher` clones this repo at a pinned commit.
-2. It runs this repo's `entrypoint.sh`.
-3. `entrypoint.sh` builds `private-ai-gateway` with `cargo build --release
-   --locked --bin private-ai-gateway`.
-4. The built binary runs with runtime config from Compose environment, mounted
-   files, dstack encrypted secrets, and dstack KMS.
-
-Source provenance in attestation reports is derived from the git-launcher pin,
-not from gateway JSON. If the launcher config is absent, the report omits
-source provenance and the value is unknown. The current native verifier does not
-yet bind the reported commit or image digest to reviewed source; that policy is
-an explicit TODO.
-
-The canonical report publishes the exact measured `app_compose` preimage so an
-independent verifier can check it against the RTMR3-bound `compose-hash`. Keep
-plaintext secrets out of the Compose file. Supply values through Phala encrypted
-environment variables; the measured Compose contains the variable references,
-not their values.
-
-The launcher stays generic. Build, install, and run logic belongs to this repo.
-For production, prefer a Rust-capable gateway image so the toolchain is covered
-by a gateway-owned image digest instead of installing Rust at boot.
-
-Deployment files:
-
-- [deploy/README.md](deploy/README.md)
-- [deploy/compose.yaml](deploy/compose.yaml)
-- [deploy/upstreams.example.json](deploy/upstreams.example.json)
-- [entrypoint.sh](entrypoint.sh)
-
-## Middleware
-
-The gateway runs in no-middleware mode unless middleware is configured. In
-middleware mode the middleware runs in-process, between the frontend and
-backend:
-
-- Public `/v1/models` and its sub-catalogs are served from the control plane.
-- Public inference requests are decrypted and normalized by the frontend, then
-  handed to the middleware, which consults the control plane to
-  authorize and route the request and shapes the provider request.
-- The middleware selects a configured target route, forwards through the
-  backend, transforms the response, injects usage cost, and reports usage back
-  to the control plane. Verification facts still come from the backend.
-- Streaming responses stay streaming across backend, middleware, and frontend.
-- Middleware-generated OpenAI-compatible responses are passed through downstream
-  E2EE when the original user request used E2EE.
-
-The middleware is configured by the `middleware` section of the static gateway
-config; see the [configuration reference](docs/configuration-reference.md#middleware).
-
-## API Surface
-
-| Endpoint | Purpose |
+| Path | Contents |
 | --- | --- |
-| `GET /` | Basic ACI version and keyset digest. |
-| `GET /v1/models` | OpenAI-compatible model list from backend or middleware. |
-| `POST /v1/chat/completions` | OpenAI-compatible chat completions. |
-| `POST /v1/completions` | OpenAI-compatible legacy completions. |
-| `POST /v1/embeddings` | OpenAI-compatible buffered embeddings. |
-| `GET /v1/aci/attestation?nonce=<n>` | Gateway attestation report: quote, keyset, provenance. |
-| `GET /v1/aci/receipts/{id}` | Signed ACI receipt by chat id or receipt id. |
-| `GET /v1/aci/sessions/{session_id}` | Attested-session record referenced by a receipt. |
-| `GET /v1/aci/sessions?upstream_name=&model=` | List a provider's imported attested sessions. |
-| `GET /v1/attestation/report` · `GET /v1/signature/{id}` | Legacy dstack-vllm-proxy aliases. |
-| `GET /v1/metrics` | Gateway-owned Prometheus metrics. |
-| `GET /v1/admin/upstreams` | Authenticated upstream config snapshot. |
-| `PUT /v1/admin/upstreams` | Authenticated upstream config replacement. |
+| `src/aci/` | ACI wire types, canonicalization, receipts, E2EE, upstream transports, and verifiers |
+| `src/bin/aci/` | `aci` verifier, audit, session, send, and local proxy commands |
+| `src/aggregator/` | request service, routing state, receipts, sessions, and metrics |
+| `src/http/` | Axum routes and HTTP response handling |
+| `src/middleware/` | in-process control-plane client, transforms, failover, pricing, and SSE handling |
+| `clients/verifier-ts/` | browser verifier plus Node and Bun verified transports |
+| `clients/pi-provider/` | Pi provider extension and branded packages |
+| `deploy/` | dstack git-launcher deployment example |
+| `docs/` | operator guides, references, security notes, and review records |
+| `examples/` | Rust verification examples and the sample control plane |
+| `scripts/` | provider verifier bridge and smoke suites |
+| `spec/` | ACI specification, related work, and test vectors |
+| `tests/` | Rust integration tests and provider-verifier tests |
 
-## Runtime Configuration
+## License
 
-The full field and environment-variable reference is
-[docs/configuration-reference.md](docs/configuration-reference.md).
-
-The gateway consumes one read-only JSON config and one writable state directory:
-
-| Item | Path | Mutability |
-| --- | --- | --- |
-| Static gateway config | `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Read at startup. |
-| Gateway state directory | `state_dir` inside the gateway config, default `/var/lib/private-ai-gateway` | Gateway-owned writable files. |
-
-The gateway derives its writable files from `state_dir`: `upstreams.json` for
-the active upstream database and `sessions.jsonl` for the attested-session log.
-Deployment-owned read-only inputs, such as an upstream seed file or TLS
-certificates, stay explicit paths in the static config.
-
-Unknown config fields are rejected at startup. See
-[docs/configuration-reference.md](docs/configuration-reference.md) for the
-minimal config example and the full field reference.
-
-For client-facing TLS binding, set `tls.domain_certificates` with one mounted
-leaf certificate per public hostname. The gateway reads each certificate,
-computes `sha256(SPKI)`, and publishes that digest in the attested keyset. Raw
-SPKI configuration is not supported; all TLS bindings are derived from mounted
-certificate material.
-
-### Multi-Domain Listening
-
-The gateway process still has one `bind` listener. Multi-domain support means
-the same gateway workload can answer attestation requests for multiple public
-hostnames and select the correct downstream TLS binding from the request host.
-TLS termination, certificate issuance, DNS, SNI routing, and reverse-proxy
-configuration are deployment-owned and out of scope for this repo.
-
-For each public hostname, mount the leaf certificate that the external
-TLS-terminating component serves for that hostname, then list it in
-`tls.domain_certificates`:
-
-```json
-{
-  "tls": {
-    "domain_certificates": [
-      {
-        "domain": "api.example.com",
-        "certificate_path": "/run/certs/api.pem"
-      },
-      {
-        "domain": "chat.example.com",
-        "certificate_path": "/run/certs/chat.pem"
-      }
-    ]
-  }
-}
-```
-
-The component in front of the gateway must forward the original HTTP `Host`.
-Clients should request the attestation report through the same public hostname
-they will use for gateway traffic. For example, a frontend pinned to
-`https://chat.example.com` should fetch
-`https://chat.example.com/v1/aci/attestation`; the gateway will bind
-`chat.example.com` to the SPKI derived from `/run/certs/chat.pem`.
-
-When domain bindings are configured,
-`GET /v1/aci/attestation` uses the request `Host` to add the matching
-`attestation.evidence.downstream_tls_binding` entry while keeping all configured
-TLS keys in the attested keyset. Requests whose `Host` does not match a
-configured domain binding fail closed instead of returning an unbound report.
-
-`dstack_endpoint` accepts HTTP(S) endpoints and Unix socket endpoints such as
-`unix:/var/run/dstack.sock`.
-
-## Test And Smoke Suites
-
-Run the standard local checks:
-
-```bash
-cargo test
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-```
-
-Run local multi-upstream smoke after changing routing, upstream verification,
-receipt hashing, dynamic upstream config, or metrics:
-
-```bash
-scripts/local_multi_upstream_smoke.sh
-```
-
-Run live upstream smoke after changing provider adapters, attested sessions, or
-receipt audit fields:
-
-```bash
-uv run python scripts/live_e2e/run.py --profile quick --port 0
-```
-
-The live smoke verifies every configured upstream in
-`scripts/live_e2e/providers.json`, sends one request per supported surface, then
-checks each receipt's `upstream.verified.session_id` against
-`GET /v1/aci/sessions/{session_id}`.
-
-Run the slower Phala deployment smoke when you need to validate the deployment
-surface:
-
-```bash
-scripts/phala_multi_upstream_smoke.sh
-```
-
-The Phala smoke deploys two mocked upstream ACI services and one gateway CVM,
-then asserts model routing, provider-facing request hashes, verified upstream
-events, and metrics model ids.
-
-## Repository Map
-
-```text
-src/main.rs                    binary entrypoint and runtime config
-src/dstack.rs                  dstack SDK KMS key provider and quote provider
-src/aci/                       ACI wire types, keys, receipts, upstreams
-src/aggregator/service.rs      report, forwarding, E2EE, receipt finalization
-src/aggregator/upstream_config.rs runtime upstream config and provider adapters
-src/http/app.rs                Axum HTTP routers and middleware/backend wiring
-src/bin/aci/                   `aci` verifier CLI: verify, audit, sessions, send, serve
-clients/                       verifier-ts verifier library (browser + node); pi-provider pi provider extension
-docs/                          design notes, configuration reference, provider reviews
-deploy/                        git-launcher and dstack compose examples
-examples/                      cargo example binaries + a reference control plane (control-plane/)
-scripts/                       local and Phala smoke tests
-tests/                         unit and integration coverage
-```
-
-## More Docs
-
-- [ACI spec, quickstart, and test vectors](spec/README.md)
-- [Client verifiers](clients/README.md)
-- [Coding agent integrations](clients/coding-agents.md)
-- [Pi provider](clients/pi-provider/README.md)
-- [OpenCode provider](clients/opencode-provider/README.md)
-- [Deployment guide](deploy/README.md)
-- [Configuration reference](docs/configuration-reference.md)
-- [Live E2E test suite](docs/live-e2e-test-suite.md)
-- [Providers (verification + audit)](docs/providers/README.md)
-- [Provider audit criteria](docs/providers/audit-criteria.md)
-- [Roadmap](docs/roadmap.md)
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Private inference you can verify.
 
 Private AI Gateway sits between your app and AI providers. Keep the OpenAI or
-Anthropic API shape you already use. The gateway verifies confidential
-workloads and binds each network hop to their attested keys before your prompt
-leaves the protected path.
+Anthropic API shape you already use. An ACI client verifies the gateway before
+sending your prompt; a request constraint makes that gateway verify the model
+backend before forwarding it.
 
 This repo contains the Rust reference implementation of
 [Attested Confidential Inference (ACI)](spec/aci.md). Use it to test ACI or
@@ -25,7 +25,7 @@ Then use the Chat Completions API you already know. Replace `YOUR_API_KEY` and
 `MODEL_ID` with values from your provider:
 
 ```bash
-~/.local/bin/aci curl https://api.redpill.ai/v1/chat/completions -- \
+~/.local/bin/aci curl https://tee.redpill.ai/v1/chat/completions -- \
   --fail-with-body \
   --no-buffer \
   --header "Authorization: Bearer YOUR_API_KEY" \
@@ -65,7 +65,7 @@ or [`aci serve`](docs/quickstart.md#use-it-as-a-local-endpoint) for receipt
 verification, and read the [verification guide](docs/attested-confidential-inference.md)
 before sending sensitive data.
 
-This repo contains the implementation and verifier. It does not issue Redpill
+This repo contains the implementation and verifier. It does not issue RedPill
 API credentials or operate the example service. Continue with the
 [ACI quickstart](docs/quickstart.md) for the full verification path, or read the
 [ACI specification](spec/aci.md) for the trust model and wire protocol.
@@ -87,8 +87,8 @@ infrastructure between your app and the gateway workload.
 
 ## Add one field
 
-Your app doesn't need a new SDK. Add `provider.aci_verified` to any supported
-request that must use a verified provider:
+Keep your existing request shape and add `provider.aci_verified` when the
+request must use a verified provider:
 
 ```json
 {
@@ -295,9 +295,11 @@ Browser clients can use
 [`@phala/aci-verifier`](clients/verifier-ts/README.md) for service, quote,
 report-binding, receipt, body-hash, and session verification. Node and Bun apps
 can import `connectAci()` from `@phala/aci-verifier/runtime` to get an
-instance-scoped, attested SPKI-pinned fetch transport. See the
-[client architecture](clients/architecture.md) and
-[coding-agent guide](clients/coding-agents.md) for framework integrations.
+instance-scoped, attested SPKI-pinned fetch transport. Applications that also
+need live model discovery, capability mapping, receipt history, and automatic
+response-completion verification can use
+[`@phala/aci-provider`](clients/provider/README.md). Native adapters are
+available for [Pi and OpenCode](clients/coding-agents.md).
 
 ## Docs
 
@@ -309,8 +311,8 @@ Start at the [documentation index](docs/README.md). The main paths are:
 | Run the gateway locally | [Local development](docs/getting-started.md) |
 | Configure the gateway, middleware, or an upstream | [Configuration reference](docs/configuration-reference.md) |
 | Integrate an HTTP client | [HTTP API reference](docs/api-reference.md) |
-| Use the verified TypeScript transport | [ACI client architecture](clients/architecture.md) |
-| Use ACI from Pi | [Pi provider extension](clients/pi-provider/README.md) |
+| Use the verified TypeScript transport or shared provider | [ACI clients](clients/README.md) |
+| Use ACI from Pi or OpenCode | [Coding-agent integrations](clients/coding-agents.md) |
 | Implement a control plane | [Control-plane contract](docs/control-plane-contract.md) |
 | Deploy with dstack git-launcher | [Deployment guide](deploy/README.md) |
 | Review provider verification | [Provider index](docs/providers/README.md) |
@@ -348,7 +350,9 @@ same one-hour retention window unless the binary configuration changes in code.
 | `src/http/` | Axum routes and HTTP response handling |
 | `src/middleware/` | in-process control-plane client, transforms, failover, pricing, and SSE handling |
 | `clients/verifier-ts/` | browser verifier plus Node and Bun verified transports |
-| `clients/pi-provider/` | Pi provider extension and branded packages |
+| `clients/provider/` | framework-neutral provider lifecycle, model catalog, receipts, and inspection |
+| `clients/pi-provider/` | native Pi provider and branded packages |
+| `clients/opencode-provider/` | native OpenCode plugin and branded packages |
 | `deploy/` | dstack git-launcher deployment example |
 | `docs/` | operator guides, references, security notes, and review records |
 | `examples/` | Rust verification examples and the sample control plane |

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Private AI Gateway
 
-Private inference you can verify.
+**Call the LLM APIs you already know. Verify who can read the request before
+you send it.**
 
-Private AI Gateway sits between your app and AI providers. Keep the OpenAI or
-Anthropic API shape you already use. An ACI client verifies the gateway before
-sending your prompt; a request constraint makes that gateway verify the model
-backend before forwarding it.
+Private AI Gateway is an OpenAI- and Anthropic-compatible gateway for private
+inference. It runs inside a trusted execution environment (TEE), verifies the
+confidential provider path selected for the model, and gives the client
+evidence it can check independently.
 
-This repo contains the Rust reference implementation of
-[Attested Confidential Inference (ACI)](spec/aci.md). Use it to test ACI or
-build your own gateway and provider integrations. It is a developer preview.
+This repository contains the Rust reference implementation of
+[Attested Confidential Inference (ACI)](spec/aci.md). It is a developer
+preview.
 
-## Try a private inference request
+## Try it
 
 Install the `aci` CLI on Linux or macOS:
 
@@ -21,8 +22,8 @@ curl --proto '=https' --tlsv1.2 -fsSL \
   | sh
 ```
 
-Then use the Chat Completions API you already know. Replace `YOUR_API_KEY` and
-`MODEL_ID` with values from your provider:
+Then call Chat Completions as usual. Replace `YOUR_API_KEY` and `MODEL_ID`
+with values from your provider:
 
 ```bash
 ~/.local/bin/aci curl https://tee.redpill.ai/v1/chat/completions -- \
@@ -38,10 +39,10 @@ Then use the Chat Completions API you already know. Replace `YOUR_API_KEY` and
   }'
 ```
 
-Before curl sends the body, `aci` verifies a fresh hardware quote, the measured
-gateway workload, and the TLS key it reached. It then pins curl to that exact
-key. The transcript appears on stderr while the normal API response streams on
-stdout. Abridged verification output:
+Before curl sends the request body, `aci` verifies a fresh hardware quote,
+the measured gateway workload, and the TLS key it reached. It pins curl to
+that key and prints a transcript to stderr while the API response streams on
+stdout:
 
 ```text
 PASS  id-1  hardware quote verifies and binds report_data
@@ -51,44 +52,79 @@ VERIFIED (5 pass, 1 skipped: custody policy not implemented)
 PINNED      curl -> attested TLS key
 ```
 
-The `provider.aci_verified` field handles the next hop. It tells the verified
-gateway code to refuse the request unless the selected model backend passes its
-own attestation and channel-binding checks. When your policy accepts the
-measured gateway and provider workloads, plaintext stays inside those attested
-workloads. The model processes it there. Under the TEE threat model, the model
-operator and cloud host cannot inspect the protected memory that holds it.
+`provider.aci_verified` protects the second hop. It tells the verified gateway
+to refuse the request unless the selected model backend passes its own
+attestation and channel-binding checks.
 
-The full transcript reports every skipped policy check. The current CLI does
-not yet evaluate private-key custody, and `aci curl` does not verify the
-response receipt. Use [`aci send`](docs/quickstart.md#verify-one-inference-end-to-end)
-or [`aci serve`](docs/quickstart.md#use-it-as-a-local-endpoint) for receipt
-verification, and read the [verification guide](docs/attested-confidential-inference.md)
-before sending sensitive data.
+Together, these checks limit remote plaintext access to workloads your policy
+accepts: the gateway, any confidential provider router, and the model runner.
+Under the TEE threat model, the gateway operator, model operator, and cloud
+host cannot inspect those workloads' protected memory. Your local app still
+sees the prompt and response.
 
-This repo contains the implementation and verifier. It does not issue RedPill
-API credentials or operate the example service. Continue with the
-[ACI quickstart](docs/quickstart.md) for the full verification path, or read the
-[ACI specification](spec/aci.md) for the trust model and wire protocol.
+> [!IMPORTANT]
+> The transcript shows skipped checks. The current CLI does not yet evaluate
+> private-key custody, and `aci curl` does not verify the response receipt.
+> Use [`aci send`](docs/quickstart.md#5-verify-one-inference-end-to-end) or
+> [`aci serve`](docs/quickstart.md#4-use-it-as-a-local-endpoint) when your
+> policy requires receipt verification.
 
-## Why this exists
+The example is a live deployment operated outside this repository. This
+project does not issue its API credentials. Continue with the
+[full quickstart](docs/quickstart.md) to inspect evidence, pin an accepted
+release, and verify a complete exchange.
 
-HTTPS protects your connection to a domain. It can't tell you which program is
-handling your prompt, whether that program runs in protected hardware, or
-whether a gateway sent the prompt to a different backend.
+## Why HTTPS is not enough
 
-ACI lets you check those details. It connects the gateway's attested keyset, the
-provider's attestation, the channel used for forwarding, and the request and
-response hashes in one verifiable trail.
+HTTPS proves that you reached a domain. It does not prove:
 
-The gateway and model still need plaintext to do their jobs. Private inference
-makes the workloads that see that plaintext verifiable. The optional E2EE v2
-compatibility extension also hides supported inference fields from
-infrastructure between your app and the gateway workload.
+- which program is handling your prompt;
+- whether that program runs in protected hardware;
+- whether its TLS key belongs to that protected workload; or
+- whether a gateway forwarded the prompt to an unverified model runner.
 
-## Add one field
+ACI connects those facts into one chain:
 
-Keep your existing request shape and add `provider.aci_verified` when the
-request must use a verified provider:
+| Proof | What you learn |
+| --- | --- |
+| Nonce-bound hardware quote | The report is fresh and comes from a genuine TEE. |
+| Measured workload and attested keyset | Which code and keys are inside that TEE. |
+| Enforced channel binding | The connection carrying plaintext ends at an accepted workload. |
+| Signed response receipt | Which request, response, route, and verification result the gateway recorded. |
+| Attested session | Which provider evidence and channel binding backed an aggregated request. |
+
+The proof is useful because the client verifies hashes, signatures, quote
+evidence, measurements, and channel keys locally. A response header that merely
+says `verified` is not evidence.
+
+## Where your data goes
+
+```mermaid
+flowchart LR
+    client[Your app] -->|attested, pinned channel| gateway[Gateway TEE]
+    gateway -->|verified, bound channel| provider[Accepted provider workload or route]
+    provider --> gateway --> client
+    gateway -.->|auth hash, routing, pricing, usage| control[Optional control plane]
+```
+
+The accepted gateway, provider-router, and model workloads see plaintext when
+they must process it. Infrastructure outside those workloads does not receive
+inference content through the documented path.
+
+The optional control plane receives routing and account metadata, not prompts,
+responses, raw bearer tokens, or provider credentials. The gateway forwards
+the caller's routing object as metadata, so do not place secrets in that
+object. See the exact [control-plane contract](docs/control-plane-contract.md).
+
+The optional [E2EE v2 compatibility extension](spec/e2ee-v2.md) also keeps
+supported content fields encrypted across infrastructure between the client
+and the gateway workload. It does not remove the gateway or model from the
+trust boundary.
+
+## Make a request fail closed
+
+Add one field to any supported prompt request that must use a verified
+provider:
 
 ```json
 {
@@ -102,263 +138,132 @@ request must use a verified provider:
 }
 ```
 
-With that flag set:
+With that constraint, a verification or channel-binding failure stops the
+request before the provider receives the prompt. A successful response carries
+`x-receipt-id`, which resolves to a signed receipt containing hashes rather
+than the prompt or response body.
 
-- verification or channel-binding failure stops the request before the provider
-  receives your prompt
-- a successful response includes `x-receipt-id`, which points to a signed
-  receipt covering the request, response, route, and verification result
+For a stricter policy, verify the current attested sessions first and pass the
+accepted IDs in `provider.aci_session_ids`. See
+[session pinning](docs/attested-confidential-inference.md#pin-an-upstream-session).
 
-The receipt stores hashes, not your prompt or response body. When the provider
-returns an enforceable binding, the receipt also links to an immutable session
-record with the provider's claims and evidence.
+> [!WARNING]
+> Private inference is opt-in. Merely configuring a TEE provider does not make
+> every request fail closed. Require `provider.aci_verified`, pass a non-empty
+> `provider.aci_session_ids` list, or use a hostname configured in
+> `middleware.tee_only_domains`.
 
-## Where your data goes
+## Choose a client
 
-```mermaid
-flowchart LR
-    client[Your app] -->|inference request| gateway[Attested gateway workload]
-    gateway -->|channel bound to verified key| provider[Verified provider workload]
-    provider -->|model response| gateway
-    gateway -->|response and receipt ID| client
-    gateway -.->|auth, routing, usage, and status metadata| control[Optional control plane]
-```
+| You want to | Use |
+| --- | --- |
+| Make an arbitrary API request over a verified, SPKI-pinned channel | [`aci curl`](src/bin/aci/README.md#run-a-curl-request-over-the-verified-channel) |
+| Verify one chat response and its receipt end to end | [`aci send`](docs/quickstart.md#5-verify-one-inference-end-to-end) |
+| Give any local OpenAI-compatible app a verified endpoint | [`aci serve`](docs/quickstart.md#4-use-it-as-a-local-endpoint) |
+| Verify artifacts in a browser, or add pinned fetch to Node or Bun | [`@phala/aci-verifier`](clients/verifier-ts/README.md) |
+| Add catalog, lifecycle, receipts, and inspection to a host adapter | [`@phala/aci-provider`](clients/provider/README.md) |
+| Use private inference from Pi or OpenCode | [Coding-agent integrations](clients/coding-agents.md) |
 
-Two workloads see plaintext: the attested gateway workload and the verified
-provider workload that runs the model. The optional E2EE v2 compatibility
-extension keeps supported prompt fields encrypted until they reach the gateway
-workload. The provider binding stops an ACI-required request from using a
-channel that doesn't match the verified provider key.
+All supported inference transports verify before sending model request bytes.
+Browser JavaScript can verify artifacts but cannot enforce a certificate SPKI
+pin, so use a Node or Bun transport, the CLI, or a local verifying proxy when
+the channel itself must be pinned.
 
-The optional control plane stays out of the inference-content path. The gateway
-doesn't send it prompt or response bodies, raw bearer tokens, or provider
-credentials. It gets the bearer-token hash, requested model, routing options,
-and the metadata needed for auth, pricing, and usage reporting. The routing
-object is forwarded as-is, so don't put prompts or secrets in it. The
-[control-plane contract](docs/control-plane-contract.md) lists every field.
+## Run your own gateway
 
-## How the proof works
+Self-hosting is the operator path. It requires a dstack SDK endpoint, gateway
+state, at least one upstream, and a deployment policy for authentication,
+networking, measurements, and provider credentials.
 
-A trusted execution environment (TEE) is a hardware-isolated place to run code.
-This gateway uses Intel TDX through dstack. ACI builds a verification chain on
-top of it:
+- [Local development](docs/getting-started.md) starts the gateway against a
+  forwarded dstack socket.
+- [Configuration reference](docs/configuration-reference.md) defines every
+  gateway and upstream field.
+- [Deployment guide](deploy/README.md) deploys the gateway with dstack
+  git-launcher.
+- [Live test suite](docs/live-e2e-test-suite.md) exercises local and provider
+  paths.
 
-1. The gateway publishes a nonce-bound attestation report whose hardware quote
-   binds the workload keyset digest. The nonce prevents an old report from
-   passing as a fresh one.
-2. A provider adapter checks the selected backend's evidence before the prompt
-   leaves the gateway.
-3. The gateway takes the provider key from that evidence and requires the real
-   forwarding channel to use it.
-4. After the response, the gateway signs a receipt containing request and
-   response hashes, the route, and the verification result.
-5. For a deeper audit, the receipt can link to a content-addressed session with
-   the full provider evidence.
+The gateway supports two routing modes. Direct mode maps a public model ID to
+a configured upstream. Middleware mode asks an external control plane for
+authorization, pricing, and an ordered route list. Inference handling remains
+inside the Rust gateway process in both modes.
 
-You still decide what counts as trusted: hardware roots, measurements, workload
-source, provider adapters, and claims. The reference `aci` CLI and TypeScript
-client verify the quote and report-binding chain; their default policy still
-leaves some appraisal decisions, including private-key custody and exact
-source-build acceptance, to the relying party. Read the
-[verification and security guide](docs/attested-confidential-inference.md)
-before sending sensitive data.
+## What you still need to trust
 
-> [!IMPORTANT]
-> Private inference is opt-in. Configuring a TEE provider does not make every
-> request fail closed. Set `provider.aci_verified: true`, pass a non-empty
-> `provider.aci_session_ids` allowlist, or use a hostname listed in
-> `middleware.tee_only_domains`. Without one of these constraints, the gateway
-> may still forward after verification fails and record the failure in the
-> receipt.
+ACI makes the evidence inspectable. It does not choose your policy for you.
+Before treating a deployment as private, decide which hardware roots,
+measurements, workload releases, KMS roots, provider adapters, and claim
+sources you accept.
 
-## Pick a routing mode
+Current boundaries include:
 
-The gateway has two routing modes:
+- The reference CLI verifies the DCAP quote and RTMR3 compose measurement but
+  does not reconstruct all dstack boot measurements or complete the
+  private-key-custody check.
+- A reported repository, commit, image, or model name is not proof by itself.
+  Accept it only when measured evidence or another trusted provenance system
+  corroborates it.
+- Provider verifiers prove different facts. Most do not prove the exact model
+  weights that served a request.
+- Requests without an ACI constraint may continue after verification fails and
+  record that failure in the receipt.
+- Receipts are held in memory for one hour by the reference implementation and
+  disappear on restart. Session records are content-addressed JSONL, not an
+  externally witnessed transparency log.
+- A local process connected to a forwarded development dstack socket inherits
+  the remote CVM's identity. It is not equivalent to a reviewed production
+  deployment.
 
-- Direct mode maps the public model ID through `upstreams.json` and sends the
-  request to one configured upstream.
-- Middleware mode asks an external control plane to authorize the request,
-  price it, and return an ordered route list. Request handling stays in the
-  gateway's Rust process. The control plane receives metadata, not inference
-  content or provider credentials.
+Read the [verification and security guide](docs/attested-confidential-inference.md)
+for the complete trust boundary, proof layers, and non-goals. Provider-specific
+claims and limitations are in the [provider index](docs/providers/README.md).
 
 ## API coverage
 
-Current API coverage:
+The current gateway supports:
 
-- OpenAI Chat Completions, legacy Completions, Embeddings, and Responses create
-- Anthropic Messages
-- buffered and SSE responses where the selected surface supports streaming
-- the ACI E2EE v2 compatibility extension for Chat Completions, Completions,
-  and Embeddings
-- canonical attestation, receipt, session, metrics, and admin APIs
-- legacy dstack-vllm-proxy attestation and signature aliases
+- OpenAI Chat Completions, Completions, Embeddings, and Responses create;
+- Anthropic Messages;
+- buffered and SSE responses where the selected API supports streaming;
+- E2EE v2 for Chat Completions, Completions, and Embeddings;
+- canonical attestation, receipt, session, metrics, and admin APIs; and
+- legacy dstack-vllm-proxy attestation and signature aliases.
 
-The [HTTP API reference](docs/api-reference.md) lists every route, mode-specific
-behavior, authentication rule, and size limit.
+See the [HTTP API reference](docs/api-reference.md) for route behavior,
+authentication, mode differences, and limits.
 
-## Run it locally
+## Documentation
 
-The production binary has no generated-key or fake-quote mode. A local run
-still needs a reachable dstack SDK endpoint. If the process is outside a dstack
-CVM, first [forward and verify a dev CVM socket](docs/getting-started.md#connect-to-the-dstack-sdk).
-
-### Prerequisites
-
-- Rust stable
-- Python 3.12 and [uv](https://docs.astral.sh/uv/)
-- a reachable dstack SDK endpoint
-
-The smoke suites need extra tools. See the [testing guide](docs/live-e2e-test-suite.md)
-before running them.
-
-### Start the gateway
-
-Install the Python environment used by the provider verifiers:
-
-```bash
-uv sync --locked
-```
-
-Create a static gateway config:
-
-```bash
-mkdir -p /tmp/private-ai-gateway-state
-
-cat >/tmp/private-ai-gateway.config.json <<'JSON'
-{
-  "bind": "127.0.0.1:8086",
-  "state_dir": "/tmp/private-ai-gateway-state",
-  "dstack_endpoint": "unix:/tmp/aci-dstack-sock-dev.dstack.sock"
-}
-JSON
-```
-
-Start the service:
-
-```bash
-PRIVATE_AI_GATEWAY_CONFIG_PATH=/tmp/private-ai-gateway.config.json \
-  cargo run --release --locked --bin private-ai-gateway
-```
-
-The gateway starts with no inference routes when
-`/tmp/private-ai-gateway-state/upstreams.json` is absent or empty. In another
-terminal, confirm the process and fetch a nonce-bound canonical report:
-
-```bash
-curl --fail --silent --show-error http://127.0.0.1:8086/health
-
-NONCE="$(openssl rand -hex 32)"
-curl --fail --silent --show-error \
-  "http://127.0.0.1:8086/v1/aci/attestation?nonce=$NONCE" \
-  -o report.json
-```
-
-`/health` should return `{"status":"ok"}`. A successful report contains
-`api_version: "aci/1"`, a `workload_keyset_digest`, and the plain
-`attestation.workload_keyset` object bound by the quote.
-
-For local inference without provider credentials, run the
-[multi-upstream smoke test](docs/live-e2e-test-suite.md#run-the-local-multi-upstream-smoke-test).
-For a real provider, continue with the
-[configuration reference](docs/configuration-reference.md#upstream-configuration).
-
-## Verify the response
-
-Save the response body exactly as received and read `x-receipt-id` from the
-headers. Fetch the receipt with the same bearer token you used for inference:
-
-```bash
-curl --fail --silent --show-error \
-  -H "Authorization: Bearer $API_KEY" \
-  "$GATEWAY_URL/v1/aci/receipts/$RECEIPT_ID" \
-  -o receipt.json
-```
-
-Check the captured files with the `aci` CLI:
-
-```bash
-aci audit \
-  --report report.json \
-  --receipt receipt.json \
-  --nonce "$NONCE" \
-  --response-body response.json
-```
-
-This runs the same quote, binding-chain, receipt, body-hash, and session checks
-as the live client. Review skipped checks in the transcript and apply your own
-source provenance, key-custody, key-expiry, and provider policy. The
-[verification guide](docs/attested-confidential-inference.md) covers the full
-flow.
-
-Browser clients can use
-[`@phala/aci-verifier`](clients/verifier-ts/README.md) for service, quote,
-report-binding, receipt, body-hash, and session verification. Node and Bun apps
-can import `connectAci()` from `@phala/aci-verifier/runtime` to get an
-instance-scoped, attested SPKI-pinned fetch transport. Applications that also
-need live model discovery, capability mapping, receipt history, and automatic
-response-completion verification can use
-[`@phala/aci-provider`](clients/provider/README.md). Native adapters are
-available for [Pi and OpenCode](clients/coding-agents.md).
-
-## Docs
-
-Start at the [documentation index](docs/README.md). The main paths are:
+Start at the [documentation index](docs/README.md), or jump directly to a
+task:
 
 | Goal | Document |
 | --- | --- |
-| Understand the trust model and verify artifacts | [ACI verification and security model](docs/attested-confidential-inference.md) |
-| Run the gateway locally | [Local development](docs/getting-started.md) |
-| Configure the gateway, middleware, or an upstream | [Configuration reference](docs/configuration-reference.md) |
-| Integrate an HTTP client | [HTTP API reference](docs/api-reference.md) |
-| Use the verified TypeScript transport or shared provider | [ACI clients](clients/README.md) |
-| Use ACI from Pi or OpenCode | [Coding-agent integrations](clients/coding-agents.md) |
+| Understand the privacy claim and verify the proof | [Verification and security](docs/attested-confidential-inference.md) |
+| Use the CLI against a live service | [ACI quickstart](docs/quickstart.md) |
+| Integrate a client or coding agent | [ACI clients](clients/README.md) |
+| Run or configure the gateway | [Local development](docs/getting-started.md) and [configuration](docs/configuration-reference.md) |
 | Implement a control plane | [Control-plane contract](docs/control-plane-contract.md) |
 | Deploy with dstack git-launcher | [Deployment guide](deploy/README.md) |
-| Review provider verification | [Provider index](docs/providers/README.md) |
-| Run tests and live provider checks | [Testing guide](docs/live-e2e-test-suite.md) |
-| Implement the protocol | [ACI specification](spec/README.md) |
-| Contribute a change | [Contributing guide](CONTRIBUTING.md) |
-
-## Security boundaries
-
-Keep these limits in mind before treating a deployment as private:
-
-- A generic OpenAI-compatible route stays a normal TLS route. It becomes
-  confidential only when an implemented provider adapter can verify it and bind
-  the forwarding channel.
-- Requests without an ACI constraint may continue after verification fails.
-- The attested gateway workload sees plaintext. The external control plane gets
-  routing and usage metadata, but not prompt or response bodies.
-- Receipts live in memory for one hour and disappear on restart. They store body
-  hashes, not the request or response itself.
-- Reported source or image metadata still needs a verifier policy. Reporting a
-  value doesn't mean your deployment has approved it.
-- A local process using a forwarded dev socket has the remote CVM's identity and
-  measurements. It is not equivalent to a reviewed production deployment.
-
-Attested-session records are stored in `<state_dir>/sessions.jsonl` and use the
-same one-hour retention window unless the binary configuration changes in code.
+| Audit provider verification | [Provider verification](docs/providers/README.md) |
+| Implement ACI | [Specification index](spec/README.md) |
+| Contribute | [Contributing guide](CONTRIBUTING.md) |
 
 ## Repository layout
 
 | Path | Contents |
 | --- | --- |
-| `src/aci/` | ACI wire types, canonicalization, receipts, E2EE, upstream transports, and verifiers |
-| `src/bin/aci/` | `aci` verifier, audit, session, curl, send, and local proxy commands |
-| `src/aggregator/` | request service, routing state, receipts, sessions, and metrics |
-| `src/http/` | Axum routes and HTTP response handling |
-| `src/middleware/` | in-process control-plane client, transforms, failover, pricing, and SSE handling |
-| `clients/verifier-ts/` | browser verifier plus Node and Bun verified transports |
-| `clients/provider/` | framework-neutral provider lifecycle, model catalog, receipts, and inspection |
-| `clients/pi-provider/` | native Pi provider and branded packages |
-| `clients/opencode-provider/` | native OpenCode plugin and branded packages |
+| `src/aci/` | ACI types, receipts, E2EE, transports, and verifiers |
+| `src/bin/aci/` | CLI verifier, audit, curl, send, and local proxy |
+| `src/aggregator/` | routing, receipt, session, and metrics services |
+| `src/middleware/` | control-plane client, transforms, failover, and pricing |
+| `clients/` | TypeScript verifier, provider kernel, Pi, and OpenCode adapters |
 | `deploy/` | dstack git-launcher deployment example |
-| `docs/` | operator guides, references, security notes, and review records |
-| `examples/` | Rust verification examples and the sample control plane |
+| `docs/` | guides, references, security notes, and review records |
 | `scripts/` | provider verifier bridge and smoke suites |
-| `spec/` | ACI specification, related work, and test vectors |
-| `tests/` | Rust integration tests and provider-verifier tests |
+| `spec/` | ACI specification and test vectors |
+| `tests/` | Rust integration and provider-verifier tests |
 
 ## License
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -27,7 +27,8 @@ and native coding-agent integrations:
   It reuses the reference implementation's verification code:
   `aci verify` (live attestation), `aci audit` (saved artifacts),
   `aci sessions` (the §9.2 audit of the service's current attested
-  sessions, with a `--require-claim` claims policy), `aci send` (one
+  sessions, with a `--require-claim` claims policy), `aci curl` (run the
+  installed curl over the attested SPKI-pinned channel), `aci send` (one
   inference with receipt verification), and `aci serve` (a local verifying
   proxy: forwards any endpoint over the pinned channel, records each
   exchange's digests for on-demand receipt verification, and pins sessions

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,83 +1,93 @@
 # ACI clients
 
-Start with the [client product architecture](architecture.md) for the product
-goal, shared trust contract, component ownership, and remaining release work.
-Framework-specific coding-agent configuration is in
-[`coding-agents.md`](coding-agents.md).
+Use these clients when an application must verify the remote workload and its
+channel before sending model request bytes. Choose the smallest layer that
+matches your host.
 
-Four client layers cover verification, framework-neutral provider behavior,
-and native coding-agent integrations:
+## Choose a client
 
-- [`verifier-ts`](verifier-ts) — `@phala/aci-verifier`, a TypeScript verifier
-  for the browser, Node, and Bun. One call, `verifyService(url)`, fetches the
-  report with a fresh nonce and returns a full §9.1 transcript. It also
-  covers receipts and body hashes (§9.3) and sessions (§8, §9.2). The
-  hardware quote is verified with `@phala/dcap-qvl`; every other check is
-  Web Crypto. Its runtime subpath also exposes `connectAci()`, an
-  instance-scoped verified transport with tested Node and Bun adapters that
-  applications can inject into OpenAI Node, OpenAI Agents JS, Vercel AI SDK,
-  LangChain JS, OpenCode and other fetch-aware clients. Ships an ESM bundle
-  for `<script type="module">`.
-  Both runtime transports and the CLI can pin reviewed RTMR3-bound compose hashes;
-  self-declared repository and commit fields are informational labels.
-  Key custody (§9.1 check 5) is an honest skip in both verifiers; the channel
-  check (6) needs an observed SPKI (or the `aci` CLI / `aci serve` proxy for a
-  pinned channel) — this client ships no E2EE (§6) this round.
-- `aci` — the command-line verifier at [`../src/bin/aci`](../src/bin/aci).
-  It reuses the reference implementation's verification code:
-  `aci verify` (live attestation), `aci audit` (saved artifacts),
-  `aci sessions` (the §9.2 audit of the service's current attested
-  sessions, with a `--require-claim` claims policy), `aci curl` (run the
-  installed curl over the attested SPKI-pinned channel), `aci send` (one
-  inference with receipt verification), and `aci serve` (a local verifying
-  proxy: forwards any endpoint over the pinned channel, records each
-  exchange's digests for on-demand receipt verification, and pins sessions
-  per §5.3 — a fixed `--session` list, or a `--require-claim` policy that
-  derives the accepted set and refreshes it when the service refuses a
-  superseded pin).
-- [`provider`](provider) — `@phala/aci-provider`, the framework-neutral ACI
-  provider. It owns verified connection lifecycle, live model discovery,
-  TEE-only and allowlist filtering, model capability mapping, bounded receipt
-  history, response-completion receipt verification, and content-addressed
-  session inspection. Pi and OpenCode use this package rather than implementing
-  those behaviors separately.
-- [`pi-provider`](pi-provider) — a [pi](https://pi.dev/) provider
-  extension that turns the gateway (or any ACI service) into a first-class
-  chat provider in pi's model picker, with **attested TLS (SPKI) pinning** as
-  the security control (always fail closed). The npm workspaces monorepo
-  ships the vendor-neutral
-  [`@phala/pi-provider-aci`](pi-provider/packages/pi-provider-aci) adapter plus
-  thin branded distributions,
-  [`pi-provider-redpill`](pi-provider/packages/pi-provider-redpill) and
-  [`pi-provider-phala-cloud`](pi-provider/packages/pi-provider-phala-cloud).
-  It adds Pi configuration, model types, settings, commands, credentials, and
-  footer state around the shared provider.
-  Pi uses its native Provider/Auth API and verifies the signed receipt plus
-  cited session before every response stream completes. The transport retains
-  bounded wire digests, provider-scoped receipt commands display or re-run a
-  recorded audit, and provider-scoped session commands remain available for
-  direct session inspection.
-  See [`pi-provider/README.md`](pi-provider/README.md)
-  for install and use. The coordinated npm release process is documented in
-  [`releasing.md`](releasing.md).
-- [`opencode-provider`](opencode-provider) — the native OpenCode v1 server
-  plugin. `@phala/opencode-provider-aci` maps the shared provider into
-  OpenCode's config, auth, model, and lifecycle hooks;
-  `opencode-provider-redpill` supplies API-key authentication, while
-  `opencode-provider-phala-cloud` also adds Phala Cloud device login. Both use
-  shared branded profiles. It verifies every receipt before the response stream
-  completes, so a failed audit stops the generation/tool loop, and adds a
-  provider-scoped read-only inspection tool for connection, attestation,
-  receipt, and session status. Provider-scoped OpenCode commands expose those
-  inspections without adding a second verifier or credential store.
+| Need | Use | What it owns |
+| --- | --- | --- |
+| Run a familiar curl command over an attested channel | [`aci curl`](../src/bin/aci/README.md#run-a-curl-request-over-the-verified-channel) | Service verification and TLS SPKI pinning, then delegates the request to system curl. |
+| Verify one chat request, receipt, and cited session | [`aci send`](../docs/quickstart.md#5-verify-one-inference-end-to-end) | One complete command-line exchange and audit. |
+| Verify artifacts in a browser, or add pinned fetch to Node or Bun | [`@phala/aci-verifier`](verifier-ts/README.md) | Reports, quotes, measurements, pinned runtime transport, wire digests, receipts, and sessions. |
+| Build a provider adapter for another host | [`@phala/aci-provider`](provider/README.md) | Verified connection lifecycle, model catalog, filtering, receipt history, response verification, and inspection. |
+| Use ACI in Pi | [`@phala/pi-provider-aci`](pi-provider/README.md) or a branded package | Native Pi auth, model picker, persistence, commands, and fail-closed receipt verification. |
+| Use ACI in OpenCode | [`@phala/opencode-provider-aci`](opencode-provider/README.md) or a branded package | Native OpenCode provider, auth, catalog, tools, lifecycle, and fail-closed receipt verification. |
 
-SDKs that accept a function can use `connectAci().fetch` directly. Native Pi
-and OpenCode integrations use their official provider and plugin APIs through
-the packages above. A base URL alone cannot inject ACI's attested TLS transport;
-hosts without a custom-fetch or provider-plugin extension point are not claimed
-as native integrations in this release.
+If your SDK accepts a custom `fetch`, start with `connectAci()` from
+`@phala/aci-verifier/runtime`. If you are integrating a coding agent or another
+host with its own provider lifecycle, use `@phala/aci-provider` and map its
+host-neutral contracts into the host's official APIs.
 
-[docs/quickstart.md](../docs/quickstart.md) exercises both verifier
-surfaces against a live deployment. The `pi-provider` extension is loaded
-with pi's `-e` flag pointing at one of the package directories (e.g.
-`pi -e clients/pi-provider/packages/pi-provider-aci`), or installed from npm; see its README for the invocation.
+A base URL alone cannot install an attested TLS transport. A host needs a
+custom-fetch hook, a provider-plugin boundary, or a local proxy such as
+`aci serve`.
+
+## What every supported path enforces
+
+The Rust and TypeScript clients share the same security meaning:
+
+1. Fetch an attestation report with a fresh nonce.
+2. Verify the TDX quote and the nonce-bound workload keyset.
+3. Verify that the published compose is measured into RTMR3.
+4. Reject an expired identity and any configured release-policy mismatch.
+5. Send inference bytes only over TLS whose observed SPKI appears in the
+   attested keyset.
+6. Add verified-serving or session constraints before an aggregator forwards.
+7. Capture exact wire digests and verify signed receipts and cited sessions
+   when the selected client promises response verification.
+8. Fail closed when a required check fails.
+
+The browser verifier can check artifacts and quote evidence, but browser APIs
+do not expose the peer certificate needed for SPKI pinning. Use the Node or Bun
+runtime transport, the Rust CLI, or `aci serve` for a pinned channel.
+
+## Verification versus release acceptance
+
+Hardware verification and release acceptance are separate decisions:
+
+- **Hardware-bound mode** proves that a genuine TDX workload owns the
+  attested keys and reports the measured compose.
+- **Reviewed-release mode** also requires the measured compose hash to appear
+  in an operator-supplied allowlist.
+
+`source_provenance.repo_url` and `repo_commit` are useful labels, but they are
+not bound into the quote. The RTMR3-bound compose hash is the value clients can
+pin. A branded production client should obtain accepted compose hashes through
+an authenticated release channel.
+
+The current Rust CLI and TypeScript verifier honestly skip the complete
+private-key-custody policy. Review all skipped checks before sending sensitive
+data.
+
+## Coding-agent packages
+
+The client workspace publishes eight packages:
+
+| Host | Neutral package | RedPill | Phala Cloud |
+| --- | --- | --- | --- |
+| Shared kernel | [`@phala/aci-provider`](provider/README.md) | Shared profile | Shared profile and account flow |
+| Pi | [`@phala/pi-provider-aci`](pi-provider/packages/pi-provider-aci/README.md) | [`pi-provider-redpill`](pi-provider/packages/pi-provider-redpill/README.md) | [`pi-provider-phala-cloud`](pi-provider/packages/pi-provider-phala-cloud/README.md) |
+| OpenCode | [`@phala/opencode-provider-aci`](opencode-provider/packages/opencode-provider-aci/README.md) | [`opencode-provider-redpill`](opencode-provider/packages/opencode-provider-redpill/README.md) | [`opencode-provider-phala-cloud`](opencode-provider/packages/opencode-provider-phala-cloud/README.md) |
+
+The branded packages are thin distributions over the same verifier and
+provider kernel. They add product identity, default endpoints, environment
+names, and authentication options. They do not implement separate verification
+logic.
+
+See [Coding-agent integrations](coding-agents.md) for installation and host
+behavior, [Client architecture](architecture.md) for component ownership, and
+[Releasing](releasing.md) for the coordinated npm release process.
+
+## Trust boundary
+
+The local application or coding agent sees plaintext prompts and responses.
+These clients protect the remote model HTTP path. MCP servers, tools, browser
+automation, shell commands, WebSockets, extensions, and host telemetry have
+separate trust boundaries.
+
+Provider authentication is also outside ACI. RedPill packages accept API keys.
+Phala Cloud packages additionally expose the shared device authorization flow.
+Pi and OpenCode persist credentials through their own native stores; the ACI
+packages do not create a parallel credential database.

--- a/clients/architecture.md
+++ b/clients/architecture.md
@@ -17,20 +17,20 @@ bound to those keys.
 ```mermaid
 flowchart LR
   classDef upstream fill:#e8f3ff,stroke:#2878b5,color:#102a43
-  classDef pr fill:#fff4d6,stroke:#b7791f,color:#4a2c0a
-  classDef refactor fill:#e8f8ee,stroke:#25855a,color:#123c2b
+  classDef host fill:#fff4d6,stroke:#b7791f,color:#4a2c0a
+  classDef client fill:#e8f8ee,stroke:#25855a,color:#123c2b
   classDef pending fill:#ffe9e7,stroke:#c4473a,color:#541e18
   classDef external fill:#f3f4f6,stroke:#6b7280,color:#1f2937
 
   subgraph local[Client machine]
-    pi[Pi provider<br/>original PR, refactored]:::pr
-    ocadapter[OpenCode provider<br/>new]:::refactor
-    core[ACI provider core<br/>new]:::refactor
+    pi[Native Pi provider<br/>packages]:::host
+    ocadapter[Native OpenCode<br/>provider plugin]:::client
+    core[Shared @phala/aci-provider<br/>kernel]:::client
     sdk[OpenAI, Agents, LangChain,<br/>Vercel AI SDK]:::external
     opencode[OpenCode on Bun]:::external
-    connect[connectAci shared runtime client<br/>current refactor]:::refactor
-    node[Node fetch adapter<br/>current refactor]:::refactor
-    bun[Bun fetch adapter<br/>current refactor]:::refactor
+    connect[connectAci shared<br/>runtime client]:::client
+    node[Node fetch adapter]:::client
+    bun[Bun fetch adapter]:::client
 
     pi --> core
     opencode --> ocadapter --> core
@@ -41,17 +41,17 @@ flowchart LR
   end
 
   subgraph trust[Shared trust contract]
-    identity[Quote, nonce, keyset,<br/>compose and expiry<br/>existing verifier checks]:::upstream
-    release[Reviewed compose allowlist<br/>TS/Pi: current refactor<br/>Rust flag: existing upstream]:::refactor
-    audit[Verified serving, wire digests,<br/>receipt and session policy<br/>current refactor]:::refactor
-    channel[Hostname and attested<br/>TLS SPKI binding]:::refactor
+    identity[Quote, nonce, keyset,<br/>compose and expiry]:::upstream
+    release[Reviewed compose allowlist<br/>shared client policy]:::client
+    audit[Verified serving, wire digests,<br/>automatic receipt/session checks]:::client
+    channel[Hostname and attested<br/>TLS SPKI binding]:::client
     identity --> release --> audit --> channel
   end
 
   node --> identity
   bun --> identity
 
-  subgraph tee[Private AI Gateway inside the TEE - existing upstream]
+  subgraph tee[Private AI Gateway inside the TEE]
     api[OpenAI, Responses and<br/>Anthropic API surfaces]:::upstream
     frontend[ACI frontend<br/>attestation and receipts]:::upstream
     routing[Optional control-plane<br/>auth and routing]:::upstream
@@ -69,34 +69,33 @@ flowchart LR
 
 Legend:
 
-- Blue: capability that already existed upstream before the Pi integration.
-- Yellow: Pi-specific product surface introduced by the original PR.
-- Green: framework-neutral transport and trust-policy work added while the PR
-  was refactored.
+- Blue: gateway protocol and Rust verification capabilities.
+- Yellow: released Pi-specific product surface.
+- Green: released framework-neutral transport, provider, and trust-policy
+  capabilities.
 - Red: work still required to complete the production product.
 - Gray: external client or provider software.
 
-The history is more precise than a single color can show for components that
-were hardened in place:
+Component ownership and release status:
 
-| Component or behavior | Origin |
+| Component or behavior | Owner or status |
 | --- | --- |
-| ACI protocol, gateway surfaces, attestation, receipts and sessions | Existing upstream |
-| Rust `aci` verifier, `aci serve`, TLS channel binding and `--accept-compose` | Existing upstream |
-| TypeScript quote, nonce/keyset, compose and expiry checks | Existing upstream |
-| Pi provider, branded packages, model discovery and initial Pi TLS pinning | Original PR |
-| Framework-neutral model, lifecycle, policy, account-to-key contract, and structured inspection core | Current OpenCode work |
-| Native OpenCode v1 plugin, provider-scoped inspection commands, plus RedPill and Phala Cloud distributions | Current OpenCode work |
-| `connectAci()` framework-neutral, instance-scoped runtime client | Current refactor |
-| Node adapter using the supported undici dispatcher hook | Current refactor |
-| Bun adapter using the supported `fetch({ tls, proxy })` hooks | Current refactor |
-| Quote-before-pin enforcement, no verification downgrade, origin isolation and safe multi-SPKI rotation | Current refactor |
-| TypeScript/Pi `acceptedComposeHashes` aligned with Rust policy | Current refactor |
-| Streaming wire-digest capture, Pi response verification and on-demand receipt/session audit | Current refactor |
-| Compiled ESM npm packages, declaration maps, package lint, clean-install smoke and OIDC release workflow | Current refactor |
-| Direct OpenCode integration through its provider `options.fetch` hook | Current refactor |
-| Fail-closed OpenCode provider ownership, live model discovery, end-of-stream receipt audit and read-only inspection tool | Current OpenCode work |
-| Coding-agent integration guide around the shared transport boundary | Current refactor |
+| ACI protocol, gateway surfaces, attestation, receipts and sessions | Gateway implementation |
+| Rust `aci` verifier, `aci serve`, TLS channel binding and `--accept-compose` | Rust client |
+| TypeScript quote, nonce/keyset, compose and expiry checks | TypeScript verifier |
+| Pi provider, branded packages, model discovery and Pi TLS pinning | Released Pi adapter |
+| Framework-neutral model, lifecycle, policy, account-to-key contract, and structured inspection core | Released client stack |
+| Native OpenCode v1 plugin, provider-scoped inspection commands, plus RedPill and Phala Cloud distributions | Released client stack |
+| `connectAci()` framework-neutral, instance-scoped runtime client | Released client stack |
+| Node adapter using the supported undici dispatcher hook | Released client stack |
+| Bun adapter using the supported `fetch({ tls, proxy })` hooks | Released client stack |
+| Quote-before-pin enforcement, no verification downgrade, origin isolation and safe multi-SPKI rotation | Released client stack |
+| TypeScript/Pi `acceptedComposeHashes` aligned with Rust policy | Released client stack |
+| Streaming wire-digest capture and automatic response-completion receipt/session verification in Pi and OpenCode | Released client stack |
+| Compiled ESM npm packages, declaration maps, package lint, clean-install smoke and OIDC release workflow | Released client stack |
+| Direct OpenCode integration through its provider `options.fetch` hook | Released client stack |
+| Fail-closed OpenCode provider ownership, live model discovery, cancellation-safe receipt audit, and read-only inspection tool | Released client stack |
+| Coding-agent integration guide around the shared transport boundary | Released client stack |
 | Reviewed compose publication from RedPill and Phala release pipelines | Pending product work |
 
 Account authentication is outside the ACI trust protocol. RedPill adapters
@@ -212,8 +211,8 @@ deployment release process must still close the trust loop:
 5. Exercise both Rust and TypeScript clients against the same accepted and
    rejected measurements.
 
-The repository can publish all eight npm packages in dependency order from a
-signed GitHub Release. Publishing alone does not create a reviewed-release
+The release workflow publishes all eight npm packages in dependency order from
+a signed GitHub Release. Publishing alone does not create a reviewed-release
 claim: the RedPill and Phala deployment pipelines still need to supply the
 independently reviewed compose hashes consumed by the branded policies.
 

--- a/clients/architecture.md
+++ b/clients/architecture.md
@@ -1,221 +1,145 @@
-# ACI client product architecture
+# ACI client architecture
 
-## Product goal
+This page is for maintainers building a new client or host adapter. It defines
+the product boundary, component ownership, and the security contract every
+supported integration must preserve.
 
-An ACI client must verify the remote confidential workload before it sends any
-model request bytes. Pi is one consumer of that capability, not the product
-boundary. The same verified connection must work for SDK applications and for
-standalone coding agents without duplicating verification in every framework.
+## Design goal
 
-In plain terms, normal HTTPS proves which domain a client reached. ACI adds
-proof of which TEE workload is behind that domain, which workload keys it owns,
-which compose was measured at launch, and whether the channel actually used is
-bound to those keys.
+An ACI client verifies the remote confidential workload before sending model
+request bytes. That capability belongs in a shared transport and verifier, not
+inside Pi, OpenCode, or any one SDK integration.
 
-## Architecture and ownership
+Normal HTTPS authenticates a domain. The ACI client additionally checks which
+TEE workload is behind that domain, which keys it owns, which compose was
+measured at launch, and whether the connection carrying plaintext is bound to
+an attested key.
+
+## Layers
 
 ```mermaid
 flowchart LR
-  classDef upstream fill:#e8f3ff,stroke:#2878b5,color:#102a43
-  classDef host fill:#fff4d6,stroke:#b7791f,color:#4a2c0a
-  classDef client fill:#e8f8ee,stroke:#25855a,color:#123c2b
-  classDef pending fill:#ffe9e7,stroke:#c4473a,color:#541e18
-  classDef external fill:#f3f4f6,stroke:#6b7280,color:#1f2937
-
-  subgraph local[Client machine]
-    pi[Native Pi provider<br/>packages]:::host
-    ocadapter[Native OpenCode<br/>provider plugin]:::client
-    core[Shared @phala/aci-provider<br/>kernel]:::client
-    sdk[OpenAI, Agents, LangChain,<br/>Vercel AI SDK]:::external
-    opencode[OpenCode on Bun]:::external
-    connect[connectAci shared<br/>runtime client]:::client
-    node[Node fetch adapter]:::client
-    bun[Bun fetch adapter]:::client
-
-    pi --> core
-    opencode --> ocadapter --> core
-    core --> connect
-    sdk --> connect
-    connect -->|Node host| node
-    connect -->|Bun host| bun
-  end
-
-  subgraph trust[Shared trust contract]
-    identity[Quote, nonce, keyset,<br/>compose and expiry]:::upstream
-    release[Reviewed compose allowlist<br/>shared client policy]:::client
-    audit[Verified serving, wire digests,<br/>automatic receipt/session checks]:::client
-    channel[Hostname and attested<br/>TLS SPKI binding]:::client
-    identity --> release --> audit --> channel
-  end
-
-  node --> identity
-  bun --> identity
-
-  subgraph tee[Private AI Gateway inside the TEE]
-    api[OpenAI, Responses and<br/>Anthropic API surfaces]:::upstream
-    frontend[ACI frontend<br/>attestation and receipts]:::upstream
-    routing[Optional control-plane<br/>auth and routing]:::upstream
-    backend[Verified provider backend]:::upstream
-
-    api --> frontend --> routing --> backend
-  end
-
-  channel -->|verified, SPKI-pinned TLS| api
-  backend --> provider[TEE or private model provider]:::external
-
-  pipeline[RedPill and Phala release pipeline<br/>publish reviewed compose hashes<br/>product work still pending]:::pending
-  pipeline -. supplies policy .-> release
+  app[SDK application] --> runtime[connectAci runtime]
+  pi[Pi adapter] --> provider[ACI provider kernel]
+  oc[OpenCode adapter] --> provider
+  provider --> runtime
+  runtime --> verifier[ACI verifier]
+  verifier --> transport[Node or Bun pinned transport]
+  transport --> gateway[Attested gateway]
+  gateway --> upstream[Verified model provider]
 ```
 
-Legend:
-
-- Blue: gateway protocol and Rust verification capabilities.
-- Yellow: released Pi-specific product surface.
-- Green: released framework-neutral transport, provider, and trust-policy
-  capabilities.
-- Red: work still required to complete the production product.
-- Gray: external client or provider software.
-
-Component ownership and release status:
-
-| Component or behavior | Owner or status |
-| --- | --- |
-| ACI protocol, gateway surfaces, attestation, receipts and sessions | Gateway implementation |
-| Rust `aci` verifier, `aci serve`, TLS channel binding and `--accept-compose` | Rust client |
-| TypeScript quote, nonce/keyset, compose and expiry checks | TypeScript verifier |
-| Pi provider, branded packages, model discovery and Pi TLS pinning | Released Pi adapter |
-| Framework-neutral model, lifecycle, policy, account-to-key contract, and structured inspection core | Released client stack |
-| Native OpenCode v1 plugin, provider-scoped inspection commands, plus RedPill and Phala Cloud distributions | Released client stack |
-| `connectAci()` framework-neutral, instance-scoped runtime client | Released client stack |
-| Node adapter using the supported undici dispatcher hook | Released client stack |
-| Bun adapter using the supported `fetch({ tls, proxy })` hooks | Released client stack |
-| Quote-before-pin enforcement, no verification downgrade, origin isolation and safe multi-SPKI rotation | Released client stack |
-| TypeScript/Pi `acceptedComposeHashes` aligned with Rust policy | Released client stack |
-| Streaming wire-digest capture and automatic response-completion receipt/session verification in Pi and OpenCode | Released client stack |
-| Compiled ESM npm packages, declaration maps, package lint, clean-install smoke and OIDC release workflow | Released client stack |
-| Direct OpenCode integration through its provider `options.fetch` hook | Released client stack |
-| Fail-closed OpenCode provider ownership, live model discovery, cancellation-safe receipt audit, and read-only inspection tool | Released client stack |
-| Coding-agent integration guide around the shared transport boundary | Released client stack |
-| Reviewed compose publication from RedPill and Phala release pipelines | Pending product work |
-
-Account authentication is outside the ACI trust protocol. RedPill adapters
-currently accept API keys only. Phala Cloud's device authorization and account
-metadata live in the explicit `@phala/aci-provider/phala-cloud` subpath and are
-attached only by the Phala Cloud adapters. A future RedPill Clerk OAuth flow
-should be added when that product endpoint exists, without changing the
-verifier.
-
-The shared provider exposes four host-neutral integration contracts above the
-verified transport:
-
-| Contract | Shared responsibility | Host responsibility |
+| Layer | Responsibility | Must not own |
 | --- | --- | --- |
-| Provider lifecycle | Resolve policy, establish the verified connection, expose one scoped `fetch`, and fail closed | Create and close the provider through native lifecycle hooks |
-| Model catalog | Strictly validate `/v1/models` and map its declared capabilities, pricing, limits, and modalities into `AciModel` | Map `AciModel` into the host's model type and let the host persist selection/catalog state |
-| Account authorization | Describe one browser/device flow with `AccountApiKeyAuth` and return one API key plus optional metadata | Map the flow into native auth UI and persist the key |
-| ACI inspection | Return structured status, attestation, receipt, and session results and format them for text UIs | Register native commands/tools and render the result |
+| `@phala/aci-verifier` | Quote, nonce, keyset, measurement, expiry, channel, wire-digest, receipt, and session verification | Host auth UI, model persistence, or provider branding |
+| `connectAci()` runtime | One origin-scoped verified connection and fetch implementation | Global TLS state or cross-origin pins |
+| `@phala/aci-provider` | Connection lifecycle, catalog validation, TEE filtering, capabilities, receipt history, response verification, and structured inspection | Host credential storage or host-specific UI |
+| Pi adapter | Pi Provider/Auth APIs, settings, commands, footer state, and native persistence | Independent verification or credential storage |
+| OpenCode adapter | Server-plugin config, auth loader, models, commands, tools, and disposal | Independent verification or credential storage |
+| Branded package | Provider ID, label, endpoint, environment names, accepted release policy, and optional account flow | A fork of the shared trust logic |
 
-This is the extension boundary for another coding agent. A new adapter should
-map these contracts into official host APIs. It should not implement
-attestation, receipt verification, device polling, credential storage, or
-another model catalog.
+Applications that accept a custom `fetch` can use `connectAci()` directly.
+Applications with a provider lifecycle should use the provider kernel. A host
+that exposes neither boundary needs a local verified proxy; changing only its
+base URL is not a native ACI integration.
 
-Model metadata has one authority: the gateway catalog. `supported_features`
-drives reasoning and tool support, while `supported_sampling_parameters`
-drives temperature support. Empty capability arrays are treated conservatively
-and never expanded from a model id. Required limits, modalities, base prices,
-and capability arrays are validated instead of replaced with client defaults.
-Optional cache prices remain absent.
-Provider-specific reasoning dialects remain a gateway routing concern; clients
-use the gateway's public reasoning fields.
+## Shared trust contract
 
-Account authorization is a product capability, not part of ACI. Phala Cloud
-currently implements `AccountApiKeyAuth` with its device grant. RedPill does
-not advertise account authorization, so both hosts expose only its API-key
-method. A future RedPill Clerk integration should implement the same shared
-contract once its real authorization endpoints exist; Pi and OpenCode adapters
-will not need brand-specific login code.
+Every supported runtime path must:
 
-Pi and OpenCode integrate through their official host APIs. Pi owns credentials,
-dynamic-catalog persistence, default-model persistence, and the provider
-lifecycle. OpenCode owns plugin configuration and credential persistence; its
-server plugin supplies the provider config, auth loader, verified fetch, tools,
-and disposal hook. Neither adapter maintains a parallel host state store.
+1. Fetch a fresh nonce-bound report before model traffic.
+2. Verify the hardware quote and the keyset digest bound into `report_data`.
+3. Verify `sha256(app_compose)` against the RTMR3 `compose-hash` event.
+4. Apply any configured accepted-compose policy.
+5. Reject expired keysets.
+6. Validate the destination hostname and require its observed TLS SPKI to
+   appear in the attested keyset.
+7. Apply `aci_verified` and accepted-session constraints before forwarding.
+8. Capture the exact request and response wire digests needed for receipt
+   verification.
+9. Verify the signed receipt and cited session before completing a response
+   when the host promises automatic response verification.
+10. Fail closed on every required check, including cancellation races.
 
-`connectAci()` is the runtime client for applications that accept a custom
-`fetch`. Node and Bun expose the same public API and differ only in how their
-native `fetch` receives the TLS identity callback.
+Pi and OpenCode enable response-completion receipt verification. The generic
+provider defaults to on-demand verification so an embedding host can choose
+the point at which it waits for the audit. `connectAci()` exposes the lower-level
+transport and audit primitives without adding provider lifecycle.
 
-## One trust contract, host-native integrations
+Rust names reviewed compose hashes with repeatable `--accept-compose` flags.
+TypeScript calls the same policy `acceptedComposeHashes`. Conformance tests
+must keep those semantics aligned.
 
-Pi and OpenCode inject the shared verified fetch through their official provider
-extension points. Other fetch-aware Node and Bun applications inject
-`connectAci().fetch` directly. A base URL alone cannot inject the attested TLS
-transport, so clients without a supported custom-fetch or provider-plugin
-boundary are not native ACI integrations in this release. Every supported path
-enforces the same security meaning:
+## Provider contracts
 
-1. Verify a fresh TDX quote and its nonce-bound workload keyset.
-2. Verify that `sha256(app_compose)` is measured into the quote's RTMR3.
-3. When an allowlist is configured, require the measured compose hash to be one
-   of the reviewed releases.
-4. Reject expired identities.
-5. Send inference traffic only over hostname-validated TLS whose observed SPKI
-   is in the attested keyset.
-6. Apply verified-serving and session constraints before forwarding.
-7. Retain exact wire digests and verify signed receipts/sessions on demand.
-8. Fail closed on any required check.
+The provider kernel exposes four host-neutral contracts:
 
-Implementations may use different languages while sharing policy semantics and
-conformance tests. Rust exposes the release policy as repeatable
-`--accept-compose` flags. TypeScript exposes it as
-`acceptedComposeHashes` and Pi passes the same policy through its brand profile
-or deployment configuration.
+| Contract | Shared provider owns | Host adapter owns |
+| --- | --- | --- |
+| Lifecycle | Resolve policy, establish the verified connection, expose scoped fetch, and close it | Create and dispose the provider through native hooks |
+| Model catalog | Validate `/v1/models`, filter, and map declared capabilities, prices, limits, and modalities | Convert `AciModel` into the host model type and persist selection |
+| Account authorization | Describe a browser or device flow and return one API key plus optional metadata | Present the flow and persist the resulting credential |
+| Inspection | Return structured status, attestation, receipt, and session results | Register native commands or tools and render the result |
 
-Within TypeScript, all quote, keyset, policy, rotation, request constraint,
-digest, receipt, and session logic is shared. The Node adapter uses undici's
-scoped dispatcher; the Bun adapter uses Bun's native TLS and proxy fetch
-options. Conditional npm exports select the adapter.
+A new adapter maps these contracts into official host APIs. It must not
+reimplement attestation, device polling, receipt semantics, model inference, or
+credential persistence.
 
-## Hardware proof versus release acceptance
+## Catalog authority
 
-These are deliberately separate claims:
+The gateway catalog is the only source of model capabilities:
 
-- **Hardware-bound mode:** with no compose allowlist, the client proves that a
-  genuine TDX workload owns the attested keys and reports the measured compose.
-  It does not claim that the workload release was reviewed.
-- **Reviewed-release mode:** an operator or branded distribution supplies
-  reviewed compose hashes. A different deployment fails before inference bytes
-  are sent.
+- `supported_features` controls reasoning and tool support;
+- `supported_sampling_parameters` controls temperature support;
+- required limits, modalities, prices, and capability arrays must validate;
+- missing optional cache prices remain absent; and
+- clients do not infer a model family or request dialect from the model ID.
 
-`source_provenance.repo_url` and `repo_commit` are useful labels, but they are
-self-declared by the report. They are not the release trust anchor. The compose
-hash is the value bound into RTMR3 and is therefore the value a verifier pins.
-Clients obtain accepted compose hashes from authenticated release metadata.
+Provider-specific reasoning dialects remain a gateway routing concern. Clients
+use the gateway's normalized public reasoning fields.
 
-The neutral SDK may intentionally use hardware-bound mode for self-hosted and
-development deployments. A production RedPill or Phala branded client should
-ship or securely obtain a reviewed compose allowlist and use reviewed-release
-mode by default.
+## Runtime isolation
 
-## Remaining product work
+`connectAci()` is instance-scoped. Multiple providers can coexist without
+sharing pins, connection state, credentials, model catalogs, or receipt
+history.
 
-The transport and npm release mechanics are no longer the main blockers. The
-deployment release process must still close the trust loop:
+Node uses an undici dispatcher scoped to the connection. Bun uses its native
+TLS and proxy fetch options. Conditional package exports select the adapter;
+all verification and policy logic above the TLS hook is shared.
 
-1. Review the gateway source and complete deployment compose.
-2. Produce the deterministic compose hash for the approved release.
-3. Publish the hash through an authenticated release channel.
-4. Ship it in the branded client policy, allowing an explicit overlap window
-   during controlled release rotation.
-5. Exercise both Rust and TypeScript clients against the same accepted and
-   rejected measurements.
+Pi owns credentials, dynamic-catalog persistence, default-model persistence,
+and provider lifecycle through its native APIs. OpenCode owns plugin
+configuration and credential persistence. Neither adapter maintains a parallel
+host state store.
 
-The release workflow publishes all eight npm packages in dependency order from
-a signed GitHub Release. Publishing alone does not create a reviewed-release
-claim: the RedPill and Phala deployment pipelines still need to supply the
-independently reviewed compose hashes consumed by the branded policies.
+## Release acceptance
 
-The local agent sees plaintext prompts and responses. This architecture covers
-the remote model HTTP path; MCP servers, tools, browser automation, shell
-commands, WebSockets, extensions, and telemetry have separate trust boundaries.
+Hardware proof does not identify an approved product release by itself:
+
+- In **hardware-bound mode**, the client proves a genuine TDX workload owns
+  the attested keys and reports its measured compose.
+- In **reviewed-release mode**, the client also requires that compose hash to
+  appear in a reviewed allowlist.
+
+The report's repository and commit fields are self-declared labels. The compose
+hash is the RTMR3-bound release anchor. RedPill and Phala deployment pipelines
+must publish reviewed compose hashes through an authenticated channel and
+allow a controlled overlap during rotation.
+
+The remaining release loop is:
+
+1. Review the source and complete deployment compose.
+2. Produce the deterministic compose hash.
+3. Publish it through an authenticated release channel.
+4. Ship it in the branded client policy.
+5. Exercise accepted and rejected measurements in Rust and TypeScript.
+
+Publishing the npm packages does not, by itself, establish a reviewed-release
+claim.
+
+## Boundary of this architecture
+
+The local host sees plaintext. This architecture protects the remote model
+HTTP path. MCP servers, tools, browser automation, shell commands, WebSockets,
+extensions, and host telemetry require their own threat models.

--- a/clients/opencode-provider/packages/opencode-provider-redpill/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/README.md
@@ -21,10 +21,8 @@ OpenCode persists the plugin entry and credential in its own configuration and
 auth store. `REDPILL_AI_API_KEY` is also supported for the current process, but
 environment variables are not copied into the auth store. RedPill does not
 currently expose account OAuth. Select `redpill/<model-id>` in OpenCode. The
-plugin discovers current TEE models and sends
-inference only through an attested, TLS-pinned connection. Every response
-receipt is verified before OpenCode can finish the model turn or continue its
-tool loop.
+plugin discovers current TEE models and sends inference only through an
+attested, TLS-pinned connection.
 
 Attestation is verified before model discovery, and each response receipt is
 verified before OpenCode can finish the turn. These commands display the local

--- a/clients/pi-provider/README.md
+++ b/clients/pi-provider/README.md
@@ -99,15 +99,15 @@ pi -e clients/pi-provider/packages/pi-provider-aci
 The adapter creates an instance-scoped `@phala/aci-provider`. That shared
 provider uses the Node ACI transport to:
 
-- recomputes the keyset digest from the served keyset (not trusted from the
+- recompute the keyset digest from the served keyset rather than trust the
   report),
-- checks `report_data` binds our fresh nonce,
-- checks `not_after`,
-- verifies the TDX quote to the Intel root and confirms it binds the same
+- check that `report_data` binds the fresh nonce,
+- check `not_after`,
+- verify the TDX quote to the Intel root and confirm it binds the same
   `report_data`, and
-- verifies `sha256(app_compose)` is measured into RTMR3 and, when configured,
-  belongs to the reviewed compose allowlist, and
-- opens a normal hostname-validated TLS connection whose peer SPKI must match
+- verify that `sha256(app_compose)` is measured into RTMR3 and, when configured,
+  belongs to the reviewed compose allowlist; and
+- open a hostname-validated TLS connection whose peer SPKI must match
   `workload_keyset.tls_public_keys`.
 
 Only a report that passes both binding and hardware verification yields an

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/README.md
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/README.md
@@ -3,10 +3,11 @@
 Phala Cloud Confidential AI for Pi, powered by [private-ai-gateway].
 
 A thin, Phala Cloud-branded distribution of the vendor-neutral
-[`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci): standard
-chat plus **attested TLS (SPKI) pinning** — the prompt and reply are readable
-only by the attested workload. Every response receipt is verified before Pi
-can finish the model turn or continue its tool loop.
+[`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci).
+It sends inference over an attested, SPKI-pinned gateway connection and requires
+verified provider serving. Remote plaintext is limited to the accepted gateway
+and provider workloads. Every response receipt is verified before Pi can finish
+the model turn or continue its tool loop.
 
 ## Install
 
@@ -43,8 +44,9 @@ only display the evidence or rerun an audit. The local wire-digest history keeps
 the latest 32 receipt-bearing requests by default and is cleared when Pi exits;
 gateway receipt and session artifacts have their own server-side retention.
 
-Interchangeable with `pi-provider-redpill` — both share the same
-protocol core and pin the same attested workload. If you operate your own private-ai-gateway, use the neutral
+It shares its verifier and provider core with `pi-provider-redpill`, but the two
+packages have different product IDs, authentication options, and default
+endpoints. If you operate your own private-ai-gateway, use the neutral
 [`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci) instead.
 
 [private-ai-gateway]: https://github.com/Dstack-TEE/private-ai-gateway

--- a/clients/pi-provider/packages/pi-provider-redpill/README.md
+++ b/clients/pi-provider/packages/pi-provider-redpill/README.md
@@ -3,10 +3,11 @@
 Attested AI for Pi, powered by [private-ai-gateway].
 
 A thin, RedPill-branded distribution of the vendor-neutral
-[`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci): standard
-chat plus **attested TLS (SPKI) pinning** — the prompt and reply are readable
-only by the attested workload. Every response receipt is verified before Pi
-can finish the model turn or continue its tool loop.
+[`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci).
+It sends inference over an attested, SPKI-pinned gateway connection and requires
+verified provider serving. Remote plaintext is limited to the accepted gateway
+and provider workloads. Every response receipt is verified before Pi can finish
+the model turn or continue its tool loop.
 
 ## Install
 
@@ -46,8 +47,9 @@ only display the evidence or rerun an audit. The local wire-digest history keeps
 the latest 32 receipt-bearing requests by default and is cleared when Pi exits;
 gateway receipt and session artifacts have their own server-side retention.
 
-Interchangeable with `pi-provider-phala-cloud` — both share the same
-protocol core and pin the same attested workload. If you operate your own private-ai-gateway, use the neutral
+It shares its verifier and provider core with `pi-provider-phala-cloud`, but
+the two packages have different product IDs, authentication options, and
+default endpoints. If you operate your own private-ai-gateway, use the neutral
 [`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci) instead.
 
 [private-ai-gateway]: https://github.com/Dstack-TEE/private-ai-gateway

--- a/clients/provider/README.md
+++ b/clients/provider/README.md
@@ -1,18 +1,28 @@
 # `@phala/aci-provider`
 
-Framework-neutral provider kernel for ACI gateways. It owns verified connection
-lifecycle, live model discovery, TEE-only filtering, model capability mapping,
-bounded receipt history, optional response-completion receipt verification, and
-content-addressed session inspection. It also exposes structured inspection
-results and a shared text formatter, so host adapters do not duplicate ACI
-audit semantics.
+Use this package to add ACI provider behavior to a host that already owns its
+authentication UI, model picker, and persistence. It combines the verified
+transport with live model discovery, TEE filtering, capability mapping, bounded
+receipt history, optional response-completion verification, and session
+inspection.
 
 Host adapters such as Pi and OpenCode supply their native configuration and UI.
 Applications normally install a host adapter rather than this package directly.
+Use `connectAci()` from `@phala/aci-verifier/runtime` instead when you need only
+a verified `fetch` transport.
+
+## Install
+
+```bash
+npm install @phala/aci-provider
+```
+
 Shared RedPill and Phala Cloud profiles are exported from
 `@phala/aci-provider/profiles`. Phala Cloud's account API and device
 authorization flow are isolated under `@phala/aci-provider/phala-cloud`; they
 are not part of the ACI protocol or verifier.
+
+## Create a provider
 
 ```ts
 import {
@@ -30,14 +40,21 @@ await provider.connect();
 const response = await provider.fetch("https://gateway.example.com/v1/chat/completions", {
   method: "POST",
   headers: { Authorization: `Bearer ${process.env.ACI_API_KEY}` },
-  body: JSON.stringify({ model: "model-id", messages: [] }),
+  body: JSON.stringify({
+    model: "model-id",
+    messages: [{ role: "user", content: "Say hi" }],
+  }),
 });
+
+await provider.close();
 ```
 
 The provider fails closed: model traffic is sent only after workload attestation
 and TLS SPKI binding succeed. Set `receipts.verification` to `"response"` to
 make a response stream finish or settle consumer cancellation only after its
 signed receipt and cited session have verified.
+
+## Model catalog
 
 Model discovery uses the verified connection but sends no inference API key;
 the gateway's `/v1/models` catalog is public. Host adapters own credentials and
@@ -49,6 +66,8 @@ The catalog is authoritative. The provider maps reasoning and tools only from
 limits, modalities, or request dialects from model ids. Malformed required
 metadata fails discovery instead of being replaced with guessed defaults.
 Optional cache prices remain absent when the catalog omits them.
+
+## Receipts, sessions, and inspection
 
 `provider.receipts()` returns the bounded in-process exchange history, newest
 first. `provider.verifyReceipt()` verifies the latest exchange when no id is
@@ -65,6 +84,8 @@ import { formatAciInspection, inspectAciProvider } from "@phala/aci-provider";
 const result = await inspectAciProvider(provider, { action: "receipt" });
 console.log(formatAciInspection(result));
 ```
+
+## Product authentication
 
 Products that exchange account authorization for an inference API key implement
 the host-neutral `AccountApiKeyAuth` contract. It describes the browser/device

--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -74,7 +74,7 @@ evidence) exactly as observed.
   does not reconstruct MRTD/RTMR0-2 from a dstack OS image. A
   `requireProductionOs` pass is meaningful only together with a dstack
   verifier result for the same quote, event log, and VM configuration. See
-  [How the OS image is classified](../../docs/providers/phala-direct/verification.md#how-the-os-image-is-classified).
+  [Phala-direct verification algorithm](../../docs/providers/phala-direct/verification.md#verification-algorithm).
 - **No custody check.** §9.1 check 5 (the dstack KMS chain) is not
   implemented in either in-tree verifier; both report an honest skip
   (conformance gaps item 1).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,163 +1,147 @@
-# Deploying Private AI Gateway With git-launcher
+# Deploy with git-launcher
 
-This directory contains the one-file dstack compose path for launching
-Private AI Gateway through
-[`git-launcher`](https://github.com/Dstack-TEE/dstack-examples/tree/main/git-launcher).
+This directory contains the reference dstack deployment for Private AI Gateway. It uses `git-launcher` to check out an exact gateway commit, then runs the repository-owned `entrypoint.sh` inside the confidential VM.
 
-The launcher fetches a pinned `private-ai-gateway` commit, verifies `HEAD`,
-scrubs the checkout, preserves the container environment, and runs the gateway
-repo's own [`../entrypoint.sh`](../entrypoint.sh). The launcher remains
-generic; install, build, run, and ACI policy live in this repo.
+The checked-in manifest is an auditable starting point. It is not a complete production platform. Authentication, rate limiting, external TLS termination, secret delivery, monitoring, backup, and availability remain deployment responsibilities.
 
-The checked-in compose runs in no-middleware mode: the public ACI frontend and
-verified-provider backend are the same process, and traffic is forwarded
-directly from frontend to backend. To enable middleware, configure it in the
-static gateway config (this compose leaves it disabled). See the
-[configuration reference](../docs/configuration-reference.md#middleware).
+## Deployment model
 
-## One-Command Deploy
+The default [`compose.yaml`](compose.yaml) runs one gateway process in direct-upstream mode:
 
-The compose hard-codes the released launcher image:
+```text
+client -> external TLS terminator -> gateway :8086 -> configured providers
+```
+
+The gateway serves HTTP on port `8086`; it does not terminate TLS. Configure the optional in-process middleware and its external HTTP control plane in the static config when policy-based routing is required.
+
+The compose pins this launcher image by digest:
 
 ```text
 docker.io/dstacktee/git-launcher@sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b
 ```
 
-That digest comes from
-[`git-launcher-v0.3.0`](https://github.com/Dstack-TEE/dstack-examples/releases/tag/git-launcher-v0.3.0).
+Review the launcher image, gateway commit, complete compose content, and runtime policy together. The launcher image alone does not identify the deployed workload.
 
-Prepare an audited gateway commit, then run:
+## Prepare the deployment
 
-```bash
-cd deploy
+Choose a reviewed, full 40-character gateway commit and generate a strong admin token. The admin token authorizes runtime upstream replacement.
+
+The checked-in upstream seed is empty. Before deployment, either:
+
+- replace the `gateway-upstreams` content in `compose.yaml` with reviewed routes; or
+- keep it empty and use `PUT /v1/admin/upstreams` after the process starts.
+
+[`upstreams.example.json`](upstreams.example.json) demonstrates current Anthropic, Tinfoil, NEAR AI, Chutes, and Phala-direct entries. It contains placeholders, not production policy.
+
+Do not place plaintext credentials in measured compose content. Supply secrets through the deployment's encrypted environment, KMS, or mounted secret mechanism. Keep only secret-variable references in the manifest.
+
+## One-Command Deploy
+
+From this directory:
+
+```sh
 phala deploy -n private-ai-gateway -c compose.yaml \
-  -e PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-sha> \
+  -e PRIVATE_AI_GATEWAY_REPO_COMMIT=<full-40-hex-commit> \
   -e PRIVATE_AI_GATEWAY_ADMIN_TOKEN=<long-random-admin-token>
 ```
 
-For local/dev deploys, you can also copy
-[`gateway.env.example`](./gateway.env.example), fill in its values, and pass it
-as `-e gateway.env`. For production, pass variables with repeated `-e KEY=VALUE`
-arguments so secrets such as admin tokens do not remain in a plaintext env file.
+For a development deployment, [`gateway.env.example`](gateway.env.example) shows the required variables. Passing individual encrypted variables is preferable for a production deployment because it avoids a plaintext secrets file.
 
-`compose.yaml` inlines the launcher config, the static gateway config, and the
-initial upstream config. dstack measures the raw manifest into `compose_hash`,
-and the published `app_compose` contains variable references rather than their
-values.
-After deployment, the gateway listens on port `8086`.
+Wait for the process to build and start, then check liveness:
 
-The gateway consumes two JSON files:
-
-| File | Compose config | Runtime role |
-| --- | --- | --- |
-| Static gateway config | `gateway-config` | Startup policy: bind address, TLS certificate bindings, dstack endpoint, admin token, gateway state directory, and read-only seed paths. |
-| Upstream seed config | `gateway-upstreams` seed copied to `<state_dir>/upstreams.json` on first boot | Initial provider/model routing policy. The live file is replaced by the admin API. |
-
-The checked-in compose starts with an empty upstream seed:
-
-```json
-[]
+```sh
+curl --fail http://<gateway-host>:8086/health
 ```
 
-For a real deployment, replace the `gateway-upstreams` `content:` block in
-`compose.yaml` with the provider routes you want to boot with, or keep it
-empty and set the config after boot through `PUT /v1/admin/upstreams`.
-[`upstreams.example.json`](./upstreams.example.json) shows the current
-three-provider shape.
+Liveness only proves that the process is serving requests. It does not prove provider availability or successful attestation.
 
 ## Ownership boundary
 
-The launcher is build-system agnostic. It does not know this repo is Rust and
-does not contain a Cargo install command. Its default-mode contract is:
+The launcher is build-system agnostic. It performs four operations: clone the repository, check out `COMMIT_SHA`, preserve the container environment, and run `bash entrypoint.sh` from the pinned checkout. The compose does not set `REPO_SUBDIR` because the gateway entrypoint is at the repository root.
 
-1. Clone `REPO_URL`.
-2. Check out exactly `COMMIT_SHA`.
-3. Preserve the container environment.
-4. Run `bash entrypoint.sh` from the pinned repo.
+The gateway repository owns everything after that boundary:
 
-Everything after step 4 is gateway-owned:
-
-| Concern | Owner | Location |
+| Concern | Owner | Source |
 | --- | --- | --- |
-| Workload source pin | Launcher config | `gateway-pin` in `compose.yaml` |
-| Static gateway config | Deployment compose | `gateway-config` in `compose.yaml` |
-| Runtime bootstrap env | Deployment compose | service `environment:` in `compose.yaml` points at the static gateway config and cache directory |
-| Initial upstream config | Deployment compose | `gateway-upstreams` in `compose.yaml` |
-| Toolchain bootstrap | Gateway repo | `../entrypoint.sh` |
-| Build and exec | Gateway repo | `../entrypoint.sh` |
-| Downstream ACI frontend | Gateway binary | `../src` |
-| Verified-provider backend | Gateway binary | `../src` |
-| Optional routing middleware | Gateway deployment | Router helpers exist, but this compose and static config do not wire middleware |
+| Launcher image and source pin | Deployment | `compose.yaml` and `gateway-pin` |
+| Static gateway policy | Deployment | `gateway-config` in `compose.yaml` |
+| Initial upstream policy | Deployment | `gateway-upstreams` in `compose.yaml` |
+| Toolchain bootstrap, build, and exec | Gateway repository | `entrypoint.sh` |
+| HTTP, ACI, routing, and provider verification | Gateway binary | `src/` |
+| Optional routing and authorization decisions | External control plane | `middleware.control_url` |
 
-The public gateway repo root contains `entrypoint.sh`, so the launcher config
-does not set `REPO_SUBDIR`.
-
-## Volumes and Reboots
-
-The compose uses two persistent volumes with different meanings:
-
-| Volume | Mount | Meaning |
-| --- | --- | --- |
-| `gateway-checkout` | `/var/lib/git-launcher` | Source checkout cache owned by `git-launcher`. Scrubbed on every boot with `git reset --hard` and `git clean -ffdx`. |
-| `gateway-state` | `/var/lib/private-ai-gateway` | Gateway-owned mutable state: active upstream config, attested-session log, and Rust build cache. |
-
-Do not put gateway state or build artefacts under `WORK_DIR`. The source
-checkout is allowed to disappear and reclone. By default `entrypoint.sh` stores
-Cargo/Rustup/target state under
-`PRIVATE_AI_GATEWAY_CACHE_DIR=/var/lib/private-ai-gateway/cache`, so restarts
-can reuse the toolchain and crate/build cache without making the source checkout
-mutable.
-
-## Gateway And Upstream Config
-
-The complete config and environment-variable reference is
-[`../docs/configuration-reference.md`](../docs/configuration-reference.md).
-
-The static gateway config is mounted read-only:
+The static gateway config is mounted at:
 
 ```text
 /etc/private-ai-gateway/gateway.config.json
 ```
 
-It is selected by the only gateway config-path env variable in the compose:
+The compose selects it with:
 
 ```text
 PRIVATE_AI_GATEWAY_CONFIG_PATH=/etc/private-ai-gateway/gateway.config.json
 ```
 
-The gateway config names the writable state directory:
+See [Configuration reference](../docs/configuration-reference.md) for every field and validation rule.
 
-```text
-/var/lib/private-ai-gateway
+## Persistent volumes
+
+| Volume | Mount | Contents |
+| --- | --- | --- |
+| `gateway-checkout` | `/var/lib/git-launcher` | Launcher-owned source checkout. It is scrubbed on boot. |
+| `gateway-state` | `/var/lib/private-ai-gateway` | Active upstream config, sessions, and the build/toolchain cache. |
+
+The gateway state directory contains:
+
+- `upstreams.json`
+- `sessions.jsonl` and `sessions.jsonl.lock`
+- `cache/` for Cargo, rustup, and release build output in this deployment
+
+Do not share one state volume between concurrently running gateway processes. The session store has a single-writer lock, and the rest of the state is not a multi-replica coordination protocol.
+
+### Seed behavior
+
+The read-only seed is mounted at `/etc/private-ai-gateway/upstreams.seed.json` and selected by `upstream_config_seed_path`. On startup, the gateway copies it to `<state_dir>/upstreams.json` only when the active file is missing or contains only whitespace.
+
+An existing active file always wins. Updating the seed in a later compose revision does not replace routes already stored on the persistent volume. Use the admin API for a controlled replacement. Delete the state volume only as an intentional destructive reset that also removes session and cache state.
+
+## Configure upstreams after startup
+
+Inspect the redacted active config:
+
+```sh
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer ${PRIVATE_AI_GATEWAY_ADMIN_TOKEN}" \
+  http://<gateway-host>:8086/v1/admin/upstreams
 ```
 
-Inside that directory, the gateway owns `upstreams.json` and `sessions.jsonl`.
-Operators do not configure those writable file paths individually.
+Replace all routes atomically:
 
-The compose-mounted seed is read-only:
-
-```text
-/etc/private-ai-gateway/upstreams.seed.json
+```sh
+curl --fail --silent --show-error \
+  -X PUT \
+  -H "Authorization: Bearer ${PRIVATE_AI_GATEWAY_ADMIN_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  --data-binary @upstreams.json \
+  http://<gateway-host>:8086/v1/admin/upstreams
 ```
 
-The state directory and seed path are configured inside `gateway-config`:
+The gateway validates the complete array, writes the active file atomically, swaps runtime routing state, and starts verification prewarm. The admin response redacts provider credentials.
 
-```json
-{
-  "state_dir": "/var/lib/private-ai-gateway",
-  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json"
-}
-```
+Supported provider values are:
 
-### Multi-Domain Listener Usage
+- `openai-compatible`
+- `anthropic`
+- `aci-service`
+- `tinfoil`
+- `near-ai`
+- `chutes`
+- `secret-ai`
+- `phala-direct`
 
-The compose keeps a single gateway listener on port `8086`. To serve multiple
-public domains, configure DNS, TLS termination, SNI routing, and reverse proxying
-outside this repo, and forward each public hostname to that listener with the
-original HTTP `Host` intact.
+## Bind public TLS identities
 
-Mount the leaf certificate used for each public hostname and list those
-hostnames in the static gateway config:
+TLS termination sits outside the gateway, but the gateway can include the terminator's leaf-certificate SPKI in its attested workload keyset. Mount each leaf certificate and add it to the static config:
 
 ```json
 {
@@ -166,109 +150,34 @@ hostnames in the static gateway config:
       {
         "domain": "api.example.com",
         "certificate_path": "/run/certs/api.pem"
-      },
-      {
-        "domain": "chat.example.com",
-        "certificate_path": "/run/certs/chat.pem"
       }
     ]
   }
 }
 ```
 
-When a client requests `/v1/aci/attestation` through `chat.example.com`, the
-gateway selects the `chat.example.com` certificate SPKI for
-`attestation.evidence.downstream_tls_binding`. A request with an unknown `Host`
-returns `404 not_found` instead of an attestation report.
+Preserve the original HTTP `Host` when proxying to port `8086`. The canonical `GET /v1/aci/attestation` handler selects the matching domain binding. When domain bindings are configured, an unknown or malformed host receives `404` instead of a report for another identity.
 
-At startup, if `<state_dir>/upstreams.json` is missing or whitespace-only, the
-gateway validates the seed and copies it into that active config file. If the
-active config already contains anything, the seed is ignored and the active
-config wins. This lets a single compose boot a complete initial deployment
-without blocking later admin updates.
+The verifier must also compare that reported SPKI with the certificate served to the client. Merely listing a certificate file in the workload does not prove that an external terminator uses it.
 
-Changing `gateway-upstreams` in a later compose revision does not overwrite an
-existing active config volume. Use the admin API to replace the config, or
-delete the `gateway-state` volume intentionally before redeploying.
+## Verify the deployment
 
-The static gateway config, seed, and bootstrap environment references are part
-of the attested Compose. The canonical attestation endpoint publishes that raw
-Compose preimage for independent verification. Do not place plaintext secrets
-in it. Pass secrets through dstack encrypted environment variables, KMS, or
-mounted secret files. Keep only variable references in Compose.
+Before accepting inference, a relying party should check:
 
-Source provenance is not set in the gateway config. The gateway reports the
-`REPO_URL` and `COMMIT_SHA` observed by git-launcher. The canonical report also
-returns the raw measured `app_compose`, so a verifier can hash it and match the
-RTMR3-bound `compose-hash`. The checked-in manifest measures the commit variable
-name, not its encrypted value. Binding the reported commit and accepted image
-digests to reviewed source is intentionally left as a verifier-policy TODO.
-
-Example seed:
-
-```json
-[
-  {
-    "name": "tinfoil",
-    "provider": "tinfoil",
-    "base_url": "https://inference.tinfoil.sh",
-    "models": {
-      "kimi-k2": "kimi-k2-6"
-    },
-    "bearer_token": "<tinfoil-api-key>"
-  }
-]
-```
-
-Supported provider values are `openai-compatible`, `aci-service`, `tinfoil`,
-`near-ai`, `chutes`, `secret-ai`, and `phala-direct`.
-
-For `aci-service`, `base_url` is the HTTPS origin used for both model traffic and
-`/v1/aci/attestation`. The router fetches the report through normal TLS,
-derives the attested TLS SPKI binding from that report, then pins that SPKI for
-the actual upstream model request.
-
-## Runtime Admin API
-
-When `admin_token` is set in the static gateway config, the same active config
-can be inspected and replaced:
-
-```bash
-curl -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
-  http://127.0.0.1:8086/v1/admin/upstreams
-
-curl -X PUT \
-  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
-  -H "content-type: application/json" \
-  --data-binary @upstreams.json \
-  http://127.0.0.1:8086/v1/admin/upstreams
-```
-
-The admin response redacts bearer tokens and returns the active config digest.
-
-## Verification Surface
-
-A verifier checks:
-
-| Layer | What to compare |
+| Layer | Required comparison |
 | --- | --- |
-| Launcher image | The image digest in the attested compose equals `sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b` and verifies through the `git-launcher-v0.3.0` Sigstore provenance. |
-| Launcher config | `REPO_URL` and `COMMIT_SHA` in `gateway-pin` match the audited gateway commit. |
-| Gateway config | `gateway-config` matches the reviewed startup policy, including TLS certificate bindings, state directory, dstack endpoint, admin token, and read-only input paths. |
-| Runtime env | Service `environment:` points at the reviewed gateway config and cache location. |
-| Upstream seed | `gateway-upstreams` is the reviewed initial provider policy. |
-| Gateway report | `/v1/aci/attestation` binds the ACI keyset (with dstack KMS custody evidence), the TLS SPKI if configured, and the git-launcher source provenance when present. |
+| Compose | Exact services, image digests, mounts, ports, configs, and secret references match reviewed policy. |
+| Launcher | `REPO_URL` and the full `COMMIT_SHA` identify reviewed gateway source. |
+| Gateway static config | Bind address, state paths, dstack endpoint, TLS bindings, admin posture, and middleware settings match policy. |
+| Initial upstream seed | Routes, credentials delivery, provider types, model mappings, verification pins, and refresh settings match policy. |
+| Hardware report | Quote, freshness, nonce, `report_data`, event log, measured compose, and key custody satisfy the verifier profile. |
+| TLS | The client-observed leaf SPKI matches the selected report binding. |
+| Request | The request explicitly requires ACI verification or arrives on a reviewed TEE-only route. |
 
-The launcher image digest alone does not identify the workload; the compose
-config is part of the trust surface.
+Use [Verify an attested inference](../docs/attested-confidential-inference.md) for the artifact flow. The legacy `/v1/attestation/report` endpoint is retained for compatibility; new deployment verification should use `/v1/aci/attestation`.
 
-## Toolchain Posture
+## Toolchain trust
 
-The current `entrypoint.sh` can bootstrap Rust with apt + rustup inside the
-TEE. That keeps the first deploy path simple, but it is a development-grade
-trust surface.
+`entrypoint.sh` builds `private-ai-gateway` in release mode with `cargo build --release --locked`. If Cargo is absent, it installs `rustup` through the runtime Ubuntu package repositories and resolves the current stable Rust toolchain.
 
-The production target is a gateway-owned image that already contains the
-Rust toolchain, or eventually the prebuilt gateway binary. The launcher still
-does not own that toolchain; the image would be built and attested by this repo
-and referenced by digest in `compose.yaml`.
+That bootstrap is a development-grade trust path: the runtime archive metadata, rustup distribution, resolved stable compiler, and fetched crates participate in the effective build. A production gateway-owned image should pin and attest the compiler and dependencies, or contain a reviewed prebuilt binary. The locked Cargo dependency graph prevents resolver drift but does not by itself make the runtime toolchain reproducible.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploy with git-launcher
 
-This directory contains the reference dstack deployment for Private AI Gateway. It uses `git-launcher` to check out an exact gateway commit, then runs the repository-owned `entrypoint.sh` inside the confidential VM.
+This directory contains the reference dstack deployment for Private AI Gateway. It uses the versioned [`git-launcher`](https://github.com/Dstack-TEE/dstack-examples/tree/git-launcher-v0.3.0/git-launcher) source to check out an exact gateway commit, then runs the repository-owned `entrypoint.sh` inside the confidential VM.
 
 The checked-in manifest is an auditable starting point. It is not a complete production platform. Authentication, rate limiting, external TLS termination, secret delivery, monitoring, backup, and availability remain deployment responsibilities.
 
@@ -20,6 +20,12 @@ The compose pins this launcher image by digest:
 docker.io/dstacktee/git-launcher@sha256:4437dce18ec713b0991d34bd926d324966b1a0b90fad485b8ddb3f4ed2af138b
 ```
 
+That digest comes from the
+[`git-launcher-v0.3.0` release](https://github.com/Dstack-TEE/dstack-examples/releases/tag/git-launcher-v0.3.0).
+Its
+[`VERIFY.md`](https://github.com/Dstack-TEE/dstack-examples/blob/git-launcher-v0.3.0/git-launcher/VERIFY.md)
+documents the Sigstore provenance and deployment-verification chain.
+
 Review the launcher image, gateway commit, complete compose content, and runtime policy together. The launcher image alone does not identify the deployed workload.
 
 ## Prepare the deployment
@@ -34,6 +40,11 @@ The checked-in upstream seed is empty. Before deployment, either:
 [`upstreams.example.json`](upstreams.example.json) demonstrates current Anthropic, Tinfoil, NEAR AI, Chutes, and Phala-direct entries. It contains placeholders, not production policy.
 
 Do not place plaintext credentials in measured compose content. Supply secrets through the deployment's encrypted environment, KMS, or mounted secret mechanism. Keep only secret-variable references in the manifest.
+
+dstack measures the raw manifest into `compose_hash` and publishes its
+`app_compose` preimage in the attestation report. In this manifest, the
+gateway commit and admin token remain variable references; their encrypted
+values are neither published in `app_compose` nor bound by that preimage.
 
 ## One-Command Deploy
 
@@ -57,7 +68,13 @@ Liveness only proves that the process is serving requests. It does not prove pro
 
 ## Ownership boundary
 
-The launcher is build-system agnostic. It performs four operations: clone the repository, check out `COMMIT_SHA`, preserve the container environment, and run `bash entrypoint.sh` from the pinned checkout. The compose does not set `REPO_SUBDIR` because the gateway entrypoint is at the repository root.
+The launcher is build-system agnostic. It parses rather than sources its
+config, requires a full commit ID, checks out that commit in detached mode,
+resets and cleans the checkout, and verifies that `HEAD` equals `COMMIT_SHA`.
+It then preserves the container environment and runs `bash entrypoint.sh`
+from the pinned checkout. It does not fall back to a branch, tag, short hash,
+or another commit. The compose does not set `REPO_SUBDIR` because the gateway
+entrypoint is at the repository root.
 
 The gateway repository owns everything after that boundary:
 
@@ -88,7 +105,7 @@ See [Configuration reference](../docs/configuration-reference.md) for every fiel
 
 | Volume | Mount | Contents |
 | --- | --- | --- |
-| `gateway-checkout` | `/var/lib/git-launcher` | Launcher-owned source checkout. It is scrubbed on boot. |
+| `gateway-checkout` | `/var/lib/git-launcher` | Launcher-owned source checkout. Every boot runs `git reset --hard <commit>` and `git clean -ffdx`, then verifies `HEAD`. |
 | `gateway-state` | `/var/lib/private-ai-gateway` | Active upstream config, sessions, and the build/toolchain cache. |
 
 The gateway state directory contains:
@@ -126,7 +143,7 @@ curl --fail --silent --show-error \
   http://<gateway-host>:8086/v1/admin/upstreams
 ```
 
-The gateway validates the complete array, writes the active file atomically, swaps runtime routing state, and starts verification prewarm. The admin response redacts provider credentials.
+The gateway validates the complete array, writes the active file atomically, swaps runtime routing state, and starts verification prewarm. The admin response redacts provider credentials and returns the active JCS SHA-256 `config_digest`.
 
 Supported provider values are:
 
@@ -167,12 +184,20 @@ Before accepting inference, a relying party should check:
 | Layer | Required comparison |
 | --- | --- |
 | Compose | Exact services, image digests, mounts, ports, configs, and secret references match reviewed policy. |
-| Launcher | `REPO_URL` and the full `COMMIT_SHA` identify reviewed gateway source. |
+| Launcher image | The attested digest matches the reviewed release, and its Sigstore provenance identifies the expected `Dstack-TEE/dstack-examples` workflow, ref, and commit. |
+| Gateway source | `REPO_URL` and the full `COMMIT_SHA` identify reviewed gateway source. |
 | Gateway static config | Bind address, state paths, dstack endpoint, TLS bindings, admin posture, and middleware settings match policy. |
 | Initial upstream seed | Routes, credentials delivery, provider types, model mappings, verification pins, and refresh settings match policy. |
 | Hardware report | Quote, freshness, nonce, `report_data`, event log, measured compose, and key custody satisfy the verifier profile. |
 | TLS | The client-observed leaf SPKI matches the selected report binding. |
 | Request | The request explicitly requires ACI verification or arrives on a reviewed TEE-only route. |
+
+The gateway reports the `REPO_URL` and `COMMIT_SHA` it observed in the launcher
+config. A verifier must independently approve those values and the launcher
+image; reporting them does not make them trustworthy. It must also hash the
+published `app_compose` and match it to the pre-`system-ready` `compose-hash`
+event replayed into RTMR3. That proves the manifest was measured, not that its
+images, source, compiler, or dependencies are acceptable.
 
 Use [Verify an attested inference](../docs/attested-confidential-inference.md) for the artifact flow. The legacy `/v1/attestation/report` endpoint is retained for compatibility; new deployment verification should use `/v1/aci/attestation`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ reference gateway, its deployment, and its provider integrations.
 | Reader | Goal | Document | Type |
 | --- | --- | --- | --- |
 | Evaluator | Verify a live ACI deployment | [ACI quickstart](quickstart.md) | Tutorial |
-| Evaluator | Understand the security claim and its limits | [ACI verification and security model](attested-confidential-inference.md) | Explanation and verification guide |
-| Client implementer | Use the Rust CLI, TypeScript transport, or shared provider | [ACI clients](../clients/README.md) | How-to and reference |
+| Evaluator | Understand the security claim and its limits | [ACI verification and security model](attested-confidential-inference.md) | Explanation |
+| Client implementer | Choose the Rust CLI, TypeScript transport, or shared provider | [ACI clients](../clients/README.md) | Index |
 | Coding-agent user | Use ACI natively from Pi or OpenCode | [Coding-agent integrations](../clients/coding-agents.md) | How-to |
 | Developer | Run and change the gateway locally | [Local development](getting-started.md) | Tutorial |
 | Operator | Configure runtime policy and upstreams | [Configuration reference](configuration-reference.md) | Reference |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Private AI Gateway documentation
+
+Use this index to choose the document that matches your task. The ACI protocol
+itself lives under [`spec/`](../spec/README.md); this directory documents the
+reference gateway, its deployment, and its provider integrations.
+
+## Start here
+
+| Reader | Goal | Document | Type |
+| --- | --- | --- | --- |
+| Evaluator | Verify a live ACI deployment | [ACI quickstart](quickstart.md) | Tutorial |
+| Evaluator | Understand the security claim and its limits | [ACI verification and security model](attested-confidential-inference.md) | Explanation and verification guide |
+| Client implementer | Use the Rust CLI or TypeScript verifier | [ACI clients](../clients/README.md) | How-to and reference |
+| Developer | Run and change the gateway locally | [Local development](getting-started.md) | Tutorial |
+| Operator | Configure runtime policy and upstreams | [Configuration reference](configuration-reference.md) | Reference |
+| Client implementer | Call inference and artifact endpoints | [HTTP API reference](api-reference.md) | Reference |
+| Control-plane implementer | Supply authorization, routing, catalogs, and usage ingestion | [Control-plane contract](control-plane-contract.md) | Reference |
+| Operator | Deploy the gateway in dstack | [git-launcher deployment](../deploy/README.md) | How-to |
+| Maintainer | Run unit, smoke, and live-provider tests | [Testing guide](live-e2e-test-suite.md) | How-to |
+| Contributor | Prepare and validate a change | [Contributing](../CONTRIBUTING.md) | How-to and policy |
+| Auditor | Review provider-specific evidence and policy | [Provider verification index](providers/README.md) | Reference |
+
+## ACI artifacts and lifecycle
+
+| Topic | Document | Purpose |
+| --- | --- | --- |
+| Attestation, receipts, E2EE, and end-to-end verification | [ACI verification and security model](attested-confidential-inference.md) | Defines what a relying party must verify. |
+| Attested-session records | [Attested sessions](attested-session-system.md) | Explains session IDs, claims, evidence, storage, and receipt linkage. |
+| Verification leases and Chutes nonce sessions | [Upstream verification lifecycle](upstream-verification-lifecycle.md) | Explains cached verification and provider-session state. |
+| Provider admission | [Provider audit criteria](providers/audit-criteria.md) | Defines the questions a provider integration must answer. |
+
+## Maintainer records
+
+The following documents record plans or point-in-time reviews. They can explain
+why code exists, but they are not runtime references:
+
+- [Project status and roadmap](roadmap.md)
+- [Router-mode provider review process](router-mode-provider-review.md)
+- [ACI implementation gap review](reviews/aci-spec-conformance-gaps.md)
+- [Router soundness review](reviews/router-mode-soundness.md)
+- [Router load-balancing and cache review](reviews/router-mode-load-balancing-cache.md)
+- each provider's dated `review.md` under [`providers/`](providers/README.md)
+
+Use the source files named in each living reference when a review record and the
+current implementation disagree.
+
+## Documentation conventions
+
+- `spec/aci.md` is normative for the protocol. Implementation docs describe the
+  behavior of this repository.
+- Provider `verification.md` files track the current adapter. Provider
+  `review.md` files are dated admission records.
+- Examples use the canonical `/v1/aci/*` artifact endpoints. The
+  `/v1/attestation/report` and `/v1/signature/{id}` routes exist for legacy
+  dstack-vllm-proxy clients.
+- Security statements identify the policy or request constraint that makes the
+  gateway fail closed. A provider name alone does not imply enforcement.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ reference gateway, its deployment, and its provider integrations.
 | --- | --- | --- | --- |
 | Evaluator | Verify a live ACI deployment | [ACI quickstart](quickstart.md) | Tutorial |
 | Evaluator | Understand the security claim and its limits | [ACI verification and security model](attested-confidential-inference.md) | Explanation and verification guide |
-| Client implementer | Use the Rust CLI or TypeScript verifier | [ACI clients](../clients/README.md) | How-to and reference |
+| Client implementer | Use the Rust CLI, TypeScript transport, or shared provider | [ACI clients](../clients/README.md) | How-to and reference |
+| Coding-agent user | Use ACI natively from Pi or OpenCode | [Coding-agent integrations](../clients/coding-agents.md) | How-to |
 | Developer | Run and change the gateway locally | [Local development](getting-started.md) | Tutorial |
 | Operator | Configure runtime policy and upstreams | [Configuration reference](configuration-reference.md) | Reference |
 | Client implementer | Call inference and artifact endpoints | [HTTP API reference](api-reference.md) | Reference |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,167 @@
+# HTTP API reference
+
+This reference is for client and control-plane implementers integrating with
+the current gateway binary. The ACI wire-format definitions are normative in
+the [ACI specification](../spec/aci.md).
+
+## Base behavior
+
+The gateway has one HTTP listener, configured by `bind`. It does not terminate
+TLS. A production deployment normally places a TLS endpoint in front of the
+listener and forwards the original `Host` header.
+
+All responses, including errors, carry:
+
+| Header | Value |
+| --- | --- |
+| `X-ACI-Version` | `aci/1` |
+| `X-ACI-Keyset-Digest` | digest of the active workload keyset |
+
+The router permits cross-origin browser requests. Axum limits request bodies to
+32 MiB. JSON inference requests that exceed the limit receive `413` before the
+inference handler runs.
+
+## Inference endpoints
+
+| Method and path | Surface | Streaming | ACI E2EE v2 | Notes |
+| --- | --- | --- | --- | --- |
+| `POST /v1/chat/completions` | OpenAI Chat Completions | Yes | Yes | Primary chat endpoint. |
+| `POST /v1/completions` | OpenAI legacy Completions | Yes | Yes | Encrypts `prompt` in E2EE mode. |
+| `POST /v1/embeddings` | OpenAI Embeddings | No | Yes | The gateway forces a client-supplied `stream: true` back to buffered mode. |
+| `POST /v1/responses` | OpenAI Responses create | Yes | No | E2EE headers return `400 e2ee_unsupported_endpoint`. |
+| `POST /v1/messages` | Anthropic Messages | Yes | No supported field profile | Middleware can translate between Anthropic and OpenAI provider formats. |
+
+Every completed provider-backed response includes:
+
+| Header | Meaning |
+| --- | --- |
+| `X-Receipt-Id` | Preferred identifier for the signed receipt. |
+| `X-E2EE-Applied` | `true` when the gateway encrypted the response under ACI or legacy E2EE, otherwise `false` on normal completed inference responses. |
+| `X-E2EE-Version` | E2EE wire version when encryption was applied. |
+| `X-E2EE-Algo` | Selected E2EE key algorithm when encryption was applied. |
+
+For streaming calls, the gateway sends `X-Receipt-Id` before the stream is
+complete and stores the receipt after the stream finalizer observes the terminal
+body. An upstream non-2xx returned before streaming begins is buffered and does
+not receive a receipt.
+
+### Require ACI verification
+
+The request body may contain a gateway-owned provider constraint:
+
+```json
+{
+  "provider": {
+    "aci_verified": true,
+    "aci_session_ids": ["0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
+  }
+}
+```
+
+`aci_verified` must be a boolean. `aci_session_ids` must be a non-empty array of
+bare 64-character lowercase hexadecimal IDs; duplicates are collapsed.
+Supplying session IDs implies `aci_verified: true`; combining session IDs with
+`aci_verified: false` returns `400`.
+
+The constraint causes the gateway to reject before forwarding when:
+
+- the selected route is not classified as a TEE route,
+- the route has no successful verifier result,
+- the current session ID is not in the supplied allowlist, or
+- the backend cannot enforce the verified binding.
+
+Direct mode removes `aci_verified` and `aci_session_ids` before forwarding the
+provider block. Middleware mode sends the original provider block to the
+control plane and builds a provider-specific upstream body from the returned
+route candidate.
+
+`X-Upstream-Verification` is retired. Requests that send it receive `400` with
+an instruction to use `provider.aci_verified`.
+
+### Receipt ownership
+
+If the inference request includes `Authorization: Bearer <token>`, the gateway
+stores a SHA-256 digest of that token as the receipt owner. Receipt lookup then
+requires the same bearer token:
+
+- a missing token returns `401`,
+- a different token returns `403`, and
+- an inference request without a bearer token creates a public receipt.
+
+The incoming bearer token is used for receipt ownership and middleware API-key
+hashing. Provider credentials come from the upstream config.
+
+## Model catalogs
+
+| Method and path | Direct mode | Middleware mode |
+| --- | --- | --- |
+| `GET /v1/models` | Returns the configured model-router catalog. | Relays `/models` and the query string to the control plane. |
+| `GET /v1/models/{subpath}` | `404` | Relays `/models/{subpath}` and the query string to the control plane. |
+| `GET /v1/embeddings/models` | `404` | Relays `/embeddings/models` and the query string to the control plane. |
+
+On a host listed in `middleware.tee_only_domains`, the gateway removes any
+client-supplied `tee` query parameter and relays `tee=true`.
+
+## Canonical ACI endpoints
+
+| Method and path | Authentication | Response |
+| --- | --- | --- |
+| `GET /v1/aci/attestation?nonce=<value>` | Public | Bare ACI attestation report. The URL-decoded nonce is bound into `report_data`; omission binds JSON `null`. |
+| `GET /v1/aci/receipts/{id}` | Original bearer token for owned receipts | Bare signed receipt. `{id}` accepts `receipt_id` or an upstream chat ID. |
+| `GET /v1/aci/sessions/{session_id}` | Public | Full immutable attested-session record, including evidence data when recorded. |
+| `GET /v1/aci/sessions?upstream_name=<name>&model=<id>` | Public | Newest-first session list. The broad list omits evidence data and keeps its digest. |
+
+Use a fresh, unpredictable attestation nonce for each trust decision. Fetch the
+report through the same public hostname used for inference when downstream TLS
+bindings are configured.
+
+## Legacy compatibility endpoints
+
+| Method and path | Behavior |
+| --- | --- |
+| `GET /v1/attestation/report` | Returns the gateway report with dstack-vllm-proxy compatibility fields. Query parameters include `nonce`, `signing_algo`, `version`, and `model`. |
+| `GET /v1/signature/{id}` | Returns the legacy signature wrapper with the canonical ACI receipt nested under `receipt`. |
+
+`GET /v1/attestation/report?model=<id>` may add upstream GPU evidence for
+supported providers. Chutes returns its own multi-instance legacy report. New
+ACI verifiers should use the canonical endpoints and follow the receipt's
+session reference.
+
+## Operations endpoints
+
+| Method and path | Authentication | Purpose |
+| --- | --- | --- |
+| `GET /` | Public | Returns `api_version` and `workload_keyset_digest`. |
+| `GET /health` | Public | Liveness only. Returns `{"status":"ok"}`. |
+| `GET /v1/metrics` | Public | Prometheus text generated by the gateway. |
+| `GET /v1/admin/upstreams` | Admin bearer token | Returns the active config digest and a redacted upstream list. |
+| `PUT /v1/admin/upstreams` | Admin bearer token | Validates, atomically writes, and activates a replacement JSON array. Starts background verification prewarm after the response. |
+
+If `admin_token` is absent from the static config, all admin routes return
+`404`. With an admin token configured, a missing token returns `401` and a wrong
+token returns `403`.
+
+## Middleware failover behavior
+
+The control plane returns ordered route candidates. Middleware mode tries the
+next candidate after provider-specific authentication or credit failures
+(`401`, `402`, `403`), capacity signals (`429`), and selected upstream failures
+(`500`, `502`, `503`, `504`). Request errors such as `400`, `404`, and `422` are
+terminal because another candidate would receive the same invalid request.
+
+After all candidates report capacity, a non-`basic` user tier can receive one
+delayed retry of the capacity-failed candidates. The retry waits about two
+seconds and is skipped after ten seconds of elapsed forwarding time. The
+receipt records the route that served the response. Per-attempt usage reports
+carry the full failover chain to the control plane.
+
+## Error handling
+
+The gateway keeps OpenAI and Anthropic error envelopes separate. It passes
+actionable upstream client errors through the appropriate surface, maps most
+upstream authentication failures to gateway errors, and maps a recognized
+provider capacity-exhaustion response to `429`.
+
+Streaming failures that occur after response headers are sent are represented
+inside the stream where the protocol permits it. Receipt or E2EE finalization
+errors end the body without forcing a TCP reset.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,9 +17,9 @@ All responses, including errors, carry:
 | `X-ACI-Version` | `aci/1` |
 | `X-ACI-Keyset-Digest` | digest of the active workload keyset |
 
-The router permits cross-origin browser requests. Axum limits request bodies to
-32 MiB. JSON inference requests that exceed the limit receive `413` before the
-inference handler runs.
+The router permits cross-origin browser requests. Inference handlers read JSON
+bodies under a 32 MiB limit. A larger body receives the surface's JSON `413`
+envelope and emits a `request_outcome` record with `phase=body_too_large`.
 
 ## Inference endpoints
 
@@ -31,7 +31,7 @@ inference handler runs.
 | `POST /v1/responses` | OpenAI Responses create | Yes | No | E2EE headers return `400 e2ee_unsupported_endpoint`. |
 | `POST /v1/messages` | Anthropic Messages | Yes | No supported field profile | Middleware can translate between Anthropic and OpenAI provider formats. |
 
-Every completed provider-backed response includes:
+The normal provider-backed response path adds:
 
 | Header | Meaning |
 | --- | --- |
@@ -40,10 +40,20 @@ Every completed provider-backed response includes:
 | `X-E2EE-Version` | E2EE wire version when encryption was applied. |
 | `X-E2EE-Algo` | Selected E2EE key algorithm when encryption was applied. |
 
-For streaming calls, the gateway sends `X-Receipt-Id` before the stream is
-complete and stores the receipt after the stream finalizer observes the terminal
+For a normal streaming call, the gateway sends `X-Receipt-Id` before the stream
+is complete and stores the receipt after the finalizer observes the terminal
 body. An upstream non-2xx returned before streaming begins is buffered and does
 not receive a receipt.
+
+Middleware has one exception. An unconstrained, non-E2EE stream can be committed
+as HTTP `200` after `middleware.sse_keepalive_ms` elapses without upstream
+response headers. The gateway emits `: PROCESSING` comments while it waits. It
+cannot name a receipt when it commits, so the response omits `X-Receipt-Id`. If
+the upstream later succeeds and the stream finalizes, fetch the receipt by the
+response `id`; if forwarding fails after the early commit, no receipt is
+drafted and the real failure arrives as an in-band error event. Requests with
+`provider.aci_verified` or pinned session IDs are never committed early, so
+ACI-constrained clients always receive the receipt header.
 
 ### Require ACI verification
 
@@ -163,5 +173,9 @@ upstream authentication failures to gateway errors, and maps a recognized
 provider capacity-exhaustion response to `429`.
 
 Streaming failures that occur after response headers are sent are represented
-inside the stream where the protocol permits it. Receipt or E2EE finalization
-errors end the body without forcing a TCP reset.
+inside the stream where the protocol permits it. This includes failures after
+an early HTTP `200`; the stream's error event carries the status the response
+would otherwise have used, and middleware reports that real status to the
+control plane. A client disconnect before the first upstream byte is reported
+as `499`, and a gateway-enforced connect or read deadline is reported as `504`.
+Receipt or E2EE finalization errors end the body without forcing a TCP reset.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -95,7 +95,8 @@ stores a SHA-256 digest of that token as the receipt owner. Receipt lookup then
 requires the same bearer token:
 
 - a missing token returns `401`,
-- a different token returns `403`, and
+- a different token returns `404` so the lookup does not reveal another
+  tenant's receipt, and
 - an inference request without a bearer token creates a public receipt.
 
 The incoming bearer token is used for receipt ownership and middleware API-key

--- a/docs/attested-confidential-inference.md
+++ b/docs/attested-confidential-inference.md
@@ -148,6 +148,36 @@ A receipt proves what the attested gateway recorded. A deep session audit lets
 the relying party reappraise the provider evidence instead of accepting the
 gateway's `verified` label alone.
 
+### Audit the receipt
+
+Given an established workload keyset and the exact request and response bytes,
+a relying party checks:
+
+1. The receipt `signature` verifies over the JCS form of the document without
+   its `signature` member, using the `receipt_signing_keys` entry named by
+   `key_id`.
+2. `api_version` is `aci/1`, and `workload_keyset_digest` matches the
+   established gateway identity.
+3. `request.received.body_hash` matches the plaintext request wire body. For
+   E2EE v2, it instead matches the compact JSON body reconstructed after
+   replacing encrypted fields with their decrypted values.
+4. `response.returned.body_hash` matches the exact bytes received from the
+   wire, including ordered SSE framing and any encrypted response fields.
+5. A required aggregated request has an `upstream.verified` event with
+   `required: true`, `result: "verified"`, and a `session_id`.
+6. The full session hashes to that ID, its evidence hashes to
+   `evidence.digest`, the receipt's `served_at` falls inside its validity
+   window, and its claims satisfy local policy.
+
+Compare `request.forwarded.body_hash` with `request.received.body_hash` to
+detect a gateway rewrite. Whether that rewrite is acceptable remains local
+policy. A missing or failed required check makes the response unacceptable.
+
+Fail-closed verification and session-pin refusals also carry `X-Receipt-Id`.
+Their receipts commit to the original request, the failed upstream event, and
+the exact error body, so a client can verify that the attested gateway refused
+before forwarding.
+
 ## Proof layers
 
 | Layer | Artifact | What it proves | What it does not prove by itself |

--- a/docs/attested-confidential-inference.md
+++ b/docs/attested-confidential-inference.md
@@ -1,257 +1,286 @@
-# Attested Confidential Inference
+# Verification and security model
 
-This page is the product-neutral source for `{PRODUCT_NAME}` inference docs.
-Product docs should replace every placeholder before publishing. The
-normative protocol definition is the [ACI Spec](../spec/aci.md).
+This page is for developers deciding whether an ACI deployment protects their
+inference data. It explains the privacy claim, the evidence behind it, the
+checks a client must perform, and the limits that remain.
 
-Primary reader: developers who call the OpenAI-compatible API and verifiers who
-need to prove which attested gateway served a response.
+The [ACI specification](../spec/aci.md) is normative. The
+[quickstart](quickstart.md) is the runnable walkthrough.
+
+## The privacy claim
+
+For an accepted ACI request, remote plaintext is limited to the workloads that
+must process it:
+
+1. the attested gateway workload; and
+2. the accepted provider workloads on the selected route, including a
+   confidential router and model runner when they are separate.
+
+The client verifies the gateway and its channel before sending the request.
+The measured gateway code verifies the selected provider and enforces the
+provider's attested channel binding before forwarding. A failed required check
+stops the request before that hop receives the prompt.
+
+Under the TEE threat model, the gateway operator, model operator, and cloud host
+cannot inspect protected workload memory. The local application still sees the
+prompt and response. The accepted remote workloads also see plaintext because
+they must process it.
+
+This is not a promise from an API header. It is a policy decision based on
+hardware evidence, measured software, attested keys, and enforced channels that
+the relying party checks independently.
 
 > [!IMPORTANT]
-> Upstream verification is a request constraint, not a global gateway mode.
-> Set `provider.aci_verified` to `true`, or provide a non-empty
-> `provider.aci_session_ids` allowlist, when the request must fail closed unless
-> the selected upstream verifies.
+> Provider verification is a request constraint, not a global gateway mode.
+> Set `provider.aci_verified: true`, pass a non-empty
+> `provider.aci_session_ids` list, or use a TEE-only middleware hostname when a
+> request must fail closed.
 
-## Placeholders
+## Who receives what
 
-| Placeholder | Meaning |
-| --- | --- |
-| `{PRODUCT_NAME}` | Product name shown in the wrapper docs. |
-| `{API_BASE_URL}` | Base URL without the `/v1` suffix, for example `https://api.example.com`. |
-| `{API_KEY_ENV_VAR}` | Environment variable that holds the model API key. |
-| `{API_KEY_SOURCE}` | Dashboard, console, or account flow where users create the API key. |
-| `{DEFAULT_MODEL_ID}` | Model ID used in quickstart examples. |
-| `{PRODUCTION_VERIFIER_POLICY_URL}` | Published verifier policy for accepted source provenance, image digests, keyset subjects, KMS roots, and TLS bindings. |
+| Component | Inference content | Other information |
+| --- | --- | --- |
+| Local client or agent | Plaintext prompt and response | API key and all local context |
+| Attested gateway workload | Plaintext after TLS or E2EE termination | Requested model, credential, routing constraints, and provider response |
+| Accepted provider workload or route | Plaintext needed for routing or inference | Gateway-side provider credential and request metadata |
+| Optional external control plane | No prompt or response body | Bearer-token hash, model, routing options, pricing, usage, and status metadata |
+| Cloud host and workload operator | Not through the accepted TEE memory boundary | Network timing, addresses, sizes, and operational metadata |
 
-## What Verification Proves
+The gateway forwards the caller's routing object to the control plane as
+metadata. Do not put prompts or secrets there. See the exact
+[control-plane contract](control-plane-contract.md).
 
-The API returns normal OpenAI-compatible responses and adds verifiable evidence.
-A verifier answers three separate questions:
+Provider workloads can have their own internal routing, telemetry, or storage
+boundaries. Accept only the claims that the provider verifier actually proves.
+The [provider verification index](providers/README.md) records those differences.
 
-1. The gateway attestation report proves which workload keyset serves the API:
-   the hardware quote binds the keyset digest and the verifier's fresh nonce,
-   and the report carries source provenance and evidence.
-2. The per-response receipt proves request and response hashes, selected
-   upstream verification, and the receipt signature under a key from the
+## The shortest verified path
+
+Install the CLI as shown in the [quickstart](quickstart.md), then establish the
+gateway identity:
+
+```bash
+aci verify https://tee.redpill.ai
+```
+
+The command obtains a fresh nonce-bound report and prints each pass, failure,
+or skipped policy check. It exits successfully only when its implemented checks
+produce a verified verdict.
+
+To send one chat request and verify its response receipt and cited session:
+
+```bash
+export ACI_API_KEY=<your-api-key>
+aci send https://tee.redpill.ai --prompt "What are you running on?"
+```
+
+Use `aci curl` when you need arbitrary curl behavior and a verified,
+SPKI-pinned channel. It verifies before sending, but it does not audit the
+response receipt. See the [CLI reference](../src/bin/aci/README.md) for the
+differences among `verify`, `curl`, `send`, `sessions`, `audit`, and `serve`.
+
+## How privacy is enforced
+
+ACI protects the path in three stages.
+
+### 1. Before the client sends data
+
+The client fetches `GET /v1/aci/attestation` with a fresh random nonce and
+checks the ACI §9.1 chain:
+
+1. The hardware quote verifies to an accepted TEE vendor root.
+2. The quote binds `report_data`, which binds the nonce and the digest of the
+   served workload keyset.
+3. The keyset has not expired.
+4. Measured evidence supports source or release provenance accepted by policy.
+5. Private-key custody satisfies the relying party's policy.
+6. The channel used for inference terminates at a TLS or E2EE key in that
    attested keyset.
-3. For an aggregator, the receipt's `upstream.verified` event and cited session
-   show which verified provider channel was used and preserve the claims,
-   binding, and evidence for independent policy appraisal.
 
-Verification does not rely on the product API server saying "verified". The
-verifier fetches artifacts, validates signatures and hashes locally, and applies
-the production verifier policy from `{PRODUCTION_VERIFIER_POLICY_URL}`.
+The last check matters. A valid quote beside an ordinary HTTPS connection does
+not protect the request if TLS terminates somewhere else. The Node and Bun
+runtime clients and the Rust CLI pin the observed certificate SPKI to the
+attested keyset.
 
-## Quick Request
+The browser verifier can check the quote, binding chain, measurement, receipts,
+and sessions. Browser APIs do not expose the peer certificate, so browser-only
+code cannot enforce the TLS SPKI pin.
 
-Create an API key from `{API_KEY_SOURCE}` and keep it in `{API_KEY_ENV_VAR}`.
-The neutral snippets below copy that value into `API_KEY`; product docs can
-render the final environment variable name directly.
+### 2. Before the gateway forwards data
+
+For a request that requires verified serving, the attested gateway:
+
+1. selects a provider candidate;
+2. runs or reuses that provider's verifier under its configured policy;
+3. requires a verified result;
+4. applies any client-supplied session allowlist;
+5. opens a connection that enforces the verified TLS SPKI or provider E2EE
+   public key; and
+6. forwards the prompt only after that binding succeeds.
+
+Each candidate is checked independently. A verified event for one origin,
+model scope, or channel never authorizes another. A binding mismatch invalidates
+the cached result and triggers one fresh verification before the candidate
+fails. The complete state machine is in
+[Upstream verification lifecycle](upstream-verification-lifecycle.md).
+
+Without an ACI constraint, a provider verification failure may be recorded as
+informational while the request continues. That mode is useful for mixed
+confidential and ordinary routing, but it is not a fail-closed privacy claim.
+
+### 3. After the response
+
+The gateway signs a per-request receipt under a key from its attested keyset.
+The receipt commits to:
+
+- the request body the gateway processed;
+- the body forwarded after any gateway rewrite;
+- the upstream verification result and cited session;
+- the exact response bytes returned, including raw SSE framing; and
+- the gateway keyset digest current for the exchange.
+
+The receipt stores hashes, not plaintext request or response bodies. For an
+aggregator, its `upstream.verified` event cites a content-addressed attested
+session. The session preserves the provider channel binding, typed claims, and
+evidence used by the verifier.
+
+A receipt proves what the attested gateway recorded. A deep session audit lets
+the relying party reappraise the provider evidence instead of accepting the
+gateway's `verified` label alone.
+
+## Proof layers
+
+| Layer | Artifact | What it proves | What it does not prove by itself |
+| --- | --- | --- | --- |
+| Gateway identity | Attestation report | Fresh TEE evidence binds the gateway keyset and measured workload | That the relying party approves the measured release |
+| Client channel | Observed TLS certificate or E2EE key | Inference bytes terminate at a key in the attested keyset | Provider-side privacy after the gateway |
+| Provider path | Attested session | The gateway verified and enforced a provider binding with recorded evidence | Claims the provider verifier left `unknown` |
+| Exchange integrity | Signed receipt | Request, rewrite, response, and serving record are bound to the attested gateway | An external timestamp or non-repudiable public log |
+
+Every layer has a different job. An `x-receipt-id` alone proves nothing until
+the client fetches the receipt, verifies its signature and body hashes, and
+checks the cited session under its own policy.
+
+## Pin an upstream session
+
+A client can inspect current sessions before sending sensitive data:
 
 ```bash
-export API_BASE_URL="{API_BASE_URL}"
-export API_KEY="<value from {API_KEY_ENV_VAR}>"
-export MODEL="{DEFAULT_MODEL_ID}"
-
-curl "$API_BASE_URL/v1/chat/completions" \
-  -H "Authorization: Bearer $API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "'"$MODEL"'",
-    "messages": [
-      {"role": "user", "content": "Explain why attestation matters in one sentence."}
-    ],
-    "provider": {"aci_verified": true}
-  }'
+aci sessions https://tee.redpill.ai \
+  --require-claim tee_attested=hardware_proven
 ```
 
-Save these response values:
+The command fetches each full record, recomputes its content address, validates
+the evidence digest and validity window, and applies the requested claims
+policy. Pass the accepted IDs on the inference request:
 
-- Response body bytes.
-- `x-receipt-id` response header.
-- Optional `id` field from the JSON response.
-- `x-aci-keyset-digest` header, if present.
-
-`x-receipt-id` is the stable lookup key for verification. The JSON response
-`id` can also work when the response body contains a chat completion ID.
-This example is ACI-constrained, so the gateway will not commit the stream
-before it can name the receipt. An unconstrained, non-E2EE middleware stream
-may instead start with a keepalive before an upstream is selected and omit the
-header. After a successful stream its receipt is available by response `id`;
-if forwarding fails after that early commit, no receipt is drafted. A verifier
-that requires a receipt should constrain the request.
-
-## Verification Flow
-
-Generate a fresh nonce before fetching the attestation report.
-
-```bash
-NONCE="$(openssl rand -hex 32)"
-
-curl "$API_BASE_URL/v1/aci/attestation?nonce=$NONCE" \
-  -o attestation-report.json
+```json
+{
+  "provider": {
+    "aci_verified": true,
+    "aci_session_ids": ["<accepted-session-id>"]
+  }
+}
 ```
 
-Fetch the receipt for the response.
+The gateway consumes this object and does not forward it upstream. If no listed
+session can serve, it returns `session_not_accepted` before forwarding. A
+binding rotation creates a new session ID, so an old pin cannot silently accept
+the new channel.
 
-```bash
-curl "$API_BASE_URL/v1/aci/receipts/$RECEIPT_ID" \
-  -H "Authorization: Bearer $API_KEY" \
-  -o receipt.json
-```
-
-Then verify locally. First establish the workload identity (spec §9.1):
-
-1. The hardware quote verifies to the TEE vendor root and binds `report_data`.
-2. The binding chain recomputes: hash the served `workload_keyset` object's
-   JCS form to `workload_keyset_digest`, build the §3.2 statement for your
-   nonce, and check its hash equals `report_data`.
-3. The keyset is not expired (`now < not_after`).
-4. The source provenance is acceptable to the production policy.
-5. Private-key custody evidence satisfies the policy (for this implementation,
-   the dstack KMS chain in the report evidence).
-6. The channel you use is bound: the observed TLS SPKI or the E2EE key you
-   encrypt to is listed in the attested keyset.
-
-Then verify the response (spec §9.3):
-
-1. The receipt signature (Ed25519 over the JCS form of the document
-   bytes) verifies under the keyset entry `key_id` names.
-2. The payload's `workload_keyset_digest` matches the established digest.
-3. `request.received.body_hash` matches the request bytes the gateway processed.
-   For E2EE v2, reconstruct the compact JSON body with decrypted field values.
-4. `response.returned.body_hash` matches the response bytes you received (the
-   raw SSE stream for streaming, including encrypted E2EE fields).
-
-For aggregator deployments, verify the cited session (spec §9.2): the
-`upstream.verified` event is `verified` and cites a `session_id`; the fetched
-session bytes hash to that id; the evidence data hashes to its digest; the
-session's claims satisfy your policy.
-
-The verifier should fail closed if a required artifact is missing, malformed,
-expired, unsigned, or rejected by policy.
-
-## Current Artifact Endpoints
+## Artifact endpoints
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /v1/aci/attestation?nonce=<nonce>` | Fresh gateway attestation report. |
-| `GET /v1/aci/receipts/{id}` | Signed ACI receipt. `{id}` can be a receipt ID or response chat ID. |
-| `GET /v1/aci/sessions/{session_id}` | Attested-session record referenced by receipt events. |
-| `GET /v1/aci/sessions?upstream_name=&model=` | List a provider's current attested sessions. |
-| `GET /v1/attestation/report` · `GET /v1/signature/{id}` | Legacy dstack-vllm-proxy aliases, with the `X-Signing-Algo` legacy E2EE mode. Kept for pre-ACI clients under the Appendix B rule: they never alter ACI artifacts, and their report bindings use their own quotes. New verifiers should use the `/v1/aci/*` endpoints above. |
+| `GET /v1/aci/attestation?nonce=<64-hex>` | Fresh gateway attestation report and workload keyset |
+| `GET /v1/aci/receipts/{id}` | Signed receipt, fetched with the request credential when authentication was used |
+| `GET /v1/aci/sessions/{session_id}` | Full immutable upstream session and evidence |
+| `GET /v1/aci/sessions?upstream_name=&model=` | Current abbreviated sessions for inspection before a request |
 
-## Tracing a receipt to its session
+Receipts are retained for a bounded time and should be fetched promptly. The
+reference implementation keeps them in memory for one hour and loses them on
+restart. A session must remain available while a retained receipt cites it,
+but the reference session store is not an externally witnessed transparency
+log.
 
-The artifacts are linked, not bundled. A receipt's `upstream.verified` event
-carries the content-addressed `session_id`; the typed claims, channel
-bindings, and evidence live on the session record. For a deep audit, follow
-that reference to `GET /v1/aci/sessions/{session_id}`: an immutable record with
-the full evidence and per-claim reasons, which the verifier re-checks itself.
-Because `session_id` is a content hash, the session you fetch is exactly the one
-the receipt committed to — race-free, and permanently cacheable.
+See the [HTTP API reference](api-reference.md) for authentication, response
+shapes, and legacy aliases.
 
-The gateway never stores request bodies, so there is no body to fetch: the
-rewrite (if any) is committed by `request.forwarded.body_hash` differing from
-`request.received.body_hash`, not by warehousing plaintext.
+## E2EE v2
 
-## Pinning Sessions on a Request
+E2EE v2 is an optional compatibility extension that encrypts supported content
+fields between the client and the attested gateway workload. The quote-bound
+`e2ee_public_keys` entry is the key-provenance anchor. Field AAD binds the
+ciphertext to its model, field path, nonce, timestamp, direction, and response
+ID.
 
-The link also runs forward. A request body MAY carry serving constraints
-(spec §5.3):
+E2EE v2 protects content across infrastructure in front of the gateway TEE. It
+does not hide content from accepted workloads on the inference path, and it
+does not define encryption for every API field or endpoint. It covers Chat
+Completions, Completions, and Embeddings as specified in the
+[E2EE v2 protocol](../spec/e2ee-v2.md).
 
-```json
-"provider": { "aci_verified": true, "aci_session_ids": ["<session-id>", "..."] }
-```
+The extension is frozen and supported through at least February 10, 2027.
+E2EE v3 is the planned replacement.
 
-`aci_verified` requires a verified attested session for this request;
-`aci_session_ids` requires one of the listed sessions — verify candidates from
-`GET /v1/aci/sessions` first, then pin the ids you accept. When no listed
-session can serve, the gateway refuses with `session_not_accepted` (412)
-before forwarding, and the refusal carries its own receipt. The whole
-`provider` member is consumed by the gateway and never reaches an upstream.
+## Build a verifier policy
 
-## E2EE v2 Compatibility Extension
+The same report is not automatically acceptable to every user. A production
+policy should state at least:
 
-E2EE v2 encrypts content-bearing request and response fields between the
-client and the attested gateway. It is a separate transport extension, not
-part of the core ACI specification. It is enabled by default and remains
-supported through at least February 10, 2027. E2EE v3 is the planned
-replacement. V2 is frozen except for security, correctness, and
-interoperability fixes.
-
-The normative contract is the
-[E2EE v2 compatibility protocol](../spec/e2ee-v2.md). It defines these five
-request headers:
-
-| Header | Value |
+| Policy input | Decision to make |
 | --- | --- |
-| `X-E2EE-Version` | `2` |
-| `X-Client-Pub-Key` | Client public key, hex encoded with the selected suite's curve. |
-| `X-Model-Pub-Key` | Gateway E2EE public key from the attested keyset. |
-| `X-E2EE-Nonce` | A fresh 32-byte random value encoded as 64 hex characters. |
-| `X-E2EE-Timestamp` | Current Unix time in seconds. |
+| Hardware roots and TCB states | Which TEE vendors, collateral sources, debug states, and TCB statuses are accepted? |
+| Boot and OS measurements | Which dstack or other platform images are accepted, and how are their measurements reconstructed? |
+| Workload release | Which RTMR3-bound compose hashes or equivalent measured releases were reviewed? |
+| Source provenance | How does the measured artifact map to public source and build provenance? |
+| Key custody | Which KMS roots and derivation chains establish custody for receipt, E2EE, and TLS keys? |
+| Provider evidence | Which verifier versions, channels, claim sources, and model paths are accepted? |
+| Rotation and expiry | How are overlapping releases, keysets, and session changes handled? |
 
-Do not send `X-Signing-Algo` for E2EE v2. That header selects the legacy
-compatibility path.
+The current `aci` CLI verifies the DCAP quote, nonce/keyset binding, expiry,
+RTMR3 compose measurement, and observed TLS SPKI. It reports private-key custody
+as a skipped check and does not reconstruct the complete dstack boot chain.
+`--require-production-os` appraises an RTMR3-bound OS image hash against a
+reviewed allowlist; it is not a substitute for independently reconstructing
+MRTD and RTMR0-2.
 
-The client selects either `x25519-aes-256-gcm-hkdf-sha256` or
-`secp256k1-aes-256-gcm-hkdf-sha256` by matching the `algo` on an
-`e2ee_public_keys` entry. Each encrypted field is lowercase hex of:
+Do not turn an unproven field into a stronger claim. A reported repository,
+commit, image, model ID, or TCB status remains a label until the applicable
+measurement and policy corroborate it.
 
-```text
-ephemeral_public_key || aes_gcm_nonce (12) || ciphertext || tag (16)
-```
+## Non-goals and remaining exposure
 
-The JSON structure stays OpenAI-compatible. Encrypt request content in place,
-for example `messages.0.content`, and decrypt the corresponding response fields
-such as `choices.0.message.content`. The RFC 8785 JCS AAD binds each field to
-the direction, selected algorithm, request model, full field path, request
-nonce, timestamp, and response id. See
-[E2EE v2 §5](../spec/e2ee-v2.md#5-encrypted-fields) and
-[§6](../spec/e2ee-v2.md#6-associated-data) for the complete contract.
+Even when every applicable check passes:
 
-The quote binds the workload keyset digest directly. V2 does not require, and
-does not reintroduce, a separate workload identity key or keyset endorsement.
-The attested `e2ee_public_keys` entry is the key-provenance anchor.
+- The measured code is trusted to implement the privacy policy correctly.
+  Attestation identifies code; it does not prove that the code is bug-free.
+- Exact model-weight provenance remains unknown unless the provider verifier
+  supplies and checks suitable evidence.
+- The service sees network and account metadata. ACI does not hide client IP,
+  timing, request size, model choice, or credential use. An OHTTP relay is a
+  separate metadata-privacy layer.
+- Receipts are self-timed records, not externally ordered or timestamped
+  statements. Durable non-repudiation needs a transparency service.
+- GPU attestation proves properties of a GPU only to the extent recorded by
+  the provider verifier. It may not prove a hardware binding between that GPU
+  and the serving CPU TEE.
+- Local agents, tools, MCP servers, browser automation, shell commands, and
+  telemetry can expose data outside the model HTTP path.
+- Availability is not guaranteed. Failing closed can turn verifier, collateral,
+  or channel failures into a service outage.
 
-`enable_e2ee` defaults to `true`. Setting it to `false` is an explicit
-operator opt-out: the attestation advertises no supported E2EE versions and
-the gateway rejects v2 requests before decryption.
+## Legacy compatibility
 
-## Legacy Compatibility
+`GET /v1/attestation/report`, `GET /v1/signature/{id}`, and the
+`X-Signing-Algo` E2EE mode remain for pre-ACI dstack-vllm-proxy clients. They
+use separate report bindings and do not alter canonical ACI reports, receipts,
+or sessions. New verifiers should use `/v1/aci/*`.
 
-Existing vLLM-proxy-compatible clients can continue to use:
+## Continue
 
-- `GET /v1/attestation/report?signing_algo=...`
-- `GET /v1/signature/{id}`
-- Legacy E2EE headers with `X-Signing-Algo`
-
-Those surfaces exist for compatibility. New verification should treat the ACI
-receipt as the primary per-response proof and the attested keyset as the source
-of receipt-signing and E2EE keys.
-
-## Trust Boundary
-
-Plain TLS requests are visible to the attested gateway after TLS termination.
-E2EE v2 requests are decrypted inside the attested gateway. If middleware is
-enabled, middleware is part of the same deployment trust boundary and can see
-plaintext after gateway decryption.
-
-Upstream model providers are verified before the gateway forwards request bytes.
-The receipt records the upstream verification outcome in `upstream.verified`;
-the enforced channel binding is recorded on the cited session. Some upstreams
-use TLS channel binding. Others use provider-level E2EE keys. The verifier
-should rely on the recorded binding only when the production policy accepts
-that provider and model path.
-
-## Product Wrapper Checklist
-
-Before embedding this page in a product docs site:
-
-1. Replace every placeholder in the table above.
-2. Render the product-specific API key environment variable.
-3. Set a real `{DEFAULT_MODEL_ID}` that exists in that product's model catalog.
-4. Link `{PRODUCTION_VERIFIER_POLICY_URL}` to the published verifier policy.
-5. Keep legacy compatibility sections only where old clients need them.
+- Run the [ACI quickstart](quickstart.md).
+- Compare current [provider verification](providers/README.md).
+- Inspect the [attested-session system](attested-session-system.md).
+- Read the normative [ACI specification](../spec/aci.md).
+- Track known [implementation gaps](reviews/aci-spec-conformance-gaps.md).

--- a/docs/attested-confidential-inference.md
+++ b/docs/attested-confidential-inference.md
@@ -75,13 +75,19 @@ Save these response values:
 
 `x-receipt-id` is the stable lookup key for verification. The JSON response
 `id` can also work when the response body contains a chat completion ID.
+This example is ACI-constrained, so the gateway will not commit the stream
+before it can name the receipt. An unconstrained, non-E2EE middleware stream
+may instead start with a keepalive before an upstream is selected and omit the
+header. After a successful stream its receipt is available by response `id`;
+if forwarding fails after that early commit, no receipt is drafted. A verifier
+that requires a receipt should constrain the request.
 
 ## Verification Flow
 
 Generate a fresh nonce before fetching the attestation report.
 
 ```bash
-NONCE="$(openssl rand -hex 16)"
+NONCE="$(openssl rand -hex 32)"
 
 curl "$API_BASE_URL/v1/aci/attestation?nonce=$NONCE" \
   -o attestation-report.json

--- a/docs/attested-confidential-inference.md
+++ b/docs/attested-confidential-inference.md
@@ -7,6 +7,12 @@ normative protocol definition is the [ACI Spec](../spec/aci.md).
 Primary reader: developers who call the OpenAI-compatible API and verifiers who
 need to prove which attested gateway served a response.
 
+> [!IMPORTANT]
+> Upstream verification is a request constraint, not a global gateway mode.
+> Set `provider.aci_verified` to `true`, or provide a non-empty
+> `provider.aci_session_ids` allowlist, when the request must fail closed unless
+> the selected upstream verifies.
+
 ## Placeholders
 
 | Placeholder | Meaning |
@@ -21,7 +27,7 @@ need to prove which attested gateway served a response.
 ## What Verification Proves
 
 The API returns normal OpenAI-compatible responses and adds verifiable evidence.
-A verifier checks two layers:
+A verifier answers three separate questions:
 
 1. The gateway attestation report proves which workload keyset serves the API:
    the hardware quote binds the keyset digest and the verifier's fresh nonce,
@@ -29,6 +35,9 @@ A verifier checks two layers:
 2. The per-response receipt proves request and response hashes, selected
    upstream verification, and the receipt signature under a key from the
    attested keyset.
+3. For an aggregator, the receipt's `upstream.verified` event and cited session
+   show which verified provider channel was used and preserve the claims,
+   binding, and evidence for independent policy appraisal.
 
 Verification does not rely on the product API server saying "verified". The
 verifier fetches artifacts, validates signatures and hashes locally, and applies
@@ -52,7 +61,8 @@ curl "$API_BASE_URL/v1/chat/completions" \
     "model": "'"$MODEL"'",
     "messages": [
       {"role": "user", "content": "Explain why attestation matters in one sentence."}
-    ]
+    ],
+    "provider": {"aci_verified": true}
   }'
 ```
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,183 +1,103 @@
 # Configuration Reference
 
-Private AI Gateway uses one read-only static config file and one writable state
-directory. Operators must choose the config file with
-`PRIVATE_AI_GATEWAY_CONFIG_PATH` and put gateway policy in that file.
+Private AI Gateway reads one static JSON file at startup and owns one writable
+state directory. Upstream routes have a separate JSON schema because operators
+can replace them at runtime.
 
-## Runtime Files
+Unknown fields are rejected in both schemas.
 
-| Item | Owner | Runtime path |
-| --- | --- | --- |
-| Static gateway config | Deployment | Required. Selected by `PRIVATE_AI_GATEWAY_CONFIG_PATH`. |
-| Upstream seed config | Deployment | Selected by `upstream_config_seed_path` in the static gateway config. |
-| Active upstream config | Gateway | `<state_dir>/upstreams.json` |
-| Attested-session log | Gateway | `<state_dir>/sessions.jsonl` |
+## Static Gateway Config Fields
+
+Set `PRIVATE_AI_GATEWAY_CONFIG_PATH` to a readable JSON file. The binary does
+not expose the individual static fields as environment variables. Provider
+verifier child processes use the bridge variables listed under
+[Environment Variables](#environment-variables).
 
 Operators configure `state_dir`, not the individual writable files inside it.
-The gateway creates `state_dir` on startup, seeds `upstreams.json` from the
-read-only upstream seed only when the active file is missing or empty, and
-updates `upstreams.json` through `PUT /v1/admin/upstreams` or an authenticated
-`upstream_pull` source.
+The gateway creates the directory on startup and owns the files within it.
 
-Unknown fields in the static gateway config are rejected at startup.
-
-## Minimal Config
-
-This is the smallest practical container config.
+Minimal container configuration:
 
 ```json
 {
   "bind": "0.0.0.0:8086",
   "state_dir": "/var/lib/private-ai-gateway",
-  "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
-  "upstream_pull": {
-    "url": "https://control.example/api/admin/gateway-upstreams/config",
-    "token": "<dedicated-machine-pull-token>",
-    "refresh_seconds": 300,
-    "request_timeout_seconds": 90
-  },
-  "admin_token": "<long-random-admin-token>",
   "dstack_endpoint": "unix:/var/run/dstack.sock"
 }
 ```
 
-## Config Fields
+### Static fields
 
-| Field | Default | Meaning |
+| Field | Type | Default | Contract |
+| --- | --- | --- | --- |
+| `bind` | string | `127.0.0.1:8086` | TCP listener address. The gateway serves HTTP and does not terminate TLS. |
+| `state_dir` | string | `/var/lib/private-ai-gateway` | Writable directory owned by one gateway process. An empty string is rejected. |
+| `upstream_config_seed_path` | string | unset | Read-only upstream JSON copied to `<state_dir>/upstreams.json` only when the active file is missing or whitespace-only. |
+| `upstream_pull` | object | unset | Authenticated HTTPS source for the complete runtime upstream config. See [Upstream pull](#upstream-pull). |
+| `admin_token` | string | unset | Bearer token for the upstream admin API. Admin routes return `404` when unset. |
+| `keyset_not_after_seconds` | positive integer | `2592000` | Lifetime of a newly resolved workload keyset. Zero is rejected. |
+| `subject` | string | unset | Optional policy-interpreted workload-keyset subject. The gateway publishes it but generic verifiers do not trust it without an acceptance policy. |
+| `direct_serving` | boolean | `false` | Report `service_capabilities.serving: "direct"` for a workload that performs inference itself and has no upstream hop. |
+| `enable_e2ee` | boolean | `true` | Advertise and terminate the [E2EE v2 compatibility extension](../spec/e2ee-v2.md). When false, the report advertises no supported E2EE versions and v2 requests fail. |
+| `tls` | object | empty | Downstream certificate bindings published in the attested keyset. See [Downstream TLS binding](#downstream-tls-binding). |
+| `dstack_endpoint` | string | dstack SDK default | dstack SDK endpoint. `unix:/path` and `unix:///path` are normalized to `/path`; HTTP endpoints pass through to the SDK. |
+| `middleware` | object | unset | Enables the in-process middleware and external control-plane client. See [Middleware fields](#middleware-fields). |
+
+### Runtime state files
+
+The gateway derives these paths from `state_dir`:
+
+| Path | Mutability | Purpose |
 | --- | --- | --- |
-| `bind` | `127.0.0.1:8086` | Public HTTP listener address. Use `0.0.0.0:8086` in containers that expose the gateway port. |
-| `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
-| `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
-| `upstream_pull` | unset | Optional authenticated HTTPS source for the complete runtime upstream config. See [Upstream Pull](#upstream-pull). |
-| `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
-| `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
-| `enable_e2ee` | `true` | Advertise and terminate the [E2EE v2 compatibility extension](../spec/e2ee-v2.md). Set to `false` only for an explicit TLS-only deployment; the attestation then reports `supported_e2ee_versions: []` and v2 requests fail with `e2ee_invalid_version`. |
-| `middleware` | unset | Optional middleware section. When present, the gateway consults a control plane to route and authorize each request and applies request/response transforms; when unset it serves directly. See [Middleware](#middleware). |
+| `upstreams.json` | Replaced through the admin API or `upstream_pull` | Active upstream routes and credentials. |
+| `sessions.jsonl` | Append and periodic compaction | Attested-session records. |
+| `sessions.jsonl.lock` | Advisory lock | Prevents two gateway processes from owning one session log. |
 
-## Upstream Pull
+The gateway compacts `sessions.jsonl` before serving and once per hour. It
+skips malformed or tampered records during replay, removes expired records, and
+rewrites live records through an atomic rename.
 
-`upstream_pull` lets every replica fetch the same complete runtime config from
-the control API without requiring the control API to reach replica-private
-addresses. It is intended for a secret-bearing endpoint: the dedicated token is
-sent only in an `Authorization: Bearer` header over HTTPS. Redirects are refused
-so the credential cannot be forwarded to another origin.
+Do not share one state directory between running gateway processes. The second
+process fails to acquire the session-log lock.
 
-| Field | Default | Use |
-| --- | --- | --- |
-| `upstream_pull.url` | required | HTTPS URL returning schema version 1 with an `upstreams` array. URLs containing credentials or a fragment are rejected. |
-| `upstream_pull.token` | required | Dedicated 32–256 byte machine credential. It must differ from the gateway admin token and middleware control token; do not reuse a user/admin API key. Newlines are rejected. |
-| `upstream_pull.refresh_seconds` | `300` | Successful polling cadence. Replicas apply ±10% jitter; failures retry with bounded exponential backoff. |
-| `upstream_pull.request_timeout_seconds` | `90` | Whole-request timeout, including response transfer. Responses larger than 4 MiB are rejected. |
+### Seed behavior
+
+When `upstream_config_seed_path` is set, startup follows this order:
+
+1. Read `<state_dir>/upstreams.json` if it exists.
+2. Keep it when it contains any non-whitespace bytes.
+3. Otherwise read and validate the seed.
+4. Copy the validated seed to the active path.
+
+An existing active file wins even if a new deployment changes the seed. Replace
+the active config through `PUT /v1/admin/upstreams` or reset the state volume as
+an explicit operator action.
+
+## Upstream pull
+
+`upstream_pull` lets each replica fetch the complete runtime config without
+requiring the control API to reach replica-private addresses. The gateway sends
+the dedicated token only in an `Authorization: Bearer` header over HTTPS and
+refuses redirects so the credential cannot move to another origin.
+
+| Field | Type | Default | Contract |
+| --- | --- | --- | --- |
+| `upstream_pull.url` | string | required | HTTPS URL returning schema version 1 with an `upstreams` array. Credentials and fragments are rejected. |
+| `upstream_pull.token` | string | required | Dedicated 32 to 256 byte machine credential. It must differ from `admin_token` and `middleware.control_token`. Newlines are rejected. |
+| `upstream_pull.refresh_seconds` | positive integer | `300` | Successful polling cadence. Replicas apply ±10% jitter; failures retry with bounded exponential backoff. |
+| `upstream_pull.request_timeout_seconds` | positive integer | `90` | Whole-request timeout, including response transfer. Responses larger than 4 MiB are rejected. |
 
 A pulled config is parsed, validated, and built completely before the active
-file and in-memory router are atomically replaced. Invalid responses and HTTP or
-TLS failures retain the last valid local config. An unchanged digest is not
+file and in-memory router are atomically replaced. Invalid responses and HTTP
+or TLS failures retain the last valid local config. An unchanged digest is not
 rewritten. On a new replica whose local config is empty, failure of the initial
 pull aborts startup so an empty router cannot enter the load-balancer pool.
 
-## Middleware
+## Downstream TLS binding
 
-The optional `middleware` section runs the middleware in the request
-path. When present, the gateway consults a control plane at `control_url` to
-authorize and route each request, shapes the provider request, injects response
-cost, and reports usage back to the control plane — all in-process, with no
-out-of-process hop. When the section is omitted the gateway serves directly.
-
-| Field | Default | Use |
-| --- | --- | --- |
-| `middleware.control_url` | required | Base URL of the control plane the gateway consults for routing, authorization, catalogs, and usage reporting. |
-| `middleware.control_token` | unset | Bearer token sent to the control plane. When unset, no `Authorization` header is sent. |
-| `middleware.control_timeout_ms` | `60000` | Timeout for the pre-request consult and catalog fetches. A failed or timed-out consult fails closed. |
-| `middleware.control_post_timeout_ms` | `10000` | Timeout for the fire-and-forget post-request usage report. |
-| `middleware.sse_keepalive_ms` | `5000` | Keep-alive interval for streaming responses, measured from the start of the upstream forward. A streaming request with no upstream response headers after one interval is committed as `200 text/event-stream` and heartbeated (`: PROCESSING`) until the upstream answers; a later forward failure is delivered as the surface's in-band error event whose `code`/`type` is the status the request would otherwise have carried, while the usage report keeps the real status. A response committed this early carries no `x-receipt-id` header — when the upstream answers and the stream finalizes, the receipt is issued and fetchable by the response `id`, but an early-committed stream whose forward fails never drafts one. E2EE requests and requests carrying an ACI constraint (`provider.aci_verified` — the aci CLI's default — or pinned session ids) are never committed early, and neither is a request whose current candidate has already failed once (a same-route retry usually ends in a relayable HTTP status, 429 above all, which an early 200 would demote to an in-band error). Once a stream is open the same interval drives idle heartbeats. `0` disables the heartbeat and the pre-upstream commit with it. |
-| `middleware.prefix_hash_secret` | unset | HMAC key for the consult prefix hash (the cache-affinity key). When set, it must contain at least 32 bytes of randomly generated secret material (after trimming whitespace) — anything shorter fails startup, because HMAC under a weak key is as computable as the plain hash it claims to improve on. The hash is then HMAC-SHA256(secret, prefix), so the control plane cannot dictionary-test guessed prompts — it carries no content signal beyond prefix equality. Every gateway replica must share the same value, or affinity silently fragments per replica; rotating it invalidates live affinity keys, which roll off within their 600s TTL. Unset falls back to plain SHA-256: prefix equality stays linkable and a fully-known 4KB template can be confirmed by hashing it. Either way the hash is only sent when the canonical prefix fills its 4KB cap — shorter (dictionary-enumerable) prefixes are never keyed. |
-| `middleware.send_request_features` | `true` | Extract content-derived request features (a low-biased token-count estimate — deliberately under real tokenizer output on ordinary text, but a heuristic, not a guaranteed bound; the control plane may steer on it but never empties a candidate list on it — plus input modalities, tools/response-format flags, reasoning intent, and a prefix hash for cache affinity) and send them in the pre-request consult. Content never leaves the gateway — only numbers, closed enums and a one-way hash. `false` restores the featureless consult body byte-for-byte; it is the rollback lever if extraction misbehaves. |
-| `middleware.tee_only_domains` | `[]` | Hosts (matched against the request `Host` header, case-insensitive) that serve TEE models only. On these hosts the model catalog is forced to `?tee=true`, a non-TEE model is refused with `404` at the pre-consult (before any forward), and serving is forced to attested (`aci_verified`) upstreams — a client cannot opt out via `provider.aci_verified:false`. Two predicates apply by design: the catalog/consult gate uses the model's `is_tee` capability flag, while serving is enforced against the deployment's attestation, so a listed `is_tee` model with no live attested deployment still fails closed (`503`). Empty (the default) leaves every host unrestricted. |
-
-Request outcome observation is always on and needs no configuration: every
-failed request that reaches the middleware completion path (consult denials,
-routing/shaping failures, upstream errors, stream failures, client
-disconnects; final 429s excepted, they are recorded per-attempt in the usage
-pipeline) emits a `request_outcome` tracing line carrying the client-facing
-and upstream status, route, attempt chain length, TTFT/duration, finish
-reasons, and terminal marker. Requests rejected before that path — malformed
-JSON, E2EE setup failures — do not produce lines, so
-complete request accounting still needs the usage pipeline; an oversized body
-does emit a `phase=body_too_large` line carrying the request id, and is
-answered with the surface's JSON `413` envelope (the Anthropic envelope shape
-also carries the id; the OpenAI shape, matching the upstream wire format,
-does not).
-A client that disconnects before the upstream's first byte is reported to the
-usage pipeline as a `499` with the route that was in flight and no TTFT; a
-gateway-enforced connect or read deadline is reported as a `504`, per attempt
-and as the client-facing status. Consult denials
-that carry a key identity (`userId` on the pre-consult response), every
-429/5xx denial, and the no-route 404 are also reported to the usage
-pipeline (`errorSource: "control"`, no route) so the control plane can
-account for them; unauthenticated denials (401/402/403) are trace-only. A
-request emits
-at most one primary line; a late receipt/E2EE finalization failure appends
-one supplemental `phase=finalize_error` line for the same `request_id`
-(aggregate by unique request id, letting `finalize_error` supersede).
-Completed
-responses are logged only when their finish reasons fall outside the standard
-OpenAI/Anthropic set (`anomalous_finish=true`) — the "error smuggled through a
-success" class. The `detail` field (a 240-char snippet of the upstream error
-body, which may quote request fragments) is emitted only when the
-`request_outcome` target is enabled at `debug`; at the default level it is
-blank. Silence or re-route the target via `RUST_LOG` (the subscriber uses
-`EnvFilter`).
-
-```json
-{
-  "middleware": {
-    "control_url": "https://control.example",
-    "control_token": "<control-plane-bearer-token>"
-  }
-}
-```
-
-Only `control_url` is required.
-
-## Source Provenance
-
-Source provenance is not a gateway config field. The gateway reports source
-provenance from the dstack git-launcher pin at
-`/etc/git-launcher/gateway.conf`:
-
-```text
-REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
-COMMIT_SHA=<audited-full-40-or-64-hex-commit-sha>
-WORK_DIR=/var/lib/git-launcher/private-ai-gateway
-```
-
-When the launcher config is absent, source provenance is unknown and the
-gateway omits `source_provenance` from attestation reports. Production
-deployments should use `git-launcher`. The native ACI-service verifier checks
-that `attestation.evidence.app_compose` hashes to the `compose-hash` event bound
-into RTMR3. Binding the reported repository commit or image digest to reviewed
-source remains a verifier-policy TODO.
-
-The canonical attestation endpoint publishes the raw measured `app_compose`.
-Never place plaintext tokens, API keys, or passwords in Compose. Use Phala
-encrypted environment variables and leave only variable references in the
-measured file. Their encrypted values are not published or bound by
-`app_compose`.
-
-If the launcher config exists, `COMMIT_SHA` must be a full 40- or 64-character
-hexadecimal commit hash. Branch names, tags, and short hashes are rejected at
-startup.
-
-## TLS Binding
-
-TLS binding is optional. Configure it only when clients verify the gateway's
-public TLS certificate SPKI from the attested keyset.
-
-| Field | Use |
-| --- | --- |
-| `tls.domain_certificates` | One mounted leaf certificate per public hostname. |
-
-For multi-domain listening, use `tls.domain_certificates`:
+The gateway does not serve TLS, but it can attest the leaf certificate keys
+used by a TLS terminator in the same reviewed deployment. Configure one mounted
+leaf certificate for each public hostname:
 
 ```json
 {
@@ -196,89 +116,242 @@ For multi-domain listening, use `tls.domain_certificates`:
 }
 ```
 
-Raw SPKI digest inputs are not supported. The gateway reads mounted leaf
-certificates, computes `sha256(SPKI)`, and publishes those digests in the
-attested keyset. When `tls.domain_certificates` is configured, the request
-`Host` selects the matching downstream TLS binding for
-`/v1/aci/attestation`. Unknown hosts return `404 not_found`.
+| Field | Contract |
+| --- | --- |
+| `tls.domain_certificates` | Array of unique domain and certificate entries. An empty array disables configured downstream bindings. |
+| `tls.domain_certificates[].domain` | Hostname without a scheme, port, path, whitespace, comma, or trailing dot. Matching is lowercase. |
+| `tls.domain_certificates[].certificate_path` | Non-empty path to a PEM or DER leaf certificate readable at startup. |
 
-## Upstream Config
+At startup, the gateway parses each first PEM certificate (or the DER file),
+computes `SHA256(SubjectPublicKeyInfo)`, and places the digest and domain in the
+workload keyset. Raw digest input is not supported.
 
-The upstream seed file and active upstream database use the same JSON shape: an
-array of upstream entries. The seed file is deployment-owned and read-only. The
-active file at `<state_dir>/upstreams.json` is gateway-owned and is replaced by
-the admin API.
+When at least one domain binding exists, both canonical and legacy attestation
+handlers require a `Host` that matches a configured domain. The report includes
+the selected `attestation.evidence.downstream_tls_binding`. Unknown or malformed
+hosts return `404` instead of an unbound report.
+
+TLS issuance, renewal, SNI routing, and private-key custody remain deployment
+responsibilities. A verifier must confirm that the certificate served to the
+client matches the SPKI selected in the report.
+
+## Middleware fields
+
+The optional middleware runs in the gateway process. It calls an external
+control plane over HTTP or HTTPS and then calls the ACI service in-process.
+
+```json
+{
+  "middleware": {
+    "control_url": "https://control.example",
+    "control_token": "<control-plane-bearer-token>",
+    "tee_only_domains": ["confidential.example.com"]
+  }
+}
+```
+
+| Field | Type | Default | Contract |
+| --- | --- | --- | --- |
+| `middleware.control_url` | string | required | Non-empty base URL. `/consult/pre`, `/consult/post`, and catalog paths are appended to it. |
+| `middleware.control_token` | string | unset | Optional bearer token sent to the control plane. Blank strings are treated as unset. |
+| `middleware.control_timeout_ms` | integer | `60000` | Timeout for pre-consult and catalog requests. A failed pre-consult denies the inference request. |
+| `middleware.control_post_timeout_ms` | integer | `10000` | Timeout for post-request usage reports. Failure does not change a served response. |
+| `middleware.sse_keepalive_ms` | integer | `10000` | Idle SSE comment interval. Zero disables keep-alive comments. |
+| `middleware.prefix_hash_secret` | string | unset | HMAC key for the consult prefix hash. After trimming, it must contain at least 32 bytes. Every replica must share the same value. When unset, the gateway uses plain SHA-256, which leaves prefix equality linkable. |
+| `middleware.send_request_features` | boolean | `true` | Send content-derived features in pre-consult: a low-biased token estimate, closed-enum modalities, tool and response-format flags, reasoning intent, and an optional prefix hash. No prompt text is sent. Set false to restore the featureless consult body. |
+| `middleware.tee_only_domains` | string array | `[]` | Hostnames whose catalog queries force `tee=true` and whose inference requests require an ACI-verified route. Matching uses the normalized HTTP `Host`. |
+
+The control plane must implement the
+[control-plane contract](control-plane-contract.md). In particular, it must
+deny non-TEE models when a pre-consult contains `tee: true` if the deployment
+expects a `404` at the catalog and authorization layer. The gateway still
+enforces successful upstream verification before serving any request on a
+TEE-only hostname.
+
+### Request outcome logs
+
+Middleware mode emits structured `request_outcome` tracing records for terminal
+failures and anomalous finish reasons. The default info-level record contains
+statuses, route, phase, timing, and sanitized identifiers. Raw upstream detail
+is blank unless `RUST_LOG` enables `request_outcome=debug`; that detail can
+contain provider error text and fragments of client input.
+
+Malformed JSON, body-limit rejections, and E2EE setup failures occur before the
+middleware completion path and do not emit a `request_outcome` record. Use the
+control-plane usage pipeline when complete accounting is required. Consult
+denials carrying `userId`, every `429` or `5xx` consult denial, and the no-route
+`404` are also reported to that pipeline with `errorSource: "control"` and no
+route. Unauthenticated `401`, `402`, and `403` denials remain trace-only.
+
+A request emits at most one primary outcome. A late receipt or E2EE
+finalization error adds one `phase=finalize_error` record with the same
+`request_id`; aggregators should let that record supersede the primary outcome.
+
+## Upstream configuration
+
+The seed and active upstream files use a JSON array. Each entry owns one
+provider origin and maps one or more public model IDs to provider model IDs.
 
 ```json
 [
   {
-    "name": "route-a",
-    "provider": "aci-service",
-    "base_url": "https://upstream-a.example",
+    "name": "tinfoil-primary",
+    "provider": "tinfoil",
+    "base_url": "https://inference.tinfoil.sh",
     "models": {
-      "public-model": "provider-model"
+      "confidential-chat": "kimi-k2-6"
     },
-    "accepted_subjects": ["app-id:0x<measured-app-id>"],
-    "accepted_dstack_kms_root_public_keys": ["<kms-root-public-key>"]
+    "bearer_token": "<provider-api-key>"
   }
 ]
 ```
 
-Supported `provider` values:
-
-| Provider | Use |
-| --- | --- |
-| `openai-compatible` | Generic OpenAI-compatible upstream with no provider-owned verifier. |
-| `aci-service` | ACI service that exposes dstack/DCAP evidence. |
-| `tinfoil` | Tinfoil provider adapter. |
-| `near-ai` | NEAR AI provider adapter. |
-| `chutes` | Chutes provider adapter. |
-| `secret-ai` | Direct SecretAI SecretVM origin with optional workload pinning; see [SecretAI verification](providers/secret-ai/verification.md). |
-| `phala-direct` | Direct Phala dstack-vllm-proxy endpoint. |
-
-Provider verification policy belongs on the upstream entry. For ACI service
-routes, configure accepted keyset subjects, image digests, or dstack KMS
-root public keys. For `aci-service` upstreams a subject anchors only in its
-measured form — `app-id:0x<hex>` of the RTMR3-verified app id. The upstream
-does not need to set a keyset `subject` of its own. For `secret-ai` the same
-field pins measured SecretVM workload ids on that entry.
-
-For `secret-ai`, `base_url` must be the root HTTPS inference origin. The optional
-`accepted_subjects` field pins measured SecretVM workloads in this form:
+In direct mode, the public model ID selects the first configured route for that
+model. Middleware route IDs have this exact form:
 
 ```text
-secretvm:<cpu-type>:<environment>:<template>:<artifacts-version>:sha256:<compose-sha256>
+<upstream name>:<public model ID>
 ```
 
-Without this field, the verifier still reconstructs and reports the exact
-production workload, but does not assert that its serving software was
-operator-approved. When pins are configured, a nonmatching workload fails
-verification. TDX workloads must report DCAP status `UpToDate`. An SEV-SNP
-origin must meet the componentwise AMD TCB minimum embedded in the verifier.
+The gateway rewrites the request's top-level `model` to the provider model ID
+before provider verification and forwarding. The receipt commits to both the
+client-observed body and the provider-facing body.
 
-For `aci-service`, `base_url` is the HTTPS origin used for both model traffic and
-`/v1/aci/attestation`. The router fetches the report through normal TLS,
-derives the attested TLS SPKI binding from that report, then pins that SPKI for
-the actual upstream model request.
+### Provider values
+
+| Value | Classification | Transport and verifier |
+| --- | --- | --- |
+| `openai-compatible` | non-TEE | OpenAI-compatible HTTP with no provider verifier. |
+| `anthropic` | non-TEE | Native Anthropic HTTP using `x-api-key` and `anthropic-version: 2023-06-01`; requires `path`. |
+| `aci-service` | TEE | Native Rust ACI report, dstack/DCAP, KMS-custody, and TLS-SPKI verifier. |
+| `tinfoil` | TEE | Tinfoil verifier through the Python bridge and TLS-SPKI enforcement. |
+| `near-ai` | TEE | NEAR AI verifier through the Python bridge, external dstack verifier, and TLS-SPKI enforcement. |
+| `chutes` | TEE | Per-instance attestation and encrypted Chutes E2EE transport. |
+| `secret-ai` | TEE | SecretVM CPU, GPU, workload, and inference-SPKI verifier. |
+| `phala-direct` | TEE | Direct dstack-vllm-proxy verification through the Python bridge and TLS-SPKI enforcement. |
+
+TEE classification makes a route eligible for `provider.aci_verified`. A
+successful provider verifier and enforceable binding are still required at
+request time.
+
+### Upstream fields
+
+| Field | Type | Default | Contract |
+| --- | --- | --- | --- |
+| `name` | string | required | Unique non-empty upstream name. |
+| `provider` | enum | `openai-compatible` | One provider value from the table above. |
+| `base_url` | string | required | Non-empty provider origin. `secret-ai` requires a root HTTPS URL without user info, path, query, or fragment. |
+| `path` | string | unset | Upstream path for chat-shaped surfaces. Leading `/` is added when missing. `anthropic` requires a non-empty path, normally `/v1/messages`. Other surfaces retain their public path. |
+| `models` | object | required | Non-empty map of public model ID to non-empty provider model ID. |
+| `bearer_token` | string | unset | Provider credential. The gateway never returns its value from the admin API. For `anthropic`, this becomes `x-api-key`. |
+| `basic_auth` | boolean | `false` | Send `Authorization: Basic <bearer_token>`. Allowed only for `openai-compatible` and `chutes`, and requires a token. |
+| `accepted_subjects` | string array | unset | Accepted measured ACI-service subjects, or optional SecretAI measured-workload pins. For ACI service, use `app-id:0x<hex>` values derived from RTMR3-verified evidence. |
+| `accepted_image_digests` | string array | unset | ACI-service source image allowlist. |
+| `accepted_dstack_kms_root_public_keys` | string array | unset | ACI-service accepted dstack KMS root public keys. |
+| `pccs_url` | string | Phala PCCS from `dcap_qvl` | PCCS used by the native ACI-service DCAP verifier. |
+| `verifier_cache_seconds` | positive integer | `300` | Provider-verification cache lifetime. Zero is rejected. |
+| `connect_timeout_seconds` | positive integer | `10` | Upstream HTTP connect timeout. Zero is rejected. |
+| `read_timeout_seconds` | positive integer | `600` | Upstream HTTP read timeout. Zero is rejected. |
+| `verifier_request_timeout_seconds` | positive integer | `60` | Provider verification timeout. Zero is rejected. |
+| `verification_refresh_seconds` | integer | `max(verifier_cache_seconds - 60, 1)` | Background verification refresh cadence. Zero disables proactive refresh for this entry. |
+| `session_refresh_seconds` | integer | `45` for Chutes; disabled otherwise | Chutes nonce-session refresh cadence. Zero disables it. |
+| `chutes_e2ee_api_base` | string | `https://api.chutes.ai` | Chutes discovery, evidence, and E2EE API base. Chutes only. |
+| `chutes_chute_ids` | object | unset | Map of provider model ID to chute UUID. Keys must appear in `models` values. Chutes only. |
+| `chutes_e2ee_discovery_rounds` | integer from 1 to 10 | `3` | Evidence discovery attempts per verification. Chutes only. |
+| `chutes_e2ee_discovery_interval_seconds` | non-negative integer | `0` | Delay between discovery rounds. Chutes only. |
+
+An `aci-service` entry must provide at least one accepted subject or image
+digest and at least one accepted KMS root public key. The verifier rejects an
+empty acceptance policy. The upstream keyset does not need to self-assert the
+accepted subject; the verifier derives the `app-id:0x<hex>` subject from
+measured evidence.
+
+Chutes-specific fields on another provider are rejected. For private Chutes
+origins that use Basic authentication, follow the
+[private Chutes configuration](providers/chutes/configuration.md).
+
+### Empty configuration
+
+A missing, empty, or whitespace-only `upstreams.json` parses as an empty route
+list. An explicit empty array has the same meaning. The identity, attestation,
+metrics, and admin endpoints remain available; inference model routing fails
+until routes are configured.
+
+## Admin API
+
+When `admin_token` is set, inspect the active config:
+
+```bash
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  http://127.0.0.1:8086/v1/admin/upstreams
+```
+
+The response includes `config_path`, a JCS SHA-256 `config_digest`, and redacted
+entries. It replaces `bearer_token` with `bearer_token_configured: true|false`.
+
+Replace the config atomically:
+
+```bash
+curl --fail --silent --show-error \
+  -X PUT \
+  -H "Authorization: Bearer $PRIVATE_AI_GATEWAY_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @upstreams.json \
+  http://127.0.0.1:8086/v1/admin/upstreams
+```
+
+The gateway validates the complete array before writing a temporary file and
+renaming it over the active path. It swaps the in-memory router and verifier
+state after the write succeeds, then starts verification prewarm in the
+background.
+
+## Source provenance
+
+Source provenance is not a JSON config field. The binary reads
+`/etc/git-launcher/gateway.conf` when present and accepts:
+
+```text
+REPO_URL=https://github.com/Dstack-TEE/private-ai-gateway.git
+COMMIT_SHA=<full-40-or-64-character-hex-commit>
+WORK_DIR=/var/lib/git-launcher/private-ai-gateway
+```
+
+`REPO_URL` and `COMMIT_SHA` are required when the file exists. A branch, tag,
+short hash, or non-hex commit is rejected. When the launcher file is absent, the
+report omits source provenance.
+
+The report publishes the measured `app_compose` preimage. The native ACI-service
+verifier checks that it hashes to the RTMR3-bound `compose-hash` event. That
+integrity check does not decide whether the launcher, repository revision,
+image, compiler, or dependencies are approved. Verifier policy must make those
+acceptance decisions.
+
+Never put plaintext credentials in measured Compose content. Use deployment
+secret facilities and keep only variable references in the manifest.
 
 ## Environment Variables
 
-The gateway runtime reads only these environment variables. Provider verifier
-bridges may consume provider-specific environment variables such as
-`DSTACK_VERIFIER_URL` or `PRIVATE_AI_VERIFIER_DIR`.
+The gateway process and provider-verifier children use:
 
 | Variable | Use |
 | --- | --- |
-| `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required. Selects the static gateway config file. |
-| `RUST_LOG` | Tracing filter consumed by `tracing_subscriber`. |
+| `PRIVATE_AI_GATEWAY_CONFIG_PATH` | Required path to the static gateway config. |
+| `RUST_LOG` | `tracing_subscriber` filter. Defaults to `info`. |
+| `PRIVATE_AI_VERIFIER_DIR` | Optional Python verifier checkout override consumed by provider-verifier child processes. |
+| `DSTACK_VERIFIER_URL` | External verifier URL consumed by NEAR AI and PhalaDirect bridge code. Those adapters default to `http://localhost:8080` when unset. |
 
-Deployment tooling also uses these variables:
+The repository entrypoint and deployment manifest also use:
 
 | Variable | Use |
 | --- | --- |
-| `PRIVATE_AI_GATEWAY_CACHE_DIR` | `entrypoint.sh` build and toolchain cache root. Defaults to `/var/lib/private-ai-gateway/cache`. |
-| `CARGO_HOME` | Optional override for Cargo cache. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
-| `RUSTUP_HOME` | Optional override for Rustup state. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
-| `CARGO_TARGET_DIR` | Optional override for Cargo build output. Defaults under `PRIVATE_AI_GATEWAY_CACHE_DIR`. |
-| `PRIVATE_AI_GATEWAY_REPO_COMMIT` | Used by `deploy/compose.yaml` interpolation for the git-launcher `COMMIT_SHA` pin. |
-| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Used by `deploy/compose.yaml` interpolation for the static config's `admin_token`. |
+| `PRIVATE_AI_GATEWAY_CACHE_DIR` | Toolchain and build cache root. Defaults to `/var/lib/private-ai-gateway/cache`. |
+| `CARGO_HOME` | Cargo cache override used by `entrypoint.sh`. |
+| `RUSTUP_HOME` | Rustup state override used by `entrypoint.sh`. |
+| `CARGO_TARGET_DIR` | Cargo output override used by `entrypoint.sh`. |
+| `PRIVATE_AI_GATEWAY_REPO_COMMIT` | Compose interpolation for the git-launcher source pin. |
+| `PRIVATE_AI_GATEWAY_ADMIN_TOKEN` | Compose interpolation for the static config's admin token. |
+
+Provider credentials belong in the upstream config or the deployment mechanism
+that renders it. The live test harness reads its own provider key variables; see
+the [testing guide](live-e2e-test-suite.md).

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -156,7 +156,7 @@ control plane over HTTP or HTTPS and then calls the ACI service in-process.
 | `middleware.control_token` | string | unset | Optional bearer token sent to the control plane. Blank strings are treated as unset. |
 | `middleware.control_timeout_ms` | integer | `60000` | Timeout for pre-consult and catalog requests. A failed pre-consult denies the inference request. |
 | `middleware.control_post_timeout_ms` | integer | `10000` | Timeout for post-request usage reports. Failure does not change a served response. |
-| `middleware.sse_keepalive_ms` | integer | `10000` | Idle SSE comment interval. Zero disables keep-alive comments. |
+| `middleware.sse_keepalive_ms` | integer | `5000` | SSE interval measured from the start of the upstream forward. If an unconstrained, non-E2EE streaming request has no upstream response headers after one interval, the gateway commits `200 text/event-stream` and emits `: PROCESSING` comments until the upstream answers. A later failure is sent as the surface's in-band error event, while the usage report keeps the real status. The early response has no `X-Receipt-Id`; after a successful stream the receipt is available by response `id`, while a forward failure drafts no receipt. Requests with `provider.aci_verified`, pinned session IDs, E2EE, or a candidate already failed in the same request are never committed early. After the stream opens, the same interval drives idle heartbeats. Zero disables both early commit and heartbeats. |
 | `middleware.prefix_hash_secret` | string | unset | HMAC key for the consult prefix hash. After trimming, it must contain at least 32 bytes. Every replica must share the same value. When unset, the gateway uses plain SHA-256, which leaves prefix equality linkable. |
 | `middleware.send_request_features` | boolean | `true` | Send content-derived features in pre-consult: a low-biased token estimate, closed-enum modalities, tool and response-format flags, reasoning intent, and an optional prefix hash. No prompt text is sent. Set false to restore the featureless consult body. |
 | `middleware.tee_only_domains` | string array | `[]` | Hostnames whose catalog queries force `tee=true` and whose inference requests require an ACI-verified route. Matching uses the normalized HTTP `Host`. |
@@ -176,12 +176,20 @@ statuses, route, phase, timing, and sanitized identifiers. Raw upstream detail
 is blank unless `RUST_LOG` enables `request_outcome=debug`; that detail can
 contain provider error text and fragments of client input.
 
-Malformed JSON, body-limit rejections, and E2EE setup failures occur before the
-middleware completion path and do not emit a `request_outcome` record. Use the
-control-plane usage pipeline when complete accounting is required. Consult
-denials carrying `userId`, every `429` or `5xx` consult denial, and the no-route
-`404` are also reported to that pipeline with `errorSource: "control"` and no
-route. Unauthenticated `401`, `402`, and `403` denials remain trace-only.
+Malformed JSON and E2EE setup failures occur before the middleware completion
+path and do not emit a `request_outcome` record. An oversized inference body is
+handled explicitly: it emits `phase=body_too_large` with the request ID and
+returns the surface's JSON `413` envelope. The Anthropic envelope includes the
+request ID; the OpenAI envelope does not.
+
+The control-plane usage pipeline carries the fuller accounting record. A client
+disconnect before the upstream's first byte is reported as `499` against the
+route in flight, without TTFT. A gateway-enforced connect or read deadline is
+reported as `504`. When a streaming response was committed early as HTTP `200`,
+a later in-band failure is still reported with its real status. Consult denials
+carrying `userId`, every `429` or `5xx` consult denial, and the no-route `404`
+are reported with `errorSource: "control"` and no route. Unauthenticated `401`,
+`402`, and `403` denials remain trace-only.
 
 A request emits at most one primary outcome. A late receipt or E2EE
 finalization error adds one `phase=finalize_error` record with the same

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -156,7 +156,7 @@ control plane over HTTP or HTTPS and then calls the ACI service in-process.
 | `middleware.control_token` | string | unset | Optional bearer token sent to the control plane. Blank strings are treated as unset. |
 | `middleware.control_timeout_ms` | integer | `60000` | Timeout for pre-consult and catalog requests. A failed pre-consult denies the inference request. |
 | `middleware.control_post_timeout_ms` | integer | `10000` | Timeout for post-request usage reports. Failure does not change a served response. |
-| `middleware.sse_keepalive_ms` | integer | `5000` | SSE interval measured from the start of the upstream forward. If an unconstrained, non-E2EE streaming request has no upstream response headers after one interval, the gateway commits `200 text/event-stream` and emits `: PROCESSING` comments until the upstream answers. A later failure is sent as the surface's in-band error event, while the usage report keeps the real status. The early response has no `X-Receipt-Id`; after a successful stream the receipt is available by response `id`, while a forward failure drafts no receipt. Requests with `provider.aci_verified`, pinned session IDs, E2EE, or a candidate already failed in the same request are never committed early. After the stream opens, the same interval drives idle heartbeats. Zero disables both early commit and heartbeats. |
+| `middleware.sse_keepalive_ms` | integer | `5000` | Interval for pre-header processing comments and post-header idle heartbeats. Zero disables both. See [Streaming keepalives and early commit](#streaming-keepalives-and-early-commit). |
 | `middleware.prefix_hash_secret` | string | unset | HMAC key for the consult prefix hash. After trimming, it must contain at least 32 bytes. Every replica must share the same value. When unset, the gateway uses plain SHA-256, which leaves prefix equality linkable. |
 | `middleware.send_request_features` | boolean | `true` | Send content-derived features in pre-consult: a low-biased token estimate, closed-enum modalities, tool and response-format flags, reasoning intent, and an optional prefix hash. No prompt text is sent. Set false to restore the featureless consult body. |
 | `middleware.tee_only_domains` | string array | `[]` | Hostnames whose catalog queries force `tee=true` and whose inference requests require an ACI-verified route. Matching uses the normalized HTTP `Host`. |
@@ -167,6 +167,25 @@ deny non-TEE models when a pre-consult contains `tee: true` if the deployment
 expects a `404` at the catalog and authorization layer. The gateway still
 enforces successful upstream verification before serving any request on a
 TEE-only hostname.
+
+### Streaming keepalives and early commit
+
+The interval starts when the gateway begins forwarding to an upstream. If an
+eligible stream has no upstream response headers after one interval, the
+gateway commits `200 text/event-stream` and emits `: PROCESSING` comments until
+the upstream answers. After the response opens, the same interval drives idle
+heartbeats.
+
+Only unconstrained, non-E2EE requests are eligible. The gateway does not commit
+early when the request carries `provider.aci_verified`, pinned session IDs, or
+E2EE headers, or after a candidate has already failed during the same request.
+
+An early-committed response cannot carry `X-Receipt-Id` because the upstream
+has not yet been selected. After a successful stream, the receipt is available
+by response `id`. If forwarding fails after the early commit, the gateway sends
+the surface's in-band error event and drafts no receipt. The control-plane usage
+report still records the real failure status rather than the HTTP `200` already
+sent to the client.
 
 ### Request outcome logs
 

--- a/docs/control-plane-contract.md
+++ b/docs/control-plane-contract.md
@@ -17,7 +17,8 @@ For an inference request, the gateway:
 2. Calls `POST /consult/pre` before any provider request.
 3. Shapes one upstream request per returned candidate.
 4. Tries the candidates in order and finalizes the client response.
-5. Calls `POST /consult/post` for usage and failure records.
+5. Calls `POST /consult/post` for admitted attempts and reportable request
+   outcomes, including failures and client cancellation.
 
 The pre-consult fails closed. The post-consult is best effort because the client
 response may already have been served.
@@ -188,7 +189,7 @@ The stable fields are:
 | --- | --- | --- |
 | `requestId` | Always | Groups every attempt and summary record for one client request. |
 | `endpoint` | Always | Public inference path. |
-| `status` | Always | Status attributed to this attempt or summary. |
+| `status` | Always | Status attributed to this attempt or summary. It can differ from the already-committed downstream HTTP status for a streaming failure. |
 | `durationMs` | Always | Elapsed request time when the report was produced. |
 | `selectedRouteId` | Always, nullable | Route for an attempt. `null` identifies a request-level summary. |
 | `requestModel` | Always | Public model requested by the client, or an empty string when absent. |
@@ -206,6 +207,22 @@ A request can produce multiple reports. Count attempts only when
 `selectedRouteId` is non-null. A record with a null route and a non-empty
 `errorSource` is a request-level failure, such as a reported consult denial, a
 no-route result, or the summary after the candidate chain failed.
+
+Streaming and cancellation do not erase accounting:
+
+- a client disconnect before the first upstream byte produces status `499`,
+  names the route in flight, and omits `ttftMs`;
+- a gateway-enforced connect or read deadline produces status `504` for the
+  attempt and request outcome;
+- attempts already completed during failover are reported even if the client
+  disconnects while a later candidate is in flight; and
+- an unconstrained stream can already be HTTP `200` because the gateway emitted
+  a keepalive before the upstream answered. If forwarding later fails, the
+  in-band error and post-consult record carry the real failure status.
+
+`errorMessage` is bounded operational detail, not a safe public label. It can
+contain provider text or request fragments; restrict access and retention as
+you would for other sensitive logs.
 
 The gateway may retry a broken pooled connection once. A control plane must
 ingest post-consult reports idempotently. At minimum, deduplicate by the stable

--- a/docs/control-plane-contract.md
+++ b/docs/control-plane-contract.md
@@ -1,0 +1,242 @@
+# Control-plane HTTP contract
+
+This reference is for teams implementing the external control plane used by the
+gateway's optional in-process middleware. The control plane decides who may call
+a model and which configured route candidates the gateway should try. It does
+not create attestation facts or bypass backend verification.
+
+Set `middleware.control_url` to the control-plane base URL. The gateway appends
+the paths in this document. If `middleware.control_token` is configured, every
+control-plane request includes `Authorization: Bearer <token>`.
+
+## Request flow
+
+For an inference request, the gateway:
+
+1. Parses and, when needed, decrypts the client body.
+2. Calls `POST /consult/pre` before any provider request.
+3. Shapes one upstream request per returned candidate.
+4. Tries the candidates in order and finalizes the client response.
+5. Calls `POST /consult/post` for usage and failure records.
+
+The pre-consult fails closed. The post-consult is best effort because the client
+response may already have been served.
+
+## `POST /consult/pre`
+
+The request uses camelCase:
+
+```json
+{
+  "apiKeyHash": "3f2c...",
+  "model": "public-model-id",
+  "provider": {
+    "only": ["provider-a"],
+    "aci_verified": true
+  },
+  "request": {
+    "estimatedPromptTokens": 128,
+    "hasTools": true,
+    "inputModalities": ["image", "text"],
+    "reasoning": "enabled",
+    "responseFormat": "json_schema",
+    "prefixHash": "0123456789abcdef0123456789abcdef"
+  },
+  "tee": true
+}
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `apiKeyHash` | No | Lowercase SHA-256 hex of the client's bearer token. Omitted for anonymous requests. |
+| `model` | No at the wire level | Public model ID from the client body. A control plane should reject a missing model for model inference. |
+| `provider` | No | Original client provider-routing object, forwarded without schema reduction. The control plane should validate all policy fields it supports. |
+| `request` | No | Content-derived routing features. Omitted when `middleware.send_request_features` is false or the gateway does not recognize the endpoint body. |
+| `tee` | No | `true` when the request arrived on a hostname in `middleware.tee_only_domains`. The control plane should deny a non-TEE model, normally with `404`. |
+
+### Request features
+
+The gateway derives the optional `request` block without sending the prompt,
+messages, tool arguments, files, or media to the control plane:
+
+| Field | Contract |
+| --- | --- |
+| `estimatedPromptTokens` | Low-biased heuristic for one inference context. It is not a tokenizer result or a guaranteed bound. For batched legacy completions, this is the largest item rather than the sum. A control plane may use it to order candidates but must not use it to remove the final candidate. |
+| `hasTools` | `true` when the request contains current `tools` or legacy `functions`. |
+| `inputModalities` | Deduplicated, stably ordered values from `text`, `image`, `file`, `audio`, and `video`. |
+| `reasoning` | Client intent: `enabled`, `disabled`, or `unspecified`. Response-visibility controls do not change this value. |
+| `responseFormat` | `text`, `json_object`, or `json_schema`. A missing response format becomes `text`. |
+| `prefixHash` | Optional 32-character lowercase hex cache-affinity key for the canonical first 4 KiB of a conversation. It is present only when that prefix fills the 4 KiB cap. The digest is HMAC-SHA256 when `middleware.prefix_hash_secret` is set and plain SHA-256 otherwise. It supports prefix matching; it does not prove prompt contents or request authenticity. |
+
+Treat these fields as routing hints. The gateway deliberately uses closed enums,
+counts, booleans, and an optional one-way digest so the external control plane
+does not receive inference content.
+
+An allow response:
+
+```json
+{
+  "allow": true,
+  "pricing": {
+    "inputCostPerToken": "0.000001",
+    "outputCostPerToken": "0.000002"
+  },
+  "candidates": [
+    {
+      "routeId": "provider-a:public-model-id",
+      "format": "openai",
+      "engine": "vllm",
+      "reasoningFormat": "reasoning_effort"
+    }
+  ],
+  "userId": 42,
+  "virtualKeyId": 7,
+  "spendMode": "regular",
+  "userTier": "pro"
+}
+```
+
+| Response field | Required | Contract |
+| --- | --- | --- |
+| `allow` | Yes | Boolean decision. |
+| `pricing` | No | Opaque pricing object interpreted by the current cost calculator. Use numeric strings or numbers for supported per-token fields. |
+| `candidates` | Required for an allowed inference | Ordered route candidates. An empty or missing list produces a no-route error. |
+| `candidates[].routeId` | Yes | `<upstream name>:<public model ID>` matching the active gateway upstream config. |
+| `candidates[].format` | Yes | `openai` or `anthropic`. Selects request and response transformation. |
+| `candidates[].engine` | No | `sglang` or `vllm` for engine-specific shaping. Omit for managed APIs. |
+| `candidates[].reasoningFormat` | No | Upstream reasoning dialect: `reasoning_effort`, `reasoning`, `chat_template_thinking`, `chat_template_enable_thinking`, or `thinking_type`. `thinking_type` writes DeepSeek's `thinking.type` switch and uses `reasoning_effort` for the level. When omitted, managed routes use `reasoning` and self-hosted engines use `reasoning_effort`. |
+| `candidates[].reasoningPolicy` | No | Deployment policy interpreted by the gateway. It can contain `override`, `default`, and a token `threshold`; reasoning configs use `effort`, `maxTokens`, or `enabled` as defined by the current middleware types. |
+| `userId` | No | Opaque integer copied to post-consult reports. |
+| `virtualKeyId` | No | Opaque integer copied to post-consult reports. |
+| `spendMode` | No | `regular`, `subscription`, or `subscription_overflow`. |
+| `userTier` | No | Passed upstream as `x-user-tier`. The value `basic` disables the delayed capacity retry. |
+| `rateLimit` | No | Used on a denied `429`; object fields are `limit` and Unix-seconds `resetAt`. |
+
+A denial response can return the client-facing status and message:
+
+```json
+{
+  "allow": false,
+  "status": 401,
+  "message": "Invalid API key"
+}
+```
+
+If `status` is absent, the gateway uses `403`. A denied `429` may include:
+
+```json
+{
+  "allow": false,
+  "status": 429,
+  "message": "Rate limit exceeded",
+  "rateLimit": {
+    "limit": 100,
+    "resetAt": 1786406400
+  }
+}
+```
+
+The gateway turns that block into `Retry-After` and `X-RateLimit-*` response
+headers.
+
+Any non-200 response, timeout, transport error, or invalid JSON from
+`/consult/pre` becomes a `503 control plane unavailable` denial. The gateway
+does not forward the inference request.
+
+The gateway reports a denial to `POST /consult/post` when the response contains
+`userId`, or when its status is `429` or `5xx`. An identity-free `400`, `401`,
+`402`, or `403` remains tracing-only so unauthenticated traffic cannot flood the
+usage pipeline. An allowed response with no usable candidates becomes a
+reported `404`. These reports have `selectedRouteId: null` and
+`errorSource: "control"`.
+
+## `POST /consult/post`
+
+The gateway emits post-consult records for completed attempts and selected
+gateway failures. The JSON shape is camelCase:
+
+```json
+{
+  "requestId": "req_0123...",
+  "endpoint": "/v1/chat/completions",
+  "status": 200,
+  "durationMs": 812,
+  "ttftMs": 94,
+  "isStreaming": true,
+  "attemptIndex": 0,
+  "selectedRouteId": "provider-a:public-model-id",
+  "requestModel": "public-model-id",
+  "prefixHash": "0123456789abcdef0123456789abcdef",
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 8,
+    "total_tokens": 20
+  },
+  "pricing": {
+    "inputCostPerToken": "0.000001",
+    "outputCostPerToken": "0.000002"
+  },
+  "spendMode": "regular",
+  "userId": 42,
+  "virtualKeyId": 7
+}
+```
+
+The stable fields are:
+
+| Field | Presence | Meaning |
+| --- | --- | --- |
+| `requestId` | Always | Groups every attempt and summary record for one client request. |
+| `endpoint` | Always | Public inference path. |
+| `status` | Always | Status attributed to this attempt or summary. |
+| `durationMs` | Always | Elapsed request time when the report was produced. |
+| `selectedRouteId` | Always, nullable | Route for an attempt. `null` identifies a request-level summary. |
+| `requestModel` | Always | Public model requested by the client, or an empty string when absent. |
+| `prefixHash` | Optional | Echo of the pre-consult request feature. Use it as a cache-affinity key, not as proof of request content. |
+| `usage` | Always, nullable | Raw provider usage before client cost injection. |
+| `pricing` | Always, nullable | Pricing returned by the pre-consult. |
+| `ttftMs` | Optional | Time to first token for a streaming attempt. |
+| `isStreaming` | Optional | Whether the report covers a streaming path. |
+| `attemptIndex` | Optional | Zero-based attempt order. Use this with `requestId` when ingesting retries. |
+| `spendMode`, `userId`, `virtualKeyId` | Optional | Values copied from the pre-consult. |
+| `errorSource` | Optional | `control`, `upstream`, or `gateway`. |
+| `errorMessage` | Optional | Error text for a failed record. Treat it as sensitive operational data. |
+
+A request can produce multiple reports. Count attempts only when
+`selectedRouteId` is non-null. A record with a null route and a non-empty
+`errorSource` is a request-level failure, such as a reported consult denial, a
+no-route result, or the summary after the candidate chain failed.
+
+The gateway may retry a broken pooled connection once. A control plane must
+ingest post-consult reports idempotently. At minimum, deduplicate by the stable
+request and attempt identity used by your billing model.
+
+The gateway ignores a post-consult timeout or transport failure after logging
+it. A failed usage report does not change the already selected client response.
+
+## Catalog endpoints
+
+The gateway removes `/v1` from public catalog paths and relays the remaining
+path and query string:
+
+| Public gateway request | Control-plane request |
+| --- | --- |
+| `GET /v1/models` | `GET /models` |
+| `GET /v1/models/providers/acme?zdr=true` | `GET /models/providers/acme?zdr=true` |
+| `GET /v1/embeddings/models` | `GET /embeddings/models` |
+
+The control plane owns the response schema and status. The gateway relays the
+body and status with `content-type: application/json`. A transport failure
+becomes `502 control plane unavailable`.
+
+For a TEE-only hostname, the gateway forces `tee=true` in the relayed query.
+The control plane must implement that filter if the deployment relies on the
+catalog to hide non-TEE models. Backend serving still requires a verified TEE
+route for those hostnames.
+
+## Reference implementation
+
+[`examples/control-plane`](../examples/control-plane/README.md) contains a
+small config-backed server for local integration tests. It implements the core
+`/models` and consult routes. It is not a production billing, TEE-catalog, or
+policy service.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,225 @@
+# Local development
+
+This tutorial is for contributors who want to compile the gateway, exercise its
+attestation surface, and run the local integration suite. The production binary
+always uses dstack KMS keys and dstack TDX quotes, so even a local process needs
+a reachable dstack SDK endpoint.
+
+## Prerequisites
+
+Install:
+
+- Rust stable with `rustfmt` and `clippy`
+- Python 3.12
+- [uv](https://docs.astral.sh/uv/)
+- `curl`, `jq`, and `openssl`
+- the Phala CLI and SSH access to a dev OS CVM when running outside dstack
+
+You also need a dstack SDK endpoint. A dstack CVM exposes the SDK on
+`/var/run/dstack.sock`. For local work, forward that socket to a local Unix
+socket and set `dstack_endpoint` to the forwarded path.
+
+The default paths used by the test scripts are:
+
+```text
+dstack endpoint: unix:/tmp/aci-dstack-sock-dev.dstack.sock
+dstack verifier: http://localhost:18080
+live artifacts:  /tmp/private-ai-gateway-live-e2e
+```
+
+The external dstack verifier is needed only by provider adapters that declare it
+in their provider configuration, such as NEAR AI and PhalaDirect. The gateway's
+own identity path talks to the dstack SDK socket directly.
+
+## Connect to the dstack SDK
+
+Inside a dstack CVM, use the socket at `/var/run/dstack.sock`. For local
+development, forward that socket from a dev OS CVM over SSH. Set a CVM name you
+can access, then keep this command running in its own terminal:
+
+```bash
+DSTACK_DEV_CVM=your-dev-cvm-name
+DSTACK_LOCAL_SOCKET=/tmp/aci-dstack-sock-dev.dstack.sock
+
+phala status
+phala cvms get "$DSTACK_DEV_CVM" --json
+phala ssh "$DSTACK_DEV_CVM" -- \
+  -N -L "$DSTACK_LOCAL_SOCKET:/var/run/dstack.sock"
+```
+
+The local socket path must not already belong to another process or stale
+tunnel. In a second terminal, verify the forwarded API before starting the
+gateway:
+
+```bash
+DSTACK_LOCAL_SOCKET=/tmp/aci-dstack-sock-dev.dstack.sock
+
+test -S "$DSTACK_LOCAL_SOCKET"
+curl --fail --silent --show-error \
+  --unix-socket "$DSTACK_LOCAL_SOCKET" \
+  http://dstack/Info \
+  | jq
+```
+
+The quote, key derivation, application identity, KMS behavior, and event log
+come from the remote CVM. A local process using this socket is suitable for API
+and binding tests, but its measurements are the remote dev CVM's measurements,
+not those of the intended production deployment.
+
+## Install dependencies
+
+From the repository root:
+
+```bash
+uv sync --locked
+cargo build --all-targets
+```
+
+`uv sync --locked` installs the Python packages used by the provider-verifier
+bridge. The bridge uses the vendored `scripts/confidential_verifier` package by
+default. Set `PRIVATE_AI_VERIFIER_DIR` only when testing an intentional external
+verifier checkout.
+
+## Run the repository checks
+
+Run the same checks as the main CI workflow:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+python3 -m compileall scripts
+```
+
+The TypeScript verifier has a separate workflow:
+
+```bash
+cd clients/verifier-ts
+npm ci
+npm run build
+npm test
+```
+
+## Start the gateway without inference routes
+
+Create a writable state directory and a static config:
+
+```bash
+mkdir -p /tmp/private-ai-gateway-state
+
+cat >/tmp/private-ai-gateway.config.json <<'JSON'
+{
+  "bind": "127.0.0.1:8086",
+  "state_dir": "/tmp/private-ai-gateway-state",
+  "dstack_endpoint": "unix:/tmp/aci-dstack-sock-dev.dstack.sock"
+}
+JSON
+```
+
+Start the binary:
+
+```bash
+PRIVATE_AI_GATEWAY_CONFIG_PATH=/tmp/private-ai-gateway.config.json \
+  RUST_LOG=info \
+  cargo run --bin private-ai-gateway
+```
+
+Startup performs these operations before binding the HTTP listener:
+
+1. Requests receipt-signing and E2EE keys from dstack KMS.
+2. Opens the gateway state files and takes the session-log writer lock.
+3. Loads `<state_dir>/upstreams.json`. A missing or empty file means no routes.
+4. Seals a workload keyset with the configured `not_after` lifetime.
+5. Compacts the session log.
+
+The process exits on a KMS, config, state, or session-log error.
+
+## Inspect the attested keyset surface
+
+In a second terminal:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8086/health
+
+NONCE="$(openssl rand -hex 32)"
+curl --fail --silent --show-error \
+  "http://127.0.0.1:8086/v1/aci/attestation?nonce=$NONCE" \
+  | jq '{api_version, workload_keyset_digest,
+         subject: .attestation.workload_keyset.subject}'
+```
+
+Expected health response:
+
+```json
+{"status":"ok"}
+```
+
+The attestation response should report `api_version` as `aci/1`. This check
+only confirms that the endpoint returned a report. A relying party still needs
+to verify the report as described in the
+[verification guide](attested-confidential-inference.md).
+
+## Add an upstream route
+
+The active route file is `<state_dir>/upstreams.json`. For a first direct-mode
+test, stop the gateway and create a route that matches an endpoint you control:
+
+```json
+[
+  {
+    "name": "local-openai",
+    "provider": "openai-compatible",
+    "base_url": "http://127.0.0.1:9000",
+    "models": {
+      "local-model": "upstream-model"
+    }
+  }
+]
+```
+
+Restart the gateway, then inspect the public model catalog:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8086/v1/models | jq
+```
+
+`openai-compatible` routes have no attestation verifier and cannot satisfy
+`provider.aci_verified: true`. Use them for protocol and transformation tests,
+not confidential-inference claims.
+
+For live providers, start from [`deploy/upstreams.example.json`](../deploy/upstreams.example.json)
+and follow the relevant [provider verification guide](providers/README.md).
+
+## Run the local multi-upstream smoke test
+
+The local smoke test builds containers for two mock ACI services and one router
+gateway. All three use the forwarded dstack socket.
+
+Install these additional tools:
+
+- Docker with the Compose plugin
+- `awk` and `sha256sum`
+
+Run:
+
+```bash
+DSTACK_SOCK=/tmp/aci-dstack-sock-dev.dstack.sock \
+  scripts/local_multi_upstream_smoke.sh
+```
+
+The script checks model routing, TLS-bound upstream verification, chat and
+embedding receipts, attested sessions, dynamic config, and metrics. It removes
+its Compose stack when it finishes unless `KEEP_STACK=1` is set.
+
+See the [testing guide](live-e2e-test-suite.md) for live-provider profiles and
+artifact locations.
+
+## Common startup failures
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| `PRIVATE_AI_GATEWAY_CONFIG_PATH must point to...` | The required config-path variable is missing or empty. | Set it to a readable JSON file. |
+| dstack KMS or quote request failed | The dstack endpoint is missing, stale, or not reachable by the process. | Check the forwarded socket and the `dstack_endpoint` value. |
+| `invalid upstream config` | `upstreams.json` or the configured seed violates the schema. | Check the field and provider constraints in the [configuration reference](configuration-reference.md#upstream-fields). |
+| another gateway holds the session log lock | Two processes use the same `state_dir`. | Give each local process a separate state directory or stop the other writer. |
+| `address already in use` | Another process owns the configured listener. | Change `bind` or stop the existing process. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,7 @@ Install:
 - Python 3.12
 - [uv](https://docs.astral.sh/uv/)
 - `curl`, `jq`, and `openssl`
+- Node.js 24, npm, and Bun 1.4 when changing the TypeScript clients
 - the Phala CLI and SSH access to a dev OS CVM when running outside dstack
 
 You also need a dstack SDK endpoint. A dstack CVM exposes the SDK on
@@ -91,13 +92,20 @@ cargo test --all-targets
 python3 -m compileall scripts
 ```
 
-The TypeScript verifier has a separate workflow:
+The TypeScript verifier, shared provider, and Pi and OpenCode adapters use one
+workspace. Run these commands from the repository root after changing anything
+under `clients/` or a shared ACI construction:
 
 ```bash
-cd clients/verifier-ts
-npm ci
-npm run build
-npm test
+npm --prefix clients ci
+npm --prefix clients run build
+npm --prefix clients run check
+npm --prefix clients test
+npm --prefix clients run test:bun
+npm --prefix clients run lint
+npm --prefix clients run format:check
+npm --prefix clients run lint:packages
+bash clients/package-smoke.sh
 ```
 
 ## Start the gateway without inference routes

--- a/docs/live-e2e-test-suite.md
+++ b/docs/live-e2e-test-suite.md
@@ -4,6 +4,13 @@ The live suite starts a local gateway, calls real provider APIs, verifies return
 
 The implementation lives in `scripts/live_e2e/`. This page documents the code that exists today.
 
+> [!WARNING]
+> The full provider matrix is not yet compatible with the simplified ACI
+> receipt schema. The lifecycle and embeddings cases still assert the removed
+> `transparency.request_modified` event. Use the preflight and targeted cases
+> for diagnosis, but do not treat a full-matrix failure at those assertions as
+> a gateway regression until the cases are migrated.
+
 ## What the main runner covers
 
 `scripts/live_e2e/run.py` performs these phases in order:
@@ -16,12 +23,9 @@ The implementation lives in `scripts/live_e2e/`. This page documents the code th
 6. Run structured-output fidelity cases for `full` and `strict-release` profiles.
 7. Write `summary.json` and stop the gateway.
 
-The lifecycle and embeddings cases are intended to check inference, receipt
-retrieval, artifact verification, the `upstream.verified` event, and the cited
-attested-session record. Their request-modification assertions still expect the
-removed `transparency.request_modified` event and must be migrated before the
-full live matrix is considered compatible with the simplified ACI receipt
-schema. They also exercise the legacy report and receipt-wrapper routes as
+The lifecycle and embeddings cases check inference, receipt retrieval, artifact
+verification, the `upstream.verified` event, and the cited attested-session
+record. They also exercise the legacy report and receipt-wrapper routes as
 explicit compatibility surfaces while checking canonical ACI session artifacts.
 
 The suite does not run load tests, availability measurements, browser verification, or every auxiliary smoke script in `scripts/live_e2e/`.
@@ -99,6 +103,11 @@ uv run python scripts/live_e2e/run.py \
   --env-file .env \
   --profile quick
 ```
+
+The runner writes its terminal result to `summary.json` in the artifact
+directory printed at startup. Treat the run as successful only when the
+selected cases are marked passed and the process exits with status 0, subject
+to the schema-migration warning above.
 
 Select one or more entries with repeated `--provider` arguments. A selector can match the entry name, provider type, or public model alias:
 

--- a/docs/live-e2e-test-suite.md
+++ b/docs/live-e2e-test-suite.md
@@ -1,511 +1,226 @@
-# Live E2E Test Suite Design
+# Run the Live End-to-End Suite
 
-This document defines the live E2E scripts for Private AI Gateway. The suite
-sends real traffic to supported upstream providers,
-verifies upstream attestation and channel binding, checks API fidelity, and
-proves the output back to a relying party through ACI reports and receipts.
-See [upstream-verification-lifecycle.md](upstream-verification-lifecycle.md)
-for the current verification/session lease design and the latest Chutes
-throughput findings.
+The live suite starts a local gateway, calls real provider APIs, verifies returned artifacts, and preserves a redacted artifact bundle for diagnosis. It is an operator test, not part of the credential-free CI suite.
 
-## Goals
+The implementation lives in `scripts/live_e2e/`. This page documents the code that exists today.
 
-- Verify each supported provider before sending sensitive traffic.
-- Verify that the gateway enforces the provider binding it accepted.
-- Exercise real OpenAI-compatible traffic through the gateway, not only
-  provider fixture tests.
-- Prove the no-middleware path remains behavior-compatible with the current
-  gateway.
-- Prove the middleware path can rewrite requests and select a target route
-  while backend-owned provider verification facts remain unforgeable.
-- Check API fidelity for the surfaces users rely on: streaming, tool calls,
-  structured outputs, multimodal inputs, context limits, and cache metadata.
-- Give users a concrete verification story for "I received this API response;
-  how do I know it came from the verified gateway and a verified upstream?"
+## What the main runner covers
 
-## Non-Goals
+`scripts/live_e2e/run.py` performs these phases in order:
 
-- Do not make every provider pass every feature. Providers differ. The suite
-  must be capability-aware.
-- Do not treat a live provider metadata endpoint as automatically trusted. If
-  it is not signed by the provider, a strict run uses reviewed vendored
-  reference values.
-- Do not hide provider bugs with response post-processing. The fidelity tests
-  should show the real behavior.
+1. Check tools, credentials, the dstack socket, the gateway port, and optionally the Rust build.
+2. Run the provider-verifier bridge for every selected provider.
+3. Start a temporary gateway with generated static and upstream configuration.
+4. Run one chat lifecycle case for each provider with the `chat` capability.
+5. Run one embeddings case for each provider with the `embeddings` capability.
+6. Run structured-output fidelity cases for `full` and `strict-release` profiles.
+7. Write `summary.json` and stop the gateway.
 
-## Target Script Layout
+The lifecycle and embeddings cases are intended to check inference, receipt
+retrieval, artifact verification, the `upstream.verified` event, and the cited
+attested-session record. Their request-modification assertions still expect the
+removed `transparency.request_modified` event and must be migrated before the
+full live matrix is considered compatible with the simplified ACI receipt
+schema. They also exercise the legacy report and receipt-wrapper routes as
+explicit compatibility surfaces while checking canonical ACI session artifacts.
 
-Directory:
+The suite does not run load tests, availability measurements, browser verification, or every auxiliary smoke script in `scripts/live_e2e/`.
+
+## Run the local multi-upstream smoke test
+
+The credential-free local smoke suite starts mock ACI upstreams and a gateway with Docker Compose. It requires the forwarded dstack socket but does not call the live provider matrix.
+
+```sh
+DSTACK_SOCK=/tmp/aci-dstack-sock-dev.dstack.sock \
+  scripts/local_multi_upstream_smoke.sh
+```
+
+The script checks direct model routing, TLS-bound ACI-service verification, chat and embeddings receipts, attested sessions, runtime config replacement, and metrics. It tears down the Compose stack on exit unless `KEEP_STACK=1` is set.
+
+Use this suite after changes to the ACI-service adapter, routing, receipts, sessions, config replacement, or the deployment-facing HTTP surface.
+
+## Prerequisites
+
+Install the project dependencies and build tools:
+
+```sh
+uv sync --locked
+cargo build --bin private-ai-gateway
+```
+
+The main provider matrix requires the credentials named in `scripts/live_e2e/providers.json`:
+
+```sh
+export TINFOIL_API_KEY='...'
+export NEARAI_API_KEY='...'
+export CHUTES_API_KEY='...'
+```
+
+The runner loads a dotenv file before reading the environment. Its default is `.env` in the parent directory of this repository, not `.env` inside the repository. Override it explicitly when needed:
+
+```sh
+uv run python scripts/live_e2e/run.py --env-file .env
+```
+
+Do not commit provider credentials or generated upstream configuration.
+
+### dstack socket
+
+The temporary gateway needs a dstack key provider. By default the suite expects:
 
 ```text
-scripts/live_e2e/
-  run.py
-  bfcl_v4.py
-  preflight.py
-  provider_verify.py
-  launch_gateway.py
-  cases/
-    lifecycle.py
-    embeddings.py
-    framework_no_middleware.py
-    framework_middleware.py
-    fidelity_text.py
-    fidelity_streaming.py
-    fidelity_tools.py
-    fidelity_structured_outputs.py
-    fidelity_multimodal.py
-    fidelity_context.py
-    fidelity_cache.py
-  user_verify.py
-  providers.json
-  provider_refs/
-    tinfoil.json
-    near-ai.json
-    chutes.json
-    aci-service.json
+unix:/tmp/aci-dstack-sock-dev.dstack.sock
 ```
 
-The current tree still has some older helper names, such as
-`launch_aggregator.py`. Rename those as part of the framework test work rather
-than treating the old names as product concepts.
+Start a local dstack simulator or forward a trusted test CVM socket to that path before running the suite. Use `--dstack-endpoint` to select another endpoint.
 
-`run.py` is the orchestrator. It accepts:
+The provider-verifier bridge defaults `DSTACK_VERIFIER_URL` to `http://localhost:18080` when it is not already set. NEAR AI entries declare this variable as a prerequisite.
 
-```bash
-uv run python scripts/live_e2e/run.py --profile quick
-uv run python scripts/live_e2e/run.py --profile full
-uv run python scripts/live_e2e/run.py --profile strict-release
-uv run python scripts/live_e2e/bfcl_v4.py --provider tinfoil
-uv run python scripts/live_e2e/bfcl_v4.py \
-  --provider tinfoil \
-  --test-category simple_python \
-  --max-cases 2
-uv run python scripts/live_e2e/user_verify.py \
-  --base-url https://gateway.example \
-  --chat-id chatcmpl-... \
-  --request-body request.json \
-  --response-body response.json
-cargo run --bin aci -- audit \
-  --report report.json \
-  --receipt receipt.json \
-  --nonce nonce-used-for-report \
-  --request-body request.json \
-  --response-body response.json
+The repository contains a vendored `scripts/confidential_verifier` package. Set `PRIVATE_AI_VERIFIER_DIR` only when deliberately testing another checkout.
+
+## Run a preflight check
+
+Preflight catches missing credentials, missing executables, a missing Unix socket, a busy port, and a failed gateway build without sending inference requests:
+
+```sh
+uv run python scripts/live_e2e/preflight.py \
+  --env-file .env \
+  --port 18086
 ```
 
-Profiles:
+Use `--no-build` only when the binary was already built and the goal is to avoid another compilation pass.
 
-- `quick`: one non-streaming request per provider plus receipt verification and
-  attested-session audit lookup for every verified upstream event.
-- `full`: all capability-enabled fidelity cases.
-- `strict-release`: full profile plus vendored reference pins, gateway code
-  provenance, launcher/image provenance, and fail-closed negative checks.
-- `user-verify`: no provider secrets. Verifies an already received response.
+## Run the suite
 
-## Provider Matrix
+Run the default quick profile against every configured provider:
 
-`providers.json` is the mutable test matrix. It contains public aliases, real
-upstream model ids, provider type, base URL, required env vars, and supported
-fidelity cases.
+```sh
+uv run python scripts/live_e2e/run.py \
+  --env-file .env \
+  --profile quick
+```
 
-Initial entries:
+Select one or more entries with repeated `--provider` arguments. A selector can match the entry name, provider type, or public model alias:
+
+```sh
+uv run python scripts/live_e2e/run.py \
+  --env-file .env \
+  --provider tinfoil-live \
+  --provider chutes-live
+```
+
+Pass `--port 0` to allocate a free local port automatically.
+
+## Profiles
+
+| Profile | Provider verification | Chat and embeddings | Structured outputs |
+| --- | --- | --- | --- |
+| `quick` | Live verifier result and channel-binding checks | Yes | No |
+| `full` | Same as `quick` | Yes | Yes, for entries with the capability |
+| `strict-release` | Also checks the configured model and expected binding against `provider_refs/<provider>.json` | Yes | Yes, for entries with the capability |
+
+Strict references are allowlists, not recorded golden responses. The current strict check validates that the selected model is accepted and that the verifier emitted the expected binding type. It does not pin every claim, measurement, or evidence byte.
+
+`--skip-provider-verify` skips the standalone bridge phase. Gateway requests still use the verifier configured for their provider, so this option does not turn constrained inference into unverified forwarding.
+
+## Provider matrix format
+
+The providers file is a JSON array. Required fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Unique test entry and generated upstream name. |
+| `provider` | Gateway provider type. |
+| `base_url` | Provider HTTPS origin. |
+| `public_model` | Model alias exposed by the temporary gateway. |
+| `upstream_model` | Provider model identifier. |
+| `api_key_env` | Environment variable containing the provider credential. |
+| `binding` | Channel-binding type the verifier must return. |
+
+Optional fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `capabilities` | Cases to enable, including `chat`, `embeddings`, and `structured_outputs`. Other labels document provider features for auxiliary tests. |
+| `requires` | Additional environment variables preflight must find. |
+| `structured_output_max_tokens` | Token limit for the structured-output case; default `512`. |
+| `verification_refresh_seconds` | Per-upstream verifier refresh interval. |
+| `session_refresh_seconds` | Provider session refresh interval. |
+| `chutes_e2ee_api_base` | Alternate Chutes E2EE discovery origin. |
+| `chutes_chute_ids` | Map from upstream model to known chute identifier. |
+| `chutes_e2ee_discovery_rounds` | Number of Chutes discovery passes. |
+| `chutes_e2ee_discovery_interval_seconds` | Delay between Chutes discovery passes. |
+
+Example:
 
 ```json
 [
   {
-    "name": "tinfoil-live",
+    "name": "provider-live",
     "provider": "tinfoil",
-    "base_url": "https://inference.tinfoil.sh",
-    "public_model": "live-tinfoil",
-    "upstream_model": "kimi-k2-6",
-    "api_key_env": "TINFOIL_API_KEY",
+    "base_url": "https://inference.example",
+    "public_model": "live-model",
+    "upstream_model": "provider/model-id",
+    "api_key_env": "PROVIDER_API_KEY",
     "binding": "tls_spki_sha256",
-    "capabilities": ["chat", "streaming", "tools", "structured_outputs", "context"],
-    "structured_output_max_tokens": 2048
-  },
-  {
-    "name": "near-ai-live",
-    "provider": "near-ai",
-    "base_url": "https://cloud-api.near.ai",
-    "public_model": "live-near",
-    "upstream_model": "google/gemma-4-31B-it",
-    "api_key_env": "NEARAI_API_KEY",
-    "binding": "tls_spki_sha256",
-    "requires": ["DSTACK_VERIFIER_URL"],
-    "capabilities": ["chat", "streaming", "structured_outputs", "context"]
-  },
-  {
-    "name": "chutes-live",
-    "provider": "chutes",
-    "base_url": "https://api.chutes.ai",
-    "public_model": "live-chutes",
-    "upstream_model": "moonshotai/Kimi-K2.5-TEE",
-    "api_key_env": "CHUTES_API_KEY",
-    "binding": "e2ee_public_key_sha256",
-    "chutes_chute_ids": {
-      "moonshotai/Kimi-K2.5-TEE": "..."
-    },
-    "capabilities": ["chat", "streaming", "context"]
+    "capabilities": ["chat", "streaming", "structured_outputs"],
+    "structured_output_max_tokens": 1024
   }
 ]
 ```
 
-The matrix is explicit. If a provider/model does not support images, strict
-JSON schema, or tools, that case is skipped for that entry instead of being
-marked as passed.
+Validate a new entry with the quick profile before adding a strict reference. A strict reference should come from a reviewed provider policy, not from copying the first observed value.
 
-## Provider Reference Policy
+## Artifacts
 
-Each provider gets a `provider_refs/<provider>.json` reviewed reference file.
-The verifier compares live evidence to this file in `strict-release` mode.
-In `quick` and `full`, the verifier may accept provider-current evidence, but
-it still records the evidence digest and binding in the receipt.
+The default artifact root is:
 
-Reference files should contain:
-
-```json
-{
-  "provider": "chutes",
-  "reviewed_at": "2026-05-15",
-  "expires_at": "2026-06-15",
-  "source_refs": [
-    "https://api.chutes.ai/servers/tee/measurements"
-  ],
-  "accepted_models": {
-    "moonshotai/Kimi-K2.5-TEE": {
-      "expected_binding": "e2ee_public_key_sha256",
-      "accepted_measurement_profiles": ["..."],
-      "requires_gpu_attestation": true
-    }
-  }
-}
+```text
+/tmp/private-ai-gateway-live-e2e/<UTC-like local timestamp>/
 ```
 
-Provider-specific rules:
-
-- Tinfoil: verify the Tinfoil attestation using the provider-owned verifier
-  and vendored Tinfoil model/router metadata. The accepted binding is the TLS
-  SPKI digest committed in the attestation report data.
-- NEAR AI: request attestation with TLS fingerprint binding, verify the
-  gateway workload through `DSTACK_VERIFIER_URL`, and enforce the gateway TLS
-  SPKI. NEAR AI is a router (`PerRouter`): the attested session is the verified
-  gateway channel, shared by every model. The report is fetched with a model
-  parameter only because that is the shape of NEAR's endpoint; the nested
-  `model_attestations[]` it carries are not required, checked, or recorded —
-  they are not bound to the request's instance — and the served model is a
-  receipt-level identifier. External-provider models that cannot produce
-  gateway-backed evidence are skipped unless a test explicitly expects
-  rejection.
-- Chutes: verify the TDX report data binds `nonce || e2e_pubkey`, verify DCAP,
-  verify the public measurement profile against a reviewed reference, verify
-  NVIDIA evidence when present, and hash the decoded ML-KEM public-key bytes
-  for the binding enforced by the transport. Strict production entries should
-  pin upstream model ids to concrete `chute_id` UUIDs with `chutes_chute_ids`;
-  the verifier and upstream config use the same pins.
-- ACI service: verify `/v1/aci/attestation?nonce=...`, quote report data,
-  dstack KMS key custody, accepted keyset subject or image digest, accepted
-  KMS root, and attested TLS SPKI.
-
-Reference updates must be reviewed. The script may print a proposed diff with
-`--update-refs-dry-run`, but it should not silently rewrite trust pins.
-
-## Test Phases
-
-### 00 Preflight
-
-Checks:
-
-- Required API keys are present but never printed.
-- The vendored `scripts/confidential_verifier` package exists, or
-  `PRIVATE_AI_VERIFIER_DIR` points at an explicit verifier override.
-- `DSTACK_VERIFIER_URL` responds for NEAR AI and ACI service tests.
-- A local dstack socket exists for gateway attestation tests. The runner writes
-  the static gateway config and defaults `dstack_endpoint` to
-  `unix:/tmp/aci-dstack-sock-dev.dstack.sock`; pass `--dstack-endpoint` to use
-  a different endpoint.
-- The gateway binary builds.
-- No live server is already bound to the selected local port.
-
-### 10 Provider Attestation
-
-For each provider:
-
-- Run the provider verifier directly.
-- Assert `result == verified`.
-- Assert embedded `evidence.digest`, data-URI `evidence.data`, and at least one channel binding.
-- Assert binding type matches the provider transport.
-- In strict mode, compare evidence claims to `provider_refs/<provider>.json`.
-
-Negative checks:
-
-- Mutate the TLS SPKI or E2EE public key binding and assert forwarding fails.
-- For Chutes, mutate `key_id` or public-key digest and assert `/e2e/invoke`
-  is never called.
-
-### 20 Gateway Launch
-
-The script writes a temporary upstream config from `providers.json`, starts a
-local gateway against the real dstack socket, and deletes the config on
-exit because it contains live bearer tokens.
-
-Checks:
-
-- `GET /v1/models` returns only public aliases.
-- `GET /v1/aci/attestation?nonce=<random>` verifies:
-  - the keyset digest recomputes over the served `workload_keyset` JCS form,
-  - quote report data binds the ACI attestation statement,
-  - the keyset is not expired,
-  - dstack KMS custody verifies when using dstack,
-  - source provenance is absent when unknown, or matches the git-launcher
-    repo/commit pin when present,
-  - attested TLS SPKI is present when configured.
-
-### 30 Lifecycle
-
-For each provider and enabled request mode:
-
-- Send request through the gateway.
-- Assert response status and OpenAI-compatible shape.
-- Fetch `/v1/aci/receipts/{chat_id}` with the original bearer token.
-- Verify receipt signature using the receipt key from the attested keyset.
-- Verify the payload's keyset digest matches the attestation report.
-- Verify `request.received.body_hash` equals the exact client body.
-- Verify `request.forwarded.body_hash` equals the model-rewritten upstream
-  body.
-- Verify a rewrite shows as `request.forwarded.body_hash` differing from
-  `request.received.body_hash`.
-- Verify `upstream.verified` is `verified`, `required == true`, and cites a
-  `session_id` whose fetched bytes hash to it.
-- Verify `response.returned.body_hash` equals the response body for
-  non-streaming requests or the raw ordered SSE wire bytes for streaming.
-
-The first runnable slice covers the non-streaming lifecycle and relying-party
-verification path. The verifier intentionally uses the Rust protocol code
-(`aci audit`) for ACI canonicalization, keyset binding, and receipt signature
-checks instead of reimplementing those rules in Python.
-
-### 32 Embeddings
-
-Capability-gated on `embeddings`. For each provider that lists it, the runner:
-
-- Sends `POST /v1/embeddings` through the gateway with a fixed `input` string.
-- Asserts the OpenAI-compatible response shape (`object: "list"`, non-empty
-  `data[]` with a numeric `embedding[]` whose components are not all zero).
-- Fetches `/v1/aci/receipts/{receipt_id}` using the `x-receipt-id` header value as
-  the lookup id, since OpenAI embeddings responses carry no `id` field. The
-  gateway's receipt endpoint accepts either `chat_id` or `receipt_id` as the
-  path parameter.
-- Runs the same `aci audit` offline verification against the receipt +
-  request + response bodies to confirm canonical request/forwarded/response
-  hashes and the receipt signature.
-- Asserts `receipt.endpoint == "/v1/embeddings"` and that `upstream.verified`
-  carries the provider's declared binding (e.g. `e2ee_public_key_sha256` for
-  Chutes embeddings).
-
-The first wired model is `Qwen/Qwen3-Embedding-8B-TEE` on Chutes (chute_id
-`21822836-bfa6-5426-b27e-dd5fdda1249e`), routed via the same
-`ChutesProviderBackend` E2EE path as chat. There is currently no Phala-deployed
-TEE embedding model in `Dstack-TEE/vllm-proxy` (the proxy does not register a
-`/v1/embeddings` route yet), and no Tinfoil/NEAR embedding entry — the matrix
-will expand once those land.
-
-### 35 Framework Compatibility
-
-Run the same lifecycle cases in two gateway modes:
-
-- **No middleware:** frontend calls backend directly. Assert behavior matches
-  the current request path: `body.model` is the target route id, backend rewrites
-  to the upstream model, and receipts contain the same verification and hash
-  facts as today.
-- **Fixture middleware:** frontend forwards plaintext to a local middleware
-  fixture. The fixture rewrites the request and selects a different configured
-  target route id. Backend must validate that route, verify the provider, and
-  record backend-authored route/provider facts that the middleware cannot forge.
-
-Middleware fixture checks:
-
-- Public requests with forged `X-Private-AI-Gateway-*` headers are sanitized by
-  the frontend.
-- Middleware cannot claim `upstream.verified`; backend must author that event.
-- E2EE AAD uses the original user model even when middleware selects a
-  provider-qualified target route.
-- The final receipt distinguishes `request.received`, `middleware.forwarded`,
-  `route.selected`, `upstream.forwarded`, `upstream.verified`, and
-  `response.returned`.
-
-The `bfcl_v4.py` wrapper runs the Berkeley Function Calling Leaderboard v4
-through the local gateway over OpenAI-compatible Chat Completions. It is
-intentionally separate from `run.py`: BFCL is useful for native tool-call
-fidelity and multi-turn agentic behavior, while the ACI runner remains the
-source of truth for report, receipt, and upstream binding verification.
-
-Some models need provider-specific output budgets even when they support the
-same OpenAI-compatible feature. Tinfoil `kimi-k2-6` emits a large
-`message.reasoning` field before final `message.content`; live tests showed
-that 512 completion tokens can stop in reasoning-only output, while the same
-schema succeeds with a larger budget. The provider matrix keeps this as an
-explicit per-provider test parameter instead of rewriting provider responses.
-
-By default the BFCL wrapper expects a sibling checkout at
-`../gorilla-bfcl/berkeley-function-call-leaderboard`, or an explicit
-`--bfcl-dir`. It deterministically samples a spread of 1% of BFCL v4
-`single_turn` and `multi_turn` cases with a two-case-per-category floor because
-BFCL's leaderboard CSV step computes latency standard deviation. Random
-sampling is available only with `--sample-mode random`. The wrapper exposes
-each tested provider under a BFCL-supported OpenAI Chat Completions model key,
-then runs BFCL's own `generate` and `evaluate` commands with `--run-ids` and
-`--partial-eval`. When `--max-cases` caps a broad category group, the cap keeps
-a deterministic spread of categories instead of taking the first categories
-greedily.
-
-`scripts/live_e2e/providers.glm51.json` maps the currently shared GLM 5.1
-family across Tinfoil, NEAR AI, and Chutes. It is the first cross-provider BFCL
-matrix because it exercises the same broad model family while still preserving
-each provider's native attestation and transport path.
-
-Useful tool-call fidelity slice:
-
-```bash
-python3 scripts/live_e2e/bfcl_v4.py \
-  --providers-file scripts/live_e2e/providers.glm51.json \
-  --test-category single_turn,multi_turn \
-  --max-cases 20 \
-  --no-build
-```
-
-### 40 Fidelity Cases
-
-These cases are capability-gated per provider/model.
-
-Text baseline:
-
-- Deterministic short instruction with `temperature: 0`.
-- Assert valid OpenAI response shape, stable `id`, `object`, `model`, `choices`,
-  `finish_reason`, and `usage` when provided.
-
-Streaming:
-
-- Same request with `stream: true`.
-- Parse every SSE frame.
-- Assert chunk ids are consistent, `[DONE]` arrives, final receipt exists, and
-  receipt response hash covers the exact ordered stream bytes.
-
-Tool calls:
-
-- Use OpenAI `tools` shape and force a specific tool with `tool_choice`.
-- Assert `finish_reason == tool_calls`.
-- Assert tool name and arguments parse as JSON and match the requested schema.
-- For streaming tools, assert incremental chunks reconstruct the same call.
-
-Structured outputs:
-
-- Use `response_format: { "type": "json_schema", ... }` where supported.
-- Assert the returned content parses and validates against the schema.
-- Also run `response_format: { "type": "json_object" }` for models that only
-  support JSON mode.
-
-Multimodal:
-
-- Use a tiny deterministic base64 PNG with embedded text or simple colored
-  geometry.
-- Assert the answer identifies the expected text/color/count.
-- If a model does not support image input, skip rather than fail.
-- PDF/audio/video should be separate optional cases only after the provider
-  matrix has models that explicitly support those inputs.
-
-Context:
-
-- Send a large deterministic prefix with sentinels at the beginning, middle,
-  and end.
-- Ask the model to return the sentinels only.
-- The test size is provider-specific and starts below the advertised context
-  limit. It should not infer a provider's true maximum from one failure.
-
-Cache:
-
-- For provider prompt cache, keep the reusable prefix deterministic and put
-  the varying question at the end.
-- Use provider-supported cache controls only for models that advertise support.
-- Assert cache metadata such as cached token counts or provider cache headers
-  when exposed. If no metadata is exposed, report "unobservable" instead of
-  passing.
-- Response-cache semantics, if we add them later, are tested separately from
-  provider prompt caching because they operate at a different layer.
-
-### 50 Direct Provider Comparison
-
-For each capability case, optionally send the same request directly to the
-provider using the upstream model id and provider transport. Compare normalized
-invariants:
-
-- Response shape and required fields.
-- Tool call name and JSON arguments.
-- Structured-output schema validity.
-- SSE parseability and completion.
-- Usage fields and cache fields if the provider exposes them.
-
-Do not require exact natural-language text equality. Use exact equality only
-for structured values the prompt constrains.
-
-## User Verification Story
-
-`user_verify.py` is the script we should document for users.
-
-Inputs:
-
-- Gateway base URL.
-- Chat id or receipt id.
-- Original request body, optional.
-- Response body or captured stream bytes, optional.
-
-Procedure (delegated to `aci audit`):
-
-1. Fetch `GET /v1/aci/attestation?nonce=<random>`.
-2. Verify the report binding chain (keyset bytes → digest → statement →
-   report_data) and keyset expiry.
-3. Fetch `GET /v1/aci/receipts/{chat_id}`.
-4. Verify the envelope signature under the attested receipt key and the
-   payload's keyset digest against the verified report.
-5. Verify request/response hashes when bodies are supplied.
-6. Fetch the cited `GET /v1/aci/sessions/{session_id}`, recompute the session id
-   from the fetched bytes, check the receipt's `served_at` falls in the
-   validity window and the evidence data hashes to its digest, and show the
-   typed claims.
-
-The final output should be a human-readable summary plus a machine-readable
-JSON result. The verifier should omit `source_provenance` when the gateway
-report omits it because the git-launcher pin is unavailable.
-
-The output is the `aci audit --json` transcript: a `checks` array (id,
-section, status, detail) and a `verdict` object carrying `verified`, the
-pass/fail/skip counts, and the established `workload_keyset_digest`.
-
-## OpenRouter-Derived Fidelity Checklist
-
-OpenRouter's compatibility surface is useful because it has to normalize many
-providers. Our suite should explicitly cover the same classes of behavior:
-
-- Standard chat parameters: `max_tokens`, `temperature`, `stop`, `seed`, and
-  penalty fields where providers accept them.
-- Tool calling and `tool_choice`.
-- Parallel tool calls when supported.
-- `response_format` JSON mode and strict JSON schema.
-- Streaming and non-streaming parity.
-- Multimodal message content: at minimum `image_url`, later `file`,
-  `input_audio`, and `video_url` when supported providers are available.
-- Context length behavior under large prompts.
-- Prompt-cache metadata when a provider exposes it.
-
-## Minimum Implementation Order
-
-1. `user_verify.py` for already captured responses.
-2. `provider_verify.py` plus `provider_refs`.
-3. `run.py --profile quick` for Tinfoil, NEAR AI, Chutes, including
-   attested-session audit lookup.
-4. Framework no-middleware compatibility case.
-5. Framework fixture-middleware case with route selection and rewrite receipts.
-6. Streaming and receipt hash verification.
-7. Tool and structured-output cases.
-8. Multimodal and context cases.
-9. Cache observability.
-10. Strict-release source provenance from the launcher pin and image provenance checks.
+Choose another root with `--artifacts-dir`. Each run includes:
+
+- `summary.json`, including the selected profile and phase results;
+- `aggregator.log`;
+- `aggregator-upstreams.redacted.json`;
+- standalone provider-verifier requests with credentials redacted;
+- provider-verifier outputs;
+- exact request, response, report, and receipt bytes for each lifecycle case;
+- user-verification summaries;
+- fetched session records and compact summaries;
+- structured-output inputs, outputs, and summaries when enabled.
+
+The runner removes its generated gateway config and state directory on exit. Set `KEEP_LIVE_E2E=1` to retain the temporary directory for debugging. Artifact files can still contain model inputs, outputs, attestation evidence, endpoints, and public identity material. Handle them as test records, even though configured bearer tokens are redacted.
+
+## Auxiliary scripts
+
+The main runner does not dispatch every script in the directory. Run these separately when their narrower behavior is under test:
+
+| Script | Purpose |
+| --- | --- |
+| `streaming_smoke.py` | Streaming response and receipt smoke test. |
+| `chutes_session_smoke.py` | Chutes session discovery and request behavior. |
+| `chutes_rate_probe.py` | Chutes rate and capacity observations. |
+| `router_refresh_smoke.py` | Middleware route refresh behavior. |
+| `router_session_smoke.py` | Middleware session behavior. |
+| `bfcl_v4.py` | BFCL-derived tool-calling compatibility cases. |
+| `user_verify.py` | User-facing artifact verification helper. |
+
+Read each script's `--help` output before use. These tools call live systems and can consume provider quota.
+
+## Failure diagnosis
+
+Start with `summary.json`, then inspect `aggregator.log` and the failing provider directory.
+
+| Failure | First checks |
+| --- | --- |
+| Missing environment variable | Confirm `--env-file`, the selected matrix entry, and `api_key_env` or `requires`. |
+| Missing dstack socket | Start the simulator or pass the correct `--dstack-endpoint`. |
+| Provider verification failure | Inspect `provider-verifier-output.json`, then compare it with the provider policy in `docs/providers/`. |
+| Binding-type mismatch | Check the matrix `binding` and the verifier's `channel_bindings`. Do not weaken the expectation without reviewing the provider protocol. |
+| Gateway never becomes ready | Inspect `aggregator.log`, generated model aliases, and port ownership. |
+| Receipt or session assertion failure | Compare the raw receipt, session artifact, and current canonical API schema before changing the test. |
+| Strict-reference failure | Confirm the model and policy really changed before updating `provider_refs/`. |
+
+For credential-free validation, use the project checks in [Contributing](../CONTRIBUTING.md) instead of the live suite.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,101 +1,86 @@
-# Providers
+# Provider Verification
 
-One directory per upstream provider. Each holds up to two documents:
+This section documents the TEE provider adapters that can produce verified upstream sessions. It is for operators setting acceptance policy and reviewers auditing what each `verified` result actually proves.
 
-- **`verification.md`** — a living reference for **how the gateway verifies this provider
-  and what cryptographically binds the session** it then enforces. Tracks the code.
-- **`review.md`** — a point-in-time **admissions audit** against
-  [`audit-criteria.md`](audit-criteria.md) (verdict, criteria status, required adapter
-  changes, open questions).
+Provider pages use two document types:
 
-| Provider | TEE | Session binding | Verification | Audit |
+- `verification.md` is a living reference tied to the current adapter and forwarding code.
+- `review.md` is a dated admissions audit. It preserves the evidence and decision at that time and can contain unresolved work that has since moved.
+
+Do not use a dated review as a substitute for the living verification page or current source.
+
+## Provider matrix
+
+| Provider | Attested boundary | Enforced binding | Living reference | Dated audit |
 | --- | --- | --- | --- | --- |
-| Chutes | Intel TDX + NVIDIA CC | `e2ee_public_key_sha256` | [configuration](chutes/configuration.md), [verification](chutes/verification.md) | [review](chutes/review.md) |
-| NEAR AI | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](near-ai/verification.md) | [review](near-ai/review.md) |
-| Tinfoil | AMD SEV-SNP (or TDX) + NVIDIA CC | `tls_spki_sha256` | [verification](tinfoil/verification.md) | [review](tinfoil/review.md) |
-| AciService (first-party) | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](aci-service/verification.md) | — (first-party) |
-| PhalaDirect | Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](phala-direct/verification.md) | [review](phala-direct/review.md) |
-| SecretAI | AMD SEV-SNP or Intel TDX + NVIDIA CC | `tls_spki_sha256` | [verification](secret-ai/verification.md) | [review](secret-ai/review.md) |
+| ACI service | ACI-compatible dstack service | `tls_spki_sha256` | [Verification](aci-service/verification.md) | First-party path; no separate audit |
+| Chutes | Per-instance Intel TDX workload | `e2ee_public_key_sha256` | [Configuration](chutes/configuration.md), [verification](chutes/verification.md) | [Review](chutes/review.md) |
+| NEAR AI | Intel TDX router gateway | `tls_spki_sha256` | [Verification](near-ai/verification.md) | [Review](near-ai/review.md) |
+| Phala direct | Per-model dstack-vllm-proxy endpoint | `tls_spki_sha256` | [Verification](phala-direct/verification.md) | [Review](phala-direct/review.md) |
+| SecretAI | SecretVM router workload | `tls_spki_sha256` | [Verification](secret-ai/verification.md) | [Review](secret-ai/review.md) |
+| Tinfoil | Confidential model router | `tls_spki_sha256` | [Verification](tinfoil/verification.md) | [Review](tinfoil/review.md) |
 
-The two columns are different document *types* — `verification.md` tracks the running
-code; `review.md` is a dated audit snapshot — so they are kept side by side rather than
-merged. The framework and cross-cutting reviews:
+`openai-compatible` and `anthropic` are supported transport adapters, but they do not create verified TEE sessions.
 
-- [`audit-criteria.md`](audit-criteria.md) — the admission framework, including
-  criteria 13 (source & platform provenance) and 14 (platform TCB freshness).
-- Source review lanes (router-mode providers):
-  [router-mode-soundness.md](../reviews/router-mode-soundness.md),
-  [router-mode-load-balancing-cache.md](../reviews/router-mode-load-balancing-cache.md),
-  and the process in [router-mode-provider-review.md](../router-mode-provider-review.md).
+## Shared verification invariant
 
-## Prefix-cache tenant isolation
+A provider verifier can return `verified` only with at least one enforceable channel binding. The request path then enforces the selected binding before forwarding the prompt:
 
-As observed on 2026-07-13, Private AI Gateway does not guarantee per-tenant
-prefix-cache partitioning for the active Kimi-K2.6 providers. The gateway
-preserves a caller's `cache_salt` but does not derive one from the authenticated
-RedPill tenant.
+- `tls_spki_sha256` pins `SHA256(SubjectPublicKeyInfo)` on the actual upstream TLS connection.
+- `e2ee_public_key_sha256` restricts Chutes selection to an attested instance and encrypts the request to that instance's ML-KEM public key.
 
-- Tinfoil [replaces `cache_salt`](https://github.com/tinfoilsh/confidential-model-router/blob/v0.0.118/cache_salt.go)
-  with a value derived from RedPill's shared upstream credential. The gateway
-  does not set `user_cache_secret`, so RedPill tenants share one namespace.
-- Chutes passes `cache_salt` to vLLM but does not generate it. Unsalted requests
-  share the serving instance's namespace.
+The verifier proves that the binding belongs to the attested workload according to that provider's evidence format. The forwarding backend proves that the connection or encrypted request uses the same binding. A receipt records the result and selected session.
 
-Tinfoil's behavior is attestation-backed. Chutes configuration is control-plane
-evidence and is not bound by its current attestation. The intended interface is
-caller-controlled: preserve `cache_salt` for Chutes and translate it to
-`user_cache_secret` for Tinfoil. The gateway should not derive or override the
-partition from RedPill tenant identity.
+This invariant is implemented across `src/aci/verifier/`, `src/aci/upstream/`, and `src/aggregator/service/forward.rs`. It is covered by provider bridge tests, upstream-verifier tests, and channel-binding tests.
 
-## The shared verification model
+## Claims are not uniform
 
-**A session binding is only trustworthy if it is bound into a verified attestation or
-an attestation-gated key-release protocol.** Every provider produces exactly one kind
-of binding. The bound value either lives inside the signed quote/report or identifies
-the attested policy that gates the provider's encryption secret. Each `verification.md`
-states plainly *what is bound* and *what a tamper rejects*.
+`verified` means that the provider adapter's mandatory checks and binding enforcement succeeded. It does not assert every session claim.
 
-The two binding types:
+The session layer records these claim states separately:
 
-- **`tls_spki_sha256`** — SHA-256 fingerprint of the upstream's TLS public key; the
-  backend enforces it against the actual upstream HTTPS connection before forwarding.
-- **`e2ee_public_key_sha256`** — SHA-256 of the upstream's end-to-end public key; the
-  backend encrypts the request body to that key, so only the attested enclave can
-  decrypt.
+- TEE attestation;
+- GPU attestation;
+- platform TCB freshness;
+- OS provenance;
+- serving-software provenance;
+- model-weight provenance.
 
-### Invariant: verified ⟹ enforceable binding
+Each can be asserted, refuted, or unknown. Apply relying-party policy to the claim source and evidence. In particular, do not equate a verified CPU channel with proven model weights or a CPU-bound GPU.
 
-A "verified" result that carries no enforceable channel binding is rejected
-(`src/aggregator/service/forward.rs`). Forwarding fails closed if the selected backend cannot enforce
-the accepted binding
-(`tests/upstream_verifier.rs::service_fails_if_selected_backend_cannot_enforce_channel_binding`).
-A provider can never be "verified but unpinned."
+The common audit rubric is [Provider audit criteria](audit-criteria.md). Cross-provider router reviews are preserved in [Router-mode soundness](../reviews/router-mode-soundness.md) and [Router load balancing and cache](../reviews/router-mode-load-balancing-cache.md).
 
-### The attested session record
+## Audit a request
 
-When an upstream is verified, `record_attested_upstream_session`
-(`src/aggregator/service/forward.rs`) content-addresses the verified binding,
-verifier id, target, claims, and evidence into a stable `session_id` (the
-SHA-256 of the served session bytes, 64-hex), stores an `AttestedSession`
-served by `GET /v1/aci/sessions/{session_id}`, and attaches that `session_id`
-to the receipt's `upstream.verified` event. `expires_at` bounds validity for
-new forwarding decisions; retention runs at least as long as any receipt
-citing it (see
-[../upstream-verification-lifecycle.md](../upstream-verification-lifecycle.md)).
+For a request that must use a verified provider:
 
-### How a relying party verifies it end-to-end
+1. Set `provider.aci_verified` to `true`, or send an approved `provider.aci_session_ids` allowlist.
+2. Verify the gateway report and establish its workload keyset.
+3. Verify the receipt signature and exact body hashes.
+4. Require an `upstream.verified` event with `required: true` and `result: verified`.
+5. Resolve its `session_id` through `GET /v1/aci/sessions/{session_id}`.
+6. Recompute the session identifier and evidence digest.
+7. Apply the provider-specific policy described by the living verification page.
 
-1. `GET /v1/aci/attestation?nonce=<random>` — verify the gateway's own ACI report.
-2. `GET /v1/aci/receipts/{chat_id}` — verify the receipt signature under the attested keyset.
-3. Read `upstream.verified.session_id`; `GET /v1/aci/sessions/{session_id}`.
-4. Recompute the SHA-256 of the fetched session bytes and confirm it equals the
-   cited `session_id` (nothing the middleware can forge), then audit the
-   record's channel bindings, claims, and evidence digest.
-5. The gateway has already enforced that binding on the wire before forwarding.
+The full client flow is in [Verify an attested inference](../attested-confidential-inference.md).
 
-`scripts/live_e2e/user_verify.py` and `scripts/live_e2e/cases/attested_sessions.py`
-implement this check; `verified_upstream_binding_creates_attested_session` covers record
-creation.
+## Prefix-cache isolation observation
 
-A soundness pass (2026-06) tamper-tested every provider against its live upstream; each
-`verification.md` records those results under "What a tamper rejects".
+The following is a dated operational observation, not a protocol guarantee: as observed on 2026-07-13, the gateway preserved caller-supplied `cache_salt` but did not derive a tenant-specific cache partition for the active Tinfoil and Chutes routes. Tinfoil and Chutes applied their own provider behavior after forwarding.
+
+Revalidate provider code and deployment configuration before relying on cache partitioning. Attestation can bind a provider implementation, but it does not turn an unreviewed cache policy into tenant isolation.
+
+## Updating a provider page
+
+When verifier behavior changes, update the living page in the same change. Include:
+
+- the evidence endpoints and freshness mechanism;
+- every mandatory rejection check;
+- the exact value bound into hardware evidence;
+- how forwarding enforces that value;
+- typed claims and their sources;
+- evidence or checks that are supplemental only;
+- current tests and a repository-relative reproduction command;
+- limitations that affect a relying-party decision.
+
+Preserve old audit results as dated records. Add a short supersession note rather than rewriting what the earlier audit observed.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -11,14 +11,14 @@ Do not use a dated review as a substitute for the living verification page or cu
 
 ## Provider matrix
 
-| Provider | Attested boundary | Enforced binding | Living reference | Dated audit |
+| Provider | Attested boundary | Enforced binding | Living reference | Dated audit decision |
 | --- | --- | --- | --- | --- |
 | ACI service | ACI-compatible dstack service | `tls_spki_sha256` | [Verification](aci-service/verification.md) | First-party path; no separate audit |
-| Chutes | Per-instance Intel TDX workload | `e2ee_public_key_sha256` | [Configuration](chutes/configuration.md), [verification](chutes/verification.md) | [Review](chutes/review.md) |
-| NEAR AI | Intel TDX router gateway | `tls_spki_sha256` | [Verification](near-ai/verification.md) | [Review](near-ai/review.md) |
-| Phala direct | Per-model dstack-vllm-proxy endpoint | `tls_spki_sha256` | [Verification](phala-direct/verification.md) | [Review](phala-direct/review.md) |
-| SecretAI | SecretVM router workload | `tls_spki_sha256` | [Verification](secret-ai/verification.md) | [Review](secret-ai/review.md) |
-| Tinfoil | Confidential model router | `tls_spki_sha256` | [Verification](tinfoil/verification.md) | [Review](tinfoil/review.md) |
+| Chutes | Per-instance Intel TDX workload | `e2ee_public_key_sha256` | [Configuration](chutes/configuration.md), [verification](chutes/verification.md) | [Accepted for limited traffic](chutes/review.md), 2026-05-18 |
+| NEAR AI | Intel TDX router gateway | `tls_spki_sha256` | [Verification](near-ai/verification.md) | [Acceptable with conditions](near-ai/review.md), 2026-05-18 |
+| Phala direct | Per-model dstack-vllm-proxy endpoint | `tls_spki_sha256` | [Verification](phala-direct/verification.md) | [Acceptable with conditions](phala-direct/review.md), updated 2026-07-05 |
+| SecretAI | SecretVM router workload | `tls_spki_sha256` | [Verification](secret-ai/verification.md) | [Acceptable with conditions](secret-ai/review.md), 2026-05-22 |
+| Tinfoil | Confidential model router | `tls_spki_sha256` | [Verification](tinfoil/verification.md) | [Acceptable with conditions](tinfoil/review.md), 2026-05-18 |
 
 `openai-compatible` and `anthropic` are supported transport adapters, but they do not create verified TEE sessions.
 
@@ -66,9 +66,28 @@ The full client flow is in [Verify an attested inference](../attested-confidenti
 
 ## Prefix-cache isolation observation
 
-The following is a dated operational observation, not a protocol guarantee: as observed on 2026-07-13, the gateway preserved caller-supplied `cache_salt` but did not derive a tenant-specific cache partition for the active Tinfoil and Chutes routes. Tinfoil and Chutes applied their own provider behavior after forwarding.
+The following is a dated operational observation, not a protocol guarantee. As
+observed on 2026-07-13, the gateway preserved caller-supplied `cache_salt` but
+did not derive a tenant-specific cache partition for the active Tinfoil and
+Chutes routes:
 
-Revalidate provider code and deployment configuration before relying on cache partitioning. Attestation can bind a provider implementation, but it does not turn an unreviewed cache policy into tenant isolation.
+- Tinfoil
+  [replaced `cache_salt`](https://github.com/tinfoilsh/confidential-model-router/blob/v0.0.118/cache_salt.go)
+  with a value derived from RedPill's shared upstream credential. Because the
+  gateway did not set `user_cache_secret`, RedPill tenants shared one provider
+  cache namespace.
+- Chutes passed `cache_salt` to vLLM but did not generate one. Unsalted
+  requests shared the serving instance's namespace.
+
+At that revision, Tinfoil's behavior was attestation-backed. The observed
+Chutes behavior came from control-plane evidence and was not bound by its
+current attestation. The intended caller-controlled interface was to preserve
+`cache_salt` for Chutes and translate it to `user_cache_secret` for Tinfoil,
+without deriving or overriding it from RedPill tenant identity in the gateway.
+
+Revalidate provider code and deployment configuration before relying on cache
+partitioning. Attestation can bind a provider implementation, but it does not
+turn an unreviewed cache policy into tenant isolation.
 
 ## Updating a provider page
 

--- a/docs/providers/aci-service/verification.md
+++ b/docs/providers/aci-service/verification.md
@@ -1,123 +1,177 @@
-# AciService (first-party) — attested session verification & binding
+# ACI service verification
 
-- **TEE:** Intel TDX (CPU) + NVIDIA Confidential Compute, on dstack
-- **Session binding:** `tls_spki_sha256`
-- **Verifier:** native Rust — `AciServiceUpstreamVerifier`
-  (`src/aci/verifier/aci_service.rs`). No bridge / Python; this is the path
-  for the gateway's own ACI-compatible workers.
-- **Versions:** ACI report wire format `aci/1`; verifier implementation
-  `aci-service/v2`.
-- **Status:** sound (designed with the keyset-digest binding from the start;
-  covered by `tests/upstream_verifier.rs`).
-- **Audit:** none — first-party path; [`audit-criteria.md`](../audit-criteria.md) targets
-  third-party providers.
+Use the `aci-service` provider for an upstream that publishes a canonical ACI
+report and runs on dstack with Intel TDX. The gateway verifies this path in
+native Rust and enforces an attested TLS SPKI before forwarding.
 
-## What is verified
+This page is the living reference for operators configuring the verifier and
+reviewers deciding what its `verified` result means.
 
-`AciServiceUpstreamVerifier` fetches `GET /v1/aci/attestation?nonce=<random>`
-(the spec §4 report) from the worker and verifies it natively:
+## Current contract
 
-1. **ACI report binding** (`validate_aci_report_binding`,
-   `src/aci/verifier/report.rs` — the spec §9.1(2–3) chain):
-   the SHA-256 of the served `workload_keyset` object's JCS form must
-   equal the reported `workload_keyset_digest`; rebuild the §3.2 statement
-   `{"keyset_digest":…,"nonce":…,"purpose":"aci.report_data.v1"}` for the
-   supplied nonce and check its SHA-256 equals `report_data`; check the keyset
-   is not expired (`now < not_after`). Freshness comes from the nonce; the
-   cached verification never outlives `not_after`.
-2. **Identity policy** — the attested keyset `subject` must be in
-   `accepted_subjects`, or the report's provenance `image_digest` in
-   `accepted_image_digests` (§3 identity anchors); otherwise
-   `PolicyRejected`.
-3. **DCAP quote** — `dcap_qvl` verifies the TDX quote against fetched
-   collateral.
-4. **dstack event log, app-id, and Compose** — verify RTMR3, extract and
-   accept the measured app-id, and verify the Compose preimage as described
-   below.
-5. **dstack KMS key custody** — verify the KMS signature chain for the
-   published keys against an accepted root in
-   `accepted_dstack_kms_root_public_keys` (§3.3 custody; the chain covers the
-   released key's k256 counterpart, and the link to the published Ed25519 key
-   rests on the measured workload code).
+| Property | Value |
+| --- | --- |
+| Provider configuration | `"provider": "aci-service"` |
+| Verifier | `AciServiceUpstreamVerifier` in `src/aci/verifier/aci_service.rs` |
+| Verifier ID | `aci-service/v2` |
+| Report | `GET /v1/aci/attestation?nonce=<fresh-64-hex>` |
+| CPU evidence | Intel TDX quote verified with `dcap_qvl` |
+| Workload measurement | dstack event-log replay to RTMR3, including `app-id` and `compose-hash` |
+| Key custody | dstack KMS chain for the receipt-signing key |
+| Enforced channel | `tls_spki_sha256` |
 
-## How the measured Compose is verified
+The verifier does not use the Python provider bridge. It shares its ACI §9.1
+appraisal code with the `aci` CLI.
 
-The ACI-service verifier connects `attestation.evidence.app_compose` to the
-verified TDX quote as follows:
+## Required configuration
 
-1. Verify the TDX quote and its nonce-bound `report_data`.
-2. Recompute the dstack runtime-event digests, replay the boot event log, and
-   require the result to equal RTMR3 in the verified quote.
-3. Read the pre-`system-ready` `compose-hash` event and require
-   `SHA256(UTF8(app_compose))` to equal that measured value.
+An `aci-service` upstream must provide:
 
-These checks prove integrity and measurement binding. They do not prove that an
-image, launcher, source revision, compiler, dependency, or OS build is
-acceptable. Those trust-policy checks remain separate.
+- at least one `accepted_subjects` value or `accepted_image_digests` value;
+- at least one `accepted_dstack_kms_root_public_keys` value; and
+- an HTTPS `base_url` whose service publishes an attested TLS key.
 
-## What binds the session
+The strongest current identity anchor is a measured subject in this form:
 
-The TLS SPKIs are attested through
-`workload_keyset.tls_public_keys[].spki_sha256_hex`. The keyset's JCS form
-**includes** `tls_public_keys`, so they are covered by
-`workload_keyset_digest` — which is, in turn, (a) checked against the
-reported digest and (b) folded into `report_data` (and thus into the
-verified quote). The TLS-SPKI binding is therefore double-bound to the
-attested workload.
+```text
+app-id:0x<hex-encoded-dstack-app-id>
+```
 
-For a domain-scoped keyset, the verifier also requires
-`attestation.evidence.downstream_tls_binding` to name the requested origin host and a
-SPKI present in the attested keyset. Only that selected SPKI becomes the enforced
-`tls_spki_sha256` channel binding. Service-wide keysets without per-domain entries keep
-the previous behavior: every service-wide TLS SPKI is accepted for the origin.
+The verifier derives that value from the RTMR3-verified event log. The upstream
+keyset may omit `subject`; if it includes one, it must exactly match the
+measured value.
 
-## What a tamper rejects
+See [Configuration reference](../../configuration-reference.md#upstream-fields)
+for all fields, defaults, timeouts, and cache settings.
 
-Tampering any `tls_public_keys` entry changes `workload_keyset_digest`, which
-trips two independent checks at once:
+## Verification algorithm
 
-- `WorkloadKeysetDigestMismatch` (recomputed ≠ reported),
-- `ReportDataMismatch` (statement digest no longer matches the quote's
-  report_data).
+For an uncached verification, the gateway:
 
-Other rejections: wrong nonce → `ReportDataMismatch`; expired keyset →
-`KeysetExpired`; unaccepted subject/image → `PolicyRejected`; quote that does
-not bind the report data → `QuoteReportDataMismatch`. Unit-tested in
-`tests/upstream_verifier.rs`.
+1. Generates a fresh 32-byte nonce and fetches the canonical ACI report.
+2. Recomputes the workload keyset's JCS digest and the nonce-bound ACI
+   statement. It rejects a mismatched `workload_keyset_digest`, mismatched
+   `report_data`, or expired `not_after`.
+3. Parses the TDX quote, fetches DCAP collateral from the configured PCCS,
+   verifies the quote, checks the reported TEE type, and requires the quote's
+   64-byte report-data slot to contain the ACI `report_data` value followed by
+   zeros.
+4. Requires source provenance and a published `app_compose`.
+5. Replays the dstack runtime event log and requires the resulting RTMR3 to
+   match the verified quote.
+6. Requires `sha256(UTF8(app_compose))` to match the pre-`system-ready`
+   `compose-hash` event, then extracts the measured dstack `app-id`.
+7. Applies the configured identity policy to that measured app ID or the
+   accepted image-digest path described under limitations.
+8. Verifies the dstack KMS signature chain for the receipt-signing key against
+   an accepted KMS root and the measured app ID.
+9. Selects an attested TLS SPKI that applies to the upstream origin.
 
-## Transport enforcement
+Any missing required evidence, policy mismatch, quote failure, expired keyset,
+custody failure, or unusable channel binding returns a failed verification
+event.
 
-The backend enforces the verified `tls_spki_sha256` against the upstream HTTPS
-connection before forwarding.
+## How the TLS binding is selected
 
-## Notes
+The workload keyset is part of the nonce-bound report, so changing a
+`tls_public_keys` entry changes the keyset digest and breaks the report-data
+binding.
 
-- This is the path the gateway uses for its own GPU workers once they expose an
-  ACI-compatible `/v1/aci/attestation`. It is kept minimal today; see the roadmap's
-  "Provider Soundness and Strict Pins" and the deferred standalone-Phala work.
-- Policy inputs (accepted keyset subjects / image digests / KMS root keys,
-  PCCS URL) are configured per upstream, not via broad process-level env.
+For a keyset with no domain-scoped entries, every listed service-wide SPKI is
+returned as an allowed binding for the configured origin.
 
-## Source & platform provenance, and TCB status
+For a keyset with any domain-scoped entry, the evidence must also publish:
 
-Tracking criteria 13–14 of [audit-criteria.md](../audit-criteria.md) (AciService has no
-separate `review.md`):
+```json
+{
+  "downstream_tls_binding": {
+    "domain": "worker.example.com",
+    "spki_sha256": "<64-hex>"
+  }
+}
+```
 
-- **Software provenance** (worker code → reviewed source): via the RTMR3-bound
-  `app_compose`, followed by launcher/image and source-provenance policy. The
-  native verifier proves the Compose preimage is measured. **TODO:** parse and
-  enforce the reviewed launcher/image/source allowlist rather than accepting a
-  measured app-id alone.
-- **Platform/OS provenance** (dstack guest OS / firmware → reviewed reproducible build):
-  the dstack event-log RTMR replay and KMS-root custody are verified, but the reviewed
-  dstack OS image digest is **TODO** to pin.
-- **TCB status / freshness**: **TODO** — `verify_quote_to_root` reports
-  `status` but nothing gates on it. Add an `UpToDate` / allowlist check per
-  criterion 14.
+The verifier normalizes the domain, requires it to match the configured origin
+host, and requires the selected SPKI to be one of the keyset entries applicable
+to that host. Only that selected value becomes the session's
+`tls_spki_sha256` binding.
 
-## Reproduce
+The upstream transport then pins the peer certificate's SubjectPublicKeyInfo
+digest to the verified binding before any prompt bytes are forwarded. A report
+that verifies without an enforceable TLS binding is rejected.
 
-Driven through upstream entries with `provider: "aci-service"` against workers
-that expose `/v1/aci/attestation`; see
-`scripts/phala_multi_upstream_smoke.sh` and
-`scripts/local_multi_upstream_smoke.sh`.
+## Cache and session behavior
+
+Only successful results are cached. A cached result expires at the earlier of:
+
+- `verified_at + verifier_cache_seconds`; or
+- the workload keyset's `not_after`.
+
+Every forward still enforces the cached TLS binding against the connection it
+opens. A binding mismatch invalidates the cache and allows one fresh
+verification before the candidate fails.
+
+A successful result stores the exact ACI report as session evidence. The
+current generic claim mapper records `tee_attested` as verifier-derived. It
+does not promote TCB freshness, OS provenance, serving-software provenance,
+GPU attestation, or model-weight provenance from this verifier into asserted
+typed claims.
+
+## What `verified` means
+
+A verified result establishes that:
+
+- a genuine TDX quote binds the fresh ACI report and workload keyset;
+- the dstack event log replays to the quote's RTMR3;
+- the published compose preimage matches the measured `compose-hash`;
+- the configured identity policy accepted the report;
+- the receipt key passed the configured dstack KMS custody check; and
+- the actual upstream TLS connection is restricted to an SPKI from the
+  attested keyset.
+
+It does not establish every possible workload claim. Apply the limitations
+below when deciding whether to accept this path.
+
+## Limitations
+
+- `accepted_image_digests` currently compares an allowlisted value with the
+  report's self-declared `source_provenance.image_digest`. The verifier does
+  not bind that field to the measured compose. Prefer a measured
+  `accepted_subjects` app ID until that conformance gap is closed.
+- The verifier proves that the compose bytes were measured. It does not rebuild
+  images, the launcher, dependencies, compiler output, or source from that
+  compose.
+- DCAP verification returns the collateral TCB status, but this path does not
+  currently enforce an accepted-status policy or expose the status as a typed
+  session claim.
+- The dstack custody check covers the receipt-signing role. It does not yet
+  establish custody for every E2EE and TLS private key in the workload keyset.
+- The event-log and KMS checks do not independently reconstruct and accept a
+  reviewed dstack OS image from MRTD and RTMR0-2.
+- No GPU evidence or model-weight provenance is verified by this adapter.
+- A service-wide keyset with several TLS SPKIs produces one stored session per
+  binding even though the transport accepts any listed binding for the origin.
+  This is a known session-model gap for multi-key channels.
+
+These gaps are also tracked in
+[Reference implementation conformance gaps](../../reviews/aci-spec-conformance-gaps.md).
+
+## Tests and reproduction
+
+Run the native verifier tests:
+
+```bash
+cargo test --locked --test upstream_verifier
+cargo test --locked aci::verifier
+```
+
+The local and Phala smoke suites exercise the provider through real upstream
+configuration:
+
+```bash
+bash scripts/local_multi_upstream_smoke.sh
+bash scripts/phala_multi_upstream_smoke.sh
+```
+
+The smoke suites have additional environment and infrastructure prerequisites.
+Read the [live test guide](../../live-e2e-test-suite.md) before running them.

--- a/docs/providers/audit-criteria.md
+++ b/docs/providers/audit-criteria.md
@@ -1,9 +1,9 @@
 # Provider Audit Criteria
 
-This document defines the admission bar for adding an upstream provider to the
-Private AI Gateway. It distills the NEAR AI, Tinfoil, and Chutes reviews,
-the workload-identity work, and the implementation constraints we have agreed
-on.
+This document defines the admission bar for adding a verified upstream provider
+to Private AI Gateway. It is a normative review rubric, not a record of current
+provider behavior. Use the [provider index](README.md) and each provider's
+living `verification.md` page for implemented behavior and known limitations.
 
 The goal is a strict but adoptable soundness check. A provider passes only when
 there is no known gap in the path from verified workload identity to protected
@@ -111,7 +111,7 @@ Required behavior:
 - prevent aliases from bypassing the verified model identity
 
 For gateway providers, the verified gateway channel is the authoritative check;
-static catalog metadata is never trusted. NEAR AI is the reference example — it
+static catalog metadata is never trusted. NEAR AI is the reference example: it
 is a router, so the verified gateway channel itself is authoritative; the model
 is only the shape of NEAR's `/v1/attestation/report` endpoint, and the gateway
 attestation it returns is the same for every model:
@@ -288,13 +288,13 @@ A verified measurement only proves "some specific code/firmware is running."
 Provenance proves *which* code, traced to reviewed, ideally reproducible source.
 Two distinct layers must each be covered:
 
-- **Software provenance** — the application/model/gateway code measured into the
+- **Software provenance:** the application/model/gateway code measured into the
   quote (compose hash, image digest, workload id, container measurement) maps to
   reviewed open source at a known commit/release, ideally via a reproducible build
   or a signed provenance attestation (e.g. Sigstore/in-toto with a transparency-log
   entry and a trusted builder identity), not merely "matches the provider's
   currently published value."
-- **Platform/OS provenance** — the platform layer measured into the quote (guest
+- **Platform/OS provenance:** the platform layer measured into the quote (guest
   OS image, kernel + command line, initramfs, bootloader, and the TEE firmware /
   module: TDX module `MR_SEAM`, SEV firmware/ucode level) maps to a reviewed,
   reproducible build or a documented known-good set. The OS and firmware are part
@@ -310,7 +310,7 @@ blocks strict inclusion.
 
 The verifier must read the platform TCB status (Intel TDX/SGX `TcbStatus`, AMD
 SEV-SNP reported TCB against a minimum policy) and apply a documented, consistent
-policy across providers — not silently accept any signed quote. A genuine TEE on
+policy across providers. Do not silently accept any signed quote. A genuine TEE on
 out-of-date microcode (`OutOfDate`) is still exposed to issues fixed in later TCB.
 
 - Require `UpToDate`, or an explicit allowlist (e.g. `SWHardeningNeeded` /
@@ -377,31 +377,31 @@ Every provider adapter should return the same class of result to Rust:
 ```json
 {
   "result": "verified",
-  "provider": "near-ai",
-  "model_id": "canonical-model",
   "verifier_id": "provider-verifier/version",
   "attested_scope": "router",
   "evidence": {
     "digest": "sha256:...",
     "data": "data:application/json;base64,<exact-verifier-input-bytes>"
   },
-  "verified_at": "2026-05-18T00:00:00Z",
-  "expires_at": "2026-05-18T00:05:00Z",
   "channel_bindings": [
     {
       "type": "tls_spki_sha256",
-      "origin": "https://cloud-api.near.ai",
+      "origin": "https://provider.example",
       "spki_sha256": "..."
     }
   ],
   "provider_claims": {
-    "trust_boundary": "near-ai-gateway",
-    "gateway_verified": true,
-    "gateway_tls_spki_sha256": "...",
+    "trust_boundary": "provider-router",
     "tcb_status": "UpToDate"
   }
 }
 ```
+
+The gateway supplies the provider, upstream, model, origin, forwarded-body
+hash, verification requirement, timeout, and provider options in the bridge
+request. The adapter obtains any provider-specific nonce or other freshness
+material. The gateway adds session timestamps and retention policy after the
+adapter returns; those fields are not part of the bridge result.
 
 The exact `provider_claims` fields are provider-owned. Rust should enforce the
 generic fields and the channel binding. Provider-specific meaning belongs in
@@ -435,11 +435,10 @@ The right abstraction is a provider adapter that establishes a verified lease.
 The Rust gateway should stay small: select the lease, enforce the channel,
 forward the request, and record the receipt.
 
-## Current Provider Status
+## Apply the rubric
 
-| Provider | Trust boundary | Decision | Blocking TODOs |
-| --- | --- | --- | --- |
-| NEAR AI | Verified gateway workload | Acceptable with conditions | Pin accepted gateway provenance/runtime policy; define pre-production measurement publication process; confirm no off-TEE TLS termination; finish privacy/log/storage review. |
-| Tinfoil | Verified confidential router | Acceptable with conditions | Pin audited router compose/image digest; define pre-production measurement publication process; decide runtime config update policy; record selected `Tinfoil-Enclave`; finish strict release pins. |
-| Chutes | Verified E2EE model instances | Accepted for limited traffic | Pin exact `chute_id` or unique slug for production models; resolve nonce-throughput limit before general production; document served-model alias limitations. |
-| SecretAI | Measured SecretVM inference origin | Acceptable with conditions | Pin `secretvm-verify`; support optional reviewed workload pins; require CPU-bound NRAS evidence and inference SPKI enforcement; model weights and provider logging remain outside the proof. |
+Start from the [provider matrix](README.md), then read the provider's living
+verification page and dated audit together. The living page defines the current
+algorithm and claims. The dated audit preserves the evidence and admission
+decision at the time of review. Re-run the relevant hermetic and live checks
+before changing production acceptance policy.

--- a/docs/providers/chutes/configuration.md
+++ b/docs/providers/chutes/configuration.md
@@ -1,44 +1,66 @@
-# Private Chutes configuration
+# Configure a Private Chutes Route
 
-Private Chutes routes use the Chutes provider adapter, verified instance evidence,
-and encrypted `/e2e/invoke` transport.
+Private Chutes routes use the standard `chutes` adapter, a dedicated chute origin, pinned chute identifiers, and encrypted `/e2e/invoke` transport.
 
-## Upstream configuration
+## Add the upstream
 
-Add an entry like this to `<state_dir>/upstreams.json`:
+Add an entry to the upstream seed or active runtime configuration:
 
 ```json
 [
   {
-    "name": "private-chutes-uncensored-24b",
+    "name": "private-chutes-model",
     "provider": "chutes",
-    "base_url": "https://phala-agent-askvenice-venice-uncensored.chutes.ai",
+    "base_url": "https://private-chute.example.chutes.ai",
     "models": {
-      "phala/uncensored-24b": "AskVenice/venice-uncensored"
+      "private/model": "Provider/model-id"
     },
     "bearer_token": "<admin-scoped-private-chute-credential>",
     "basic_auth": true,
     "chutes_e2ee_api_base": "https://api.chutes.ai",
     "chutes_chute_ids": {
-      "AskVenice/venice-uncensored": "28d17d83-7036-5a8c-8ca1-f148c126bd89"
-    }
+      "Provider/model-id": "00000000-0000-0000-0000-000000000000"
+    },
+    "session_refresh_seconds": 45,
+    "chutes_e2ee_discovery_rounds": 3
   }
 ]
 ```
 
-## Field mapping
+The credential must be authorized to retrieve the private chute's instance and attestation evidence as well as invoke it. The gateway returns only a redacted credential indicator from the admin API.
 
-- `base_url` is the dedicated Chute origin.
-- `models` maps the gateway's public model id to the provider-facing Chutes model id.
-- `bearer_token` contains the complete scoped credential. An admin-scoped credential
-  allows the verifier to retrieve attestation evidence as well as invoke the Chute.
-- `basic_auth: true` applies Basic authentication to discovery, evidence retrieval,
-  and encrypted `/e2e/invoke` requests.
-- `chutes_e2ee_api_base` defaults to `https://api.chutes.ai`; keeping it explicit
-  makes the central E2EE control-plane endpoint visible in the deployment config.
-- Each `chutes_chute_ids` key matches a provider-facing model id from `models`.
-  Its UUID value pins that model to a specific private Chute.
+## Field behavior
 
-The gateway verifies the instance E2EE key against Chutes attestation evidence,
-encrypts the request with ML-KEM, invokes `/e2e/invoke`, and decrypts the response.
-See [verification.md](verification.md) for the complete trust and binding model.
+| Field | Requirement |
+| --- | --- |
+| `base_url` | Dedicated chute origin used for model traffic. |
+| `models` | Maps each public gateway alias to the provider model identifier. |
+| `bearer_token` | Complete scoped credential. Required for Chutes evidence discovery. |
+| `basic_auth` | Set to `true` when the private origin and Chutes evidence calls expect Basic authentication. |
+| `chutes_e2ee_api_base` | Central discovery, evidence, and encrypted invocation origin. Defaults to `https://api.chutes.ai`. |
+| `chutes_chute_ids` | Maps each configured provider model identifier to its chute UUID. Each key must appear in `models` values. |
+| `session_refresh_seconds` | Refresh cadence for the verified single-use nonce pool. Defaults to 45 seconds for Chutes. |
+| `chutes_e2ee_discovery_rounds` | Evidence discovery attempts, from 1 to 10. Defaults to 3. |
+
+`basic_auth` requires `bearer_token` and is allowed only for `openai-compatible` and `chutes` routes. Chutes-specific fields on another provider type are rejected.
+
+## Verify before sending data
+
+Survey the current sessions:
+
+```sh
+curl --fail --silent --show-error \
+  'http://127.0.0.1:8086/v1/aci/sessions?model=private%2Fmodel' | jq
+```
+
+Then require a verified route on inference:
+
+```json
+{
+  "model": "private/model",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "provider": {"aci_verified": true}
+}
+```
+
+The gateway verifies instance evidence, restricts selection to the attested E2EE keys, encrypts the provider request, and decrypts the response. Read [Chutes verification](verification.md) before deciding which TCB and GPU claim states to accept.

--- a/docs/providers/chutes/review.md
+++ b/docs/providers/chutes/review.md
@@ -1,6 +1,12 @@
 # Chutes E2EE Review
 
 Date: 2026-05-18 UTC.
+
+> [!NOTE]
+> This is a point-in-time admissions audit. It preserves the evidence and
+> decision from the date above. Use [verification.md](verification.md) for the
+> current adapter algorithm, claims, and limitations.
+
 Provider endpoint: `https://api.chutes.ai`.
 Trust boundary: verified Chutes model instance reached through Chutes E2EE
 transport.

--- a/docs/providers/chutes/verification.md
+++ b/docs/providers/chutes/verification.md
@@ -1,77 +1,82 @@
-# Chutes — attested session verification & binding
+# Chutes Verification
 
-- **TEE:** Intel TDX (CPU) + NVIDIA Confidential Compute (GPU)
-- **Session binding:** `e2ee_public_key_sha256`
-- **Verifier:** the provider-verifier bridge, directly (`scripts/private_ai_provider_verifier.py`
-  → `verify_chutes` / `chutes_verify_instance`). Uses `dcap_qvl` for the quote; no
-  vendored verifier class.
-- **Status:** sound.
-- **Audit:** see [review.md](review.md).
+The Chutes adapter verifies each discovered TDX instance and encrypts provider traffic to that instance's attested ML-KEM public key.
 
-## What is verified
+| Property | Current behavior |
+| --- | --- |
+| Attestation scope | Per instance |
+| Verifier | `scripts/provider_verifier/chutes.py` through the provider-verifier bridge |
+| Verifier ID | `private-ai-verifier/chutes/v1` |
+| Enforced binding | `e2ee_public_key_sha256` |
+| Transport | Encrypted `/e2e/invoke` request and response |
 
-For each E2EE instance Chutes returns, `chutes_verify_instance` does, in order:
+See [Private Chutes configuration](configuration.md) for dedicated origins and chute-ID pins.
 
-1. **Fetch evidence.** Pull the instance's TDX quote and GPU evidence from the Chutes
-   API (`/e2e/instances/{chute_id}`, `/chutes/{chute_id}/evidence`).
-2. **Bind the E2EE key into the quote.** Compute
-   `expected = SHA256(nonce ‖ e2e_pubkey)`, parse `report_data` from the quote bytes
-   (`chutes_report_data`, TDX v4 offset `quote[48+520 : 48+584]`), and require
-   `report_data[0:32] == expected`. This is the anti-tamper binding.
-3. **Reject debug mode.** `chutes_debug_enabled` checks the TD attributes debug bit.
-4. **Verify the quote.** `dcap_qvl.get_collateral_and_verify(quote)` performs real Intel
-   DCAP verification (fetches collateral, checks the signature chain). The status must
-   be `UpToDate`.
-5. **Match the measurement profile.** The quote measurements must match a reviewed
-   public profile (`chutes_measurement_name` against the provider reference).
-6. **Verify the GPU.** `chutes_verify_gpu` POSTs the GPU evidence to NVIDIA NRAS over
-   TLS with `nonce = expected_report_data`, requires `x-nvidia-overall-att-result`, and
-   checks `eat_nonce == expected_report_data`.
+## Verification algorithm
 
-## What binds the session
+The adapter resolves the model's chute, discovers E2EE instances, and fetches the public measurement profiles and instance evidence. For each instance that has both evidence and an E2EE public key, it:
 
-The E2EE public key is bound into the TDX quote's `report_data`
-(`report_data[0:32] = SHA256(nonce ‖ e2e_pubkey)`), and the quote signature is verified
-by DCAP. So possession of a decryptable channel under that key implies you are talking
-to the attested enclave. The emitted binding is
-`e2ee_public_key_sha256 = SHA256(decoded ML-KEM public key)`.
+1. Decodes the TDX quote and computes `SHA256(nonce || e2e_pubkey)` using the provider's exact string concatenation format.
+2. Requires the first 32 bytes of TDX `report_data` to equal that digest.
+3. Rejects the TDX debug attribute.
+4. Fetches DCAP collateral and verifies the quote with `dcap_qvl`.
+5. Requires the verified quote measurements to match a published Chutes profile.
+6. Records the granular TCB status returned by the quote verifier.
+7. Sends available GPU evidence to NVIDIA NRAS, checks the returned overall result and nonce, and records the outcome as supplemental metadata.
 
-## What a tamper rejects
+An instance produces a binding only if steps 1 through 5 succeed. At least one instance binding is required for the provider result to be `verified`.
 
-- Tampered quote → DCAP signature verification fails (confirmed live:
-  `ISV enclave report signature is invalid`).
-- Wrong nonce → `report_data[0:32] != SHA256(nonce ‖ e2e_pubkey)` →
-  `Chutes E2EE key binding does not match report_data`.
-- Wrong/forged E2EE key → same binding mismatch.
-- `OutOfDate`/`SWHardeningNeeded` TCB → rejected (only `UpToDate` accepted).
+## Channel binding and forwarding
 
-## Transport enforcement
+The binding contains the instance ID, the `chutes-ml-kem-768` algorithm label, and `SHA256(decoded public key bytes)`. The TDX report-data check proves that the evidence nonce and public key belong to the verified instance.
 
-The backend encrypts each request body to the verified E2EE public key
-(ML-KEM-768 + HKDF-SHA256 + ChaCha20-Poly1305) and sends it to `/e2e/invoke`, then
-decrypts the response. A response that decrypts proves the bound enclave served it.
+The backend selects only an instance present in the current verified binding set. It encapsulates to that ML-KEM-768 key, derives a ChaCha20-Poly1305 key, sends the encrypted body to `/e2e/invoke`, and decrypts the buffered or streaming response. A key digest mismatch or decryption failure rejects that attempt.
 
-## Notes
+Each verified instance becomes its own attested session. Fleet membership changes do not change an unchanged instance's session ID.
 
-- Cold evidence verification is slow (~138 s); it runs off the request path via the
-  verification lease + a pooled nonce session. See the lifecycle doc.
-- `/e2e/instances` is aggressively rate-limited; the default
-  `chutes_e2ee_discovery_rounds: 3` can self-trigger a `429` on a cold chute.
-  `rounds: 1` is gentler.
-- NVIDIA NRAS tokens are fetched online over TLS and nonce-checked; the JWT signature
-  itself is not additionally verified against NRAS' JWKS (tracked defense-in-depth
-  follow-up in the roadmap).
+## Session claims
+
+| Claim | Mapping |
+| --- | --- |
+| `tee_attested` | Asserted from the verified TDX quote and bound E2EE channel. |
+| `tcb_up_to_date` | Asserted only for `UpToDate`; another reported state is refuted; absence is unknown. |
+| `gpu_attested` | Asserted as verifier-derived only when NRAS succeeds and its nonce matches. This proves a genuine CC GPU, not its binding to the serving CPU TEE. |
+| `os_known_good` | Unknown. |
+| `serving_software_known_good` | Unknown. |
+| `model_weights_provenance` | Unknown. |
+
+A stale TCB status is recorded, not rejected by the current bridge. Relying parties that require a current TCB must reject the refuted session claim.
+
+## Limitations
+
+- GPU evidence is supplemental. Failure or absence does not reject an otherwise verified CPU and E2EE-key binding.
+- The bridge decodes the NRAS JWT returned over authenticated TLS and checks its signed-result fields and nonce, but does not independently verify that JWT against NRAS JWKS.
+- Published measurement matching does not by itself prove model weights.
+- Instance discovery and evidence endpoints are provider-controlled and rate-limited. The default three discovery rounds can increase cold-start cost.
 
 ## Reproduce
 
-```bash
-set -a; . /home/h4x/workspace/redpill/.env; set +a
-cd /home/h4x/workspace/redpill/private-ai-gateway
-echo '{"api_version":"aci.provider-verifier.request.v1","provider":"chutes",
-  "upstream_name":"chutes-live","url_origin":"https://api.chutes.ai",
-  "model_id":"moonshotai/Kimi-K2.5-TEE",
-  "forwarded_body_hash":"sha256:'"$(printf '0%.0s' {1..64})"'","required":true,
-  "timeout_seconds":300,
-  "provider_options":{"chutes_api_key":"'"$CHUTES_API_KEY"'","chutes_e2ee_discovery_rounds":"1"}}' \
-  | uv run python scripts/private_ai_provider_verifier.py
+From the repository root, with `CHUTES_API_KEY` set:
+
+```sh
+request_hash="sha256:$(printf '0%.0s' {1..64})"
+jq -n \
+  --arg key "$CHUTES_API_KEY" \
+  --arg hash "$request_hash" \
+  '{
+    api_version: "aci.provider-verifier.request.v1",
+    provider: "chutes",
+    upstream_name: "chutes-live",
+    url_origin: "https://api.chutes.ai",
+    model_id: "moonshotai/Kimi-K2.5-TEE",
+    forwarded_body_hash: $hash,
+    required: true,
+    timeout_seconds: 300,
+    provider_options: {
+      chutes_api_key: $key,
+      chutes_e2ee_discovery_rounds: "1"
+    }
+  }' | uv run python scripts/private_ai_provider_verifier.py
 ```
+
+The command prints evidence and public bindings. Treat its output as sensitive operational evidence even though it should not echo the credential.

--- a/docs/providers/near-ai/review.md
+++ b/docs/providers/near-ai/review.md
@@ -1,6 +1,12 @@
 # NEAR AI Gateway Review
 
 Date: 2026-05-18 UTC.
+
+> [!NOTE]
+> This is a point-in-time admissions audit. It preserves the evidence and
+> decision from the date above. Use [verification.md](verification.md) for the
+> current adapter algorithm, claims, and limitations.
+
 Provider endpoint: `https://cloud-api.near.ai`.
 Gateway source: `nearai/cloud-api`.
 Reviewed gateway commit: `057135fad9e5f656baa94025d831f55391979334`.

--- a/docs/providers/near-ai/verification.md
+++ b/docs/providers/near-ai/verification.md
@@ -1,81 +1,83 @@
-# NEAR AI — attested session verification & binding
+# NEAR AI Verification
 
-- **TEE:** Intel TDX (CPU) + NVIDIA Confidential Compute (GPU)
-- **Session binding:** `tls_spki_sha256`
-- **Verifier:** bridge (`verify_nearai`) → vendored `confidential_verifier`
-  (`NearAICloudVerifier.verify_gateway_component` → `_verify_component`) + an external
-  dstack-verifier service (`DSTACK_VERIFIER_URL`).
-- **Status:** sound (the `report_data` binding was fixed in commit `ca7ddbd`).
-- **Audit:** see [review.md](review.md).
+The NEAR AI adapter verifies the public cloud gateway as one router-scoped TDX channel. It does not bind a request to the nested model instance that ultimately served it.
 
-## What is verified
+| Property | Current behavior |
+| --- | --- |
+| Attestation scope | Router |
+| Verifier | `scripts/provider_verifier/nearai.py` and vendored `NearAICloudVerifier` |
+| External dependency | dstack verifier at `DSTACK_VERIFIER_URL` |
+| Enforced binding | `tls_spki_sha256` |
+| Evidence endpoint | `https://cloud-api.near.ai/v1/attestation/report` |
 
-`verify_nearai` fetches a report with a fresh nonce
-(`NearaiProvider(include_tls_fingerprint=True).fetch_report` from
-`cloud-api.near.ai/v1/attestation/report`), then `_verify_component("gateway", …)` does:
+## Verification algorithm
 
-1. **Verify the TDX quote.** The dstack-verifier service verifies the quote, event log,
-   and VM config (RTMR replay). `is_valid` must be true.
-2. **Verify the compose hash.** `SHA256(app_compose)` must equal the reported
-   `compose_hash`.
-3. **Verify the report_data binding.** Parse `report_data` from the *verified* quote
-   bytes (`_tdx_report_data_hex`, TDX v4 offset `quote[48+520 : 48+584]`) and run
-   `verify_report_data(report_data, signing_address, request_nonce, tls_cert_fingerprint)`.
-   For the TLS-fingerprint format that means
-   `report_data[0:32] == SHA256(signing_address ‖ tls_cert_fingerprint)` and
-   `report_data[32:64] == nonce`. **Fail closed** if `report_data`, the nonce, or the
-   signing address is unavailable.
-4. **Verify the GPU.** Check the GPU evidence nonce equals the request nonce, then
-   `NvidiaGpuVerifier` POSTs to NVIDIA NRAS over TLS and requires a passing result.
+The provider bridge asks NEAR AI for a report with a fresh nonce and verifies the `gateway_attestation` component:
 
-## What binds the session
+1. Require a gateway attestation and `tls_cert_fingerprint`.
+2. Send the TDX quote, event log, and VM configuration to the configured dstack verifier and require `is_valid: true`.
+3. When both `app_compose` and `compose_hash` are present, require `SHA256(UTF8(app_compose))` to equal the reported hash.
+4. Parse the 64-byte `report_data` from the same quote bytes accepted by the dstack verifier.
+5. Require a request nonce and signing address.
+6. Verify the report-data layout:
 
-The TLS public-key fingerprint, the signing address, and the request nonce are all
-folded into `report_data`, which lives inside the DCAP/dstack-verified quote. So the
-`tls_spki_sha256` the gateway enforces is proven to belong to the attested TDX
-workload — not merely copied from the report JSON.
+   ```text
+   report_data[0:32] = SHA256(signing_address || tls_cert_fingerprint)
+   report_data[32:64] = request nonce
+   ```
 
-> Why this matters: before the fix, `_verify_component` read `report_data` from the
-> dstack-verifier's result (a field it never returns), so the whole binding check was
-> silently skipped. A wrong nonce or a swapped `tls_cert_fingerprint` still "verified",
-> which meant no freshness and an unauthenticated TLS-SPKI binding.
+7. When an NVIDIA payload is present, require its nonce to match and require the NVIDIA verifier to succeed.
+8. Emit one router-scoped TLS SPKI binding.
 
-## What a tamper rejects
+The bridge fails if the report-data value, nonce, signing address, or TLS fingerprint is absent. This closes the historical path where the verifier attempted to read `report_data` from a field the dstack verifier did not return.
 
-Confirmed live against `cloud-api.near.ai`:
+## Channel binding and forwarding
 
-- Tampered quote → `Dstack verification failed: Quote verification failed`.
-- Wrong nonce → `Report data check failed: mismatch`.
-- Swapped `tls_cert_fingerprint` (MITM attempt) → `Report data check failed: mismatch`.
+The accepted TDX quote covers the signing address, nonce, and TLS SPKI digest through `report_data`. The gateway pins that digest against the live NEAR AI HTTPS certificate before sending the request.
 
-The hermetic regression test `tests/soundness_report_data.rs` pins the binding logic.
+The verifier cache omits the model from its key because every configured model uses the same router channel. The receipt records the selected model; the session records the shared router evidence.
 
-## Transport enforcement
+## Session claims
 
-The backend enforces the verified `tls_spki_sha256` against the upstream HTTPS
-connection before forwarding.
+| Claim | Mapping |
+| --- | --- |
+| `tee_attested` | Asserted from the verified TDX quote and bound TLS channel. |
+| `tcb_up_to_date` | Asserted only for `UpToDate`; another surfaced status is refuted; absence is unknown. |
+| `gpu_attested` | Unknown in the current session mapping because the bridge does not emit GPU verdict fields in `provider_claims`. |
+| `os_known_good` | Unknown. |
+| `serving_software_known_good` | Unknown. |
+| `model_weights_provenance` | Unknown. |
 
-## Notes
+## Limitations
 
-- Only the **gateway** component is verified here, and NEAR AI is treated as a
-  router (`AttestationScope::PerRouter`): its nested per-model TD quotes are
-  **not** fetched or checked. The gateway does not re-verify them and nothing
-  binds them to the instance that served a given request, so the attested session
-  is the gateway *channel* only. A request-bound, per-instance model attestation
-  is a roadmap item, recorded on the receipt rather than in the session.
-- Requires a reachable dstack-verifier at `DSTACK_VERIFIER_URL` (default `:18080`).
-- NVIDIA NRAS JWT-signature hardening is a tracked defense-in-depth follow-up.
+- The bridge verifies the gateway component only. It does not fetch or verify `model_attestations[]` for the request's model.
+- Nothing in the emitted session identifies the downstream model CVM that served a response.
+- A non-`UpToDate` TCB status can remain `is_valid` and is represented as a refuted typed claim, not a bridge failure.
+- Missing compose material is not a hard failure. A present compose/hash mismatch is rejected, but the current code does not require both values to exist.
+- GPU verification can run when the gateway report includes a payload, but the resulting GPU fields are not preserved in the emitted provider claims.
+- The bridge process defaults `DSTACK_VERIFIER_URL` to `http://localhost:8080`. The live suite overrides its default to `http://localhost:18080`.
 
-## Reproduce
+## Tests and reproduction
 
-```bash
-set -a; . /home/h4x/workspace/redpill/.env; set +a
-export DSTACK_VERIFIER_URL="http://localhost:18080"
-cd /home/h4x/workspace/redpill/private-ai-gateway
-echo '{"api_version":"aci.provider-verifier.request.v1","provider":"near-ai",
-  "upstream_name":"near-ai-live","url_origin":"https://cloud-api.near.ai",
-  "model_id":"google/gemma-4-31B-it",
-  "forwarded_body_hash":"sha256:'"$(printf '0%.0s' {1..64})"'","required":true,
-  "timeout_seconds":300}' \
-  | uv run python scripts/private_ai_provider_verifier.py
+Run the report-data tamper test:
+
+```sh
+cargo test --test soundness_report_data
+```
+
+For a live verifier run, start a trusted dstack verifier and set `DSTACK_VERIFIER_URL` explicitly:
+
+```sh
+export DSTACK_VERIFIER_URL='http://localhost:18080'
+request_hash="sha256:$(printf '0%.0s' {1..64})"
+jq -n --arg hash "$request_hash" '{
+  api_version: "aci.provider-verifier.request.v1",
+  provider: "near-ai",
+  upstream_name: "near-ai-live",
+  url_origin: "https://cloud-api.near.ai",
+  model_id: "google/gemma-4-31B-it",
+  forwarded_body_hash: $hash,
+  required: true,
+  timeout_seconds: 300
+}' | uv run python scripts/private_ai_provider_verifier.py
 ```

--- a/docs/providers/phala-direct/review.md
+++ b/docs/providers/phala-direct/review.md
@@ -1,5 +1,11 @@
 # PhalaDirect Review
 
+Review record updated: 2026-07-05.
+
+> [!NOTE]
+> This page preserves the admissions decision at that date. Use
+> [verification.md](verification.md) for current adapter behavior.
+
 Provider: `phala-direct` — direct connection to a Phala dstack-vllm-proxy attestation
 endpoint, one per model. Expected to be superseded by an ACI-compatible server later
 (`aci-service` is the eventual target shape); this is the pre-ACI "direct" path.

--- a/docs/providers/phala-direct/verification.md
+++ b/docs/providers/phala-direct/verification.md
@@ -1,163 +1,100 @@
-# PhalaDirect — attested session verification & binding
+# Phala Direct Verification
 
-- **TEE:** Intel TDX (CPU) + NVIDIA Confidential Compute (GPU), Phala dstack.
-- **Topology:** the gateway connects **directly** to each model's own
-  dstack-vllm-proxy endpoint (one HTTPS endpoint per model, configured as its own
-  upstream entry). No hosted `api.redpill.ai` / `cloud-api.phala.network` hop.
-- **Session binding:** `tls_spki_sha256` (custom-domain leaf SPKI).
-- **Verifier:** bridge (`verify_phala_direct`) → vendored `confidential_verifier`
-  (`DstackVerifier`, `verify_report_data`, `NvidiaGpuVerifier`) + an external
-  dstack-verifier service (`DSTACK_VERIFIER_URL`).
-- **Requires:** the proxy serving attestation **version 2** (see
-  [Producer requirement](#producer-requirement)).
-- **Status:** sound for the TLS-SPKI binding; known-good software/OS provenance is a
-  TODO (see [review.md](review.md)).
+The `phala-direct` adapter connects to one dstack-vllm-proxy origin and verifies that origin's legacy version 2 attestation report. It is a per-model compatibility path for services that do not expose canonical ACI reports.
+
+| Property | Current behavior |
+| --- | --- |
+| Attestation scope | Per model |
+| Verifier | `scripts/provider_verifier/phala_direct.py` through the provider-verifier bridge |
+| External dependency | dstack verifier at `DSTACK_VERIFIER_URL` |
+| Enforced binding | `tls_spki_sha256` |
+| Evidence endpoint | `<base_url>/v1/attestation/report?version=2&signing_algo=ecdsa&nonce=<random>` |
 
 ## Producer requirement
 
-The binding only works if the proxy binds its custom-domain TLS SPKI into the quote.
-The proxy reads its dstack-ingress certificate (`TLS_CERT_PATH`), computes
-`SHA256(SubjectPublicKeyInfo DER)` of the leaf, and serves attestation **version 2**:
+The upstream proxy must serve attestation version 2 with a custom-domain TLS SPKI bound into TDX report data:
 
-```
-GET /v1/attestation/report?version=2&signing_algo=ecdsa&nonce=<hex>
-report_data[0:32]  = SHA256(signing_address ‖ tls_cert_fingerprint)
-report_data[32:64] = nonce
-response.tls_cert_fingerprint = <SHA256(SPKI DER) hex>
+```text
+report_data[0:32] = SHA256(signing_address || tls_cert_fingerprint)
+report_data[32:64] = request nonce
 ```
 
-Soundness depends on TLS terminating **inside** the CVM (the dstack-ingress sidecar's
-certbot key is TEE-resident). A gateway-managed / off-TEE TLS terminator would make the
-SPKI binding vacuous.
+It must also return `tls_cert_fingerprint`. A proxy that ignores `version=2` cannot produce an enforceable custom-domain binding and is rejected.
 
-## What is verified
+This property is meaningful only when TLS private-key custody belongs to the attested workload, such as a dstack-ingress sidecar inside the CVM. An off-TEE TLS terminator breaks the intended custody claim even if the digest appears in the report.
 
-`verify_phala_direct` GETs `{base_url}/v1/attestation/report?version=2&signing_algo=ecdsa`
-with a fresh nonce (and the configured `bearer_token`), then:
+## Verification algorithm
 
-1. **Require a TLS fingerprint.** `tls_cert_fingerprint` must be present — an older proxy
-   that ignored `version=2` cannot be TLS-pinned, so it is rejected.
-2. **Reject debug-mode TDs.** The TDX quote's `TD_ATTRIBUTES` TUD byte (offset 168) must
-   be zero — a debug-mode TD exposes its CPU state and private memory to the host, so the
-   TEE guarantee does not hold. (Shared `tdx_debug_enabled`, applied to every TDX provider.)
-3. **Verify the TDX quote.** The dstack-verifier service verifies the quote, event log,
-   and VM config (RTMR replay). `is_valid` must be true.
-4. **Verify the compose hash.** `SHA256(app_compose)` must equal the reported
-   `compose_hash`.
-5. **Verify the report_data binding.** Parse `report_data` from the *verified* quote
-   bytes (`_tdx_report_data_hex`, TDX v4 offset `quote[48+520 : 48+584]`) and run
-   `verify_report_data(report_data, signing_address, nonce, tls_cert_fingerprint)`:
-   `report_data[0:32] == SHA256(signing_address ‖ tls_cert_fingerprint)` and
-   `report_data[32:64] == nonce`. **Fail closed** if `report_data`, the nonce, or the
-   signing address is unavailable.
-6. **Record the GPU evidence — supplemental, not a gate.** Check the GPU evidence nonce
-   against the request nonce and run `NvidiaGpuVerifier` (NRAS), but **do not fail** on a
-   GPU error. A standalone gateway-side NRAS check only proves a CC-capable GPU *exists*
-   for a nonce; it does not prove that GPU is bound to this CPU TEE or serving this request.
-   That binding is the measured serving software's job, attested *inside* the CPU-TEE quote
-   — so GPU trust is subsumed by the CPU-TEE quote + serving-software provenance (steps
-   2–4), and the NRAS result is recorded as `gpu_verified` / `gpu_evidence_*` metadata.
+For each verification, the adapter:
 
-## What binds the session
+1. Generates a 32-byte nonce and fetches the version 2 report, using the configured provider credential when present.
+2. Requires a TDX quote, signing address, TLS fingerprint, and a matching echoed nonce when the report includes one.
+3. Rejects the TDX debug attribute.
+4. Sends the quote, event log, and VM configuration to the configured dstack verifier and requires `is_valid: true`.
+5. Requires both `app_compose` and `compose_hash`, then checks `SHA256(UTF8(app_compose))`.
+6. Parses `report_data` from the verified quote and checks the signing-address, TLS-fingerprint, and nonce layout above.
+7. Resolves the attested dstack OS-image hash to published image metadata when possible and records whether it is a development image.
+8. Sends available NVIDIA evidence to NRAS and records the nonce-matched result as supplemental metadata.
+9. Emits the report's TLS fingerprint as the channel binding.
 
-The TLS SPKI fingerprint, the signing address (secp256k1 response-signing key), and the
-request nonce are all folded into `report_data`, which lives inside the dstack-verified
-quote. So the `tls_spki_sha256` the gateway enforces is proven to belong to the attested
-TDX workload — not merely copied from the report JSON. The signing address is surfaced in
-`provider_claims` so it can be pinned alongside the SPKI.
+Steps 1 through 6 and 9 are mandatory. OS classification and GPU verification do not gate the provider result.
 
-## What a tamper rejects
+## Channel binding and forwarding
 
-Pinned hermetically by `tests/phala_direct_bridge.rs` (→ `scripts/soundness_phala_direct.py`):
+The verified TDX quote binds the signing address, fresh nonce, and custom-domain TLS SPKI. The gateway compares that digest with the live HTTPS certificate before forwarding. A missing fingerprint, wrong nonce, changed fingerprint, invalid quote, missing compose input, or compose mismatch fails before prompt forwarding on a constrained request.
 
-- Missing `tls_cert_fingerprint` (version-2 not served) → rejected.
-- Swapped `tls_cert_fingerprint` (MITM attempt) → `report_data binding failed`.
-- Wrong nonce → `report_data binding failed`.
-- dstack quote invalid → rejected (the CPU-TEE gate).
+Use one upstream entry per distinct origin. Several public aliases can share an entry only when they use the same `base_url`.
 
-GPU is **supplemental**, so a GPU evidence nonce mismatch or a failed NRAS result does
-**not** reject — the upstream still verifies, and the outcome is recorded as
-`gpu_verified: false` / `gpu_evidence_nonce_matched: false`. The shared report_data binding
-logic is also pinned by `tests/soundness_report_data.rs`.
+## Session claims
 
-## Transport enforcement
+| Claim | Mapping |
+| --- | --- |
+| `tee_attested` | Asserted from the verified TDX quote and bound TLS channel. |
+| `tcb_up_to_date` | Asserted only for `UpToDate`; another status is refuted; absence is unknown. |
+| `os_known_good` | Asserted for a resolved production dstack image, refuted for a resolved development image, unknown when resolution fails. |
+| `gpu_attested` | Asserted as verifier-derived only when NRAS succeeds and the GPU nonce matches. This does not prove that GPU served this request or is bound to the CPU TEE. |
+| `serving_software_known_good` | Unknown. Compose integrity is checked, but no reviewed digest allowlist is applied. |
+| `model_weights_provenance` | Unknown. |
 
-The backend enforces the verified `tls_spki_sha256` against the upstream HTTPS connection
-(`OpenAICompatibleBackend` → `SpkiPinVerifier`, which pins `SHA256(SPKI DER)`) before
-forwarding any request.
+## Limitations
 
-## Provider claims recorded
+- A non-current TCB state is recorded rather than rejected by the bridge.
+- Production-versus-development OS classification is recorded rather than enforced. Current policy can therefore verify a channel whose session refutes `os_known_good`.
+- The compose hash proves integrity against the report. The adapter does not compare the compose or image digests with an operator allowlist.
+- GPU evidence is an online existence and nonce check. It is not a CPU-to-GPU or request-serving proof.
+- Model weights are not measured into the accepted identity.
+- The legacy producer and external dstack verifier are additional trust and availability dependencies.
 
-`trust_boundary` (`phala-dstack-cvm`), `evidence_scope` (`model_instance`),
-`canonical_model_id`, `attestation_version` (2), `tls_spki_from_report_data`,
-`signing_address`, `report_data_nonce_matched`, `compose_hash_verified`, `tdx_debug_mode`
-(always `false` — debug TDs are rejected), `tcb_status` (the granular dstack TCB status,
-e.g. `UpToDate`), the OS-image provenance trio `os_image_hash` / `os_image_version` /
-`os_image_is_dev` and the resolved `production_os_image` decision, and the supplemental GPU
-metadata `gpu_verified`, `gpu_evidence_present`, `gpu_evidence_nonce_matched`, `gpu_arch`.
+## Tests and reproduction
 
-> **`production_os_image` is decided, not a TODO.** It is `false` for a dev image, `true`
-> for a production image, and `null` only when the hash cannot be resolved (unknown image
-> while offline). It is recorded metadata, **not a gate** — the deployed fleet currently
-> runs dev images (`dstack-nvidia-dev-*`, `is_dev: true`), so gating here would reject them;
-> the session layer decides policy. See [How the OS image is classified](#how-the-os-image-is-classified).
+Run the hermetic bridge test:
 
-## How the OS image is classified
-
-The decision is bound to the attestation, so the image download server cannot lie about it:
-
-1. The dstack verifier returns `app_info.os_image_hash` and only reports `is_valid` when
-   `os_image_hash_verified` (it reproduced MRTD/RTMRs from that exact image).
-2. dstack derives `os_image_hash = SHA256(sha256sum.txt)`, and that manifest pins
-   `SHA256(metadata.json)`. So `metadata.json`'s `is_dev` flag is **cryptographically bound**
-   to the attested hash — flipping it changes `metadata.json` → `sha256sum.txt` →
-   `os_image_hash`, which would no longer match the quote.
-3. `resolve_os_image` (`scripts/dstack_os_image.py`) re-downloads
-   `https://download.dstack.org/os-images/mr_{os_image_hash}.tar.gz`, **re-verifies both
-   equalities**, then reads `is_dev`. `production_os_image = not is_dev`.
-
-Known fleet images are seeded in `KNOWN_OS_IMAGES`, so the common path is offline; an
-unseeded hash is resolved once and cached on disk. Re-verify or add an image with
-`uv run python scripts/dstack_os_image.py <os_image_hash>`.
-
-## Notes
-
-- Requires a reachable dstack-verifier at `DSTACK_VERIFIER_URL` (default
-  `http://localhost:8080`).
-- The guest OS image is now **classified** (dev-vs-prod, bound to the attested
-  `os_image_hash`) and surfaced as `production_os_image` — but it is recorded, **not gated**.
-  Known-good pinning of the vllm-proxy image/compose digest is still **not** enforced
-  (compose-hash *integrity* is proven, but the compose is not checked against an allowlist).
-  See [review.md](review.md).
-- GPU attestation is **supplemental metadata, not a security boundary** on this path. A
-  gateway-side NRAS check is an online existence oracle (a CC-capable GPU exists for a
-  nonce); it does not prove the GPU is bound to this CPU TEE. The sound model is that the
-  CPU TEE's *measured serving software* (inside the quote) attests the GPU and sets up the
-  encrypted CPU↔GPU CC channel, refusing to serve otherwise — so GPU trust is subsumed by
-  the CPU-TEE quote + serving-software provenance. Verifying the NRAS JWT against NRAS' JWKS
-  would not change this, so it is not treated as a gating requirement.
-
-## Configuration
-
-Each model is its own dstack-vllm-proxy endpoint, so today it is configured as **one
-upstream entry per model** (its own `base_url`); see `deploy/upstreams.example.json`. The
-verifier routes by `base_url` origin and derives the binding + every claim dynamically — no
-TLS pin or claim is set in config. This collapses into a single `phala-direct` provider
-entry whose `models` map carries a per-model `endpoint` once the rich multi-model-per-
-provider config loader lands (that refactor is owned by the attested-session work and keeps
-this verifier's per-`{model, endpoint}` wiring unchanged).
-
-## Reproduce
-
-```bash
-set -a; . /home/h4x/workspace/redpill/.env; set +a
-export DSTACK_VERIFIER_URL="http://localhost:8080"
-cd /home/h4x/workspace/redpill/private-ai-gateway
-echo '{"api_version":"aci.provider-verifier.request.v1","provider":"phala-direct",
-  "upstream_name":"phala-direct-live","url_origin":"https://<model-endpoint>",
-  "model_id":"<canonical-model>",
-  "provider_options":{"phala_direct_bearer_token":"<api-key>"},
-  "forwarded_body_hash":"sha256:'"$(printf '0%.0s' {1..64})"'","required":true,
-  "timeout_seconds":300}' \
-  | uv run python scripts/private_ai_provider_verifier.py
+```sh
+cargo test --test phala_direct_bridge
 ```
+
+For a live endpoint, start a trusted dstack verifier and set the optional provider credential:
+
+```sh
+export DSTACK_VERIFIER_URL='http://localhost:8080'
+export PHALA_DIRECT_API_KEY='...'
+request_hash="sha256:$(printf '0%.0s' {1..64})"
+jq -n \
+  --arg origin 'https://model.example' \
+  --arg model 'provider/model-id' \
+  --arg key "$PHALA_DIRECT_API_KEY" \
+  --arg hash "$request_hash" \
+  '{
+    api_version: "aci.provider-verifier.request.v1",
+    provider: "phala-direct",
+    upstream_name: "phala-direct-live",
+    url_origin: $origin,
+    model_id: $model,
+    forwarded_body_hash: $hash,
+    required: true,
+    timeout_seconds: 300,
+    provider_options: {phala_direct_bearer_token: $key}
+  }' | uv run python scripts/private_ai_provider_verifier.py
+```
+
+The dated [admissions review](review.md) records the earlier policy decision and unresolved strict-release conditions.

--- a/docs/providers/secret-ai/review.md
+++ b/docs/providers/secret-ai/review.md
@@ -2,12 +2,13 @@
 
 Date: 2026-05-22 UTC.
 
-> **Historical audit snapshot.** The adapter and deployments changed after this
-> review. As of 2026-07-20, JEDI (SEV-SNP) and RYTN (TDX) expose canonical
-> evidence bound to the inference SPKI and pass the gateway verifier. The
-> implementation, current trust conditions, and limitations are documented in
-> [verification.md](verification.md). Statements below that the adapter is
-> deferred or that the channel binds a full certificate are superseded.
+> [!NOTE]
+> This is a point-in-time admissions audit. The adapter and deployments changed
+> after this review. As of 2026-07-20, JEDI (SEV-SNP) and RYTN (TDX) expose
+> canonical evidence bound to the inference SPKI and pass the gateway verifier.
+> Use [verification.md](verification.md) for current behavior. Statements below
+> that the adapter is deferred or that the channel binds a full certificate are
+> superseded.
 
 > **Gateway verification:** not yet implemented — the SecretAI adapter is deferred
 > (see the roadmap). This review stands as the admissions audit; there is no

--- a/docs/providers/tinfoil/review.md
+++ b/docs/providers/tinfoil/review.md
@@ -1,6 +1,12 @@
 # Tinfoil Router-Mode Review
 
 Date: 2026-05-18 UTC.
+
+> [!NOTE]
+> This is a point-in-time admissions audit. It preserves the evidence and
+> decision from the date above. Use [verification.md](verification.md) for the
+> current adapter algorithm, claims, and limitations.
+
 Provider endpoint: `https://inference.tinfoil.sh`.
 Router source: `tinfoilsh/confidential-model-router`.
 Reviewed commit: `41b2e93e099baf3dd8085066c205f030b280cadc`.

--- a/docs/providers/tinfoil/verification.md
+++ b/docs/providers/tinfoil/verification.md
@@ -1,88 +1,74 @@
-# Tinfoil — attested session verification & binding
+# Tinfoil Verification
 
-- **TEE:** AMD SEV-SNP (TDX also supported) + NVIDIA Confidential Compute
-- **Session binding:** `tls_spki_sha256`
-- **Verifier:** the official `tinfoil` Python SDK
-  (`SecureClient(enclave, repo).verify()`), called from the bridge
-  (`scripts/private_ai_provider_verifier.py` → `verify_tinfoil`).
-- **Status:** sound (replaced a hand-rolled, unsound verifier in commit `747b117`).
-- **Audit:** see [review.md](review.md).
+The Tinfoil adapter uses Tinfoil's official Python SDK to verify its confidential model router and pins the router's attested TLS public key.
 
-## What is verified
+| Property | Current behavior |
+| --- | --- |
+| Attestation scope | Router |
+| Verifier | `scripts/provider_verifier/tinfoil.py` using `tinfoil.SecureClient` |
+| Verifier ID | `tinfoil-verifier/v1` |
+| Enforced binding | `tls_spki_sha256` |
+| Default source repository | `tinfoilsh/confidential-model-router` |
 
-`verify_tinfoil` constructs `SecureClient(enclave=<host>, repo=<repo>)` (default repo
-`tinfoilsh/confidential-model-router`), calls `.verify()`, and reads
-`get_verification_document()`. The SDK runs Tinfoil's full reference chain — the same
-checks as `tinfoilsh/verifier` — exposed as four steps:
+## Verification algorithm
 
-1. **`fetch_digest`** — fetch the repo's latest release artifact digest.
-2. **`verify_code`** — fetch the Sigstore bundle and verify it cryptographically:
-   SCTs, **Rekor** transparency-log inclusion, and a **certificate identity** of
-   `https://token.actions.githubusercontent.com` with the repo's tag-workflow pattern.
-   This yields the golden code measurement (provenance bound to the open-source repo).
-3. **`verify_enclave`** — verify the hardware report. For SEV-SNP: the report signature
-   against the **VCEK**, the **VCEK → ASK → ARK** certificate chain to AMD's embedded
-   root, and policy (`Debug=false`, `MigrateMA=false`, `SMT`, minimum TCB). For TDX:
-   DCAP collateral + policy. Extracts `report_data[0:32]` as the TLS public-key
-   fingerprint.
-4. **`compare_measurements`** — the enclave's measurement must equal the
-   Sigstore-attested code measurement.
+The bridge constructs `SecureClient(enclave=<origin host>, repo=<repository>)`, calls `verify()`, and reads the verification document. The SDK owns the hardware and provenance verification chain. Its documented steps are:
 
-`doc.security_verified` must be true.
+1. Resolve the repository's release artifact digest.
+2. Verify the Sigstore bundle, transparency-log inclusion, and expected GitHub Actions certificate identity.
+3. Verify the SEV-SNP or TDX hardware report and its platform policy.
+4. Extract the TLS public-key fingerprint from hardware report data.
+5. Compare the enclave measurement with the Sigstore-proven release measurement.
 
-## What binds the session
+The bridge then requires:
 
-`report_data[0:32]` is the TLS public-key fingerprint, and the AMD signature covers the
-whole report (including `report_data`). The bridge emits
-`tls_spki_sha256 = doc.tls_public_key`, which equals `report_data[0:32]` — the exact
-value the gateway already enforced, now cryptographically proven rather than read from
-an unauthenticated report.
+- `security_verified` to be true;
+- a non-empty TLS public-key fingerprint; and
+- router scope, either selected explicitly by the SDK or implied by the reviewed router repository.
 
-> Why this matters: the previous hand-rolled `_verify_snp` performed **no** AMD
-> signature verification — it only compared the measurement to a *public* Sigstore
-> value. A forged report with the public measurement and any `report_data` (any TLS
-> key) passed. See [review.md](review.md) for the provider audit.
+The emitted evidence preserves the repository, release digest, code and enclave fingerprints, TLS fingerprint, HPKE key, overall verdict, and per-step statuses.
 
-## What a tamper rejects
+## Channel binding and forwarding
 
-Confirmed live against `inference.tinfoil.sh` (decompress the SEV report, flip a byte,
-recompress, verify):
+For SEV-SNP, the signed report covers the TLS fingerprint in `report_data`. The official verifier checks the AMD certificate chain and policy. For TDX, the SDK applies its DCAP path. The bridge emits the verified fingerprint as `tls_spki_sha256`.
 
-- Tampered `report_data` → `Attestation signature verification failed`.
-- Tampered measurement → `Attestation signature verification failed`.
-- Tampered signature → `Attestation signature verification failed`.
+The gateway compares the binding with the live HTTPS certificate before forwarding. All models behind the same Tinfoil router share the verifier cache and session. The served model remains a receipt field.
 
-(The signature covers the whole report, so every one of these is caught — unlike the
-old verifier, which accepted `report_data` and signature tampering.)
+## Session claims
 
-## Transport enforcement
+| Claim | Mapping |
+| --- | --- |
+| `tee_attested` | Asserted from the official hardware verifier and bound TLS channel. |
+| `tcb_up_to_date` | Asserted as verifier-derived because Tinfoil's overall verifier gates TCB policy but does not expose a separable raw status. |
+| `serving_software_known_good` | Asserted as verifier-derived from the Sigstore-proven release measurement. |
+| `gpu_attested` | Unknown. |
+| `os_known_good` | Unknown. |
+| `model_weights_provenance` | Unknown. |
 
-The backend enforces the verified `tls_spki_sha256` against the upstream HTTPS
-connection before forwarding.
+## Limitations
 
-## Notes
-
-- Verification needs egress to Tinfoil's endpoints: the attestation endpoint
-  (`<host>/.well-known/tinfoil-attestation`), `kds-proxy.tinfoil.sh` (AMD VCEK),
-  the GitHub attestation proxy, and Sigstore's TUF root.
-- Router mode: by default this verifies the **router** enclave
-  (`tinfoilsh/confidential-model-router`). Tinfoil is a router
-  (`AttestationScope::PerRouter`): the attested session is that one verified
-  enclave channel, shared by every model behind it, so verification is keyed on
-  the channel and the served model is a receipt-level identifier. Per-model TEE
-  coverage is delegated to the verified router, which attests the model enclaves
-  it fronts. Override the repo via `provider_options.tinfoil_repo`.
-- Pin the dependency deliberately; the SDK is the source of truth for the check set,
-  so upgrades should be reviewed.
+- The gateway delegates the hardware, TCB, and source-provenance check set to the pinned Tinfoil SDK. A dependency upgrade changes the verifier trust root and must be reviewed.
+- The default path proves the confidential router channel. Per-model TEE coverage depends on the verified router's own model-enclave policy and is not independently recorded by this gateway.
+- `release_digest` is preserved as evidence but is not checked against a separate operator allowlist in gateway configuration.
+- Verification needs egress to Tinfoil attestation and key-distribution endpoints, its GitHub attestation proxy, and Sigstore trust material.
+- The adapter does not establish GPU-to-router binding or model-weight provenance in the ACI session claims.
 
 ## Reproduce
 
-```bash
-cd /home/h4x/workspace/redpill/private-ai-gateway
-echo '{"api_version":"aci.provider-verifier.request.v1","provider":"tinfoil",
-  "upstream_name":"tinfoil-live","url_origin":"https://inference.tinfoil.sh",
-  "model_id":"kimi-k2-6",
-  "forwarded_body_hash":"sha256:'"$(printf '0%.0s' {1..64})"'","required":true,
-  "timeout_seconds":300}' \
-  | uv run python scripts/private_ai_provider_verifier.py
+From the repository root:
+
+```sh
+request_hash="sha256:$(printf '0%.0s' {1..64})"
+jq -n --arg hash "$request_hash" '{
+  api_version: "aci.provider-verifier.request.v1",
+  provider: "tinfoil",
+  upstream_name: "tinfoil-live",
+  url_origin: "https://inference.tinfoil.sh",
+  model_id: "kimi-k2-6",
+  forwarded_body_hash: $hash,
+  required: true,
+  timeout_seconds: 300
+}' | uv run python scripts/private_ai_provider_verifier.py
 ```
+
+See the dated [router admissions review](review.md) for the inspected provider revision and historical conditions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,9 @@
 # ACI Quickstart
 
 Verify a live ACI deployment yourself. The commands below run against
-`https://api.redpill.ai`, a live deployment of the reference implementation;
-point `ACI_URL` at any ACI service to verify that instead.
+`https://tee.redpill.ai`, a live deployment of the reference implementation
+that enforces TEE-only routing. Point `ACI_URL` at any ACI service to verify
+that instead.
 
 You need `curl`. The evidence-inspection steps also use `jq` and `openssl`.
 Install the latest `aci` CLI release on Linux or macOS:
@@ -11,7 +12,7 @@ Install the latest `aci` CLI release on Linux or macOS:
 curl --proto '=https' --tlsv1.2 -fsSL \
   https://raw.githubusercontent.com/Dstack-TEE/private-ai-gateway/main/install-aci.sh \
   | sh
-export ACI_URL=https://api.redpill.ai
+export ACI_URL=https://tee.redpill.ai
 ```
 
 The installer verifies the release SHA-256 and writes `aci` to
@@ -34,7 +35,7 @@ PASS  id-2         binding chain: keyset JCS -> digest -> statement for our nonc
 PASS  id-3         keyset not expired (now < not_after) [9.1(3)] — now 1783899770 < not_after 1786491770
 PASS  id-4         source provenance connects workload to public code [9.1(4)] — booted compose measured into RTMR3: compose-hash=7c1e…40db; repo=https://github.com/Dstack-TEE/private-ai-gateway.git commit=58b027d… (published, not independently rebuilt)
 SKIP  id-5         private-key custody and subject per policy [9.1(5)] — custody policy not implemented in this CLI yet (see src/aci/verifier/dstack.rs); subject: null (no policy constraints applied)
-PASS  id-6         the channel actually used is bound to the attested keyset (TLS SPKI or E2EE key) [9.1(6)] — observed SPKI 6ff3…9d21 for api.redpill.ai is in the attested keyset
+PASS  id-6         the channel actually used is bound to the attested keyset (TLS SPKI or E2EE key) [9.1(6)] — observed SPKI 6ff3…9d21 for tee.redpill.ai is in the attested keyset
 
 VERIFIED (5 pass, 1 skipped: custody policy not implemented)
 ```
@@ -209,9 +210,12 @@ What the proxy does:
   hostname and fails closed on a mismatch.
 - Responses stream through byte-exact while the proxy digests the raw wire
   bytes — bodies are never buffered or stored. Each POST response's receipt
-  id and body digests are recorded (the last 256 exchanges), and a 2xx
-  inference response with no receipt header is flagged immediately
-  ([aci.md](../spec/aci.md) §5.2).
+  id and body digests are recorded (the last 256 exchanges). Under the default
+  verified-serving constraint, a 2xx inference response with no receipt header
+  is flagged immediately ([aci.md](../spec/aci.md) §5.2). With
+  `--allow-unverified`, an early-committed stream may legitimately omit the
+  header; the current proxy reports that it has nothing to record. Use
+  `aci send --allow-unverified` when that response-id fallback is required.
 - Verification runs on demand from the control endpoint on
   `127.0.0.1:4181`, not per request:
 
@@ -289,14 +293,24 @@ structured data. Verified serving is demanded by default (the §5.3
 serve through anything else, and the transcript checks that the receipt
 cites one of yours.
 
-## 6. Verify from a browser or any web app
+With the default constraint, a missing `X-Receipt-Id` is a failure. With
+`--allow-unverified`, an unconstrained stream may have been committed before an
+upstream was selected; in that case `aci send` reads the response `id` and uses
+it to fetch the finalized receipt.
 
-The [`@phala/aci-verifier`](../clients/verifier-ts) library verifies a service
-from a browser tab or any web project in one call:
+## 6. Verify from TypeScript
+
+Install the public ESM package:
+
+```bash
+npm install @phala/aci-verifier
+```
+
+The browser entry verifies a service in one call:
 
 ```ts
 import { verifyService } from '@phala/aci-verifier';
-const { verdict, lines } = await verifyService('https://api.redpill.ai');
+const { verdict, lines } = await verifyService('https://tee.redpill.ai');
 console.log(verdict.line); // VERIFIED / PARTIAL / NOT VERIFIED
 ```
 
@@ -304,9 +318,15 @@ It fetches the report with a fresh nonce and verifies the hardware quote
 (via [`@phala/dcap-qvl`](https://www.npmjs.com/package/@phala/dcap-qvl) against
 the Phala PCCS), the binding chain, and the compose measurement — the same
 §9.1 checks the CLI runs, except key custody (check 5) and the TLS-certificate
-pin (check 6), which a plain browser cannot reach. A prebuilt ESM bundle
-(`npm run build:bundle`) drops into a `<script type="module">` with no build
-step.
+pin (check 6), which a plain browser cannot reach.
+
+Node 20.18.1+ and Bun 1.4+ applications can import `connectAci()` from
+`@phala/aci-verifier/runtime` for an instance-scoped, SPKI-pinned fetch
+transport. Authentication remains with your SDK: inject `aci.fetch` into the
+SDK and configure the API key there. The transport retains each request's
+authorization only for that request's private receipt lookup. See the
+[TypeScript client guide](../clients/verifier-ts/README.md) for runnable SDK
+examples and receipt verification.
 
 ## 7. Going deeper
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,19 +4,25 @@ Verify a live ACI deployment yourself. The commands below run against
 `https://api.redpill.ai`, a live deployment of the reference implementation;
 point `ACI_URL` at any ACI service to verify that instead.
 
-You need a Rust toolchain plus `curl`, `jq`, and `openssl`. The `aci` CLI
-lives in this repository:
+You need `curl`. The evidence-inspection steps also use `jq` and `openssl`.
+Install the latest `aci` CLI release on Linux or macOS:
 
 ```bash
-git clone https://github.com/Dstack-TEE/private-ai-gateway.git
-cd private-ai-gateway
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/Dstack-TEE/private-ai-gateway/main/install-aci.sh \
+  | sh
 export ACI_URL=https://api.redpill.ai
 ```
+
+The installer verifies the release SHA-256 and writes `aci` to
+`~/.local/bin`. If that directory is not already on `PATH`, add it before
+continuing. From a source checkout, replace each `aci` command below with
+`cargo run --bin aci --`.
 
 ## 1. Verify the service with one command
 
 ```bash
-cargo run --bin aci -- verify "$ACI_URL"
+aci verify "$ACI_URL"
 ```
 
 The CLI fetches `GET /v1/aci/attestation` with a fresh 32-byte random nonce
@@ -49,10 +55,10 @@ id-4 verifies that the compose the service booted is the one measured into the
 quote, and prints the hash. It does not decide whether that compose is one you
 want: that is your verifier policy ([aci.md](../spec/aci.md) §1.3). Pin the
 hashes you accept with `--accept-compose`, repeatable and available on
-`verify`, `send`, `serve` and `audit`:
+`verify`, `curl`, `send`, `serve`, and `audit`:
 
 ```bash
-cargo run --bin aci -- serve "$ACI_URL" --accept-compose 7c1e...40db
+aci curl "$ACI_URL/v1/models" --accept-compose 7c1e...40db -- --silent
 ```
 
 For a production deployment, first run a dstack verifier over the report's
@@ -63,7 +69,7 @@ implements this check. Then appraise that hash with the ACI client's production
 allowlist:
 
 ```bash
-cargo run --bin aci -- verify "$ACI_URL" --require-production-os
+aci verify "$ACI_URL" --require-production-os
 ```
 
 The ACI client verifies the DCAP quote and replays RTMR3, but does not perform
@@ -77,7 +83,41 @@ The compose hash is the value to pin because it is the one measured into
 RTMR3. `repo_url` and `repo_commit` ride along in the report unpinned: they
 are not bound into the quote, so they are a label to read, not evidence.
 
-## 2. Look at the evidence yourself
+## 2. Send a familiar API request over the verified channel
+
+Replace `YOUR_API_KEY` and `MODEL_ID` with values from your provider:
+
+```bash
+aci curl "$ACI_URL/v1/chat/completions" -- \
+  --fail-with-body \
+  --no-buffer \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "content-type: application/json" \
+  --data-binary '{
+    "model": "MODEL_ID",
+    "messages": [{"role": "user", "content": "Say hi"}],
+    "stream": true,
+    "provider": {"aci_verified": true}
+  }'
+```
+
+`aci curl` first runs the service checks from step 1. If they pass, it converts
+the observed TLS SPKI digest to curl's `sha256//...` pin format and starts the
+installed curl with that pin. Verification output goes to stderr. The untouched
+API response goes to stdout, including SSE streaming.
+
+The pin binds the client-to-gateway connection. The
+`provider.aci_verified: true` constraint makes the gateway refuse the request
+unless the chosen model backend also passed verification. This command does
+not fetch or verify the response receipt. Use `aci send` or `aci serve` for
+that deeper check.
+
+Put curl arguments after `--`. Pass short options separately, such as
+`-X POST`, because grouped or attached short options are rejected. The wrapper
+also rejects curl options that can replace the verified URL, SPKI pin,
+protocol policy, redirect policy, config, or transfer scope.
+
+## 3. Look at the evidence yourself
 
 The report is plain JSON, keyset included: `attestation.workload_keyset`
 is the keyset object itself, and its digest is over the keyset's JCS form
@@ -125,13 +165,13 @@ statement bytes, the digests, and the expected values.
 byte. To re-run the checks against saved artifacts:
 
 ```bash
-cargo run --bin aci -- audit --report report.json --nonce "$NONCE"
+aci audit --report report.json --nonce "$NONCE"
 ```
 
-## 3. Use it as a local endpoint
+## 4. Use it as a local endpoint
 
 ```bash
-cargo run --bin aci -- serve "$ACI_URL"
+aci serve "$ACI_URL"
 ```
 
 `aci serve` verifies the service first, prints the transcript, and refuses
@@ -192,7 +232,7 @@ To go from trusting the service's own gating to pinning the exact sessions
 you accept, first audit the current attested sessions:
 
 ```bash
-cargo run --bin aci -- sessions "$ACI_URL" --require-claim tee_attested=hardware_proven
+aci sessions "$ACI_URL" --require-claim tee_attested=hardware_proven
 ```
 
 Each current session record is fetched and audited
@@ -200,25 +240,26 @@ Each current session record is fetched and audited
 claims policy print as `ACCEPTED`. Then pin, either way:
 
 ```bash
-# Fixed accepted set: requests use its intersection with their own pins, or
-# this set when they supply none. A disjoint request fails locally.
-cargo run --bin aci -- serve "$ACI_URL" --session <session-id>
+# Fixed accepted set: requests intersect their own pins with this set.
+# Requests without pins use this set. A disjoint request fails locally.
+aci serve "$ACI_URL" --session <session-id>
 
 # Policy pins: derive the set from the required claims. Refuses to start if
 # nothing qualifies, and refreshes the set when the service refuses a
 # superseded pin (HTTP 412) before retrying the request once.
-cargo run --bin aci -- serve "$ACI_URL" --require-claim tee_attested=hardware_proven
+aci serve "$ACI_URL" --require-claim tee_attested=hardware_proven
 ```
 
 A request that already carries `provider.aci_session_ids` is narrowed to its
-intersection with the local accepted set. On-demand receipt verification also checks the cited session
-against the pins (§9.3(6)) and the required claims (§9.2(3)).
+intersection with the local accepted set. On-demand receipt verification also
+checks the cited session against the pins (§9.3(6)) and the required claims
+(§9.2(3)).
 
-## 4. Verify one inference end to end
+## 5. Verify one inference end to end
 
 ```bash
 export ACI_API_KEY=<your api key>
-cargo run --bin aci -- send "$ACI_URL" --prompt "What are you running on?"
+aci send "$ACI_URL" --prompt "What are you running on?"
 ```
 
 `aci send` verifies the service (fail closed), sends one chat completion
@@ -248,7 +289,7 @@ structured data. Verified serving is demanded by default (the §5.3
 serve through anything else, and the transcript checks that the receipt
 cites one of yours.
 
-## 5. Verify from a browser or any web app
+## 6. Verify from a browser or any web app
 
 The [`@phala/aci-verifier`](../clients/verifier-ts) library verifies a service
 from a browser tab or any web project in one call:
@@ -267,7 +308,7 @@ pin (check 6), which a plain browser cannot reach. A prebuilt ESM bundle
 (`npm run build:bundle`) drops into a `<script type="module">` with no build
 step.
 
-## 6. Going deeper
+## 7. Going deeper
 
 [README.md](../spec/README.md) routes the rest by task. [aci.md](../spec/aci.md) §9 is the
 procedure this walkthrough exercised.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,7 +65,7 @@ aci curl "$ACI_URL/v1/models" --accept-compose 7c1e...40db -- --silent
 For a production deployment, first run a dstack verifier over the report's
 quote, event log, and VM configuration. Require it to reproduce the boot
 measurements (MRTD and RTMR0-2), establish `os_image_hash`, and return
-`is_valid: true`. The [Phala direct verification path](providers/phala-direct/verification.md#how-the-os-image-is-classified)
+`is_valid: true`. The [Phala-direct verification algorithm](providers/phala-direct/verification.md#verification-algorithm)
 implements this check. Then appraise that hash with the ACI client's production
 allowlist:
 

--- a/docs/reviews/aci-spec-conformance-gaps.md
+++ b/docs/reviews/aci-spec-conformance-gaps.md
@@ -195,13 +195,10 @@ item.
 
 18. **The live E2E scripts predate the simplified protocol.** Parts of
    `scripts/live_e2e/` (e.g. `cases/embeddings.py`, `cases/lifecycle.py`)
-   still assert removed mechanism (transparency events), and
-   `scripts/phala_multi_upstream_smoke.sh` /
-   `scripts/local_multi_upstream_smoke.sh` still use `workload_id` and
-   `accepted_workload_ids`. The in-process integration suites (`tests/`)
-   and `docs/live-e2e-test-suite.md` cover the new protocol; the live
-   scripts need the same pass, and the public deployment serves the
-   previous build until redeployed.
+   still assert removed transparency events. The multi-upstream smoke scripts
+   and attested-session case have been migrated to the simplified schema, and
+   the in-process integration suites (`tests/`) cover the new protocol. The
+   remaining live lifecycle cases need the same pass.
 
 19. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
    test vectors byte-for-byte, but the workflow triggers only on

--- a/docs/reviews/aci-spec-conformance-gaps.md
+++ b/docs/reviews/aci-spec-conformance-gaps.md
@@ -36,7 +36,14 @@ item.
    silently. Sessions do better: the JSONL store survives restarts and
    extends retention per citing receipt (§8 retention rule).
 
-4. **Chutes per-instance sessions carry no §8.2 evidence.** The Chutes
+4. **Superseded 2026-08-27: Chutes per-instance sessions carried no §8.2
+   evidence.** Commit `8dd8c1d` changed the implementation so every
+   per-instance session retains the shared nonce-bound verification evidence
+   bundle. Current clients can therefore verify the evidence digest and data;
+   the remaining evidence-appraisal limitation is tracked in item 17.
+
+   The rest of this item preserves the original finding and design analysis.
+   The Chutes
    verifier's raw evidence is fleet-wide and nonce-bound, so sealing it into
    each per-instance session would mint a new session id for every
    verification round and every fleet change. The implementation instead
@@ -201,9 +208,10 @@ item.
    remaining live lifecycle cases need the same pass.
 
 19. **Client CI triggers are path-scoped.** `verifier-ts` tests pin the spec
-   test vectors byte-for-byte, but the workflow triggers only on
-   `clients/verifier-ts/**`, so an edit to `spec/test-vectors.md` alone does
-   not rerun them (Rust CI catches drift via `tests/spec_vectors.rs`).
+   test vectors byte-for-byte, and the unified TypeScript workflow runs for
+   changes anywhere under `clients/**`. It still does not trigger for an edit
+   to `spec/test-vectors.md` alone; Rust CI catches that drift through
+   `tests/spec_vectors.rs`.
 
 ## Beyond-spec surfaces (intentional, keep honest)
 

--- a/docs/reviews/router-mode-load-balancing-cache.md
+++ b/docs/reviews/router-mode-load-balancing-cache.md
@@ -1,5 +1,10 @@
 # Router-Mode Review: Load Balancing, Routing, and Cache Locality
 
+> [!NOTE]
+> This is a point-in-time audit dated 2026-05-18. Provider routing and cache
+> behavior can change independently of this repository. Revalidate the deployed
+> provider revision before relying on these observations.
+
 Scope: load balancing, routing behavior, retries, overload handling, and
 KV/prompt-cache locality for the two router-mode providers we accept today -
 Tinfoil `inference.tinfoil.sh` and NEAR AI `cloud-api.near.ai`. Soundness and

--- a/docs/reviews/router-mode-soundness.md
+++ b/docs/reviews/router-mode-soundness.md
@@ -1,5 +1,10 @@
 # Router-Mode Soundness Review
 
+> [!NOTE]
+> This is a point-in-time audit of the revisions listed below, dated 2026-05-18.
+> Source paths and line numbers refer to the repository layout at that time. Use
+> the provider `verification.md` pages for the current gateway adapters.
+
 Reviewer: Codex (router-mode soundness lane only).
 Date: 2026-05-18 UTC.
 Scope: soundness, privacy, provenance, attested source/config/image/measurement,
@@ -271,8 +276,9 @@ What we do today (read-only review, no changes made):
   `ExternalProviderVerifier::private_inference(...)` and run our Python bridge
   `scripts/private_ai_provider_verifier.py` (`verify_tinfoil`, `verify_nearai`).
   Each returns one `channel_bindings` entry of type `tls_spki_sha256` bound to
-  the provider URL origin (`src/aci/verifier.rs:749-839`,
-  `scripts/private_ai_provider_verifier.py:286-376`).
+  the provider URL origin (`src/aci/verifier/providers.rs`,
+  `scripts/provider_verifier/tinfoil.py`, and
+  `scripts/provider_verifier/nearai.py`).
 - The ACI backend forwards over an HTTPS connection that enforces the verified
   SPKI; that part of the chain is consistent with what both routers expect.
 - We do not pin model-side measurements ourselves, do not surface the
@@ -419,4 +425,5 @@ change.
   beyond what is visible in this repo.
 - An end-to-end signature-verification audit of the response signature
   chain emitted by either provider; we relied on the existing
-  `examples/verify_aci_artifacts.rs` and `tests/receipt.rs` for that.
+  `aci audit` implementation under `src/bin/aci/` and `tests/receipt.rs` for
+  that.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 This page records current implementation status and the next engineering priorities. It is non-normative and carries no release-date commitment.
 
-Last reviewed: 2026-08-12.
+Last reviewed: 2026-08-15.
 
 ## Implemented
 
@@ -19,8 +19,9 @@ The current gateway includes:
 - multi-domain downstream TLS identities and TEE-only middleware domains;
 - the E2EE v2 compatibility extension for chat completions, text completions,
   and embeddings;
-- the `aci` CLI for live verification, offline audit, session inspection, one
-  verified chat request, and a local verifying proxy;
+- the `aci` CLI for live verification, offline audit, session inspection,
+  arbitrary curl requests over an attested SPKI-pinned channel, one verified
+  chat request with receipt checks, and a local verifying proxy;
 - unit and integration tests, ACI test vectors, a TypeScript verifier, provider-verifier tooling, and a live provider suite.
 
 Implementation does not imply that every provider proves the same claims. Review [Provider verification](providers/README.md) and treat unproven claims as unknown.
@@ -62,9 +63,8 @@ These boundaries are present in the current code and should inform deployment de
 ### API and client coverage
 
 - Move live verification cases to canonical `/v1/aci/*` artifacts while retaining explicit legacy compatibility tests.
-- Extend the first-class client beyond `aci send` so arbitrary supported API
-  requests can use the same verification, pinning, receipt, and session-policy
-  checks.
+- Extend `aci curl` beyond preflight verification and SPKI pinning so arbitrary
+  supported API requests can also opt into receipt and session-policy checks.
 - Define or reject a native Anthropic Messages E2EE profile at the API boundary.
 - Expand Responses API conformance and streaming interoperability tests.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 This page records current implementation status and the next engineering priorities. It is non-normative and carries no release-date commitment.
 
-Last reviewed: 2026-08-15.
+Last reviewed: 2026-08-31.
 
 ## Implemented
 
@@ -11,6 +11,8 @@ The current gateway includes:
 - OpenAI-compatible chat, text completion, embeddings, and Responses endpoints;
 - Anthropic Messages compatibility;
 - direct-upstream routing and an in-process middleware path backed by an HTTP control plane;
+- pre-first-byte SSE keepalives for unconstrained middleware streams, with
+  explicit cancellation, timeout, and post-commit failure accounting;
 - runtime upstream replacement with validation, redaction, atomic persistence, prewarm, and background refresh;
 - provider adapters for OpenAI-compatible, Anthropic, ACI service, Chutes, Tinfoil, NEAR AI, SecretAI, and Phala direct deployments;
 - request-level fail-closed verification constraints and current-session allowlists;
@@ -22,7 +24,19 @@ The current gateway includes:
 - the `aci` CLI for live verification, offline audit, session inspection,
   arbitrary curl requests over an attested SPKI-pinned channel, one verified
   chat request with receipt checks, and a local verifying proxy;
-- unit and integration tests, ACI test vectors, a TypeScript verifier, provider-verifier tooling, and a live provider suite.
+- unit and integration tests, ACI test vectors, provider-verifier tooling, and
+  a live provider suite;
+- the public `@phala/aci-verifier` ESM package, with browser verification and
+  instance-scoped Node and Bun transports that verify identity, pin TLS,
+  enforce serving policy, capture wire digests, and audit receipts and cited
+  sessions;
+- the public `@phala/aci-provider` shared provider and native Pi and OpenCode
+  adapters for generic ACI, RedPill, and Phala Cloud, for eight published npm
+  packages in total;
+- host-native authentication, credential and model persistence, and provider
+  lifecycle in Pi and OpenCode, with gateway-authoritative model capabilities;
+- automatic signed-receipt and cited-session verification before a Pi or
+  OpenCode response stream completes, including consumer cancellation.
 
 Implementation does not imply that every provider proves the same claims. Review [Provider verification](providers/README.md) and treat unproven claims as unknown.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,6 +72,12 @@ These boundaries are present in the current code and should inform deployment de
 - Define a durable receipt-store interface and retention policy suitable for process restarts and multiple replicas.
 - Evaluate hash chaining or external witnessing for session transparency.
 - Document backup, recovery, file permissions, storage growth, and multi-replica ownership for production state.
+- Add provider-verification and Chutes nonce-pool metrics for cache health,
+  refresh results, binding mismatches, and pool depletion.
+- Replace the runtime apt and rustup bootstrap with a pinned, gateway-owned
+  runner image or reviewed prebuilt binary.
+- Define multi-region identity and state behavior, including KMS application
+  identity, receipt locality, failover, and session availability.
 - Add deployment health, readiness, and alerting guidance based on concrete service-level objectives.
 
 ### API and client coverage
@@ -81,6 +87,13 @@ These boundaries are present in the current code and should inform deployment de
   supported API requests can also opt into receipt and session-policy checks.
 - Define or reject a native Anthropic Messages E2EE profile at the API boundary.
 - Expand Responses API conformance and streaming interoperability tests.
+- Expand live provider coverage for streaming, tools, structured output,
+  multimodal input, context limits, cache behavior, and strict release
+  provenance without treating unsupported capabilities as passes.
+- Decide whether to ship the planned backend-only local proxy that reuses the
+  provider verifiers and transports without claiming a local TEE-backed ACI
+  service identity. This is distinct from `aci serve`, which verifies and
+  proxies an existing remote ACI service.
 
 ### Middleware and control plane
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,256 +1,87 @@
-# Private AI Gateway Roadmap
+# Project Status and Roadmap
 
-Date: 2026-06-09 UTC.
-Current phase: refactoring the feature-complete prototype into a gateway
-framework, then hardening it into a strict review candidate.
+This page records current implementation status and the next engineering priorities. It is non-normative and carries no release-date commitment.
 
-This document is the gateway-local progress tracker. The ACI spec defines
-the protocol. This repo proves an adoptable implementation: OpenAI-compatible
-surface, ACI receipts, dstack identity, upstream verification, and provider
-adapters that fail closed when binding material cannot be enforced.
+Last reviewed: 2026-08-12.
 
-## Status Table
+## Implemented
 
-| Area | Status | Notes |
-| --- | --- | --- |
-| OpenAI-compatible chat/completions surface | Done | `/v1/chat/completions`, `/v1/completions`, streaming, E2EE addon, legacy aliases, and vLLM-compatible error behavior are covered by tests. |
-| OpenAI-compatible embeddings surface | Done | `/v1/embeddings` forwards through the same receipt/attestation pipeline as chat. Buffered-only (client-sent `stream:true` is forced back to buffered). The E2EE v2 compatibility extension encrypts the `input` request field and each `data[].embedding` response field. Provider adapters in this slice: openai-compatible only — Chutes embeddings (TEI native paths, not `/v1/embeddings`) and Tinfoil/NEAR-AI embedding routes still need adapter work. |
-| Model routing and runtime config | Done | One upstream config file, admin `GET`/`PUT`, model alias rewrite before verification/forwarding/receipt hashing in no-middleware mode. Production upstream policy should live in this config file, not in broad process-level allowlist env vars. |
-| ACI identity and self-attestation | In progress | dstack KMS-backed keys, the quote-bound keyset digest, TLS SPKI publication, and local dstack simulator support are implemented. Launcher provenance is tracked separately but still part of the release story. |
-| Receipts | In progress | Request/response body hashes, streaming hashing, upstream verification events, middleware route events, and the legacy `/v1/signature` alias are implemented. Persistent storage decision is still open. |
-| Attested sessions | In progress | Upstream verified TLS/SPKI or provider E2EE bindings now create session ids, audit records, and receipt references. Downstream session ids are pending TLS/domain binding work. |
-| Upstream verification lifecycle | In progress | Startup prewarm, background verification refresh, and Chutes session refresh exist. Provider soundness review is still strict-release work. |
-| Provider adapters | In progress | Tinfoil, NEAR AI, Chutes, SecretAI, and direct vLLM-proxy-backed GPU workers are the launch surface. OpenAI-compatible remains useful for deployment bring-up. ACI service upstreams stay minimal until first-party GPU workers move from vLLM-proxy to an ACI-compatible server. |
-| Frontend/middleware/backend framework | Shipped | Frontend/backend split with an optional middleware that consults the control plane to route, transform, cost-inject, and report usage; the middleware-disabled path stays behavior-compatible. |
-| Multi-domain downstream TLS binding | In progress | Domain-tagged TLS SPKIs can be configured, published in the keyset, and selected in report evidence from the HTTP `Host`. Downstream session ids are still pending. |
-| Client serving constraints | Implemented | Spec §5.3: `provider.aci_verified` and `provider.aci_session_ids` in any prompt-endpoint body; membership enforced by the measured code, refusal via `session_not_accepted`, member stripped before forwarding (recorded as the §7.4 rewrite). Enforced in the gateway: the member is consumed and stripped on the single body parse, membership is checked before forwarding, and the refusal is receipt-recorded. |
-| E2EE v2 compatibility extension | Implemented | The [frozen v2 contract](../spec/e2ee-v2.md) is enabled by default: X25519 and secp256k1 suites, JCS field AAD, replay protection, buffered and streaming response encryption, and attested key selection. It requires no workload identity key. V2 is supported through at least February 10, 2027 while v3 is developed as its replacement. |
-| JCS workload keyset | Implemented | Spec §3.1/§4.1: the keyset digest is over the JCS form and the report embeds the keyset as a plain `workload_keyset` object (base64 armor dropped). Implemented across the gateway, CLI, TS client, vectors, and docs. |
-| CLI verifier policy | Partial | User-configurable §1.3 policy for the `aci` CLI and `aci serve`. Landed: required claims (`--require-claim`, §9.2(3)), attested-session pinning (`aci sessions`, `serve --session` / `--require-claim` with refresh-on-412), compose pins, and an RTMR3 `os-image-hash` production allowlist (`--require-production-os`). The OS allowlist relies on a separate dstack verifier to bind the hash to MRTD/RTMR0-2. Remaining: custody checking (§9.1(5)), in-client dstack boot verification, and exact source-build provenance policy. |
-| Local backend proxy mode | Planned | Let an end user run the verified-provider backend as a laptop-local OpenAI-compatible proxy without local TEE requirements. |
-| Live E2E fidelity suite | In progress | BFCL/OpenAI-compatible harness exists. Strict profiles and broader fidelity coverage remain P0 before external review. |
-| Production operations | Next | Durable stores, deployment docs, metrics review, multi-region behavior, and rate-limit/load tests follow the strict-release pass. |
+The current gateway includes:
 
-## Pending Tasks
+- OpenAI-compatible chat, text completion, embeddings, and Responses endpoints;
+- Anthropic Messages compatibility;
+- direct-upstream routing and an in-process middleware path backed by an HTTP control plane;
+- runtime upstream replacement with validation, redaction, atomic persistence, prewarm, and background refresh;
+- provider adapters for OpenAI-compatible, Anthropic, ACI service, Chutes, Tinfoil, NEAR AI, SecretAI, and Phala direct deployments;
+- request-level fail-closed verification constraints and current-session allowlists;
+- enforced TLS SPKI and Chutes E2EE public-key channel bindings;
+- signed ACI receipts, canonical attestation reports, and immutable attested sessions;
+- multi-domain downstream TLS identities and TEE-only middleware domains;
+- the E2EE v2 compatibility extension for chat completions, text completions,
+  and embeddings;
+- the `aci` CLI for live verification, offline audit, session inspection, one
+  verified chat request, and a local verifying proxy;
+- unit and integration tests, ACI test vectors, a TypeScript verifier, provider-verifier tooling, and a live provider suite.
 
-### P0: Attested Sessions and Audit Log
+Implementation does not imply that every provider proves the same claims. Review [Provider verification](providers/README.md) and treat unproven claims as unknown.
 
-An attested session is a connection or application-level encryption context that
-has been verified against attestation evidence and enforceable binding material.
-Both downstream user sessions and upstream provider sessions should use this
-concept.
+## Known limitations
 
-- Define the session record shape: session id, direction, target, verification
-  time, expiry, byte-preserving verifier evidence, verified claim tags, and
-  enforceable session binding material. Implemented for upstream sessions.
-  Provider-owned scope details such as gateway, router, or model-instance proof
-  live in `verification.provider_claims`.
-- Treat TLS with SPKI pinning and provider/client E2EE as supported binding
-  types. Implemented for upstream sessions.
-- Write each successful upstream session verification to an audit log that can
-  be queried by session id. Implemented at
-  `GET /v1/aci/sessions/{session_id}`.
-- Make receipts reference the upstream session id used for the request.
-  Implemented as `upstream.verified.session_id` when a verified binding exists.
-- Add downstream session ids once the gateway can select and report
-  domain-specific TLS bindings.
-- Keep the implementation small: reuse the existing upstream lease lifecycle
-  where possible, and avoid introducing a policy DSL.
+These boundaries are present in the current code and should inform deployment decisions:
 
-### Router Upstreams: Model Attestation and One Session per Channel
+- Upstream verification is opt-in per request or route. An unconstrained request is not guaranteed to use a verified upstream.
+- The Rust CLI and TypeScript client verify TDX quotes and the ACI binding
+  chain, but they do not reconstruct dstack boot measurements or implement a
+  complete private-key-custody and exact source-build acceptance policy.
+- Receipt storage is in memory and expires after one hour. A process restart removes prior receipts.
+- Session storage is content-addressed JSONL, not a hash-chained or externally witnessed transparency log.
+- The gateway does not prove model-weight provenance unless a provider verifier supplies evidence that supports that claim. Current provider mappings normally leave it unknown.
+- A non-`UpToDate` TCB value can be recorded as a refuted session claim without making every provider verifier fail. Relying parties must enforce their TCB policy.
+- E2EE covers selected request and response fields, not all metadata. It is not supported on `/v1/responses`, and no native Anthropic Messages field profile is documented.
+- The example control plane implements only the minimal request-decision contract. It is not a production router or a complete catalog service.
+- The deployment example exposes the gateway directly and assumes the operator supplies authentication, rate limiting, observability, secret delivery, and availability controls appropriate to the environment.
+- The live end-to-end runner still uses legacy report and receipt-wrapper routes for parts of its compatibility checks.
 
-An attested session is a verified secure channel, and we never create more than
-one session per channel. The channel boundary a provider attests is a first-class
-property, `UpstreamProvider::attestation_scope()` → `AttestationScope`: per E2EE
-instance (Chutes), per model TEE (Phala-direct), and per router gateway TD
-(NEAR AI) or model router (Tinfoil), where one channel fronts many models.
-The scope is the single source of truth: it drives channel-keyed verification (the
-model is dropped from the verifier cache key for routers, so every model resolves
-to one verified channel and one attested session) and is enforced fail-closed at
-the verifier seam — a verifier must attest the scope its provider is declared to
-use, so a router channel can never be sealed from model-scoped evidence. The
-served model stays a receipt-level fact (see
-[attested-session-system.md](attested-session-system.md)).
+## Priorities
 
-Remaining:
+### Verification completeness
 
-- **Request-bound, per-instance model attestation on the receipt.** Today,
-  per-model TEE coverage is delegated to the verified router: the router attests
-  its backend model TEEs, and we verify the router's own integrity and source
-  provenance, so the delegation is sound. What it does not yet establish is which
-  *specific* backend instance served a *given* request. Once an upstream can
-  attest that exact instance, surface it as its own scoped, request-bound model
-  attestation on the receipt — tightening the delegation, never folded into the
-  channel session.
+- Publish explicit relying-party policies for accepted TCB states, measurements, software provenance, and provider-specific roots.
+- Complete the client verifier policy for dstack boot measurements,
+  private-key custody, and exact source-build provenance.
+- Expand strict provider references beyond model and binding type where stable, independently reviewed pins are available.
+- Add negative live tests for rotation, stale evidence, key expiry, and session-allowlist rejection.
 
-### P0: Multi-Domain Downstream TLS Binding
+### Durable audit and operations
 
-The gateway currently assumes one downstream TLS identity. Production deployments
-may need multiple custom domains bound to the same gateway workload.
+- Define a durable receipt-store interface and retention policy suitable for process restarts and multiple replicas.
+- Evaluate hash chaining or external witnessing for session transparency.
+- Document backup, recovery, file permissions, storage growth, and multi-replica ownership for production state.
+- Add deployment health, readiness, and alerting guidance based on concrete service-level objectives.
 
-- Add runtime config for a domain-to-certificate mapping. Implemented as
-  `tls.domain_certificates` in the static gateway config loaded from
-  `PRIVATE_AI_GATEWAY_CONFIG_PATH`. Raw SPKI inputs are not supported.
-- Publish all configured domain SPKI bindings in the attested keyset.
-  Implemented.
-- Select the configured downstream domain binding from the HTTP `Host` and
-  publish it in the gateway attestation evidence. Implemented.
-- Ensure receipts and attested-session audit records identify the downstream
-  domain/session used by the request.
-- Keep certificate issuance, renewal, and TLS serving out of scope for this
-  repo; another component may mount certificates and terminate TLS for the
-  gateway deployment.
+### API and client coverage
 
-### P0: Frontend / Middleware / Backend Refactor
+- Move live verification cases to canonical `/v1/aci/*` artifacts while retaining explicit legacy compatibility tests.
+- Extend the first-class client beyond `aci send` so arbitrary supported API
+  requests can use the same verification, pinning, receipt, and session-policy
+  checks.
+- Define or reject a native Anthropic Messages E2EE profile at the API boundary.
+- Expand Responses API conformance and streaming interoperability tests.
 
-Shipped. The gateway is split into a frontend (public ACI endpoints, downstream
-E2EE, request-context creation, receipt signing), a backend (target-route
-validation, provider verification, upstream binding, backend-authored receipt
-facts), and an optional middleware between them. The middleware runs
-**in-process**: it consults the control plane to authorize and route each
-request, shapes the provider request, transforms and cost-injects the response,
-and reports usage — with no out-of-process hop. The middleware-disabled path
-stays behavior-compatible with the direct request path and is covered by the
-full test suite. Verification facts always come from backend observations, never
-middleware claims (`middleware.forwarded`, `route.selected`, `request.forwarded`,
-backend-owned `response.received`, frontend-owned `response.returned`).
+### Middleware and control plane
 
-### P0: Provider Soundness and Strict Pins
+- Provide a production-grade reference control plane or narrow the example contract further so its intended scope is unmistakable.
+- Add contract tests for catalog subpaths, query preservation, TEE-only domain filtering, candidate ordering, and failover decisions.
+- Document control-plane authentication and transport requirements for deployments that cross a trust boundary.
 
-- Treat the upstream config file as the source of truth for production upstreams.
-  Do not rely on global upstream allowlist env vars for production policy.
-  Model-specific GPU workers should be represented as explicit config entries
-  with their URL, bearer token, public model alias, and canonical upstream model
-  name.
-- Support direct vLLM-proxy-backed GPU workers as a launch path. These workers
-  have the same verification shape as the NEAR AI model path, but the gateway
-  connects directly to the GPU workload instead of routing through another
-  gateway. Add or document the adapter as a direct vLLM-proxy verifier path.
-- Defer first-party ACI-compatible GPU worker support. The ACI service upstream path
-  should remain small for now. When first-party GPU workers are upgraded from
-  vLLM-proxy to an ACI-compatible server, revisit accepted workload IDs, image
-  digests, KMS roots, and the vLLM-proxy-derived server component.
-- NEAR AI: pin reviewed gateway source/image/compose provenance and runtime
-  policy, then document the exact release accepted by the adapter.
-- Tinfoil: move from "provider-current verifier result" to a strict release
-  pin for the reviewed router digest/release, or document why the provider's
-  published measurements are the complete release root.
-- Provider release process: require supported gateway/router providers to
-  publish candidate source/release material and expected measurements before
-  production rollout, so strict verifiers can review and pin upgrades without
-  blindly trusting new workloads.
-- Chutes: use explicit per-model `chute_id` pins in production configs and
-  complete long-window nonce-throughput testing.
-- SecretAI: adapter implemented for measured production TDX/SEV-SNP workloads,
-  optional exact workload pins, CPU-bound NRAS evidence, and enforced inference
-  SPKI. Model-weight provenance and provider logging remain open. See
-  [verification](providers/secret-ai/verification.md).
-- Verifier code is now vendored. The provider-verifier bridge imports
-  `scripts/confidential_verifier` (vendored from `Phala-Network/private-ai-verifier`,
-  see its `VENDOR.md`) instead of a sibling checkout, so the gateway no longer breaks
-  when the upstream verifier drifts or carries uncommitted edits. A hermetic contract
-  test (`tests/contract_verifier_bridge.rs`) fails closed if the bridge and the
-  vendored package fall out of sync. Re-sync with upstream deliberately and update the
-  baseline commit in `VENDOR.md`.
-- Deferred: standalone / self-hosted Phala dstack-vLLM node verification through the
-  deep verifier and the live harness. The bridge today only dispatches
-  `tinfoil`/`near-ai`/`chutes`, and the vendored verifier's Phala/RedPill paths go
-  through the hosted `api.redpill.ai` / `cloud-api.phala.network` endpoints, not a raw
-  node's `/v1/attestation/report`. The gateway already verifies first-party
-  ACI-service workers natively in Rust (`AciServiceUpstreamVerifier`); the follow-up is a `phala`
-  bridge branch + a standalone-dstack verifier so the deep/user verifier and harness
-  can verify a raw node the same way as the other providers. Pairs with the direct
-  vLLM-proxy worker bullet above.
-- Attestation soundness pass complete for all verifying providers. Each provider's
-  session binding is now cryptographically tied to a verified quote (see the soundness
-  section in `docs/upstream-verification-lifecycle.md`): Chutes (DCAP +
-  `report_data`↔`nonce‖e2e_pubkey`), NEAR AI (`report_data` binding now enforced),
-  Tinfoil (official `tinfoil` SDK: AMD signature chain + Sigstore provenance + TLS
-  binding), and AciService (TLS keys covered by the keyset digest bound into
-  `report_data`). Live tamper tests confirm rejection.
-- Follow-up (defense-in-depth, not a forgeable hole): verify the NVIDIA NRAS GPU JWT
-  signature against NRAS' JWKS. Today the GPU tokens are fetched online from NRAS over
-  TLS and the request nonce is checked (Chutes via `eat_nonce`, NEAR AI via the
-  component nonce), but the JWT signature itself is decoded with
-  `verify_signature: False`. Closing it means fetching and caching NVIDIA's JWKS and
-  handling key rotation; it hardens the relayed/offline case and adds a second layer
-  if TLS to NRAS is ever compromised.
+## Change discipline
 
-### P0: Live E2E and User Verification
+A roadmap item moves to “implemented” only when code, tests, and the relevant living documentation agree. Provider observations and dated audits remain evidence records; they do not silently become protocol guarantees.
 
-- Split quick/full/strict profiles in the live E2E suite.
-- Add framework tests for no-middleware compatibility and fixture middleware
-  route selection.
-- Make strict profile cover tool calls, structured output, media input, context
-  size, cache-affinity behavior where observable, streaming, receipts, and
-  source/launcher provenance.
-- Finish the user verification script for already captured responses.
-- Verification artifacts are *linked, not bundled* (the batch verification-bundle
-  API was dropped). A receipt carries the typed claim verdicts inline (shallow
-  audit) plus a content-addressed `session_id`; a verifier follows that reference
-  to `GET /v1/aci/sessions/{session_id}` for the full evidence and re-verifies locally
-  (deep audit). Gateway identity is fetched once at preflight via
-  `GET /v1/aci/attestation?nonce=`. Keep `/v1/signature/{id}` backward
-  compatible with existing vLLM-proxy clients. If a high-volume auditor ever needs
-  to avoid the follow-up GET, `?expand=` on the receipt is a clean additive
-  optimization — not modeled now.
-- Document E2EE receipt semantics clearly. E2EE already provides AEAD integrity
-  for encrypted fields. Receipts are still attached like normal TLS requests and
-  hash the gateway-observed decrypted request body plus the returned response
-  hashes. Verifiers should not compare `request.received.body_hash` with the
-  original encrypted HTTP body.
-- Write neutral docs with `{API_KEY_ENV_VAR}` and product wrappers that render
-  `REDPILL_AI_API_KEY` for RedPill and `PHALA_AI_API_KEY` for Phala.
+When behavior changes, update at least:
 
-### P1: Local Backend Proxy Mode
-
-- Add a mode that runs only the verified-provider backend as a local
-  OpenAI-compatible proxy for end users and agents. This mode should not require
-  a local TEE, dstack KMS, or gateway self-attestation because the process runs
-  on the user's own machine and is part of the user's local trust boundary.
-- Reuse the same provider adapters, upstream verification lifecycle, and
-  transport/session binding logic as the gateway backend. The local proxy must
-  fail closed when the upstream provider cannot be verified or when the verified
-  binding cannot be enforced.
-- Keep the configuration minimal: local bind address, provider credentials, and
-  the upstream config as a read-only input. Avoid adding a separate verifier DSL
-  or local policy system.
-- Document the trust model clearly: local proxy mode verifies upstream
-  providers for the local user, but it does not claim to provide a TEE-backed
-  ACI service identity to downstream clients.
-
-### P1: Production State and Operations
-
-- Decide the persistent receipt store boundary. The current in-memory store is
-  acceptable only for prototype and short-lived tests. (The gateway never stores
-  request bodies — receipts hold hashes, not content.)
-- Add durable provider lease/session observability and Chutes nonce pool
-  metrics.
-- Replace runtime apt/rustup bootstrap with a gateway-owned runner image or
-  prebuilt binary image.
-- Define multi-region behavior: replicated KMS app id and receipt locality.
-
-## Provider Soundness
-
-Supported providers must pass the criteria in
-[providers/audit-criteria.md](providers/audit-criteria.md). Each provider directory
-under [providers/](providers/README.md) holds its `review.md` (admissions audit) and,
-once implemented, its `verification.md` (how the gateway verifies it). The current
-provider reports are:
-
-- [providers/tinfoil/review.md](providers/tinfoil/review.md)
-- [providers/near-ai/review.md](providers/near-ai/review.md)
-- [providers/chutes/review.md](providers/chutes/review.md)
-- [providers/secret-ai/review.md](providers/secret-ai/review.md)
-
-The implementation should stay minimal: each provider adapter owns its
-transport and verification rules. The config selects a provider and model map;
-it does not expose arbitrary verifier commands or policy DSLs.
-
-## References
-
-- [README.md](../README.md)
-- [live-e2e-test-suite.md](live-e2e-test-suite.md)
-- [configuration-reference.md](configuration-reference.md)
-- [upstream-verification-lifecycle.md](upstream-verification-lifecycle.md)
-- [router-mode-provider-review.md](router-mode-provider-review.md)
+- [API reference](api-reference.md) for routes or wire behavior;
+- [Configuration reference](configuration-reference.md) for fields and defaults;
+- [Control-plane contract](control-plane-contract.md) for middleware decisions;
+- [Provider verification](providers/README.md) for verifier claims and limitations;
+- [Live end-to-end suite](live-e2e-test-suite.md) for runnable validation.

--- a/docs/router-mode-provider-review.md
+++ b/docs/router-mode-provider-review.md
@@ -1,5 +1,11 @@
 # Router-Mode Provider Review
 
+Maintainer record last updated: 2026-06-10.
+
+This page records the review method and first-pass scope. It is not a current
+provider verification reference. See [Provider verification](providers/README.md)
+for the running adapters.
+
 Status: first-pass review complete. Provider-specific reports and the shared
 admission checklist are under `docs/providers/`.
 

--- a/docs/upstream-verification-lifecycle.md
+++ b/docs/upstream-verification-lifecycle.md
@@ -95,6 +95,35 @@ The refresh job obtains the verified provider event, refreshes model session non
 
 This provider-session refresh is separate from the general verifier cache refresh. One maintains instance discovery and nonces; the other renews the attestation result used to authorize those instances.
 
+Provider-session material is subordinate to the verification result. A pooled
+nonce cannot extend trust after verification expires, and every selected
+instance must still match a current verified E2EE-key binding.
+
+For each request, the Chutes backend:
+
+1. Resolves the provider model to a chute ID, with a five-minute local cache.
+2. Removes one unexpired, single-use nonce whose instance ID and E2EE public-key
+   digest match the current verified binding set.
+3. Refills the pool through verified instance discovery when no matching nonce
+   remains.
+4. Encapsulates to the selected ML-KEM-768 key, derives the request key with
+   HKDF-SHA256, encrypts with ChaCha20-Poly1305, and calls `/e2e/invoke`.
+5. Decrypts the buffered or streaming provider response before normal receipt
+   finalization.
+
+The pool uses the provider's `nonce_expires_in` value when present and a
+55-second fallback otherwise. Expired entries are discarded, and selecting a
+nonce removes it from the pool. The model cache and nonce pools are in memory;
+a process restart rebuilds them through prewarm, refresh, or the next request.
+
+A dated live probe on 2026-05-18 observed roughly 138 to 145 seconds for cold
+Chutes evidence verification and roughly one second for warmed small prompts.
+A short 120 requests-per-minute stage and a 25-request burst completed without
+provider `429` responses. These measurements are a lower bound from one model
+and account, not a current latency or throughput guarantee. They explain why
+prewarm and background session refresh keep evidence discovery off the normal
+request path.
+
 ## Failover interaction
 
 Middleware mode can evaluate several candidate routes. Verification failure on a route required to be attested makes that candidate ineligible. The router can try another eligible candidate without forwarding the prompt to the failed one.

--- a/docs/upstream-verification-lifecycle.md
+++ b/docs/upstream-verification-lifecycle.md
@@ -50,7 +50,9 @@ applies the fail-closed gate.
 
 The manager runs at the smallest enabled interval and refreshes only upstreams whose policy enables refresh. Refresh bypasses the existing cache. A successful result replaces the cached event; a failed refresh leaves the previous unexpired successful event in place.
 
-The ACI-service verifier also limits its cached result to the attestation report's `stale_after` timestamp. Its usable lifetime is the earlier of that timestamp and the configured cache deadline.
+The ACI-service verifier also limits its cached result to the workload keyset's
+`not_after` timestamp. Its usable lifetime is the earlier of keyset expiry and
+the configured cache deadline.
 
 Cache lifetime is not a promise that a connection remains safe for that duration. Every forward still enforces the cached channel binding against the connection it uses.
 

--- a/docs/upstream-verification-lifecycle.md
+++ b/docs/upstream-verification-lifecycle.md
@@ -1,294 +1,114 @@
-# Upstream Verification and Lease Lifecycle
+# Upstream Verification Lifecycle
 
-This note records the current high-level design and the Chutes throughput
-findings from the live probes on 2026-05-18 UTC. It is implementation-facing:
-ACI should stay simpler than this document.
+This page explains when the gateway verifies an upstream, how long a verified result is reused, and how channel-binding failures affect forwarding. It applies to the direct-upstream configuration managed by `UpstreamConfigManager`.
 
-## What We Proved
+For field definitions and defaults, see [Configuration reference](configuration-reference.md). For the resulting audit record, see [Attested sessions](attested-session-system.md).
 
-The gateway can run Chutes through config-backed credentials and E2EE
-transport without provider credentials in the gateway process environment.
-The live launcher writes the provider key into upstream config as
-`bearer_token`, starts the gateway, and strips the provider key env var from
-the child process. The Rust Chutes adapter passes the config-backed key and
-Chutes tuning to the verifier bridge as structured stdin input.
+## Security property
 
-Live artifacts:
+A request is fail closed only when it requires ACI verification:
 
-- Config-path sanity: `/tmp/private-ai-gateway-live-e2e/20260518-042641-chutes-rate-probe`
-- Warmed ramp: `/tmp/private-ai-gateway-live-e2e/20260518-043114-chutes-rate-probe`
-- Lease/session refresh check: `/tmp/private-ai-gateway-live-e2e/20260518-052653-chutes-rate-probe`
-- Tinfoil TLS-binding lifecycle: `/tmp/private-ai-gateway-live-e2e/20260518-053809`
-- NEAR AI TLS-binding lifecycle: `/tmp/private-ai-gateway-live-e2e/20260518-053819`
+- `provider.aci_verified` is `true`;
+- `provider.aci_session_ids` is a non-empty allowlist; or
+- middleware marks the selected route as TEE-only.
 
-Measured against `google/gemma-4-31B-turbo-TEE` through the public alias
-`gemma-chutes`:
+For a required request, the gateway does not forward the prompt unless a verifier returns `verified` and the current request can be sent through an enforced channel binding. An unconstrained request can still run the configured verifier and record its result, but a failed or missing result does not by itself block forwarding.
 
-| Stage | Requests | Result | Rate limit | Latency |
-| --- | ---: | --- | ---: | --- |
-| Cold verification warmup | 1 | 200 | 0 | 138.247s |
-| Fixed 60 rpm | 10 | 10/10 200 | 0 | avg 1.052s, max 1.453s |
-| Fixed 120 rpm | 20 | 20/20 200 | 0 | avg 1.171s, max 2.057s |
-| Burst, concurrency 10 | 25 | 25/25 200 | 0 | avg 1.152s, max 1.649s |
+## Verification keys and scope
 
-The lease/session refresh check used explicit upstream config fields:
-`verification_refresh_seconds: 0`, `session_refresh_seconds: 30`, and
-`chutes_e2ee_discovery_rounds: 3`. It sent two warmed requests 65 seconds
-apart, beyond the local fallback nonce TTL. Both requests stayed fast:
-1.543s and 1.062s. Gateway logs showed background session refreshes at
-05:29:13, 05:29:43, and 05:30:13 UTC with 20, 30, and 10 refreshed nonces.
+The verifier input contains the upstream config name, origin, upstream model identifier, hash of the body that will be forwarded, and whether verification is required.
 
-This is a lower bound, not a ceiling. It proves the warmed path can sustain at
-least a short 120 rpm stage and a 25-request burst without 429s. It does not
-yet prove long-window throughput over many nonce TTL cycles.
+Caching follows the provider's attestation scope:
 
-The main latency split is clear:
+- Router-scoped providers use one verification key for the origin. The model is omitted because all routed models share the same attested channel.
+- Per-model or per-instance providers include the model in the verification key.
 
-- Cold Chutes evidence and verification is very slow: roughly 138-145 seconds
-  in the latest probes.
-- Warmed encrypted invocation is fast: roughly 1 second for the small probe
-  prompts.
+Only successful verification events are cached. Failed verification is returned to the caller and is not stored as a reusable success.
 
-So Chutes evidence verification must stay off the user request path in normal
-operation.
+## Startup and configuration replacement
 
-Non-Chutes live checks also passed:
+After startup, the manager prewarms verification for configured targets. Replacing upstream configuration through the admin API constructs and validates a new runtime snapshot, publishes it, and starts another prewarm.
 
-- Tinfoil verified `kimi-k2-6`, returned one TLS SPKI channel binding, served a
-  real chat completion, and the receipt/report verification example accepted
-  the full response chain.
-- NEAR AI verified `google/gemma-4-31B-it`, returned one TLS SPKI channel
-  binding, served a real chat completion, and the receipt/report verification
-  example accepted the full response chain.
+For a router-scoped upstream, prewarm chooses one deterministic representative model. For per-model providers, it verifies each distinct upstream model.
 
-These providers do not have a separate provider session lease in the current
-implementation. Their lease is the cached verification result plus channel
-binding. The backend enforces the TLS binding against the actual upstream HTTPS
-connection before sending the request.
+A successful prewarm also records the corresponding attested session. This makes the audit surface useful before the first user request. Request-time verification records the same content-addressed session idempotently.
 
-## Terms
+Prewarm results are logged after the background task finishes. They are not
+included in the startup or admin response. A failed prewarm does not prevent
+the process from serving unrelated routes. A later constrained request still
+applies the fail-closed gate.
 
-This implementation has two different kinds of cached state.
+## Cache and background refresh
 
-Verification lease:
+`verifier_cache_seconds` controls the maximum reuse period for provider-verifier results. Its default is 300 seconds.
 
-The cached result of verifying an upstream workload identity and its channel
-binding. A valid verification lease says, "this upstream identity and binding
-were verified under this provider adapter's rules until the verifier cache
-expires." It never authorizes a different transport key.
+`verification_refresh_seconds` controls proactive refresh:
 
-Provider session lease:
+- omitted: refresh at `max(verifier_cache_seconds - 60, 1)` seconds;
+- positive integer: use that interval;
+- `0`: disable proactive refresh for that upstream.
 
-Provider-specific material needed to send requests after the identity has been
-verified. For Chutes this is a pool of single-use invocation nonces, each tied
-to an instance id and E2EE public-key digest. A session lease is only usable
-when it matches a currently verified channel binding.
+The manager runs at the smallest enabled interval and refreshes only upstreams whose policy enables refresh. Refresh bypasses the existing cache. A successful result replaces the cached event; a failed refresh leaves the previous unexpired successful event in place.
 
-Tinfoil and NEAR AI currently have no provider session lease. After
-verification, each request creates a normal HTTPS connection and enforces the
-verified TLS binding on that connection.
+The ACI-service verifier also limits its cached result to the attestation report's `stale_after` timestamp. Its usable lifetime is the earlier of that timestamp and the configured cache deadline.
 
-The session lease is subordinate to the verification lease. Session material
-cannot extend trust after verification expires.
+Cache lifetime is not a promise that a connection remains safe for that duration. Every forward still enforces the cached channel binding against the connection it uses.
 
-Attested session record:
+## Request-time flow
 
-A separate, read-only audit artifact written when a verified upstream event is
-recorded (`record_attested_upstream_session`). The verified material — upstream
-name, endpoint, verifier id, identity, channel bindings, typed claims, and
-evidence — is serialized once; the served bytes are stored, and `session_id` is
-their SHA-256 (spec §8). The id is attached to the receipt. A relying party
-fetches the record from `/v1/aci/sessions/{session_id}` and recomputes the hash to
-confirm it is exactly what the receipt cited.
+For a constrained request, the gateway follows this sequence:
 
-Its `expires_at` bounds validity for new forwarding decisions, not retention.
-The record is a per-receipt historical attestation, so it must stay resolvable
-for as long as any receipt that cites it (the validity period reuses the
-receipt TTL, and retention extends per citation); expiring it with the ~300 s
-lease would strand `session_id`s in still-valid receipts. The record is not a claim that
-the binding is still live now — `established_at` records when it was verified,
-and the forwarding path only ever uses a binding from a fresh verification
-lease.
+1. Resolve the candidate upstream and the body that would be forwarded.
+2. Obtain a cached successful verifier event or perform verification.
+3. Require a verified result.
+4. Derive current attested sessions and apply any `aci_session_ids` allowlist.
+5. Connect through a client that enforces the verified channel binding.
+6. Forward the prompt only after the binding is satisfied.
+7. Record the verification event and selected session in the signed receipt.
 
-## Current No-Middleware Lifecycle
+TLS SPKI bindings are enforced by the pinned TLS client. Chutes E2EE public-key bindings are enforced by the provider backend when it selects and encrypts to a verified instance.
 
-The implementation today is equivalent to the framework's middleware-disabled
-mode: the public frontend and provider backend are one request path in the same
-process. The client `body.model` is both the user-facing model and the target
-route id.
+## Binding mismatch and reverification
 
-Startup:
+A channel-binding mismatch can indicate normal rotation or an attack. The gateway handles it as a state transition that must be reverified:
 
-1. Load the single upstream config file.
-2. Build a provider backend and verifier per configured upstream.
-3. Prewarm upstream verification in the background.
-4. Provider verifiers may record provider session material during prewarm.
+1. Invalidate the cached verifier event owned by the gateway.
+2. Run one fresh verification.
+3. Retry only if the new result verifies and its binding can be enforced.
+4. Treat another mismatch as terminal for that candidate and leave the stale cache entry invalidated.
 
-Request path:
+Caller-supplied verification events are not placed in the gateway cache, so the gateway does not invalidate or silently replace them.
 
-1. Treat the public model id as the target route id.
-2. Rewrite the target route id to the upstream model id.
-3. Verify the selected upstream, usually from a cached verification lease.
-4. Refuse forwarding if verification is required and no verified binding exists.
-5. Forward only through a backend that can enforce the verified binding.
-6. Record the verified upstream event and request/response hashes in the
-   receipt.
+For a request with an explicit session allowlist, the allowlist is applied again to the freshly derived sessions. A rotated binding therefore cannot pass by citing its historical session identifier.
 
-## Framework Lifecycle Target
+## Chutes provider sessions
 
-The frontend/middleware/backend framework keeps the same lease semantics but
-moves responsibility boundaries:
+Chutes has a second lifecycle because its router discovers a changing set of attested instances. `session_refresh_seconds` controls proactive provider-session refresh:
 
-1. Frontend terminates downstream E2EE and records the user-facing request.
-2. Optional middleware sees plaintext and may choose a target route id.
-3. Backend validates the target route id, then runs the same verification lease
-   and provider session lease path described here.
-4. Backend records provider verification and provider-facing forwarding facts in
-   shared request context.
-5. Frontend finalizes the user-facing response and signs the receipt.
+- omitted for Chutes: 45 seconds;
+- positive integer: use that interval;
+- `0`: disable proactive session refresh.
 
-The verifier lease never belongs to middleware. Middleware may request a route;
-backend decides whether that route is configured, verified, and enforceable.
+The refresh job obtains the verified provider event, refreshes model session nonces through the Chutes backend, and records a result per model. If the backend finds a channel-binding mismatch, the manager forces verifier refresh before considering the session refreshed.
 
-Verification refresh:
+This provider-session refresh is separate from the general verifier cache refresh. One maintains instance discovery and nonces; the other renews the attestation result used to authorize those instances.
 
-The background refresh loop renews verification before cache expiry. The
-default cadence is verifier cache TTL minus 60 seconds, so the normal 300
-second cache refreshes every 240 seconds. If an upstream sets
-`verification_refresh_seconds: 0`, it is skipped by the proactive refresh loop.
-When multiple positive intervals exist, the current loop wakes at the shortest
-active interval.
+## Failover interaction
 
-Refresh is non-destructive: a failed refresh does not delete the previous good
-verification lease. User traffic can continue using the old verified identity
-until that cache entry expires.
+Middleware mode can evaluate several candidate routes. Verification failure on a route required to be attested makes that candidate ineligible. The router can try another eligible candidate without forwarding the prompt to the failed one.
 
-Provider session refresh:
+After a request reaches an upstream, the gateway can fail over on configured transient and account-specific statuses: `401`, `402`, `403`, `429`, `500`, `502`, `503`, and `504`. Recognized capacity bodies are also failover signals. Non-basic user tiers can receive one delayed capacity retry within the initial ten-second window.
 
-For Chutes, the default session refresh interval is 45 seconds. Refresh uses
-the cached verified binding to fetch a fresh `/e2e/instances` batch and records
-only nonces whose instance key matches the verified binding. If Chutes returns
-only keys outside the verified set, the refresh asks the verifier to refresh
-evidence and widen the accepted key set.
+Each candidate goes through its own verification and binding checks. A verified event for one upstream never authorizes another.
 
-Chutes nonce use:
+## Operational signals
 
-1. Resolve model id to chute id, cached for 300 seconds.
-2. Pop one unexpired nonce whose instance id and E2EE public-key digest match
-   the verified binding.
-3. If none exists, fetch `/e2e/instances`, filter by the verified binding, and
-   record matching nonces.
-4. Encrypt the OpenAI request body with Chutes ML-KEM-768 + HKDF-SHA256 +
-   ChaCha20-Poly1305 and send `/e2e/invoke`.
-5. Decrypt the buffered or streaming Chutes response before normal ACI receipt
-   hashing.
+Use these surfaces when diagnosing lifecycle behavior:
 
-The nonce pool uses the provider-reported `nonce_expires_in` when present,
-otherwise it uses a local 55 second TTL. Expired nonces are discarded. Nonces
-are single-use locally: popping a nonce removes it from the usable pool.
+- gateway logs for prewarm, refresh, invalidation, and binding-mismatch messages;
+- `GET /v1/aci/sessions` for current materialized sessions;
+- `GET /v1/admin/upstreams` for redacted active configuration and its digest;
+- `GET /v1/metrics` for gateway-owned request metrics;
+- the receipt's `upstream.verified` events for the decision made on a specific request.
 
-## Design Review
-
-The good parts:
-
-- Verification and transport enforcement are separated cleanly. The verifier
-  decides what identity and binding to trust; the backend must prove it can
-  enforce that binding before forwarding.
-- Chutes is handled as a provider adapter, not forced into ACI service. That keeps
-  ACI clean and makes provider adoption practical.
-- Config is the operator-owned source of truth for provider credentials and
-  provider-specific tuning. Verifier commands are not user-configured.
-- Request forwarding is fail-closed when verification is required.
-- Background refresh keeps cold provider evidence latency off the normal
-  request path.
-
-The current compromises:
-
-- Verification refresh scheduling is coarse. The loop wakes at the shortest
-  active configured interval, while individual targets opt in or out. This is
-  simple, but not a precise per-upstream scheduler.
-- Chutes session refresh is only as good as the intersection between the
-  verified E2EE key set and Chutes' sampled `/e2e/instances` response. Multiple
-  discovery rounds improve this, but do not make the provider's sampling
-  deterministic.
-- Chutes verification can record fresh nonces during verifier refresh, but the
-  session refresh result currently reports `refreshed_nonces: 0` for the
-  `refreshed_via_verifier` path. That is an instrumentation gap.
-- All provider sessions are in memory. Restarting the gateway loses warmed
-  nonces and model-id cache, which is acceptable for now because those leases
-  are short-lived.
-- We have short-window throughput lower bounds, not a long-window ceiling.
-
-## Provider verification soundness
-
-A soundness pass (2026-06) tamper-tested each provider's attestation verification
-against the live upstream APIs. Per-provider "how it is verified and bound" references
-live in [`providers/`](providers/README.md). Findings and the resulting state:
-
-- **NEAR AI (TDX):** the quote is verified by the dstack verifier, but the
-  `report_data` binding was being skipped (the check was gated on a field the dstack
-  verifier never returns), so a wrong nonce or a swapped TLS fingerprint still
-  verified. Fixed: `report_data` is now parsed from the verified quote and the nonce
-  + signing-address + TLS-SPKI binding is enforced (fail-closed).
-- **Chutes (TDX):** sound. The quote signature is verified with `dcap_qvl` (real DCAP
-  collateral; `UpToDate` required) and `report_data` binds `SHA256(nonce‖e2e_pubkey)`.
-- **Tinfoil (SEV-SNP, router mode):** the previous hand-rolled `_verify_snp` did **no**
-  AMD signature verification — it only compared the measurement to a public Sigstore
-  value, so a forged report with any `report_data` (TLS-SPKI) passed. Replaced with
-  Tinfoil's official Python verifier (`tinfoil` SDK), which performs the full
-  reference chain: AMD report signature + VCEK→ASK→ARK certificate chain and policy,
-  Sigstore-verified code-measurement provenance bound to the GitHub repo/workflow
-  identity, and the TLS public-key binding. The enforced binding value
-  (`report_data[0:32]`) is unchanged; it is now cryptographically proven. Tamper tests
-  confirm a modified `report_data`, measurement, or signature are all rejected.
-- **NVIDIA GPU (NRAS), all providers:** tokens are fetched online from NRAS over TLS
-  and the request nonce is checked (Chutes via `eat_nonce`, NEAR AI via the component
-  nonce). The JWT signature is not additionally verified against NRAS' JWKS — a
-  defense-in-depth follow-up, not a forgeable hole.
-
-The principle: lean on the hardware/vendor reference verifier (Intel DCAP via
-`dcap_qvl`, AMD via the `tinfoil`/`go-sev-guest` chain, NVIDIA via NRAS) rather than
-re-implementing attestation crypto, and always bind the result to the transport.
-
-## Next Measurements
-
-To understand Chutes throughput better, run a long warmed test across several
-nonce TTLs:
-
-```bash
-python3 scripts/live_e2e/chutes_rate_probe.py \
-  --providers-file /tmp/chutes-gemma-provider.json \
-  --provider chutes \
-  --stage 120@0.5 \
-  --stage 180@0.333 \
-  --burst-concurrency 20 \
-  --warmup 1 \
-  --no-build \
-  --keep-going-after-429 \
-  --port 0
-```
-
-The signal to watch is not just 429s. Also check whether background session
-refresh keeps the nonce pool healthy after the first minute and whether any
-request falls back into slow evidence refresh.
-
-## Open Questions
-
-- P0: preserve this lifecycle across the frontend/backend split with the
-  middleware. The middleware-disabled path must remain
-  behavior-compatible with the direct request path.
-- P0: finish strict-release pins from the provider reports under
-  [providers/](providers/README.md): NEAR AI gateway
-  provenance/runtime policy, Tinfoil router compose/image identity, and Chutes
-  exact model-to-chute resolution. The first-pass soundness reviews are saved,
-  but these provider-specific TODOs still gate general production inclusion.
-- Should verification refresh become a real per-upstream scheduler before we
-  add more providers?
-- Should Chutes expose pool metrics: verified key count, pooled nonce count,
-  nonce refresh success/failure, and channel-binding mismatch count?
-- Should `refreshed_via_verifier` report the number of nonces recorded by the
-  verifier bridge?
-- Should we maintain a small proactive low-watermark refresh in addition to the
-  fixed 45 second session refresh?
-- What sustained Chutes request rate can the current account/model support over
-  10-15 minutes without nonce starvation or provider-side 429s?
+Do not infer a successful current verification from the mere presence of an unexpired session. Sessions are audit artifacts. The request path obtains and enforces current verifier state independently.

--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -110,6 +110,20 @@ Point the gateway at the server:
 
 The public gateway `GET /v1/models` request is relayed to this server as `GET /models`.
 
+## Data boundary
+
+The gateway does not send prompts, responses, raw bearer tokens, or provider
+credentials to the control plane. Pre-consult receives the bearer-token hash,
+public model, the caller's provider-routing object, the TEE-only flag, and
+optional derived features such as token estimates, closed-enum modalities,
+reasoning intent, and a prefix hash. Post-consult receives status, route,
+timing, usage, pricing, and bounded operational error detail.
+
+Treat the caller's provider-routing object and post-consult error detail as
+sensitive metadata. The provider object is forwarded without schema reduction,
+and provider error text can contain request fragments. Do not place prompts or
+secrets in routing fields, and restrict control-plane logs and retention.
+
 ## Authenticate a remote connection
 
 Set a bearer token on both sides:

--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -1,72 +1,132 @@
-# Control plane
+# Minimal Control Plane
 
-A **minimal, config-driven** implementation of the gateway's control plane — the
-decision plane the gateway consults. It exists so the stack runs end-to-end and
-gives a working, testable example of the gateway↔control HTTP surface (the three
-endpoints below).
+This directory contains a config-backed server for local middleware integration. It implements the smallest useful subset of the gateway's control-plane HTTP contract. It is not a production authorization, billing, catalog, or high-availability service.
 
-## What it does
+See the complete [control-plane contract](../../docs/control-plane-contract.md) before implementing another control plane.
 
-- `GET /models` — lists the models from the config.
-- `POST /consult/pre` — `{apiKeyHash?, model, reasoning?}` → allow/deny + pricing
-  + ordered route candidates, all from the config. Denies unknown models; if
-  `keys` is non-empty it requires the request's `apiKeyHash` to be in the list
-  (empty list = anonymous allowed). Reasoning-aware routing is optional and this
-  minimal example does not implement it. A candidate can return
-  `effectiveReasoning` to override the normalized request. Candidates can set
-  `reasoningFormat` to `"reasoning_effort"`, `"reasoning"`,
-  `"chat_template_thinking"`, `"chat_template_enable_thinking"` or
-  `"thinking_type"` (DeepSeek's `thinking: {"type": ...}` switch, with
-  `reasoning_effort` as the level) to select the upstream parameter dialect
-  explicitly. When omitted, the gateway preserves
-  its legacy behavior: managed routes use nested `reasoning`, while SGLang and
-  vLLM routes use `reasoning_effort`.
+## Implemented behavior
 
-  Declaring a dialect also opts the route into reading a caller's
-  `chat_template_kwargs` thinking switch. Some callers can only express "no
-  thinking" that way, and left untranslated the switch reaches the upstream as
-  an opaque key that only a real vLLM/SGLang server acts on — a vendor API
-  behind the same route ignores it and keeps thinking. On a route that declares
-  a dialect, a switch set to `false` is re-encoded in that dialect. An explicit
-  `reasoning`/`reasoning_effort` still wins, and a switch set to `true` is never
-  translated: encoding "on" would have to invent an effort the caller did not
-  ask for.
-- `POST /consult/post` — accepts the usage report and drops it (no billing).
+The example exposes:
 
-No database; configuration only.
+| Route | Behavior |
+| --- | --- |
+| `GET /` | Plain-text liveness response. |
+| `GET /models` | Lists every configured model as an OpenAI-shaped catalog. |
+| `POST /consult/pre` | Checks the optional API-key-hash allowlist, resolves a model, and returns its pricing and ordered candidates, including any route-specific reasoning dialect. |
+| `POST /consult/post` | Parses and discards a usage report, then returns `{"ok":true}`. |
 
-## Config
+When `keys` is missing or empty, anonymous inference is allowed. When it contains hashes, `apiKeyHash` must match one of them.
 
-Reads JSON from `CONTROL_CONFIG_PATH` (default `/etc/pag/control.config.json`).
-See [`control.config.example.json`](./control.config.example.json).
+The example does not implement:
+
+- `/models/*` sub-catalogs;
+- `/embeddings/models`;
+- `tee=true` catalog filtering;
+- `provider.only` or other provider-routing policy;
+- special TEE-only denial behavior;
+- rate limits, spending, durable usage ingestion, or idempotency;
+- config reload;
+- direct TLS or mutual TLS.
+
+Do not use this server as the policy component of a production TEE-only hostname without implementing and testing those missing controls.
+
+## Configure
+
+Copy the example file:
+
+```sh
+cp control.config.example.json control.config.json
+```
+
+The schema is:
+
+```json
+{
+  "keys": ["<lowercase sha256 of an accepted bearer token>"],
+  "models": {
+    "public-model": {
+      "pricing": {
+        "inputCostPerToken": "0.000001",
+        "outputCostPerToken": "0.000002"
+      },
+      "candidates": [
+        {
+          "routeId": "upstream-name:public-model",
+          "format": "openai",
+          "engine": "vllm",
+          "reasoningFormat": "reasoning_effort"
+        }
+      ]
+    }
+  }
+}
+```
+
+`format` must be `openai` or `anthropic`. Optional `engine` must be `sglang` or
+`vllm`. Optional `reasoningFormat` selects `reasoning_effort`, the nested
+`reasoning` object, `chat_template_thinking`,
+`chat_template_enable_thinking`, or `thinking_type`. The last value uses
+DeepSeek's `thinking: {"type": ...}` switch and carries the effort level in
+`reasoning_effort`. When omitted, the gateway uses nested `reasoning` for
+managed routes and `reasoning_effort` for routes with an `engine`.
+
+Declaring a reasoning format also lets the gateway interpret a caller's
+`chat_template_kwargs` thinking switch. A `false` switch is re-encoded in the
+declared upstream dialect. An explicit `reasoning` or `reasoning_effort` value
+wins. A `true` switch is not translated because doing so would require the
+gateway to invent an effort level.
+
+Candidate route IDs must match the active gateway upstream config exactly:
+
+```text
+<upstream name>:<public model ID>
+```
+
+The server reads its config once at startup from `CONTROL_CONFIG_PATH`, defaulting to `/etc/pag/control.config.json`.
 
 ## Run
 
-The control plane listens on a TCP port; the gateway reaches it over HTTP(S) at
-the `middleware.control_url` from its static config.
+Node.js 18 or newer is required.
 
-```bash
-npm install && npm run build
+```sh
+npm ci
+npm run typecheck
+npm run build
+
 CONTROL_CONFIG_PATH=./control.config.example.json \
 PRIVATE_AI_GATEWAY_CONTROL_PORT=8789 \
 node build/server.js
 ```
 
-Then point the gateway at it by setting `middleware.control_url` to
-`http://127.0.0.1:8789` in the static gateway config.
+Point the gateway at the server:
 
-## Remote mode
+```json
+{
+  "middleware": {
+    "control_url": "http://127.0.0.1:8789"
+  }
+}
+```
 
-The control plane can run on a separate host that the gateway reaches over the
-network. The consult payloads carry only request metadata, including
-`apiKeyHash`, `model`, optional normalized `reasoning`, and usage counts.
+The public gateway `GET /v1/models` request is relayed to this server as `GET /models`.
 
-- **Authentication** — set `PRIVATE_AI_GATEWAY_CONTROL_TOKEN` on the control. When
-  set, it enforces `Authorization: Bearer <token>` on `/consult/*` and `/models`;
-  the gateway sends it via `middleware.control_token`. Unset = local dev, no auth.
-- **TLS** — terminate TLS at a reverse proxy in front of this process (the
-  gateway dials `https://…`). The process itself speaks plain HTTP + token, so
-  the code change stays minimal; optional hardening is direct TLS / mTLS.
-- **Availability** — the gateway fails **closed** (503) if the control is
-  unreachable, since the pre-request consult gates authorization. Deploy it near
-  the gateway, with HA.
+## Authenticate a remote connection
+
+Set a bearer token on both sides:
+
+```sh
+export PRIVATE_AI_GATEWAY_CONTROL_TOKEN='<long-random-token>'
+```
+
+```json
+{
+  "middleware": {
+    "control_url": "https://control.example",
+    "control_token": "<same-token>"
+  }
+}
+```
+
+When the server variable is set, it protects `/consult/*` and `/models`. It does not protect the root liveness route. The server itself speaks plain HTTP, so a remote deployment must terminate authenticated TLS at a trusted proxy or run inside another protected transport.
+
+The gateway denies inference with `503` when pre-consult times out, fails transport, returns non-200, or returns invalid JSON. Post-consult delivery is best effort and does not roll back a response already served.

--- a/install-aci.sh
+++ b/install-aci.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+set -eu
+
+repository="Dstack-TEE/private-ai-gateway"
+requested_release="${ACI_VERSION:-latest}"
+
+case "$requested_release" in
+  latest)
+    release_path="latest/download"
+    ;;
+  v[0-9]*)
+    case "$requested_release" in
+      *[!A-Za-z0-9._-]*)
+        echo "ACI_VERSION contains unsupported characters: $requested_release" >&2
+        exit 1
+        ;;
+    esac
+    release_path="download/$requested_release"
+    ;;
+  *)
+    echo "ACI_VERSION must be 'latest' or a tag such as v0.1.0" >&2
+    exit 1
+    ;;
+esac
+
+operating_system="$(uname -s)"
+machine_architecture="$(uname -m)"
+
+case "$operating_system" in
+  Linux)
+    system_target="unknown-linux-musl"
+    ;;
+  Darwin)
+    system_target="apple-darwin"
+    ;;
+  *)
+    echo "aci release binaries do not support $operating_system" >&2
+    exit 1
+    ;;
+esac
+
+case "$machine_architecture" in
+  x86_64 | amd64)
+    rust_architecture="x86_64"
+    ;;
+  arm64 | aarch64)
+    rust_architecture="aarch64"
+    ;;
+  *)
+    echo "aci release binaries do not support architecture $machine_architecture" >&2
+    exit 1
+    ;;
+esac
+
+target="$rust_architecture-$system_target"
+asset="aci-$target"
+release_url="https://github.com/$repository/releases/$release_path"
+
+if [ "${ACI_INSTALL_DIR+x}" = x ]; then
+  install_directory="$ACI_INSTALL_DIR"
+else
+  : "${HOME:?HOME must be set, or set ACI_INSTALL_DIR}"
+  install_directory="$HOME/.local/bin"
+fi
+test -n "$install_directory" || {
+  echo "ACI_INSTALL_DIR must not be empty" >&2
+  exit 1
+}
+
+temporary_directory="$(mktemp -d)"
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+  --fail --silent --show-error --location \
+  "$release_url/$asset" \
+  --output "$temporary_directory/$asset"
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+  --fail --silent --show-error --location \
+  "$release_url/$asset.sha256" \
+  --output "$temporary_directory/$asset.sha256"
+
+expected_digest="$(awk 'NR == 1 {print $1}' "$temporary_directory/$asset.sha256")"
+case "$expected_digest" in
+  '' | *[!0-9a-fA-F]*)
+    echo "release checksum is not a SHA-256 digest" >&2
+    exit 1
+    ;;
+esac
+test "${#expected_digest}" -eq 64 || {
+  echo "release checksum is not a SHA-256 digest" >&2
+  exit 1
+}
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_digest="$(sha256sum "$temporary_directory/$asset" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_digest="$(shasum -a 256 "$temporary_directory/$asset" | awk '{print $1}')"
+else
+  echo "installing aci requires sha256sum or shasum" >&2
+  exit 1
+fi
+
+test "$actual_digest" = "$expected_digest" || {
+  echo "aci checksum verification failed" >&2
+  exit 1
+}
+
+mkdir -p "$install_directory"
+install -m 0755 "$temporary_directory/$asset" "$install_directory/aci"
+
+echo "installed aci to $install_directory/aci"
+case ":${PATH}:" in
+  *:"$install_directory":*)
+    ;;
+  *)
+    echo "add $install_directory to PATH to run aci" >&2
+    ;;
+esac

--- a/scripts/confidential_verifier/VENDOR.md
+++ b/scripts/confidential_verifier/VENDOR.md
@@ -32,7 +32,8 @@ Keep this list current so we can diff against upstream and re-sync deliberately.
 
 To pull upstream fixes, diff this tree against a fresh checkout at a newer commit, re-apply the local
 changes above, update the baseline commit here, and run the bridge contract test
-(`tests/contract_verifier_bridge.py`) plus `run.py --profile quick`.
+(`cargo test --locked --test contract_verifier_bridge`) plus
+`uv run python scripts/live_e2e/run.py --profile quick`.
 
 ## Runtime dependencies
 

--- a/scripts/live_e2e/cases/attested_sessions.py
+++ b/scripts/live_e2e/cases/attested_sessions.py
@@ -83,7 +83,22 @@ def assert_upstream_attested_session(
     if "session_id" in session:
         raise RuntimeError(f"{provider.name} attested session embeds its own id")
     expect_equal(
-        provider, "session.upstream_name", session.get("upstream_name"), provider.name
+        provider,
+        "session.upstream_name",
+        session.get("upstream_name"),
+        provider.name,
+    )
+    expect_equal(
+        provider,
+        "session.upstream_name",
+        session.get("upstream_name"),
+        event.get("upstream_name"),
+    )
+    expect_equal(
+        provider,
+        "session.endpoint",
+        _norm_endpoint(session.get("endpoint")),
+        _norm_endpoint(event.get("url_origin")),
     )
     expect_equal(
         provider,

--- a/scripts/live_e2e/chutes_session_smoke.py
+++ b/scripts/live_e2e/chutes_session_smoke.py
@@ -47,7 +47,11 @@ UPSTREAM_MODEL = "zai-org/GLM-5.1-TEE"
 
 
 def list_sessions() -> list[dict]:
-    r = requests.get(f"{BASE}/v1/aci/sessions", params={"provider": NAME}, timeout=10)
+    r = requests.get(
+        f"{BASE}/v1/aci/sessions",
+        params={"upstream_name": NAME},
+        timeout=10,
+    )
     if r.status_code != 200:
         return []
     return (r.json() or {}).get("sessions", [])

--- a/scripts/live_e2e/router_refresh_smoke.py
+++ b/scripts/live_e2e/router_refresh_smoke.py
@@ -51,7 +51,11 @@ PRESETS = {
 
 def list_sessions(name: str) -> list[dict]:
     try:
-        r = requests.get(f"{BASE}/v1/aci/sessions", params={"provider": name}, timeout=5)
+        r = requests.get(
+            f"{BASE}/v1/aci/sessions",
+            params={"upstream_name": name},
+            timeout=5,
+        )
         if r.status_code == 200:
             return (r.json() or {}).get("sessions", [])
     except Exception:
@@ -97,7 +101,6 @@ def main() -> int:
                     "state_dir": str(state_dir),
                     "upstream_config_seed_path": str(upstream_seed_path),
                     "dstack_endpoint": DEFAULT_DSTACK_ENDPOINT,
-                    "receipt_ttl_seconds": 3600,
                 }
             )
         )

--- a/scripts/live_e2e/router_session_smoke.py
+++ b/scripts/live_e2e/router_session_smoke.py
@@ -103,7 +103,6 @@ def main() -> int:
                     "state_dir": str(state_dir),
                     "upstream_config_seed_path": str(upstream_seed_path),
                     "dstack_endpoint": DEFAULT_DSTACK_ENDPOINT,
-                    "receipt_ttl_seconds": 3600,
                 }
             )
         )

--- a/src/bin/aci/README.md
+++ b/src/bin/aci/README.md
@@ -87,7 +87,7 @@ verifies the DCAP quote and replays RTMR3, but it does not reconstruct MRTD or
 RTMR0-2 from the dstack OS image. Before relying on `policy-os: pass`, run a
 dstack verifier over the same quote, event log, and VM configuration, and
 require `is_valid: true`; that result establishes `os_image_hash` from those
-boot measurements. See [How the OS image is classified](../../../docs/providers/phala-direct/verification.md#how-the-os-image-is-classified).
+boot measurements. See the [Phala-direct verification algorithm](../../../docs/providers/phala-direct/verification.md#verification-algorithm).
 
 ## Where verification lives
 

--- a/src/bin/aci/README.md
+++ b/src/bin/aci/README.md
@@ -38,7 +38,7 @@ Use `aci curl` when you already know the API and want native curl behavior,
 including streaming, uploads, output flags, and authentication:
 
 ```bash
-cargo run --bin aci -- curl https://api.redpill.ai/v1/chat/completions -- \
+cargo run --bin aci -- curl https://tee.redpill.ai/v1/chat/completions -- \
   --header "Authorization: Bearer $API_KEY" \
   --header "content-type: application/json" \
   --data-binary '{
@@ -48,7 +48,7 @@ cargo run --bin aci -- curl https://api.redpill.ai/v1/chat/completions -- \
   }'
 ```
 
-The CLI verifies `https://api.redpill.ai`, prints the verification transcript
+The CLI verifies `https://tee.redpill.ai`, prints the verification transcript
 to stderr, converts the observed SPKI digest to curl's `sha256//...` pin
 format, and starts the installed `curl`. The response stays on stdout, so
 curl output and streaming work normally. If verification or pinning fails,
@@ -71,6 +71,11 @@ inspect or buffer the response.
 fixed accepted set, composed with request pins by intersection, and
 `--require-claim <name[=source]>` derives the pin set from the audited
 current sessions, refreshing it when the service refuses a superseded pin.
+
+`send` requires `X-Receipt-Id` under its default verified-serving constraint.
+With `send --allow-unverified`, an unconstrained stream may start before the
+gateway can name a receipt; the command then uses the response `id` to fetch
+and verify the finalized receipt.
 
 All six commands accept `--require-production-os`. Under that strict policy,
 the client reads the RTMR3-bound `os-image-hash` and requires it to be in the

--- a/src/bin/aci/README.md
+++ b/src/bin/aci/README.md
@@ -4,6 +4,21 @@ The reference command-line client for the ACI protocol
 ([spec/aci.md](../../../spec/aci.md)). It reuses the gateway's own
 verification code and fails closed: exit code 0 means VERIFIED.
 
+Install the latest Linux or macOS release:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/Dstack-TEE/private-ai-gateway/main/install-aci.sh \
+  | sh
+```
+
+The installer supports x86-64 and ARM64, verifies the release SHA-256, and
+installs to `~/.local/bin` by default. Set `ACI_INSTALL_DIR` to choose another
+directory or `ACI_VERSION=v0.1.0` to install a specific release. You also need
+the system `curl`, which `aci curl` runs after verification.
+
+From a source checkout, use Cargo instead:
+
 ```bash
 cargo run --bin aci -- <command> --help
 ```
@@ -14,14 +29,50 @@ cargo run --bin aci -- <command> --help
 | `audit` | The same checks offline, over saved artifacts (report, receipt, bodies, session). |
 | `sessions <url>` | Audit the service's current attested sessions (spec 9.2), optionally under a `--require-claim` policy. The accepted ids are what you pin (spec 5.3). |
 | `send <url>` | One verified chat completion end to end: verify, send over the pinned channel, then verify the receipt and its cited session. |
+| `curl <https-url>` | Verify the URL's ACI service, then run the installed curl with the attested TLS SPKI pinned. |
 | `serve <url>` | Local verifying proxy. Forwards every method and path over the pinned channel, records each POST exchange's digests, and verifies receipts on demand from a control endpoint (default `127.0.0.1:4181`). |
+
+## Run a curl request over the verified channel
+
+Use `aci curl` when you already know the API and want native curl behavior,
+including streaming, uploads, output flags, and authentication:
+
+```bash
+cargo run --bin aci -- curl https://api.redpill.ai/v1/chat/completions -- \
+  --header "Authorization: Bearer $API_KEY" \
+  --header "content-type: application/json" \
+  --data-binary '{
+    "model": "'"$MODEL"'",
+    "messages": [{"role": "user", "content": "Say hi"}],
+    "provider": {"aci_verified": true}
+  }'
+```
+
+The CLI verifies `https://api.redpill.ai`, prints the verification transcript
+to stderr, converts the observed SPKI digest to curl's `sha256//...` pin
+format, and starts the installed `curl`. The response stays on stdout, so
+curl output and streaming work normally. If verification or pinning fails,
+the request body is not sent.
+
+`provider.aci_verified: true` protects the next hop when a gateway can route
+to multiple model runners. It makes the gateway refuse the request unless the
+selected upstream has passed ACI verification. The TLS pin alone protects the
+client-to-gateway connection.
+
+Put curl arguments after `--`. The wrapper reserves URL, redirect, config,
+protocol, transfer-scope, and public-key-pinning options because those options
+could escape the verified transfer. Pass short options and their values as
+separate arguments, for example `-X POST`, not `-XPOST`; grouped short options
+are rejected so they cannot hide a reserved option. Use `aci send` or
+`aci serve` when you also want receipt verification. `aci curl` does not
+inspect or buffer the response.
 
 `serve` pins sessions two ways, both opt-in: `--session <id>` defines a
 fixed accepted set, composed with request pins by intersection, and
 `--require-claim <name[=source]>` derives the pin set from the audited
 current sessions, refreshing it when the service refuses a superseded pin.
 
-All five commands accept `--require-production-os`. Under that strict policy,
+All six commands accept `--require-production-os`. Under that strict policy,
 the client reads the RTMR3-bound `os-image-hash` and requires it to be in the
 verifier's reviewed production-image allowlist. Development and unknown hashes
 fail closed. Updating the allowlist requires a verifier release.

--- a/src/bin/aci/args.rs
+++ b/src/bin/aci/args.rs
@@ -1,15 +1,17 @@
 //! Argument parsing for the `aci` CLI, built on clap's derive API.
 
+use std::ffi::OsString;
+
 use clap::{Args, Parser, Subcommand};
 
 use crate::checks::RequiredClaim;
 
 /// Reference client for the ACI protocol (spec/aci.md).
 ///
-/// Verify a live service, audit saved artifacts offline, or run one
-/// verified chat completion end to end.
+/// Verify a live service, audit saved artifacts offline, or run requests over
+/// an attested, SPKI-pinned channel.
 #[derive(Debug, Parser)]
-#[command(name = "aci")]
+#[command(name = "aci", version)]
 pub struct Cli {
     #[arg(
         long,
@@ -45,6 +47,10 @@ pub enum Command {
                  is also read from the ACI_API_KEY environment variable."
     )]
     Send(SendArgs),
+    #[command(
+        about = "Verify the target's ACI service, then run the system curl with its TLS SPKI pinned."
+    )]
+    Curl(CurlArgs),
     #[command(
         about = "Local verifying proxy (default 127.0.0.1:4180, plain HTTP on localhost). \
                  Verifies the service on startup and refuses to start unless VERIFIED, \
@@ -219,6 +225,27 @@ pub struct SendArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct CurlArgs {
+    #[arg(help = "HTTPS URL to request after its ACI service has been verified.")]
+    pub url: String,
+    #[arg(
+        long = "accept-compose",
+        value_name = "HEX",
+        help = "Compose hash to accept (spec 1.3 verifier policy); repeatable. Without \
+                it the compose measurement is verified and reported, and you appraise \
+                the provenance yourself."
+    )]
+    pub accepted_composes: Vec<String>,
+    #[arg(
+        last = true,
+        allow_hyphen_values = true,
+        value_name = "CURL_ARG",
+        help = "Arguments passed to curl. Put them after `--`; aci owns the URL and transport-security options."
+    )]
+    pub curl_args: Vec<OsString>,
+}
+
+#[derive(Debug, Args)]
 pub struct SessionsArgs {
     #[arg(help = "Base URL of the ACI service whose attested sessions to audit.")]
     pub base_url: String,
@@ -331,5 +358,36 @@ mod tests {
         );
         let err = session_id("not-hex").unwrap_err();
         assert!(err.contains("spec 5.3"), "{err}");
+    }
+
+    #[test]
+    fn curl_args_after_separator_are_passed_through() {
+        let cli = Cli::try_parse_from([
+            "aci",
+            "curl",
+            "https://example.com/v1/chat/completions",
+            "--accept-compose",
+            "abcd",
+            "--",
+            "--header",
+            "content-type: application/json",
+            "--data-binary",
+            "@request.json",
+        ])
+        .unwrap();
+        let Command::Curl(args) = cli.command else {
+            panic!("expected curl command");
+        };
+        assert_eq!(args.accepted_composes, ["abcd"]);
+        assert_eq!(
+            args.curl_args,
+            [
+                "--header",
+                "content-type: application/json",
+                "--data-binary",
+                "@request.json",
+            ]
+            .map(OsString::from)
+        );
     }
 }

--- a/src/bin/aci/curl.rs
+++ b/src/bin/aci/curl.rs
@@ -1,0 +1,302 @@
+//! `aci curl`: verify an ACI origin, then delegate the request to curl.
+//!
+//! The ACI client performs the attestation checks and records the TLS leaf's
+//! SPKI. The system curl handles the actual request with that SPKI pinned, so
+//! uploads, downloads, streaming, authentication, and output behave like curl.
+
+use std::ffi::{OsStr, OsString};
+use std::process::{Command, ExitStatus};
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+use crate::args::CurlArgs;
+use crate::verify::verify_service;
+
+const CURL_SECURITY_ARGS: [&str; 5] = [
+    "--proto",
+    "=https",
+    "--proto-redir",
+    "=https",
+    "--pinnedpubkey",
+];
+
+const RESERVED_LONG_OPTIONS: [&str; 8] = [
+    "--pinnedpubkey",
+    "--proto",
+    "--proto-redir",
+    "--url",
+    "--config",
+    "--next",
+    "--location",
+    "--location-trusted",
+];
+
+pub async fn run(args: CurlArgs, require_production_os: bool) -> Result<i32, String> {
+    let (url, origin) = request_url_and_origin(&args.url)?;
+    validate_curl_args(&args.curl_args)?;
+
+    let verification = verify_service(
+        &origin,
+        None,
+        &args.accepted_composes,
+        require_production_os,
+        false,
+    )
+    .await?;
+
+    eprintln!("== ACI verification: {origin} ==");
+    eprint!("{}", verification.transcript.render_human(false));
+    if !verification.transcript.verified() {
+        return Err("service verification failed; curl was not started (fail closed)".into());
+    }
+
+    let observed_spki = verification
+        .observed_spki
+        .as_deref()
+        .ok_or("verified service has no observed TLS SPKI; curl was not started")?;
+    let pin = curl_spki_pin(observed_spki)?;
+    eprintln!("PINNED      curl -> attested TLS key");
+
+    let command_args = curl_command_args(&url, &pin, &args.curl_args);
+    run_curl(OsStr::new("curl"), &command_args)
+}
+
+fn request_url_and_origin(value: &str) -> Result<(String, String), String> {
+    let url =
+        reqwest::Url::parse(value).map_err(|e| format!("invalid request URL {value:?}: {e}"))?;
+    if url.scheme() != "https" {
+        return Err(format!(
+            "request URL must use https so the attested TLS key can be pinned: {value:?}"
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("request URL must not contain credentials; pass authentication to curl".into());
+    }
+    if url.fragment().is_some() {
+        return Err("request URL must not contain a fragment".into());
+    }
+    if url.host_str().is_none() {
+        return Err(format!("request URL {value:?} has no host"));
+    }
+
+    Ok((url.to_string(), url.origin().ascii_serialization()))
+}
+
+fn curl_spki_pin(spki_sha256_hex: &str) -> Result<String, String> {
+    let digest = hex::decode(spki_sha256_hex)
+        .map_err(|e| format!("attested TLS SPKI digest is not valid hex: {e}"))?;
+    if digest.len() != 32 {
+        return Err(format!(
+            "attested TLS SPKI digest has {} bytes, expected 32",
+            digest.len()
+        ));
+    }
+    Ok(format!("sha256//{}", BASE64.encode(digest)))
+}
+
+/// Reject options that could replace the verified URL, pin, protocol policy,
+/// or curl option scope. Everything else remains native curl behavior.
+fn validate_curl_args(args: &[OsString]) -> Result<(), String> {
+    for arg in args {
+        let value = arg
+            .to_str()
+            .ok_or("curl arguments must be valid UTF-8 so security options can be validated")?;
+        if value.starts_with('-') && !value.starts_with("--") && value != "-" && value.len() != 2 {
+            return Err(format!(
+                "curl argument {value:?} groups a short option or attaches its value; \
+                 pass each short option and value as separate arguments so aci can validate them"
+            ));
+        }
+        let long_name = value.split_once('=').map_or(value, |(name, _)| name);
+        // curl accepts unambiguous long-option abbreviations. Reject every
+        // prefix of a reserved option so `--pinnedp`, for example, cannot
+        // replace the attested pin on curl versions where it is unambiguous.
+        let reserved_long = long_name.starts_with("--")
+            && RESERVED_LONG_OPTIONS
+                .iter()
+                .any(|reserved| reserved.starts_with(long_name));
+        let reserved = reserved_long || matches!(value, "-K" | "-:" | "-L");
+
+        if reserved {
+            return Err(format!(
+                "curl argument {value:?} is managed by aci and cannot be overridden"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn curl_command_args(url: &str, pin: &str, user_args: &[OsString]) -> Vec<OsString> {
+    let mut args = Vec::with_capacity(7 + user_args.len());
+    // `-q` must be curl's first argument to disable the implicit curlrc, which
+    // could otherwise introduce another URL or transfer scope before our pin.
+    args.push(OsString::from("-q"));
+    args.extend(CURL_SECURITY_ARGS.map(OsString::from));
+    args.push(OsString::from(pin));
+    args.extend(user_args.iter().cloned());
+    args.push(OsString::from(url));
+    args
+}
+
+fn run_curl(curl_binary: &OsStr, args: &[OsString]) -> Result<i32, String> {
+    let status = Command::new(curl_binary)
+        .args(args)
+        .status()
+        .map_err(|e| format!("failed to start system curl: {e}"))?;
+    Ok(exit_code(status))
+}
+
+fn exit_code(status: ExitStatus) -> i32 {
+    status.code().unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn derives_origin_from_https_request_url() {
+        let (url, origin) =
+            request_url_and_origin("https://Example.COM:8443/v1/chat/completions?q=1").unwrap();
+        assert_eq!(url, "https://example.com:8443/v1/chat/completions?q=1");
+        assert_eq!(origin, "https://example.com:8443");
+    }
+
+    #[test]
+    fn rejects_urls_that_cannot_be_safely_pinned() {
+        assert!(request_url_and_origin("http://example.com/v1/models").is_err());
+        assert!(request_url_and_origin("https://user@example.com/v1/models").is_err());
+        assert!(request_url_and_origin("https://example.com/v1/models#response").is_err());
+    }
+
+    #[test]
+    fn converts_hex_digest_to_curl_pin() {
+        assert_eq!(
+            curl_spki_pin(&"00".repeat(32)).unwrap(),
+            "sha256//AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        );
+        assert!(curl_spki_pin("00").is_err());
+        assert!(curl_spki_pin("not-hex").is_err());
+    }
+
+    #[test]
+    fn rejects_curl_options_that_can_escape_the_verified_transfer() {
+        for arg in [
+            "--pinnedpubkey",
+            "--pinnedpubkey=sha256//other",
+            "--pinnedp",
+            "--proto",
+            "--proto-r=all",
+            "--proto-redir=all",
+            "--url=https://other.example",
+            "--confi",
+            "--config",
+            "--next",
+            "-:",
+            "--location",
+            "--locatio",
+            "--location-trusted",
+            "--location-t",
+            "-L",
+        ] {
+            let err = validate_curl_args(&[OsString::from(arg)]).unwrap_err();
+            assert!(err.contains("managed by aci"), "{arg}: {err}");
+        }
+        validate_curl_args(&[
+            OsString::from("--header"),
+            OsString::from("Authorization: Bearer token"),
+            OsString::from("--data-binary"),
+            OsString::from("@request.json"),
+            OsString::from("--upload-file"),
+            OsString::from("payload.bin"),
+            OsString::from("--proto-default"),
+            OsString::from("https"),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_grouped_and_attached_short_options() {
+        for arg in [
+            "-sS",
+            "-Kfile",
+            "-sKconfig",
+            "-sL",
+            "-XPOST",
+            "-Haccept:json",
+        ] {
+            let err = validate_curl_args(&[OsString::from(arg)]).unwrap_err();
+            assert!(err.contains("separate arguments"), "{arg}: {err}");
+        }
+        validate_curl_args(&[
+            OsString::from("-s"),
+            OsString::from("-S"),
+            OsString::from("-X"),
+            OsString::from("POST"),
+            OsString::from("-H"),
+            OsString::from("accept: application/json"),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn builds_a_curl_command_with_config_disabled_and_pin_applied() {
+        let args = curl_command_args(
+            "https://example.com/v1/models",
+            "sha256//pin",
+            &[OsString::from("--silent")],
+        );
+        let expected = [
+            "-q",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--pinnedpubkey",
+            "sha256//pin",
+            "--silent",
+            "https://example.com/v1/models",
+        ];
+        assert_eq!(
+            args.iter().map(OsString::as_os_str).collect::<Vec<_>>(),
+            expected.map(OsStr::new)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runs_external_curl_and_preserves_its_exit_code() {
+        let directory = tempfile::tempdir().unwrap();
+        let fake_curl = directory.path().join("curl");
+        fs::write(
+            &fake_curl,
+            "#!/bin/sh\n[ \"$1\" = \"-q\" ] || exit 91\n[ \"$2\" = \"--silent\" ] || exit 92\nexit 23\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&fake_curl).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_curl, permissions).unwrap();
+
+        let code = run_curl(
+            fake_curl.as_os_str(),
+            &[OsString::from("-q"), OsString::from("--silent")],
+        )
+        .unwrap();
+        assert_eq!(code, 23);
+    }
+
+    #[test]
+    fn reports_when_curl_cannot_be_started() {
+        let err = run_curl(
+            OsStr::new("/path/that/does/not/contain/curl"),
+            &[OsString::from("--version")],
+        )
+        .unwrap_err();
+        assert!(err.contains("failed to start system curl"), "{err}");
+    }
+}

--- a/src/bin/aci/main.rs
+++ b/src/bin/aci/main.rs
@@ -1,13 +1,14 @@
 //! `aci` — reference client for the ACI protocol (`spec/aci.md`).
 //!
-//! Verify a live service, audit saved artifacts offline, or run one
-//! verified chat completion end to end.
+//! Verify a live service, audit saved artifacts offline, or run requests over
+//! an attested, SPKI-pinned channel.
 
 mod args;
 mod audit;
 mod capture;
 mod checks;
 mod client;
+mod curl;
 mod send;
 mod serve;
 mod sessions;
@@ -37,6 +38,7 @@ async fn run() -> Result<i32, String> {
         args::Command::Audit(a) => audit::run(a, args.require_production_os).await,
         args::Command::Sessions(a) => sessions::run(a, args.require_production_os).await,
         args::Command::Send(a) => send::run(a, args.require_production_os).await,
+        args::Command::Curl(a) => curl::run(a, args.require_production_os).await,
         args::Command::Serve(a) => serve::run(a, args.require_production_os).await,
     }
 }

--- a/src/bin/aci/verify.rs
+++ b/src/bin/aci/verify.rs
@@ -14,9 +14,9 @@ use crate::checks::{
 use crate::client::{host_of, normalize_base_url, random_nonce_hex, AciClient};
 use crate::transcript::Transcript;
 
-/// Everything `aci send` and `aci serve` need after a full online
-/// verify: the transcript, the report, and the client that observed the
-/// channel (ready to have the attested SPKI pinned).
+/// Everything `aci send`, `aci curl`, and `aci serve` need after a full online
+/// verify: the transcript, the report, and the client that observed the channel
+/// (ready to have the attested SPKI pinned).
 pub struct ServiceVerification {
     pub transcript: Transcript,
     pub report: AttestationReport,

--- a/tests/install_aci.sh
+++ b/tests/install_aci.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -eu
+
+repository_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+cleanup() {
+  rm -rf "$test_directory"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+fake_bin="$test_directory/bin"
+payload="$test_directory/payload"
+checksum="$test_directory/checksum"
+install_directory="$test_directory/install"
+mkdir -p "$fake_bin"
+printf '%s\n' 'fake aci release binary' >"$payload"
+
+asset="aci-x86_64-unknown-linux-musl"
+digest="$(sha256sum "$payload" | awk '{print $1}')"
+printf '%s  %s\n' "$digest" "$asset" >"$checksum"
+
+cat >"$fake_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+case "$url" in
+  *.sha256)
+    cp "$ACI_INSTALLER_TEST_CHECKSUM" "$output"
+    ;;
+  *)
+    cp "$ACI_INSTALLER_TEST_PAYLOAD" "$output"
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/curl"
+
+PATH="$fake_bin:$PATH" \
+  ACI_INSTALLER_TEST_PAYLOAD="$payload" \
+  ACI_INSTALLER_TEST_CHECKSUM="$checksum" \
+  ACI_INSTALL_DIR="$install_directory" \
+  ACI_VERSION=v0.1.0 \
+  sh "$repository_root/install-aci.sh"
+
+cmp "$payload" "$install_directory/aci"
+test -x "$install_directory/aci"
+
+printf '%064d  %s\n' 0 "$asset" >"$checksum"
+bad_install_directory="$test_directory/bad-install"
+if PATH="$fake_bin:$PATH" \
+  ACI_INSTALLER_TEST_PAYLOAD="$payload" \
+  ACI_INSTALLER_TEST_CHECKSUM="$checksum" \
+  ACI_INSTALL_DIR="$bad_install_directory" \
+  ACI_VERSION=v0.1.0 \
+  sh "$repository_root/install-aci.sh"; then
+  echo "installer accepted a mismatched checksum" >&2
+  exit 1
+fi
+test ! -e "$bad_install_directory/aci"
+
+echo "aci installer tests passed"

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -69,7 +69,7 @@ impl SessionStore for FailingSessionStore {
         None
     }
 
-    fn list_sessions(&self, _provider: Option<&str>, _now: u64) -> Vec<AttestedSession> {
+    fn list_sessions(&self, _upstream_name: Option<&str>, _now: u64) -> Vec<AttestedSession> {
         Vec::new()
     }
 }


### PR DESCRIPTION
## Summary

- rebuild the root README around the private-inference user journey: familiar LLM API, concrete privacy claim, and independently verifiable proof
- reorganize the documentation for evaluators, client developers, operators, control-plane implementers, and contributors
- align configuration, provider verification, deployment, testing, roadmap, and review docs with the current code
- add `aci curl`, which verifies the ACI service and then runs the system curl over the attested SPKI-pinned channel
- add a checksum-verifying installer, installer tests, and a tagged Linux/macOS release workflow

## Why

Most users already understand OpenAI-compatible APIs. The README now gets them to a normal `/v1/chat/completions` request quickly, while showing why the path is private: the client verifies the gateway workload and pins its attested TLS key, and `provider.aci_verified` makes the gateway fail closed unless the model backend and forwarding binding verify too.

The deeper deployment and audit paths remain available without putting their setup cost in front of API consumers.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `sh -n install-aci.sh tests/install_aci.sh`
- `shellcheck install-aci.sh tests/install_aci.sh`
- `sh tests/install_aci.sh`
- `actionlint` on both GitHub workflows
- local-link validation across all changed Markdown files
- release build for `x86_64-unknown-linux-musl`, including strip and version check
- live `aci curl https://api.redpill.ai/v1/models`: verified the TDX quote and measured compose, matched and pinned the attested TLS SPKI, and returned the model catalog

## Deferred

- `npm ci` and the TypeScript verifier suite were intentionally not run in this pass.
- The first `v0.1.0` tag should be created after merge so the new workflow can publish the installer assets.