### PR TITLE
Add thinking_type: DeepSeek's reasoning switch as a route dialect

### DIFF
--- a/examples/control-plane/README.md
+++ b/examples/control-plane/README.md
@@ -15,8 +15,10 @@ endpoints below).
   minimal example does not implement it. A candidate can return
   `effectiveReasoning` to override the normalized request. Candidates can set
   `reasoningFormat` to `"reasoning_effort"`, `"reasoning"`,
-  `"chat_template_thinking"` or `"chat_template_enable_thinking"` to select the
-  upstream parameter dialect explicitly. When omitted, the gateway preserves
+  `"chat_template_thinking"`, `"chat_template_enable_thinking"` or
+  `"thinking_type"` (DeepSeek's `thinking: {"type": ...}` switch, with
+  `reasoning_effort` as the level) to select the upstream parameter dialect
+  explicitly. When omitted, the gateway preserves
   its legacy behavior: managed routes use nested `reasoning`, while SGLang and
   vLLM routes use `reasoning_effort`.
 

--- a/examples/control-plane/src/config.ts
+++ b/examples/control-plane/src/config.ts
@@ -25,7 +25,8 @@ export interface RouteCandidate {
     | 'reasoning_effort'
     | 'reasoning'
     | 'chat_template_thinking'
-    | 'chat_template_enable_thinking';
+    | 'chat_template_enable_thinking'
+    | 'thinking_type';
 }
 
 export interface ModelEntry {

--- a/src/middleware/request_transform.rs
+++ b/src/middleware/request_transform.rs
@@ -256,6 +256,12 @@ fn candidate_params(
     for key in ["reasoning", "reasoning_effort", "include_reasoning"] {
         object.remove(key);
     }
+    // On the OpenAI wire `thinking` is the thinking_type dialect's key, written
+    // below from the effective reasoning and never taken from the caller. On
+    // the Anthropic wire it is the caller's own control and passes through.
+    if candidate.format == ProviderFormat::Openai {
+        object.remove("thinking");
+    }
     let Some(effective) = effective else {
         return Ok(params);
     };
@@ -294,6 +300,25 @@ fn candidate_params(
         }
         (ProviderFormat::Openai, ReasoningFormat::ChatTemplateEnableThinking) => {
             set_chat_template_reasoning(object, &effective, candidate, "enable_thinking")?;
+        }
+        (ProviderFormat::Openai, ReasoningFormat::ThinkingType) => {
+            if effective.max_tokens.is_some() {
+                return invalid_reasoning(candidate, "cannot represent max_tokens");
+            }
+            let Some(enabled) = reasoning_enabled(&effective) else {
+                return invalid_reasoning(candidate, "reasoning configuration is empty");
+            };
+            object.insert(
+                "thinking".to_string(),
+                json!({ "type": if enabled { "enabled" } else { "disabled" } }),
+            );
+            // The level only means something next to an enabled switch.
+            if let Some(effort) = effective.effort.filter(|_| enabled) {
+                object.insert(
+                    "reasoning_effort".to_string(),
+                    Value::String(effort.as_str().to_string()),
+                );
+            }
         }
         (ProviderFormat::Anthropic, _) => return invalid_reasoning(candidate, "has no adapter"),
     }
@@ -1218,6 +1243,7 @@ fn openai_chat_complete_config(engine: Option<Engine>) -> ProviderConfig {
         "prediction",
         "reasoning",
         "reasoning_effort",
+        "thinking",
         "web_search_options",
         "prompt_cache_key",
         "safety_identifier",
@@ -1841,6 +1867,96 @@ mod tests {
             assert!(body.get("reasoning_effort").is_none());
             assert!(body.get("reasoning").is_none());
         }
+    }
+
+    /// DeepSeek's dialect: `thinking.type` is the switch, `reasoning_effort`
+    /// the level. The switch is always written; the level only next to an
+    /// enabled switch; a budget cannot be expressed at all.
+    #[test]
+    fn thinking_type_reasoning_format_writes_switch_and_level() {
+        let candidate: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "vendor:m",
+            "format": "openai",
+            "reasoningFormat": "thinking_type",
+        }))
+        .unwrap();
+        let shape = |request: Value| {
+            let (params, requested, _) =
+                crate::middleware::reasoning::normalize_chat_request(&request).unwrap();
+            build_candidates(
+                &params,
+                Endpoint::ChatComplete,
+                std::slice::from_ref(&candidate),
+                requested.as_ref(),
+            )
+            .map(|bodies| bodies[0].1.clone())
+        };
+        let base = json!({ "model": "m", "messages": [{ "role": "user", "content": "hi" }] });
+        let with = |field: &str, value: Value| {
+            let mut request = base.clone();
+            request[field] = value;
+            request
+        };
+
+        for (request, thinking, effort) in [
+            (with("reasoning_effort", "none".into()), "disabled", None),
+            (
+                with("reasoning", json!({ "enabled": false })),
+                "disabled",
+                None,
+            ),
+            (
+                with("reasoning", json!({ "effort": "high" })),
+                "enabled",
+                Some("high"),
+            ),
+            (
+                with("reasoning", json!({ "enabled": true })),
+                "enabled",
+                None,
+            ),
+            // A caller's chat-template switch is read as intent on a route
+            // that declares a dialect, and lands in this dialect.
+            (
+                with(
+                    "chat_template_kwargs",
+                    json!({ "thinking": false, "enable_thinking": false }),
+                ),
+                "disabled",
+                None,
+            ),
+        ] {
+            let body = shape(request.clone()).unwrap();
+            assert_eq!(body["thinking"], json!({ "type": thinking }), "{request}");
+            assert_eq!(
+                body.get("reasoning_effort").and_then(Value::as_str),
+                effort,
+                "{request}"
+            );
+            assert!(body.get("reasoning").is_none(), "{request}");
+        }
+
+        // A budget has no encoding on this wire.
+        assert!(shape(with("reasoning", json!({ "max_tokens": 512 }))).is_err());
+
+        // With nothing to say the switch stays absent, and a caller-supplied
+        // `thinking` does not stand in for it: on the OpenAI wire the gateway
+        // owns that key. On the Anthropic wire it is the caller's own control
+        // and still passes through.
+        let callers = with(
+            "thinking",
+            json!({ "type": "enabled", "budget_tokens": 1024 }),
+        );
+        let body = shape(callers.clone()).unwrap();
+        assert!(body.get("thinking").is_none());
+        let anthropic: RouteCandidate = serde_json::from_value(json!({
+            "routeId": "anthropic:m",
+            "format": "anthropic",
+        }))
+        .unwrap();
+        let bodies =
+            build_candidates(&callers, Endpoint::ChatComplete, &[anthropic], None).unwrap();
+        assert_eq!(bodies[0].1["thinking"]["budget_tokens"], 1024);
     }
 
     #[test]

--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -33,6 +33,9 @@ pub enum Engine {
 /// OpenAI Chat Completions uses `reasoning_effort`. Some OpenAI-compatible
 /// providers instead expose a richer nested `reasoning` object, so candidates
 /// can opt into that dialect explicitly.
+///
+/// `thinking_type` is DeepSeek's shape: `thinking: {"type": "enabled" |
+/// "disabled"}` is the switch and `reasoning_effort` the level.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 pub enum ReasoningFormat {
     #[serde(rename = "reasoning_effort")]
@@ -43,6 +46,8 @@ pub enum ReasoningFormat {
     ChatTemplateThinking,
     #[serde(rename = "chat_template_enable_thinking")]
     ChatTemplateEnableThinking,
+    #[serde(rename = "thinking_type")]
+    ThinkingType,
 }
 
 /// Canonical public/control reasoning effort.


### PR DESCRIPTION
## Why

Some OpenAI-compatible DeepSeek deployments take `reasoning_effort: "none"` as advice rather than a switch: a prompt that asks the model to think overrides it. On those APIs `thinking.type` is the only hard off. Measured on one such deployment with `max_tokens: 4`, reading `prompt_tokens` (the chat template renders ~79 extra tokens of thinking scaffold when thinking is on):

| messages | no param | `reasoning_effort:"none"` | `thinking:{type:"disabled"}` |
|---|---|---|---|
| one plain user turn | 96 (on) | 17 (off) | 17 (off) |
| "Please think and answer…" | 91 (on) | **91 (on, ignored)** | 12 (off) |

`thinking:{type:"disabled"}` + `reasoning_effort:"high"` → off (the switch wins); `thinking:{type:"enabled"}` + any effort value → 200 and on.

## What

A fifth `ReasoningFormat`, `thinking_type`, for DeepSeek's wire shape: always write `thinking: {"type": "enabled" | "disabled"}` from the effective reasoning; add `reasoning_effort` alongside only when thinking is on and an effort was given. A budget (`max_tokens`) has no encoding on this wire and is rejected the way the `reasoning_effort` dialect rejects it.

Two small things to make that stick:

- `thinking` joins the OpenAI chat pass-through list so the encoded value survives `transform_to_provider_request`. It is only ever our value: on OpenAI-format candidates `candidate_params` now strips a caller's `thinking` along with `reasoning`/`reasoning_effort`/`include_reasoning`. That is behaviour-preserving — a caller's `thinking` was never on that list, so it never reached an OpenAI-format upstream over this path before and still does not. Anthropic-format candidates are untouched: there `thinking` is the caller's own control and keeps passing through (pinned by the test).
- On a route that declares this dialect, a caller's switched-off `chat_template_kwargs` is read as intent (existing #143 behaviour) and now lands as `thinking:{type:"disabled"}`.

Nothing changes for routes that do not opt in; a control plane selects the dialect per candidate via `reasoningFormat: "thinking_type"`.

## Test

- New `thinking_type_reasoning_format_writes_switch_and_level` covers `effort:none`, `enabled:false`, `effort:high`, `enabled:true`, the derived chat-template switch, the `max_tokens` rejection, that a caller's `thinking` does not stand in for ours on the OpenAI wire, and that it still passes through on the Anthropic wire.
- `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check` clean.
