### PR TITLE
Let a replica pull its complete upstream config from the control API

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -16,7 +16,8 @@ directory. Operators must choose the config file with
 Operators configure `state_dir`, not the individual writable files inside it.
 The gateway creates `state_dir` on startup, seeds `upstreams.json` from the
 read-only upstream seed only when the active file is missing or empty, and
-updates `upstreams.json` through `PUT /v1/admin/upstreams`.
+updates `upstreams.json` through `PUT /v1/admin/upstreams` or an authenticated
+`upstream_pull` source.
 
 Unknown fields in the static gateway config are rejected at startup.
 
@@ -29,6 +30,12 @@ This is the smallest practical container config.
   "bind": "0.0.0.0:8086",
   "state_dir": "/var/lib/private-ai-gateway",
   "upstream_config_seed_path": "/etc/private-ai-gateway/upstreams.seed.json",
+  "upstream_pull": {
+    "url": "https://control.example/api/admin/gateway-upstreams/config",
+    "token": "<dedicated-machine-pull-token>",
+    "refresh_seconds": 300,
+    "request_timeout_seconds": 90
+  },
   "admin_token": "<long-random-admin-token>",
   "dstack_endpoint": "unix:/var/run/dstack.sock"
 }
@@ -41,10 +48,32 @@ This is the smallest practical container config.
 | `bind` | `127.0.0.1:8086` | Public HTTP listener address. Use `0.0.0.0:8086` in containers that expose the gateway port. |
 | `state_dir` | `/var/lib/private-ai-gateway` | Gateway-owned writable state directory. The active upstream config and attested-session log are derived from this directory. |
 | `upstream_config_seed_path` | unset | Read-only JSON seed copied to `<state_dir>/upstreams.json` only when the active upstream config is missing or empty. |
+| `upstream_pull` | unset | Optional authenticated HTTPS source for the complete runtime upstream config. See [Upstream Pull](#upstream-pull). |
 | `admin_token` | unset | Bearer token for `GET` and `PUT /v1/admin/upstreams`. When unset, the admin API is not exposed. |
 | `dstack_endpoint` | dstack SDK default | dstack SDK endpoint, such as `unix:/var/run/dstack.sock`. |
 | `enable_e2ee` | `true` | Advertise and terminate the [E2EE v2 compatibility extension](../spec/e2ee-v2.md). Set to `false` only for an explicit TLS-only deployment; the attestation then reports `supported_e2ee_versions: []` and v2 requests fail with `e2ee_invalid_version`. |
 | `middleware` | unset | Optional middleware section. When present, the gateway consults a control plane to route and authorize each request and applies request/response transforms; when unset it serves directly. See [Middleware](#middleware). |
+
+## Upstream Pull
+
+`upstream_pull` lets every replica fetch the same complete runtime config from
+the control API without requiring the control API to reach replica-private
+addresses. It is intended for a secret-bearing endpoint: the dedicated token is
+sent only in an `Authorization: Bearer` header over HTTPS. Redirects are refused
+so the credential cannot be forwarded to another origin.
+
+| Field | Default | Use |
+| --- | --- | --- |
+| `upstream_pull.url` | required | HTTPS URL returning schema version 1 with an `upstreams` array. URLs containing credentials or a fragment are rejected. |
+| `upstream_pull.token` | required | Dedicated 32–256 byte machine credential. It must differ from the gateway admin token and middleware control token; do not reuse a user/admin API key. Newlines are rejected. |
+| `upstream_pull.refresh_seconds` | `300` | Successful polling cadence. Replicas apply ±10% jitter; failures retry with bounded exponential backoff. |
+| `upstream_pull.request_timeout_seconds` | `90` | Whole-request timeout, including response transfer. Responses larger than 4 MiB are rejected. |
+
+A pulled config is parsed, validated, and built completely before the active
+file and in-memory router are atomically replaced. Invalid responses and HTTP or
+TLS failures retain the last valid local config. An unchanged digest is not
+rewritten. On a new replica whose local config is empty, failure of the initial
+pull aborts startup so an empty router cannot enter the load-balancer pool.
 
 ## Middleware
 

--- a/src/aggregator/upstream_config/builders.rs
+++ b/src/aggregator/upstream_config/builders.rs
@@ -366,7 +366,7 @@ fn build_aci_service_verifier(
     }
 }
 
-fn config_digest(config: &[UpstreamConfig]) -> Result<String, UpstreamConfigError> {
+pub(super) fn config_digest(config: &[UpstreamConfig]) -> Result<String, UpstreamConfigError> {
     // A local version stamp over the serialized config, not a protocol artifact.
     let bytes = serde_json::to_vec(config).map_err(|e| {
         UpstreamConfigError::InvalidConfig(format!("failed to serialize upstream config: {e}"))

--- a/src/aggregator/upstream_config/mod.rs
+++ b/src/aggregator/upstream_config/mod.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -18,13 +18,15 @@ use crate::aggregator::service::{UpstreamVerificationRequest, UpstreamVerifier};
 
 mod builders;
 mod dynamic;
+mod pull;
 #[cfg(test)]
 mod tests;
 mod validation;
 
+pub use pull::{PullRefreshOutcome, UpstreamConfigPuller, UpstreamPullConfig};
 pub use validation::parse_config_text;
 
-use builders::{build_chutes_provider_backend, build_state};
+use builders::{build_chutes_provider_backend, build_state, config_digest};
 use dynamic::{DynamicUpstreamBackend, DynamicUpstreamVerifier};
 use validation::{
     read_config_file, session_refresh_seconds, snapshot_for, unique_upstream_models,
@@ -340,6 +342,7 @@ pub struct UpstreamConfigManager {
     path: PathBuf,
     options: UpstreamRuntimeOptions,
     state: Arc<RwLock<Arc<ConfiguredUpstreams>>>,
+    update_lock: Arc<Mutex<()>>,
     session_sink: Arc<RwLock<Option<Arc<dyn UpstreamSessionSink>>>>,
 }
 
@@ -355,6 +358,7 @@ impl UpstreamConfigManager {
             path,
             options,
             state: Arc::new(RwLock::new(state)),
+            update_lock: Arc::new(Mutex::new(())),
             session_sink: Arc::new(RwLock::new(None)),
         })
     }
@@ -436,14 +440,49 @@ impl UpstreamConfigManager {
         &self,
         config: Vec<UpstreamConfig>,
     ) -> Result<UpstreamConfigSnapshot, UpstreamConfigError> {
+        self.replace_inner(config, false).map(Option::unwrap)
+    }
+
+    /// Validate and atomically install a config only when its digest differs.
+    /// Pull polling uses this to avoid rewriting the secret-bearing state file
+    /// on every unchanged response. The update lock also serializes an admin PUT
+    /// racing a pull so an older build cannot overwrite a newer one after it.
+    pub fn replace_if_changed(
+        &self,
+        config: Vec<UpstreamConfig>,
+    ) -> Result<Option<UpstreamConfigSnapshot>, UpstreamConfigError> {
+        self.replace_inner(config, true)
+    }
+
+    fn replace_inner(
+        &self,
+        config: Vec<UpstreamConfig>,
+        skip_unchanged: bool,
+    ) -> Result<Option<UpstreamConfigSnapshot>, UpstreamConfigError> {
+        let _update = self
+            .update_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         validate_config(&config)?;
+        if skip_unchanged {
+            // The digest depends only on the config, so compare before paying
+            // for a full router/verifier build on every unchanged poll.
+            let next_digest = config_digest(&config)?;
+            let current = self
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if current.config_digest == next_digest {
+                return Ok(None);
+            }
+        }
         let next = Arc::new(build_state(&config, &self.options)?);
         write_config_file(&self.path, &config)?;
         *self
             .state
             .write()
-            .expect("upstream config manager state poisoned") = next.clone();
-        Ok(snapshot_for(&self.path, &next))
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = next.clone();
+        Ok(Some(snapshot_for(&self.path, &next)))
     }
 
     pub async fn prewarm_upstream_verification(&self) -> Vec<UpstreamPrewarmResult> {

--- a/src/aggregator/upstream_config/pull.rs
+++ b/src/aggregator/upstream_config/pull.rs
@@ -1,0 +1,326 @@
+//! Authenticated pull client for a control API's upstream config endpoint.
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use reqwest::header::{ACCEPT, AUTHORIZATION};
+use serde::Deserialize;
+
+use super::{UpstreamConfig, UpstreamConfigManager};
+
+const MAX_PULL_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamPullConfig {
+    pub url: String,
+    pub token: String,
+    #[serde(default = "default_refresh_seconds")]
+    pub refresh_seconds: u64,
+    #[serde(default = "default_request_timeout_seconds")]
+    pub request_timeout_seconds: u64,
+}
+
+impl fmt::Debug for UpstreamPullConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpstreamPullConfig")
+            .field("url", &self.url)
+            .field("token", &"[REDACTED]")
+            .field("refresh_seconds", &self.refresh_seconds)
+            .field("request_timeout_seconds", &self.request_timeout_seconds)
+            .finish()
+    }
+}
+
+const fn default_refresh_seconds() -> u64 {
+    300
+}
+
+const fn default_request_timeout_seconds() -> u64 {
+    90
+}
+
+impl UpstreamPullConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        let url = reqwest::Url::parse(self.url.trim())
+            .map_err(|err| format!("upstream_pull.url is invalid: {err}"))?;
+        if url.scheme() != "https" {
+            return Err("upstream_pull.url must use https".to_string());
+        }
+        if url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(
+                "upstream_pull.url must be an HTTPS URL without credentials or a fragment"
+                    .to_string(),
+            );
+        }
+        if !(32..=256).contains(&self.token.len()) {
+            return Err("upstream_pull.token must contain 32 to 256 bytes".to_string());
+        }
+        if self.token.contains(['\r', '\n']) {
+            return Err("upstream_pull.token must not contain newline characters".to_string());
+        }
+        if self.refresh_seconds == 0 {
+            return Err("upstream_pull.refresh_seconds must be greater than zero".to_string());
+        }
+        if self.request_timeout_seconds == 0 {
+            return Err(
+                "upstream_pull.request_timeout_seconds must be greater than zero".to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PullRefreshOutcome {
+    Updated {
+        upstream_count: usize,
+        config_digest: String,
+    },
+    Unchanged {
+        upstream_count: usize,
+        config_digest: String,
+    },
+}
+
+// Unknown top-level fields are tolerated so the control API can extend the
+// response without breaking older gateways; `schema_version` is the
+// compatibility gate.
+#[derive(Debug, Deserialize)]
+struct PullResponse {
+    schema_version: u8,
+    upstreams: Vec<UpstreamConfig>,
+}
+
+#[derive(Clone)]
+pub struct UpstreamConfigPuller {
+    manager: Arc<UpstreamConfigManager>,
+    config: UpstreamPullConfig,
+    client: reqwest::Client,
+}
+
+impl UpstreamConfigPuller {
+    pub fn new(
+        manager: Arc<UpstreamConfigManager>,
+        config: UpstreamPullConfig,
+    ) -> Result<Self, String> {
+        config.validate()?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.request_timeout_seconds))
+            // Never forward the machine Bearer token to a redirect target.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|err| format!("failed to build upstream pull HTTP client: {err}"))?;
+        Ok(Self {
+            manager,
+            config,
+            client,
+        })
+    }
+
+    pub fn refresh_seconds(&self) -> u64 {
+        self.config.refresh_seconds
+    }
+
+    pub async fn refresh(&self) -> Result<PullRefreshOutcome, String> {
+        let response = self
+            .client
+            .get(&self.config.url)
+            .header(ACCEPT, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", self.config.token))
+            .send()
+            .await
+            .map_err(|err| format!("gateway config pull request failed: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "gateway config pull returned HTTP {}",
+                response.status().as_u16()
+            ));
+        }
+        if response
+            .content_length()
+            .is_some_and(|n| n > MAX_PULL_RESPONSE_BYTES as u64)
+        {
+            return Err("gateway config pull response exceeds 4 MiB".to_string());
+        }
+        let mut body = Vec::with_capacity(
+            response
+                .content_length()
+                .unwrap_or(0)
+                .min(MAX_PULL_RESPONSE_BYTES as u64) as usize,
+        );
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk
+                .map_err(|err| format!("failed to read gateway config pull response: {err}"))?;
+            if body.len().saturating_add(chunk.len()) > MAX_PULL_RESPONSE_BYTES {
+                return Err("gateway config pull response exceeds 4 MiB".to_string());
+            }
+            body.extend_from_slice(&chunk);
+        }
+        self.apply_response(&body)
+    }
+
+    fn apply_response(&self, bytes: &[u8]) -> Result<PullRefreshOutcome, String> {
+        let payload: PullResponse = serde_json::from_slice(bytes)
+            .map_err(|err| format!("invalid gateway config pull response: {err}"))?;
+        if payload.schema_version != 1 {
+            return Err(format!(
+                "unsupported gateway config pull schema_version {}",
+                payload.schema_version
+            ));
+        }
+        let upstream_count = payload.upstreams.len();
+        match self
+            .manager
+            .replace_if_changed(payload.upstreams)
+            .map_err(|err| format!("rejected pulled gateway config: {err}"))?
+        {
+            Some(snapshot) => Ok(PullRefreshOutcome::Updated {
+                upstream_count,
+                config_digest: snapshot.config_digest,
+            }),
+            None => Ok(PullRefreshOutcome::Unchanged {
+                upstream_count,
+                config_digest: self.manager.snapshot().config_digest,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::aggregator::upstream_config::{UpstreamRuntimeOptions, UpstreamVerifierMode};
+
+    fn manager(path: PathBuf) -> Arc<UpstreamConfigManager> {
+        Arc::new(
+            UpstreamConfigManager::load(
+                path,
+                UpstreamRuntimeOptions {
+                    verifier_mode: UpstreamVerifierMode::None,
+                    accepted_subjects: Vec::new(),
+                    accepted_image_digests: Vec::new(),
+                    accepted_dstack_kms_root_public_keys: Vec::new(),
+                    pccs_url: None,
+                    verifier_cache_seconds: 300,
+                    connect_timeout_seconds: 10,
+                    read_timeout_seconds: 600,
+                    verifier_request_timeout_seconds: 60,
+                },
+            )
+            .unwrap(),
+        )
+    }
+
+    fn config() -> UpstreamPullConfig {
+        UpstreamPullConfig {
+            url: "https://control.example/api/admin/gateway-upstreams/config".to_string(),
+            token: "0123456789abcdef0123456789abcdef".to_string(),
+            refresh_seconds: 300,
+            request_timeout_seconds: 90,
+        }
+    }
+
+    fn temp_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "private-ai-gateway-pull-{label}-{}-{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn pull_config_requires_https_and_a_dedicated_secret() {
+        let base = config();
+        assert!(base.validate().is_ok());
+
+        for url in [
+            "http://control.example/api/admin/gateway-upstreams/config",
+            "https://user@control.example/api/admin/gateway-upstreams/config",
+            "https://control.example/api/admin/gateway-upstreams/config#secret",
+        ] {
+            let mut config = base.clone();
+            config.url = url.to_string();
+            assert!(config.validate().is_err(), "accepted unsafe URL {url}");
+        }
+
+        let mut empty = base.clone();
+        empty.token.clear();
+        assert!(empty.validate().is_err());
+        let mut newline = base;
+        newline.token = "0123456789abcdef0123456789abcdef\nheader: injected".to_string();
+        assert!(newline.validate().is_err());
+    }
+
+    #[test]
+    fn valid_pull_updates_once_and_an_identical_pull_does_not_rewrite() {
+        let path = temp_path("update");
+        let puller = UpstreamConfigPuller::new(manager(path.clone()), config()).unwrap();
+        let body = br#"{
+          "schema_version": 1,
+          "generated_at": "2026-08-26T00:00:00Z",
+          "upstreams": [{
+            "name": "gpu-a",
+            "base_url": "https://gpu-a.example",
+            "models": {"public-a": "upstream-a"},
+            "bearer_token": "provider-secret"
+          }]
+        }"#;
+
+        let first = puller.apply_response(body).unwrap();
+        assert!(matches!(first, PullRefreshOutcome::Updated { .. }));
+        let metadata = std::fs::metadata(&path).unwrap();
+        let modified = metadata.modified().unwrap();
+        let second = puller.apply_response(body).unwrap();
+        assert!(matches!(second, PullRefreshOutcome::Unchanged { .. }));
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            modified
+        );
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("provider-secret"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_pull_never_replaces_the_last_valid_config() {
+        let path = temp_path("retain");
+        let initial = r#"[{
+          "name":"old",
+          "base_url":"https://old.example",
+          "models":{"public-old":"upstream-old"},
+          "bearer_token":"old-secret"
+        }]"#;
+        std::fs::write(&path, initial).unwrap();
+        let manager = manager(path.clone());
+        let original_digest = manager.snapshot().config_digest;
+        let puller = UpstreamConfigPuller::new(manager.clone(), config()).unwrap();
+
+        for body in [
+            br#"{"schema_version":2,"generated_at":"now","upstreams":[]}"#.as_slice(),
+            br#"{"schema_version":1,"generated_at":"now","upstreams":[{"name":"broken"}]}"#
+                .as_slice(),
+            b"not-json".as_slice(),
+        ] {
+            assert!(puller.apply_response(body).is_err());
+            assert_eq!(manager.snapshot().config_digest, original_digest);
+            assert!(std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("old-secret"));
+        }
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/aggregator/upstream_config/tests.rs
+++ b/src/aggregator/upstream_config/tests.rs
@@ -335,6 +335,7 @@ async fn prewarm_verification_deduplicates_upstream_models() {
             verifier_request_timeout_seconds: 60,
         },
         state,
+        update_lock: Arc::new(Mutex::new(())),
         session_sink: Arc::new(RwLock::new(None)),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,13 @@ use private_ai_gateway::aggregator::service::{
 };
 use private_ai_gateway::aggregator::session_store::JsonlSessionStore;
 use private_ai_gateway::aggregator::upstream_config::{
-    parse_config_text, UpstreamConfigManager, UpstreamRuntimeOptions, UpstreamVerifierMode,
+    parse_config_text, PullRefreshOutcome, UpstreamConfigManager, UpstreamConfigPuller,
+    UpstreamPullConfig, UpstreamRuntimeOptions, UpstreamVerifierMode,
 };
 use private_ai_gateway::dstack::{DstackAciProvider, DstackAciProviderConfig};
 use private_ai_gateway::http::{build_router_with_admin, build_router_with_admin_and_middleware};
 use private_ai_gateway::middleware::{Middleware, MiddlewareConfig};
+use rand::Rng;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use x509_parser::prelude::parse_x509_certificate;
@@ -67,6 +69,7 @@ struct GatewayConfigFile {
     bind: Option<String>,
     state_dir: Option<String>,
     upstream_config_seed_path: Option<String>,
+    upstream_pull: Option<UpstreamPullConfig>,
     admin_token: Option<String>,
     /// Keyset lifetime in seconds: `not_after` = launch time + this (§3.4).
     /// Defaults to [`DEFAULT_KEYSET_NOT_AFTER_SECONDS`] (30 days).
@@ -93,6 +96,7 @@ impl Default for GatewayConfigFile {
             bind: None,
             state_dir: None,
             upstream_config_seed_path: None,
+            upstream_pull: None,
             admin_token: None,
             keyset_not_after_seconds: None,
             subject: None,
@@ -143,6 +147,26 @@ fn upstream_config_path(state_dir: &Path) -> PathBuf {
 
 fn session_log_path(state_dir: &Path) -> PathBuf {
     state_dir.join("sessions.jsonl")
+}
+
+fn validate_pull_token_separation(config: &GatewayConfigFile) -> Result<(), String> {
+    let Some(pull) = &config.upstream_pull else {
+        return Ok(());
+    };
+    if config.admin_token.as_deref() == Some(pull.token.as_str()) {
+        return Err("upstream_pull.token must be distinct from admin_token".to_string());
+    }
+    if config
+        .middleware
+        .as_ref()
+        .and_then(|middleware| middleware.control_token.as_deref())
+        == Some(pull.token.as_str())
+    {
+        return Err(
+            "upstream_pull.token must be distinct from middleware.control_token".to_string(),
+        );
+    }
+    Ok(())
 }
 
 fn resolve_source_provenance() -> Result<SourceProvenance, String> {
@@ -368,6 +392,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let upstream_config_path = upstream_config_path(&state_dir);
     let session_log_path = session_log_path(&state_dir);
     let upstream_config_seed_path = gateway_config.upstream_config_seed_path.clone();
+    let upstream_pull_config = gateway_config.upstream_pull.clone();
     let admin_token = gateway_config.admin_token.clone();
     let source_provenance = resolve_source_provenance()?;
     let tls_public_keys = resolve_tls_public_keys(&gateway_config.tls)?;
@@ -380,6 +405,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .into());
     }
+    validate_pull_token_separation(&gateway_config).map_err(invalid_input)?;
 
     let provider = Arc::new(
         DstackAciProvider::new(dstack_endpoint, DstackAciProviderConfig::default()).await?,
@@ -401,6 +427,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             verifier_request_timeout_seconds: DEFAULT_VERIFIER_REQUEST_TIMEOUT_SECONDS,
         },
     )?);
+    let upstream_puller = match upstream_pull_config {
+        Some(config) => {
+            let puller = UpstreamConfigPuller::new(upstream_config.clone(), config)
+                .map_err(invalid_input)?;
+            // Try once before constructing the service so a new replica with an
+            // empty seed can serve the current catalog immediately. Failure is
+            // fail-open only with respect to the last valid local config; the
+            // background task keeps retrying and never replaces it with empty or
+            // invalid data.
+            let initial_pull_succeeded = match puller.refresh().await {
+                Ok(outcome) => {
+                    log_pull_outcome(&outcome);
+                    true
+                }
+                Err(err) => {
+                    if upstream_config.snapshot().upstreams.is_empty() {
+                        return Err(invalid_input(format!(
+                            "initial gateway config pull failed and no local upstream config is available: {err}"
+                        ))
+                        .into());
+                    }
+                    tracing::warn!(error = %err, "initial gateway config pull failed; retaining local config");
+                    false
+                }
+            };
+            Some((puller, initial_pull_succeeded))
+        }
+        None => None,
+    };
     let upstream = upstream_config.backend();
     let receipt_store = Arc::new(InMemoryReceiptStore::default());
     let upstream_verifier: Arc<dyn UpstreamVerifier> = upstream_config.verifier();
@@ -515,6 +570,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the store.
     upstream_config.set_session_sink(service.clone());
     spawn_upstream_lifecycle(upstream_config.clone());
+    if let Some((puller, initial_pull_succeeded)) = upstream_puller {
+        spawn_upstream_pull(puller, upstream_config.clone(), initial_pull_succeeded);
+    }
 
     let app = if let Some(middleware_config) = middleware_config {
         let middleware = Arc::new(Middleware::new(&middleware_config).map_err(invalid_input)?);
@@ -531,6 +589,92 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     private_ai_gateway::http::app::serve_with_write_idle_timeout(listener, app).await?;
     Ok(())
+}
+
+fn log_pull_outcome(outcome: &PullRefreshOutcome) {
+    match outcome {
+        PullRefreshOutcome::Updated {
+            upstream_count: 0,
+            config_digest,
+        } => tracing::warn!(
+            upstreams = 0,
+            config_digest = %config_digest,
+            "gateway config pull installed an empty config; this replica now serves no upstreams"
+        ),
+        PullRefreshOutcome::Updated {
+            upstream_count,
+            config_digest,
+        } => tracing::info!(
+            upstreams = upstream_count,
+            config_digest = %config_digest,
+            "gateway config pull installed an update"
+        ),
+        PullRefreshOutcome::Unchanged {
+            upstream_count,
+            config_digest,
+        } => tracing::info!(
+            upstreams = upstream_count,
+            config_digest = %config_digest,
+            "gateway config pull unchanged"
+        ),
+    }
+}
+
+fn spawn_upstream_pull(
+    puller: UpstreamConfigPuller,
+    upstream_config: Arc<UpstreamConfigManager>,
+    initial_pull_succeeded: bool,
+) {
+    tokio::spawn(async move {
+        let refresh_seconds = puller.refresh_seconds();
+        let initial_failure_delay = 5_u64.min(refresh_seconds);
+        let mut failure_delay_seconds = initial_failure_delay;
+        let mut next_delay_seconds = if initial_pull_succeeded {
+            jittered_refresh_seconds(refresh_seconds)
+        } else {
+            initial_failure_delay
+        };
+        loop {
+            tokio::time::sleep(Duration::from_secs(next_delay_seconds)).await;
+            match puller.refresh().await {
+                Ok(outcome) => {
+                    let updated = matches!(outcome, PullRefreshOutcome::Updated { .. });
+                    log_pull_outcome(&outcome);
+                    failure_delay_seconds = initial_failure_delay;
+                    next_delay_seconds = jittered_refresh_seconds(refresh_seconds);
+                    if updated {
+                        let manager = upstream_config.clone();
+                        tokio::spawn(async move {
+                            log_prewarm_results(manager.prewarm_upstream_verification().await);
+                        });
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        retry_seconds = failure_delay_seconds,
+                        "gateway config pull failed; retaining current config"
+                    );
+                    next_delay_seconds = failure_delay_seconds;
+                    failure_delay_seconds = failure_delay_seconds
+                        .saturating_mul(2)
+                        .min(60)
+                        .min(refresh_seconds);
+                }
+            }
+        }
+    });
+}
+
+fn jittered_refresh_seconds(refresh_seconds: u64) -> u64 {
+    // Stable polls are jittered by ±10% so replicas with the same measured
+    // config do not all ask the control API to build the secret response at once.
+    let jitter_span = (refresh_seconds / 10).max(1);
+    let jitter = rand::thread_rng().gen_range(0..=jitter_span * 2);
+    refresh_seconds
+        .saturating_sub(jitter_span)
+        .saturating_add(jitter)
+        .max(1)
 }
 
 fn spawn_upstream_lifecycle(upstream_config: Arc<UpstreamConfigManager>) {
@@ -651,6 +795,7 @@ mod tests {
         load_gateway_config, resolve_state_dir, resolve_tls_public_keys,
         seed_upstream_config_if_empty, session_log_path,
         source_provenance_from_git_launcher_config, upstream_config_path,
+        validate_pull_token_separation,
     };
 
     const TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -713,6 +858,67 @@ kBH1U3IsAJyU8UbZqzFEUGG7Ro3vdOQ=
 
         assert_eq!(config.state_dir.as_deref(), Some("/gateway/state"));
         let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn gateway_config_parses_upstream_pull_without_debugging_its_token() {
+        let config_path = temp_path("gateway-config-upstream-pull");
+        std::fs::write(
+            &config_path,
+            r#"{
+                "upstream_pull": {
+                    "url": "https://service.example/api/admin/gateway-upstreams/config",
+                    "token": "pull-secret",
+                    "refresh_seconds": 120,
+                    "request_timeout_seconds": 30
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+        let pull = config.upstream_pull.expect("upstream_pull must parse");
+        assert_eq!(pull.refresh_seconds, 120);
+        let debug = format!("{pull:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("pull-secret"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn gateway_config_rejects_reused_pull_credentials() {
+        for (name, body) in [
+            (
+                "admin",
+                r#"{
+                  "admin_token":"0123456789abcdef0123456789abcdef",
+                  "upstream_pull":{
+                    "url":"https://service.example/api/admin/gateway-upstreams/config",
+                    "token":"0123456789abcdef0123456789abcdef"
+                  }
+                }"#,
+            ),
+            (
+                "control",
+                r#"{
+                  "upstream_pull":{
+                    "url":"https://service.example/api/admin/gateway-upstreams/config",
+                    "token":"0123456789abcdef0123456789abcdef"
+                  },
+                  "middleware":{
+                    "control_url":"https://control.example",
+                    "control_token":"0123456789abcdef0123456789abcdef"
+                  }
+                }"#,
+            ),
+        ] {
+            let config_path = temp_path(&format!("reused-pull-{name}"));
+            std::fs::write(&config_path, body).unwrap();
+            let config = load_gateway_config(config_path.to_str().unwrap()).unwrap();
+            let err = validate_pull_token_separation(&config).unwrap_err();
+            assert!(err.contains("must be distinct"));
+            let _ = std::fs::remove_file(config_path);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

`PUT /v1/admin/upstreams` requires the control API to reach every replica's private address. That does not hold once replicas scale behind a load balancer, and a newly started replica has no way to obtain the current catalog on its own.

## What

An optional `upstream_pull` section lets each replica fetch the same complete, secret-bearing config itself. Push is unchanged and still supported; the two cannot revert each other, because the config a control API generates is a pure function of its own state.

```json
"upstream_pull": {
  "url": "https://control.example/api/admin/gateway-upstreams/config",
  "token": "<dedicated-machine-pull-token>",
  "refresh_seconds": 300,
  "request_timeout_seconds": 90
}
```

The response is schema version 1 with an `upstreams` array. Unknown top-level fields are tolerated so the control API can extend it without breaking older gateways; `schema_version` is the compatibility gate.

## Credential handling

The endpoint hands out provider credentials, so the token is treated as a machine secret rather than an admin key:

- 32-256 bytes, rejected at startup when it equals `admin_token` or `middleware.control_token`
- redacted in `Debug` output (covered by a test that asserts the secret never appears)
- sent only in an `Authorization` header over HTTPS; non-HTTPS URLs, URLs with userinfo, and URLs with a fragment are rejected
- redirects refused outright, so the credential is never forwarded to another origin

## Failure behavior

A pulled config is parsed, validated and built completely before the active file and in-memory router are atomically replaced. Any invalid response or transport failure retains the last valid local config rather than degrading the replica. Responses are capped at 4 MiB, enforced both on `Content-Length` and while streaming the body.

An unchanged digest is not rewritten, so a steady-state poll leaves the secret-bearing state file untouched. The digest is computed before the router build, so an unchanged poll does not pay for a full build. An update that installs an empty config is logged at warn, since it leaves the replica serving no upstreams.

A shared update lock serializes an admin PUT racing a pull, so an older build cannot land on top of a newer one. Successful polls are jittered by ±10% and failures retry with bounded exponential backoff. On a replica whose local config is empty, failure of the initial pull aborts startup so an empty router cannot enter the load-balancer pool.

## Tests

- `pull_config_requires_https_and_a_dedicated_secret` — scheme, userinfo, fragment, empty token, embedded newline
- `valid_pull_updates_once_and_an_identical_pull_does_not_rewrite` — asserts the file mtime is unchanged on the second identical response
- `invalid_pull_never_replaces_the_last_valid_config` — wrong schema version, malformed upstream, non-JSON; each asserts the digest and the on-disk secret are untouched
- `gateway_config_parses_upstream_pull_without_debugging_its_token`
- `gateway_config_rejects_reused_pull_credentials` — both the admin and control-token cases

`cargo fmt`, `cargo clippy --all-targets` and the crate tests pass.
