### PR TITLE
fix(clients): use the verified Redpill endpoint

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -61,5 +61,4 @@ coding-agent guide covers Codex, Claude Code and OpenCode compatibility.
 [docs/quickstart.md](../docs/quickstart.md) exercises both verifier
 surfaces against a live deployment. The `pi-provider` extension is loaded
 with pi's `-e` flag pointing at one of the package directories (e.g.
-`pi -e clients/pi-provider/packages/pi-provider-aci`), or installed from npm
-after the first `clients-v0.2.0` release; see its README for the invocation.
+`pi -e clients/pi-provider/packages/pi-provider-aci`), or installed from npm; see its README for the invocation.

--- a/clients/pi-provider/README.md
+++ b/clients/pi-provider/README.md
@@ -29,13 +29,13 @@ history cannot receive a complete body-hash audit and fails explicitly.
 
 ## Install
 
-After the `0.2.0` npm release:
+Install the published package:
 
 ```bash
 pi install npm:@phala/pi-provider-aci
 ```
 
-Before the first npm release, use the source checkout:
+For a source checkout:
 
 ```bash
 npm --prefix clients/verifier-ts ci

--- a/clients/pi-provider/package-lock.json
+++ b/clients/pi-provider/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-pi-providers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-pi-providers",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -30,7 +30,7 @@
     },
     "../verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",
@@ -4915,10 +4915,10 @@
     },
     "packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.2.0"
+        "@phala/aci-verifier": "^0.2.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4930,10 +4930,10 @@
       }
     },
     "packages/pi-provider-phala-cloud": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/pi-provider-aci": "^0.2.0"
+        "@phala/pi-provider-aci": "^0.2.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4945,10 +4945,10 @@
       }
     },
     "packages/pi-provider-redpill": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/pi-provider-aci": "^0.2.0"
+        "@phala/pi-provider-aci": "^0.2.1"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/clients/pi-provider/package.json
+++ b/clients/pi-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-pi-providers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Vendor-neutral Pi provider for private-ai-gateway (ACI) + thin branded distributions (redpill, phala-cloud)",
   "license": "MIT",

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.2.0"
+    "@phala/aci-verifier": "^0.2.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -53,7 +53,7 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/pi-provider-aci": "^0.2.0"
+    "@phala/pi-provider-aci": "^0.2.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/README.md
+++ b/clients/pi-provider/packages/pi-provider-redpill/README.md
@@ -14,9 +14,10 @@ pi install npm:pi-provider-redpill
 export REDPILL_LLM_API_KEY=...
 ```
 
-The default gateway is `https://api.redpill.ai/v1`; override with `REDPILL_BASE_URL`.
-`api.redpill.ai`, `tee.redpill.ai`, and `inference.phala.com` are the same backend
-and accept the same key.
+The default ACI gateway is `https://tee.redpill.ai/v1`; override with
+`REDPILL_BASE_URL`. `tee.redpill.ai` and `inference.phala.com` enforce TEE-only
+routing and accept the same key. `api.redpill.ai` is the general API endpoint,
+not the default verified transport.
 
 ```text
 /model redpill/deepseek/deepseek-v4-flash

--- a/clients/pi-provider/packages/pi-provider-redpill/index.ts
+++ b/clients/pi-provider/packages/pi-provider-redpill/index.ts
@@ -17,7 +17,7 @@ import { createProvider } from "@phala/pi-provider-aci";
 export default createProvider({
   providerId: "redpill",
   label: "Redpill AI",
-  defaultBaseUrl: "https://api.redpill.ai/v1",
+  defaultBaseUrl: "https://tee.redpill.ai/v1",
   apiKeyEnv: "REDPILL_LLM_API_KEY",
   envPrefix: "REDPILL",
   footerKey: "redpill",

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Redpill AI for Pi with verified ACI transport and on-demand signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/pi-provider-aci": "^0.2.0"
+    "@phala/pi-provider-aci": "^0.2.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -92,11 +92,10 @@ Verification failures are reported as `{ ok: false, checks }` â€” never thrown â
 so a caller cannot pass by forgetting a `try/catch`. Errors are thrown only
 for malformed input.
 
-> **Release status:** `0.2.0` is the first public-package release candidate.
-> The repository builds an ESM package with declarations, validates it with
-> publint and Are The Types Wrong, and publishes it with npm provenance from a
-> `clients-v<version>` GitHub Release. Until that release is created, use the
-> source checkout rather than assuming the npm name already exists.
+> **Release status:** Public releases are available from npm. The repository
+> builds an ESM package with declarations, validates it with publint and Are The
+> Types Wrong, and publishes it with npm provenance from a `clients-v<version>`
+> GitHub Release.
 
 ## Usage
 

--- a/clients/verifier-ts/package-lock.json
+++ b/clients/verifier-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/aci-verifier",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- make `https://tee.redpill.ai/v1` the default for `pi-provider-redpill`
- keep `api.redpill.ai` documented as the general API endpoint rather than the default verified transport
- prepare the coordinated client packages as `0.2.1`
- remove stale pre-publication wording from the client documentation

## Why

`api.redpill.ai` currently load-balances across multiple gateway replicas with different attested TLS keys. Attestation and the subsequent pinned connection can land on different replicas, correctly causing `connectAci()` to fail closed with an SPKI mismatch. The TEE-only `tee.redpill.ai` route was stable across repeated live pinned-transport checks and is already the intended security-specific hostname in the deployment configuration.

This change does not add retries or weaken channel binding.

## Verification

- `connectAci()` from the public `@phala/aci-verifier@0.2.0` package established a verified, SPKI-pinned connection to `tee.redpill.ai` in 3/3 independent attempts
- the same check against `inference.phala.com` passed 3/3
- `api.redpill.ai` reproduced the cross-replica SPKI mismatch
- package and lockfile versions remain coordinated at `0.2.1`