### PR TITLE
fix(release): use npm trusted publishing only

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -67,8 +67,6 @@ jobs:
           bash clients/package-smoke.sh
 
       - name: Publish packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           publish_if_missing() {
             name="$1"


### PR DESCRIPTION
## Summary

- remove the retired `NPM_TOKEN` reference from the publish step
- publish exclusively through npm Trusted Publishing (OIDC)
- keep the existing provenance, environment, version validation, and idempotent package ordering

## Verification

- confirmed all four `0.2.0` packages are public with SLSA provenance
- confirmed the GitHub `npm` environment exists
- confirmed the workflow retains `permissions.id-token: write` and `environment: npm`
- no package version or release tag changes