### PR TITLE
Report identity-bearing consult denials and the no-route 404 to the usage pipeline

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -73,7 +73,12 @@ pipeline) emits a `request_outcome` tracing line carrying the client-facing
 and upstream status, route, attempt chain length, TTFT/duration, finish
 reasons, and terminal marker. Requests rejected before that path — malformed
 JSON, oversized bodies, E2EE setup failures — do not produce lines, so
-complete request accounting still needs the usage pipeline. A request emits
+complete request accounting still needs the usage pipeline. Consult denials
+that carry a key identity (`userId` on the pre-consult response), every
+429/5xx denial, and the no-route 404 are also reported to the usage
+pipeline (`errorSource: "control"`, no route) so the control plane can
+account for them; unauthenticated denials (401/402/403) are trace-only. A
+request emits
 at most one primary line; a late receipt/E2EE finalization failure appends
 one supplemental `phase=finalize_error` line for the same `request_id`
 (aggregate by unique request id, letting `finalize_error` supersede).

--- a/src/middleware/completion.rs
+++ b/src/middleware/completion.rs
@@ -384,10 +384,13 @@ pub async fn run(
                 &detail_snippet(message.as_bytes()),
             );
         }
-        // Record 5xx and 429 denials as gateway failures; other user denials
-        // (401/402/404) are caller-attributable and left unrecorded. Tagging
-        // these ErrorSource::Control keeps them out of upstream-health signals.
-        if status == 429 || status >= 500 {
+        // Report every denial the control plane could attribute to a key
+        // (identity present), plus 429/5xx regardless. Unauthenticated
+        // denials (401/402/403, malformed-body 400) stay unreported: a report
+        // without identity is unattributable and a scanner would otherwise
+        // flood the usage pipeline. ErrorSource::Control keeps these out of
+        // upstream-health signals.
+        if consult.user_id.is_some() || status == 429 || status >= 500 {
             meter.gateway_failure(status, ErrorSource::Control, message, stream);
         }
         if status == 429 {
@@ -425,6 +428,9 @@ pub async fn run(
                 "",
             );
         }
+        // The control plane answered with nothing to route to; report it as
+        // its failure so the request is accounted for, like a denial.
+        meter.gateway_failure(404, ErrorSource::Control, &message, stream);
         let body = errors::envelope_bytes(surface, "model_not_found", &message, Some(&request_id));
         return finalize_generated(404, body, &[], e2ee, outcome_ctx);
     }

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -590,6 +590,55 @@ async fn denial_returns_forbidden_envelope() {
 }
 
 #[tokio::test]
+async fn identity_bearing_denial_is_reported_as_a_control_failure() {
+    // A 4xx denial the control plane attributed to a key must reach the
+    // usage pipeline: reported with errorSource "control", the identity, and
+    // no route — not a 5xx, not a 429, yet still accounted for.
+    let (control_url, posts) = spawn_control_capturing(
+        200,
+        json!({
+            "allow": false,
+            "status": 400,
+            "message": "This model does not support image input.",
+            "userId": 7,
+            "virtualKeyId": 3
+        }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let service = build_service();
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, chat_input()).await).await;
+    assert_eq!(status, 400);
+
+    let report = wait_for_post(&posts, |r| r["status"].as_i64() == Some(400)).await;
+    assert_eq!(report["errorSource"], json!("control"));
+    assert_eq!(report["userId"], json!(7));
+    assert_eq!(report["virtualKeyId"], json!(3));
+    assert!(report["selectedRouteId"].is_null());
+    assert!(report["usage"].is_null());
+}
+
+#[tokio::test]
+async fn empty_candidates_is_reported_as_a_control_failure() {
+    let (control_url, posts) = spawn_control_capturing(
+        200,
+        json!({ "allow": true, "candidates": [], "userId": 7, "virtualKeyId": 3 }),
+    )
+    .await;
+    let mw = middleware(control_url);
+    let service = build_service();
+
+    let (status, _, _) = response_parts(mw.handle_completion(&service, chat_input()).await).await;
+    assert_eq!(status, 404);
+
+    let report = wait_for_post(&posts, |r| r["status"].as_i64() == Some(404)).await;
+    assert_eq!(report["errorSource"], json!("control"));
+    assert_eq!(report["userId"], json!(7));
+    assert!(report["selectedRouteId"].is_null());
+}
+
+#[tokio::test]
 async fn control_unavailable_fails_closed() {
     // Unreachable control plane -> consult_pre fails closed with a 503 denial.
     let mw = middleware("http://127.0.0.1:1".to_string());


### PR DESCRIPTION
## Why

`completion.rs` reported a consult denial to `consult/post` only for 429 and 5xx; every other denial (400/401/402/403/404) was a `request_outcome` tracing line and nothing else. A control plane that refuses a whole class of requests with a 400/404 (a capability rule fed wrong model metadata, say) therefore leaves no trace in the usage pipeline and is found by accident.

## What

- `completion.rs` deny branch: report when `consult.user_id.is_some() || status == 429 || status >= 500`, `ErrorSource::Control` as before. Identity is the gate rather than a status list: denials the control plane attributed to a key carry `userId`; 401/402/403 and malformed-body 400s do not, and stay trace-only so a scanner cannot flood the pipeline with unattributable reports.
- Empty-candidates 404 (`model_not_found`) is reported too — the second unreported 4xx on this path.
- `docs/configuration-reference.md` observability paragraph updated.

Reports carry `errorSource: "control"` and no route, the same shape as the 429/5xx denial reports a control plane already receives, so nothing new is attributed to upstream health.

## Tests

`tests/middleware_completion.rs` +2: identity-bearing 400 → a post with `errorSource: "control"`, `userId`, `virtualKeyId`, null route/usage; empty candidates → 404 post with `errorSource: "control"`. Full suite green, `cargo fmt`/`clippy` clean.