### PR TITLE
fix(release): publish local package directories

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -77,7 +77,7 @@ jobs:
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "$name@$version is already published; skipping"
             else
-              npm publish "$directory" --access public --provenance
+              npm publish "./$directory" --access public --provenance
             fi
           }
 


### PR DESCRIPTION
Prefix release package directories with `./` so npm treats them as local paths instead of GitHub shorthand. The first `clients-v0.2.0` run failed before publishing any package because `clients/verifier-ts` resolved to `git@github.com:clients/verifier-ts.git`. Verified with the exact corrected verifier dry-run, including tests, build, bundle, and pack.