### PR TITLE
Reap downstream-stalled streams on the public entry, not just the UDS hop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,8 @@ dependencies = [
  "hex",
  "hkdf",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "k256",
  "ml-kem",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = "0.3"
 # Serving the public entry directly (rather than via axum::serve) is what lets the
 # connection IO be wrapped with a write-idle timeout; axum 0.7 takes a concrete
 # TcpListener and offers no hook for that. Deliberately NOT hyper-util's
-# `server-auto`: it would pull in hyper/http2, and Cargo unifies features
+# `server-auto`: it would enable hyper-util/http2, and Cargo unifies features
 # crate-wide, so every axum::serve here would start negotiating HTTP/2 — where
 # flow control means a stalled reader never blocks the socket write and the
 # timeout below could never arm.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,15 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 futures-util = "0.3"
+# Serving the public entry directly (rather than via axum::serve) is what lets the
+# connection IO be wrapped with a write-idle timeout; axum 0.7 takes a concrete
+# TcpListener and offers no hook for that. Deliberately NOT hyper-util's
+# `server-auto`: it would pull in hyper/http2, and Cargo unifies features
+# crate-wide, so every axum::serve here would start negotiating HTTP/2 — where
+# flow control means a stalled reader never blocks the socket write and the
+# timeout below could never arm.
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "service"] }
 async-stream = "0.3"
 
 # HTTP client (upstream forwarding). Rustls with native roots keeps TLS

--- a/src/http/app/mod.rs
+++ b/src/http/app/mod.rs
@@ -67,6 +67,11 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use hyper::body::Incoming;
+use hyper::server::conn::http1::Builder as HyperHttp1Builder;
+use hyper_util::rt::TokioIo;
+use hyper_util::service::TowerToHyperService;
+use tower::ServiceExt as _;
 use tower_http::cors::CorsLayer;
 
 /// Request-body cap for the inference surface. Multimodal chat payloads with
@@ -84,6 +89,7 @@ mod backend;
 mod error_responses;
 mod handlers;
 mod util;
+mod write_idle_timeout;
 
 use handlers::{
     aci_attestation_report, aci_list_sessions, aci_receipt, admin_get_upstreams,
@@ -91,6 +97,73 @@ use handlers::{
     embeddings, embeddings_models, health, messages, metrics, models, models_subpath,
     receipt_by_chat_id, responses, root,
 };
+
+/// Serve the public entry, wrapping each connection's IO with a write-idle
+/// timeout.
+///
+/// This is `axum::serve` plus one thing: the accepted stream is wrapped in
+/// [`write_idle_timeout::WriteIdleTimeout`] before hyper sees it. Upgrade
+/// support and the accept-error handling mirror `axum::serve`.
+///
+/// HTTP/1 only, and deliberately so. `axum = "0.7"` with default features
+/// enables `hyper/http1` but not `http2`, so the public listener was already
+/// h1-only before this change; reaching for hyper-util's auto builder to
+/// "match axum" would instead turn HTTP/2 on crate-wide. That would be worse
+/// than a behaviour change: under h2 flow control a downstream that stops
+/// consuming stops hyper from queueing DATA rather than blocking the socket
+/// write, so `poll_write` never goes pending, the timer never arms, and the
+/// leak this function exists to close would stay open on exactly those
+/// connections.
+///
+/// The wrapper cannot live anywhere else. A downstream that stops reading
+/// without closing blocks the serving connection's write, which stops the
+/// response body from being polled, which pins the streaming forward's upstream
+/// connection open forever. Hyper only learns of a *closed* downstream, and a
+/// timeout on the body's poll chain can never fire because that chain is exactly
+/// what is no longer polled — so it has to sit in the IO layer, which hyper
+/// always polls.
+///
+/// axum 0.7 takes a concrete `TcpListener` and exposes no hook for wrapping the
+/// IO (`Listener` arrived in 0.8), hence the explicit accept loop.
+pub async fn serve_with_write_idle_timeout(
+    listener: tokio::net::TcpListener,
+    app: Router,
+) -> std::io::Result<()> {
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            Err(err) => {
+                if util::is_connection_error(&err) {
+                    continue;
+                }
+                // Same rationale as axum: a full fd table (EMFILE) must not kill
+                // the accept loop, so log loudly and back off rather than exit.
+                tracing::error!(error = %err, "accept error");
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+        let service = app
+            .clone()
+            .map_request(|request: hyper::Request<Incoming>| request.map(axum::body::Body::new));
+        tokio::spawn(async move {
+            let hyper_service = TowerToHyperService::new(service);
+            let io = TokioIo::new(write_idle_timeout::WriteIdleTimeout::new(
+                stream,
+                write_idle_timeout::DOWNSTREAM_WRITE_IDLE_TIMEOUT,
+            ));
+            if let Err(err) = HyperHttp1Builder::new()
+                .serve_connection(io, hyper_service)
+                .with_upgrades()
+                .await
+            {
+                // Mostly clients that connect and go away without sending a
+                // request; axum swallows these too.
+                tracing::debug!(peer = %peer, error = %err, "connection closed");
+            }
+        });
+    }
+}
 
 #[derive(Clone)]
 pub struct AppState {

--- a/src/http/app/util.rs
+++ b/src/http/app/util.rs
@@ -136,6 +136,19 @@ pub(super) fn enforce_admin(state: &AppState, headers: &HeaderMap) -> Option<Res
     }
 }
 
+/// Whether an `accept` error is an ordinary per-connection failure (the peer
+/// went away between the SYN and the accept) rather than a listener-level
+/// problem. Mirrors the same helper in axum: these are skipped silently, while
+/// anything else — EMFILE above all — is logged and backed off.
+pub(super) fn is_connection_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::force_tee_true;

--- a/src/http/app/write_idle_timeout.rs
+++ b/src/http/app/write_idle_timeout.rs
@@ -170,12 +170,15 @@ mod tests {
         }
     }
 
-    /// An IO that accepts exactly one write, then stalls — models a downstream
-    /// that consumes for a while and only then stops reading.
-    struct StallsAfterOneWrite {
+    /// An IO that stalls, then accepts exactly one write, then stalls for good
+    /// — models a downstream that pauses reading, resumes briefly, and stops.
+    /// The leading stall matters: it is what arms the timer that the accepted
+    /// write must then reset.
+    struct StallsAroundOneWrite {
+        pending_before_accept: usize,
         accepted: bool,
     }
-    impl AsyncRead for StallsAfterOneWrite {
+    impl AsyncRead for StallsAroundOneWrite {
         fn poll_read(
             self: Pin<&mut Self>,
             _: &mut Context<'_>,
@@ -184,13 +187,16 @@ mod tests {
             Poll::Pending
         }
     }
-    impl AsyncWrite for StallsAfterOneWrite {
+    impl AsyncWrite for StallsAroundOneWrite {
         fn poll_write(
             mut self: Pin<&mut Self>,
             _: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             if self.accepted {
+                Poll::Pending
+            } else if self.pending_before_accept > 0 {
+                self.pending_before_accept -= 1;
                 Poll::Pending
             } else {
                 self.accepted = true;
@@ -212,33 +218,45 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     }
 
-    /// The other half of the invariant: progress must *reset* the deadline, not
-    /// merely delay the first arming. Without this, dropping `self.timer = None`
-    /// from the `Poll::Ready` arms would still pass the test above while cutting
-    /// every healthy stream at `idle` in production.
+    /// The other half of the invariant: progress must *reset* an already-armed
+    /// deadline. The timer is armed by a pending write, so the test must first
+    /// stall to arm it, then let the write through, then stall again — without
+    /// that leading stall, dropping `self.timer = None` from the `Poll::Ready`
+    /// arms would go unnoticed while cutting every healthy stream at `idle`.
     #[tokio::test(start_paused = true)]
     async fn accepted_write_resets_the_deadline() {
         let idle = Duration::from_secs(600);
-        let mut io = WriteIdleTimeout::new(StallsAfterOneWrite { accepted: false }, idle);
+        let mut io = WriteIdleTimeout::new(
+            StallsAroundOneWrite {
+                pending_before_accept: 1,
+                accepted: false,
+            },
+            idle,
+        );
 
-        // First write is accepted well into the window; the deadline must restart
-        // from here rather than from the connection's start.
-        tokio::time::advance(Duration::from_secs(500)).await;
-        let written = io
-            .write(b"first")
-            .await
-            .expect("accepted write must succeed");
-        assert_eq!(written, 5, "the stub accepts the whole buffer");
-
-        // A second write now stalls. If the timer had not been reset it would
-        // fire ~100s from now; it must instead take the full idle window.
+        // First poll goes pending and arms the timer at t=0. Wake it well into
+        // the window; the stub then accepts, which must discard that timer.
         let start = tokio::time::Instant::now();
+        let mut first = std::pin::pin!(io.write(b"first"));
+        assert!(
+            futures_util::poll!(first.as_mut()).is_pending(),
+            "the stub must stall the first poll so the timer gets armed"
+        );
+        tokio::time::advance(Duration::from_secs(500)).await;
+        let written = first.await.expect("accepted write must succeed");
+        assert_eq!(written, 5, "the stub accepts the whole buffer");
+        assert_eq!(start.elapsed(), Duration::from_secs(500));
+
+        // A second write now stalls. Had the accepted write not reset the timer
+        // armed at t=0 it would fire at t=600, ~100s from now; it must instead
+        // take the full idle window from here.
+        let resumed = tokio::time::Instant::now();
         let err = io.write(b"second").await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         assert!(
-            start.elapsed() >= idle,
+            resumed.elapsed() >= idle,
             "deadline was not reset by the accepted write: fired after {:?}",
-            start.elapsed()
+            resumed.elapsed()
         );
     }
 }

--- a/src/http/app/write_idle_timeout.rs
+++ b/src/http/app/write_idle_timeout.rs
@@ -1,0 +1,244 @@
+//! Downstream write-idle timeout for served connections.
+//!
+//! A streaming forward holds the upstream connection open while it pumps the
+//! response to the downstream. If the downstream stops reading (its TCP/UDS
+//! receive side is not drained — e.g. a client or middleware that stalls without
+//! closing), the serving connection's write blocks, the response body stops
+//! being polled, and the upstream connection is held indefinitely (eventually
+//! `CLOSE_WAIT`, leaking sockets and kernel memory). Hyper only learns of a
+//! *closed* downstream; a stalled-open one has no signal.
+//!
+//! [`WriteIdleTimeout`] wraps the downstream IO and fails a write that stays
+//! pending past `idle`. The error tears the connection down, which drops the
+//! response body and with it the upstream stream — closing the upstream
+//! connection. The timeout lives in the IO layer (which hyper always polls),
+//! not in the body's poll chain (which a stalled downstream never polls).
+//!
+//! It is a no-progress timeout, not a total one: any accepted write resets it,
+//! so a long but flowing stream (a slow LLM that keeps emitting) is never cut —
+//! only a downstream that accepts nothing for `idle` is.
+//!
+//! The flip side, and it is deliberate: *any* accepted write resets the deadline,
+//! including a single byte. A downstream that advertises a tiny window and drains
+//! a byte every few minutes keeps the connection alive indefinitely — the same
+//! leak reached by trickle instead of by full stall. Bounding that needs a
+//! byte-rate floor or an absolute cap, which is a separate policy decision;
+//! this type only promises to reap downstreams that accept *nothing*.
+
+use std::future::Future;
+use std::io::{self, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::{sleep, Sleep};
+
+/// How long a downstream write may make no progress before the connection is
+/// torn down. Generous on purpose: legitimate streams keep flowing well under
+/// this, so it only reaps genuinely stalled downstreams. Matches the upstream
+/// read timeout order of magnitude.
+pub(super) const DOWNSTREAM_WRITE_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+pub(super) struct WriteIdleTimeout<IO> {
+    inner: IO,
+    idle: Duration,
+    timer: Option<Pin<Box<Sleep>>>,
+}
+
+impl<IO> WriteIdleTimeout<IO> {
+    pub(super) fn new(inner: IO, idle: Duration) -> Self {
+        Self {
+            inner,
+            idle,
+            timer: None,
+        }
+    }
+
+    /// Called while the inner write is pending. Arms (once) and polls the idle
+    /// timer; fires a `TimedOut` error if it elapses. Generic in the success
+    /// type so both `poll_write` (`usize`) and the vectored variant can reuse it.
+    fn poll_idle<T>(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<T>> {
+        let idle = self.idle;
+        let timer = self.timer.get_or_insert_with(|| Box::pin(sleep(idle)));
+        match timer.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                self.timer = None;
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "downstream write idle timeout",
+                )))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<IO: AsyncRead + Unpin> AsyncRead for WriteIdleTimeout<IO> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<IO: AsyncWrite + Unpin> AsyncWrite for WriteIdleTimeout<IO> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write(cx, buf) {
+            Poll::Ready(r) => {
+                self.timer = None;
+                Poll::Ready(r)
+            }
+            Poll::Pending => self.poll_idle(cx),
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write_vectored(cx, bufs) {
+            Poll::Ready(r) => {
+                self.timer = None;
+                Poll::Ready(r)
+            }
+            Poll::Pending => self.poll_idle(cx),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    /// Flush is bounded too. With a bare `TcpStream` underneath this is a no-op,
+    /// but the type is generic: insert any buffering IO (in-process TLS being the
+    /// obvious one) and a stalled downstream would otherwise park here forever,
+    /// silently defeating the timeout with nothing to catch it.
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match Pin::new(&mut self.inner).poll_flush(cx) {
+            Poll::Ready(r) => {
+                self.timer = None;
+                Poll::Ready(r)
+            }
+            Poll::Pending => self.poll_idle(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use tokio::io::AsyncWriteExt;
+
+    /// An IO whose writes never make progress — models a downstream that has
+    /// stopped reading.
+    struct StalledIo;
+    impl AsyncRead for StalledIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+    impl AsyncWrite for StalledIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    /// An IO that accepts exactly one write, then stalls — models a downstream
+    /// that consumes for a while and only then stops reading.
+    struct StallsAfterOneWrite {
+        accepted: bool,
+    }
+    impl AsyncRead for StallsAfterOneWrite {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+    impl AsyncWrite for StallsAfterOneWrite {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            if self.accepted {
+                Poll::Pending
+            } else {
+                self.accepted = true;
+                Poll::Ready(Ok(buf.len()))
+            }
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_write_times_out_after_idle() {
+        let mut io = WriteIdleTimeout::new(StalledIo, Duration::from_secs(600));
+        let err = io.write(b"hello").await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+
+    /// The other half of the invariant: progress must *reset* the deadline, not
+    /// merely delay the first arming. Without this, dropping `self.timer = None`
+    /// from the `Poll::Ready` arms would still pass the test above while cutting
+    /// every healthy stream at `idle` in production.
+    #[tokio::test(start_paused = true)]
+    async fn accepted_write_resets_the_deadline() {
+        let idle = Duration::from_secs(600);
+        let mut io = WriteIdleTimeout::new(StallsAfterOneWrite { accepted: false }, idle);
+
+        // First write is accepted well into the window; the deadline must restart
+        // from here rather than from the connection's start.
+        tokio::time::advance(Duration::from_secs(500)).await;
+        let written = io
+            .write(b"first")
+            .await
+            .expect("accepted write must succeed");
+        assert_eq!(written, 5, "the stub accepts the whole buffer");
+
+        // A second write now stalls. If the timer had not been reset it would
+        // fire ~100s from now; it must instead take the full idle window.
+        let start = tokio::time::Instant::now();
+        let err = io.write(b"second").await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            start.elapsed() >= idle,
+            "deadline was not reset by the accepted write: fired after {:?}",
+            start.elapsed()
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,7 +529,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tracing::info!(%bind, "private-ai-gateway listening");
     let listener = tokio::net::TcpListener::bind(&bind).await?;
-    axum::serve(listener, app).await?;
+    private_ai_gateway::http::app::serve_with_write_idle_timeout(listener, app).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## The bug

A downstream that stops reading **without closing** pins a streaming forward's upstream connection open forever.

The serving connection's write blocks → the response body stops being polled → nothing in the body's poll chain can ever fire. Not the upstream `read_timeout`, not the SSE keep-alive, not `MeterStream`'s drop. Hyper only learns of a *closed* downstream; a stalled-open one has no signal at all.

## Why it is unprotected today

`37e9078` identified this and fixed it — but wired `WriteIdleTimeout` only into `serve_unix_listener`, the internal hop to the then-existing executor. **The public TCP entry has never had it**: it was already a bare `axum::serve` at the time, and `9383e8b` removed the module as dead code when the UDS path went away, noting it could be re-added *"if that failure mode ever appears"*.

## Reproduction

Against this binary behind an L4 proxy, 100 clients that read two chunks then stop reading without closing their sockets:

| | before | after |
|---|---|---|
| streams established | fd=207, ESTABLISHED=195 | fd=210, ESTABLISHED=198 |
| **+600s** (upstream `read_timeout` elapsed) | fd=207, ESTABLISHED=195 — **unchanged** | **fd=12, ESTABLISHED=0** |
| after the clients finally close | **47 upstream + 47 downstream pinned**, still there 5 min later, RSS flat at 315 MB | — |

Each leak costs two fds, ~1 MB of RSS and one upstream connection, and never comes back — so the terminal state is fd or memory exhaustion. Raising the fd limit only lengthens the fuse.

With the wrapper in place the same run tears every stalled connection down 600s after it was established, and fd returns to its idle baseline.

## The change

Restore the module unchanged and wrap the accepted stream in it. The timeout has to sit in the **IO layer**, which hyper always polls, rather than in the body chain, which a stalled downstream never polls again.

axum 0.7 takes a concrete `TcpListener` and offers no hook for wrapping the IO (`Listener` arrived in 0.8), so the accept loop is explicit; upgrade support and accept-error handling mirror axum's.

### HTTP/1 only, deliberately

axum 0.7's default features enable `hyper/http1` but **not** `http2`, so this listener was already h1-only. Reaching for hyper-util's `server-auto` to "match axum" would turn HTTP/2 on **crate-wide** via Cargo's global feature unification — and under h2 flow control a stalled reader stops hyper queueing DATA rather than blocking the socket write, so `poll_write` never goes pending and this timeout could never arm on exactly the connections that need it.

### Known limits

- **Flush is bounded too.** With a bare `TcpStream` underneath the flush is a no-op, but the type is generic and any buffering IO inserted later (in-process TLS being the obvious one) would otherwise park a stalled downstream there forever with nothing to catch it.
- **No-progress, not total.** A downstream that drains a byte every few minutes still holds the connection. Bounding that needs a byte-rate floor or an absolute cap — a separate policy call, out of scope here.

## Tests

Two unit tests on the wrapper: a permanently stalled write times out, and an accepted write **resets** the deadline. The second one matters — without it, a regression that armed the timer once and never cleared it would still pass the first test while cutting every healthy stream at 600s.

`cargo fmt`, `cargo clippy --all-targets -D warnings`, and the full suite are green.