### PR TITLE
Fix complete ACI session and channel verification

### DIFF
--- a/clients/coding-agents.md
+++ b/clients/coding-agents.md
@@ -155,6 +155,10 @@ export const AciPlugin: Plugin = async () => {
           acceptedComposeHashes: ['<reviewed-sha256-app-compose>'],
         },
       });
+      if (!next.identity.transcript.verdict.verified) {
+        await next.close();
+        throw new Error(next.identity.transcript.verdict.line);
+      }
       provider.options = { ...options, baseURL: next.baseURL, fetch: next.fetch };
 
       const previous = connection;

--- a/clients/coding-agents.md
+++ b/clients/coding-agents.md
@@ -98,7 +98,7 @@ plugin injects the shared ACI client. First add the verifier dependency:
 ```json
 {
   "dependencies": {
-    "@phala/aci-verifier": "^0.2.0"
+    "@phala/aci-verifier": "^0.2.2"
   }
 }
 ```

--- a/clients/pi-provider/package-lock.json
+++ b/clients/pi-provider/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-pi-providers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-pi-providers",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -30,7 +30,7 @@
     },
     "../verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",
@@ -4915,10 +4915,10 @@
     },
     "packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.2.1"
+        "@phala/aci-verifier": "^0.2.2"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4930,10 +4930,10 @@
       }
     },
     "packages/pi-provider-phala-cloud": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@phala/pi-provider-aci": "^0.2.1"
+        "@phala/pi-provider-aci": "^0.2.2"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4945,10 +4945,10 @@
       }
     },
     "packages/pi-provider-redpill": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@phala/pi-provider-aci": "^0.2.1"
+        "@phala/pi-provider-aci": "^0.2.2"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/clients/pi-provider/package.json
+++ b/clients/pi-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-pi-providers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Vendor-neutral Pi provider for private-ai-gateway (ACI) + thin branded distributions (redpill, phala-cloud)",
   "license": "MIT",

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.2.1"
+    "@phala/aci-verifier": "^0.2.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -53,7 +53,7 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/pi-provider-aci": "^0.2.1"
+    "@phala/pi-provider-aci": "^0.2.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Redpill AI for Pi with verified ACI transport and on-demand signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/pi-provider-aci": "^0.2.1"
+    "@phala/pi-provider-aci": "^0.2.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/clients/releasing.md
+++ b/clients/releasing.md
@@ -48,22 +48,8 @@ temporary directory. It never writes package artifacts into the repository.
 
 ## Trusted publishing
 
-The package names are new, so the first release must create them before their
-npm settings pages exist. Create a one-day granular access token from an npm
-user who can publish in the `@phala` scope. Because none of the packages exist
-yet, the token cannot select them individually: temporarily grant **All
-Packages** read/write access and enable **Bypass 2FA**. Organization permission
-alone does not grant package publishing permission. Put the token in the
-protected GitHub `npm` environment as `NPM_TOKEN`, publish the first
-`clients-v0.2.0` release through the workflow, then immediately remove and
-revoke it. Because the bootstrap publish still runs on a GitHub-hosted runner
-with `--provenance`, the first release also receives npm provenance.
-
-For the two unscoped packages, use the npm organization UI or `npm access grant`
-to grant the chosen Phala release team read/write access before revoking the
-bootstrap token.
-
-After that bootstrap, configure an npm trusted publisher for each package with:
+All four packages publish through npm trusted publishing. Each package's
+trusted publisher is configured with:
 
 - organization/user: `Dstack-TEE`
 - repository: `private-ai-gateway`
@@ -71,9 +57,8 @@ After that bootstrap, configure an npm trusted publisher for each package with:
 - GitHub environment: `npm`
 - allowed action: `npm publish`
 
-The workflow prefers npm's short-lived OIDC identity when the trusted publisher
-exists and only falls back to `NPM_TOKEN` for the bootstrap. No npm token should
-remain in repository or environment secrets after the first release.
+The workflow uses npm's short-lived OIDC identity. It does not require an npm
+token, and no npm token should be stored in repository or environment secrets.
 
 Create and publish a GitHub Release whose tag is `clients-v<version>`, for
 example `clients-v0.2.0`. The workflow checks that the tag matches every package

--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -128,19 +128,18 @@ const apiKey = process.env.ACI_API_KEY;
 if (!apiKey) throw new Error('ACI_API_KEY is required');
 
 const aci = await connectAci({
-  baseURL: 'https://api.example.com/v1',
+  baseURL: 'https://tee.redpill.ai/v1',
   apiKey,
-  policy: {
-    requireProductionOs: true,
-    acceptedComposeHashes: ['<reviewed-sha256-app-compose>'],
-  },
+  policy: { requireProductionOs: true },
   serving: {
-    // Every JSON POST demands verified serving. When session ids are supplied,
-    // request pins are intersected with this locally accepted set.
+    // Every successful JSON POST must carry a receipt and cite verified serving.
     requireVerified: true,
-    acceptedSessionIds: ['<reviewed-attested-session-id>'],
+    requireReceipt: true,
   },
 });
+if (!aci.identity.transcript.verdict.verified) {
+  throw new Error(aci.identity.transcript.verdict.line);
+}
 
 const openai = new OpenAI({
   baseURL: aci.baseURL,
@@ -149,7 +148,7 @@ const openai = new OpenAI({
 });
 
 const response = await openai.chat.completions.create({
-  model: 'your-model',
+  model: 'z-ai/glm-5.2',
   messages: [{ role: 'user', content: 'Hello' }],
 });
 
@@ -164,6 +163,13 @@ if (!audit.transcript.verdict.verified) {
 await aci.refresh(); // Verify a fresh report and rotate the scoped dispatcher.
 await aci.close();
 ```
+
+Install the two ESM packages with `npm install openai @phala/aci-verifier`.
+Run the same source under Node 20.18.1+ or Bun 1.4.0+; the `/runtime` export
+selects the matching pinned transport. Set `ACI_API_KEY` to the Redpill key.
+For release-level pinning, add the reviewed deployment's compose hash under
+`policy.acceptedComposeHashes`; do not copy a hash from the endpoint and trust
+it on first use.
 
 The public API is identical in Node and Bun. Internally, Node passes a scoped
 `undici` dispatcher to `fetch`, while Bun passes its documented

--- a/clients/verifier-ts/package-lock.json
+++ b/clients/verifier-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phala/aci-verifier",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {

--- a/clients/verifier-ts/src/bun/transport.ts
+++ b/clients/verifier-ts/src/bun/transport.ts
@@ -6,7 +6,14 @@ import type {
 } from '../runtime/transport.js';
 
 export function createPinnedTransport(options: PinnedTransportOptions): PinnedTransport {
-  const checkServerIdentity = createPinnedServerIdentityCheck(options.hostname, options.spkiPins);
+  let observedSpkiSha256: string | undefined;
+  const checkServerIdentity = createPinnedServerIdentityCheck(
+    options.hostname,
+    options.spkiPins,
+    (value) => {
+      observedSpkiSha256 = value;
+    },
+  );
   let closed = false;
 
   return {
@@ -42,6 +49,9 @@ export function createPinnedTransport(options: PinnedTransportOptions): PinnedTr
             { cause: error },
           );
         });
+    },
+    observedSpkiSha256() {
+      return observedSpkiSha256;
     },
     async close() {
       closed = true;

--- a/clients/verifier-ts/src/node/transport.ts
+++ b/clients/verifier-ts/src/node/transport.ts
@@ -16,9 +16,16 @@ type NodeFetch = (
 const nodeFetch: NodeFetch = globalThis.fetch;
 
 export function createPinnedTransport(options: PinnedTransportOptions): PinnedTransport {
+  let observedSpkiSha256: string | undefined;
   const tls = {
     ...(options.ca === undefined ? {} : { ca: options.ca }),
-    checkServerIdentity: createPinnedServerIdentityCheck(options.hostname, options.spkiPins),
+    checkServerIdentity: createPinnedServerIdentityCheck(
+      options.hostname,
+      options.spkiPins,
+      (value) => {
+        observedSpkiSha256 = value;
+      },
+    ),
   };
   const dispatcher: PinnedDispatcher = options.proxy
     ? new ProxyAgent({ uri: options.proxy, allowH2: false, requestTls: tls })
@@ -49,6 +56,9 @@ export function createPinnedTransport(options: PinnedTransportOptions): PinnedTr
             { cause: error },
           );
         });
+    },
+    observedSpkiSha256() {
+      return observedSpkiSha256;
     },
     async close() {
       if (closed) return;

--- a/clients/verifier-ts/src/runtime/connection.ts
+++ b/clients/verifier-ts/src/runtime/connection.ts
@@ -1,6 +1,11 @@
 import { createHash, randomBytes } from 'node:crypto';
 
-import { computeVerdict, receiptTranscriptFromDigests, reportTranscript } from '../transcript.js';
+import {
+  bindReportTranscriptChannel,
+  computeVerdict,
+  receiptTranscriptFromDigests,
+  reportTranscript,
+} from '../transcript.js';
 import type { AttestationReport, ReceiptEnvelope, SessionRecord, WorkloadKeyset } from '../types.js';
 import type {
   PinnedTransport,
@@ -185,9 +190,31 @@ class RuntimeAciConnection implements AciConnection {
       });
     }
 
+    const observedSpkiSha256 = candidate.observedSpkiSha256();
+    if (!observedSpkiSha256) {
+      await candidate.close();
+      throw new AciConnectionError(
+        'channel_binding',
+        'pinned ACI channel probe did not observe a TLS peer SPKI',
+      );
+    }
+    const transcript = bindReportTranscriptChannel(identity.transcript, {
+      observedSpkiSha256,
+      host: identity.hostname,
+    });
+    const channelCheck = transcript.lines.find((line) => line.id === 'id-6');
+    if (channelCheck?.status !== 'pass') {
+      await candidate.close();
+      throw new AciConnectionError(
+        'channel_binding',
+        `pinned ACI channel did not satisfy id-6: ${channelCheck?.detail ?? 'check did not run'}`,
+      );
+    }
+    const boundIdentity: VerifiedAciIdentity = { ...identity, transcript };
+
     const previous = this.transport;
     this.transport = candidate;
-    this.currentIdentity = identity;
+    this.currentIdentity = boundIdentity;
     this.rotationRequired = false;
     if (previous) await previous.close();
   }

--- a/clients/verifier-ts/src/runtime/tls-pin.ts
+++ b/clients/verifier-ts/src/runtime/tls-pin.ts
@@ -6,6 +6,7 @@ import { AciConnectionError } from './types.js';
 export function createPinnedServerIdentityCheck(
   expectedHostname: string,
   spkiPins: readonly string[],
+  onVerified?: (spkiSha256: string) => void,
 ): NonNullable<import('node:tls').ConnectionOptions['checkServerIdentity']> {
   const expectedPins = spkiPins.map(normalizePin);
   if (expectedPins.length === 0) {
@@ -26,7 +27,10 @@ export function createPinnedServerIdentityCheck(
         `could not compute TLS SPKI for ${hostname}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    if (expectedPins.some((expected) => hexEqual(actual, expected))) return undefined;
+    if (expectedPins.some((expected) => hexEqual(actual, expected))) {
+      onVerified?.(actual);
+      return undefined;
+    }
     return new Error(
       `TLS SPKI pin mismatch for ${hostname}: peer=${actual} expected=${expectedPins.join(',')}`,
     );

--- a/clients/verifier-ts/src/runtime/transport.ts
+++ b/clients/verifier-ts/src/runtime/transport.ts
@@ -8,6 +8,8 @@ export interface PinnedTransportOptions {
 
 export interface PinnedTransport {
   fetch: AciFetch;
+  /** TLS peer SPKI observed and accepted by the latest handshake. */
+  observedSpkiSha256(): string | undefined;
   close(): Promise<void>;
 }
 

--- a/clients/verifier-ts/src/transcript.ts
+++ b/clients/verifier-ts/src/transcript.ts
@@ -459,7 +459,7 @@ export async function reportTranscript(
     ),
   );
 
-  lines.push(channelLine(report, verification.keyset, options));
+  lines.push(channelLine(verification.keyset, options));
 
   return {
     lines,
@@ -469,13 +469,22 @@ export async function reportTranscript(
   };
 }
 
+/** @internal Re-appraise id-6 after a runtime transport observes the TLS peer. */
+export function bindReportTranscriptChannel(
+  transcript: ReportTranscript,
+  channel: NonNullable<TranscriptOptions['channel']>,
+): ReportTranscript {
+  const channelCheck = channelLine(transcript.verification.keyset, { online: true, channel });
+  const lines = transcript.lines.map((entry) => (entry.id === 'id-6' ? channelCheck : entry));
+  return { ...transcript, lines, verdict: computeVerdict(lines) };
+}
+
 /**
  * id-6 — the channel actually used (§9.1(6)): a TLS SPKI the caller's own
  * stack observed, matched against the attested keyset. Online with none,
  * the channel is unbound (§1.1) and the check fails; offline it is a skip.
  */
 function channelLine(
-  report: AttestationReport,
   keyset: WorkloadKeyset | undefined,
   options: TranscriptOptions,
 ): TranscriptLine {

--- a/clients/verifier-ts/test/pinned-transport-fixture.ts
+++ b/clients/verifier-ts/test/pinned-transport-fixture.ts
@@ -105,7 +105,9 @@ export async function assertPinnedTransport(factory: PinnedTransportFactory): Pr
     ca,
   });
   try {
+    assert.equal(transport.observedSpkiSha256(), undefined);
     assert.equal(await transport.fetch(primary.url).then((response) => response.text()), 'primary');
+    assert.equal(transport.observedSpkiSha256(), spki);
     await assert.rejects(
       transport.fetch(other.url),
       (error: unknown) =>
@@ -131,6 +133,7 @@ export async function assertPinnedTransport(factory: PinnedTransportFactory): Pr
   });
   try {
     await assert.rejects(mismatched.fetch(mismatchServer.url), /SPKI pin mismatch/);
+    assert.equal(mismatched.observedSpkiSha256(), undefined);
   } finally {
     await mismatched.close();
     await mismatchServer.close();

--- a/clients/verifier-ts/test/transcript.test.ts
+++ b/clients/verifier-ts/test/transcript.test.ts
@@ -11,6 +11,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import {
   jcsBytes,
+  computeKeysetDigest,
+  computeReportData,
   verifyReportBinding,
   reportTranscript,
   receiptTranscript,
@@ -24,6 +26,7 @@ import {
   type WorkloadKeyset,
 } from '../src/index.js';
 import { makeMeasuredComposeReport } from './fixtures.js';
+import { bindReportTranscriptChannel } from '../src/transcript.js';
 
 const report = JSON.parse(
   readFileSync(new URL('../../test/fixtures/aci_report.json', import.meta.url), 'utf8'),
@@ -75,6 +78,33 @@ test('transcript: a wrong nonce fails the binding chain (id-2)', async () => {
   const { lines, verdict } = await reportTranscript(report, 'a'.repeat(64), { now: FIXED_NOW });
   assert.equal(verdict.verified, false);
   assert.equal(lines.find((l) => l.id === 'id-2')?.status, 'fail');
+});
+
+test('transcript: a runtime-observed TLS peer satisfies id-6', async () => {
+  const observedSpkiSha256 = 'ab'.repeat(32);
+  const channelReport = structuredClone(report);
+  const workloadKeyset: WorkloadKeyset = {
+    not_after: FIXED_NOW + 300,
+    receipt_signing_keys: [],
+    e2ee_public_keys: [],
+    tls_public_keys: [{ domain: 'gateway.example', spki_sha256: observedSpkiSha256 }],
+  };
+  channelReport.attestation.workload_keyset = workloadKeyset;
+  const digest = await computeKeysetDigest(workloadKeyset);
+  channelReport.workload_keyset_digest = digest;
+  channelReport.attestation.report_data = await computeReportData(digest, FIXTURE_NONCE);
+
+  const unbound = await reportTranscript(channelReport, FIXTURE_NONCE, {
+    now: FIXED_NOW,
+    online: true,
+  });
+  assert.equal(unbound.lines.find((line) => line.id === 'id-6')?.status, 'fail');
+
+  const bound = bindReportTranscriptChannel(unbound, {
+    observedSpkiSha256,
+    host: 'gateway.example',
+  });
+  assert.equal(bound.lines.find((line) => line.id === 'id-6')?.status, 'pass');
 });
 
 test('transcript: compose policy accepts reviewed releases and rejects other measurements', async () => {

--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -71,8 +71,8 @@ pub(super) fn chutes_instance_id<'a>(
 }
 
 /// Typed claims for one Chutes instance: the verifier's facts for that instance
-/// only, so its session is content-addressed on its own data and survives fleet
-/// churn (a sibling instance joining or failing does not change it).
+/// only. The session separately retains the shared verification evidence bundle
+/// that proves those facts.
 pub(super) fn per_instance_session_claims(
     event: &UpstreamVerifiedEvent,
     instance_id: &str,
@@ -779,8 +779,8 @@ mod claim_mapping_tests {
             c1.extra.get("gpu_verified").and_then(Value::as_bool),
             Some(true)
         );
-        // Fleet-wide fields are dropped, so the slice (and the session content id)
-        // does not change when a sibling instance does (per-instance idempotency).
+        // Fleet-wide fields are dropped, so this claim slice does not change
+        // when a sibling instance does.
         assert!(!c1.extra.contains_key("verified_instance_ids"));
         assert!(!c1.extra.contains_key("instance_tcb_statuses"));
         assert!(!c1.extra.contains_key("instance_measurements"));

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -699,18 +699,15 @@ impl AciService {
                 Some(instance_id) => per_instance_session_claims(event, instance_id),
                 None => session_claims_for_event(event),
             };
-            // A per-instance (Chutes) binding excludes the shared, nonce-bound raw
-            // evidence so re-verifying the same instance is a no-op; a single
-            // channel keeps the event's evidence.
-            let evidence = if instance.is_some() {
-                EvidenceRef::default()
-            } else {
-                event
-                    .evidence
-                    .as_ref()
-                    .map(EvidenceRef::from_value)
-                    .unwrap_or_default()
-            };
+            // Chutes verifies a fleet in one nonce-bound evidence bundle, then
+            // exposes one channel binding per instance. Each per-instance
+            // session must retain that bundle so a receipt citation remains
+            // independently auditable under ACI section 9.2.
+            let evidence = event
+                .evidence
+                .as_ref()
+                .map(EvidenceRef::from_value)
+                .unwrap_or_default();
             let session_id = self.seal_attested_session(
                 event,
                 identity.clone(),

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -303,6 +303,51 @@ async fn verified_upstream_binding_creates_attested_session() {
 }
 
 #[tokio::test]
+async fn chutes_instance_session_retains_verification_evidence() {
+    let (svc, _) = make_service(br#"{"id":"chat-xyz","model":"x"}"#);
+    let evidence_data = "data:application/json;base64,YWJj";
+    let evidence_digest = private_ai_gateway::aci::digest::sha256_hex(b"abc");
+    let event = UpstreamVerifiedEvent {
+        provider_type: Some("chutes".to_string()),
+        url_origin: Some("https://stub-upstream".to_string()),
+        verifier_id: "private-ai-verifier/chutes/v1".to_string(),
+        evidence: Some(serde_json::json!({
+            "digest": evidence_digest,
+            "data": evidence_data,
+        })),
+        channel_bindings: vec![ChannelBinding::E2eePublicKeySha256 {
+            provider: "chutes".to_string(),
+            key_id: Some("instance-1".to_string()),
+            algorithm: "chutes-ml-kem-768".to_string(),
+            public_key_sha256: "aa".repeat(32),
+        }],
+        ..verified_event("stub-upstream", "x")
+    };
+
+    let result = svc
+        .forward_chat_completion(br#"{"model":"x","messages":[]}"#, None, false, Some(event))
+        .await
+        .unwrap();
+    let session_id = payload_event(&result.receipt, "upstream.verified")["session_id"]
+        .as_str()
+        .expect("verified Chutes binding should produce a session id")
+        .to_string();
+    let session = svc
+        .get_attested_session(&session_id)
+        .expect("Chutes session should be queryable");
+
+    assert_eq!(
+        session.document().evidence.digest.as_deref(),
+        Some(evidence_digest.as_str())
+    );
+    assert_eq!(
+        session.document().evidence.data_uri.as_deref(),
+        Some(evidence_data)
+    );
+    assert!(session.document().evidence.digest_matches_data());
+}
+
+#[tokio::test]
 async fn verified_upstream_binding_fails_without_persisted_session() {
     let (svc, received) = make_service_raw(br#"{"id":"chat-xyz","model":"x"}"#);
     let svc = svc.with_session_store(Arc::new(FailingSessionStore));


### PR DESCRIPTION
## Summary

- retain the shared Chutes verification evidence bundle in every per-instance attested session, so `upstream-2` can verify the cited session under ACI section 9.2
- record the TLS peer SPKI accepted by the Node and Bun pinned transports and re-appraise `id-6` before `connectAci()` exposes the connection
- fail closed if a pinned channel probe cannot produce an `id-6` pass
- prepare the coordinated `0.2.2` npm client release and update the trusted-publishing documentation to reflect the existing OIDC-only workflow

## Why

Production Chutes receipts cited per-instance sessions with an empty `evidence` object. The receipt signature and body hashes passed, but the official verifier correctly rejected `upstream-2` because the session evidence could not hash to its digest.

The runtime SDK separately enforced the attested SPKI in its scoped transport, but its public identity transcript was generated before the pinned probe and therefore reported `id-6` as failed. This made a successfully pinned connection appear unverified.

## Verification

- `npm --prefix clients/verifier-ts test` (50 passed)
- `npm --prefix clients/verifier-ts run test:bun` (Bun 1.4.0 passed)
- `npm --prefix clients/verifier-ts run lint:package`
- `npm --prefix clients/pi-provider run check`
- `npm --prefix clients/pi-provider run lint`
- `npm --prefix clients/pi-provider run format:check`
- `npm --prefix clients/pi-provider test` (30 passed)
- `npm --prefix clients/pi-provider run lint:packages`
- `bash clients/package-smoke.sh`
- live local-build probe against `https://tee.redpill.ai/v1`: Node 24 and Bun 1.4.0 report `identityVerified: true`, `id-6: pass`; a GLM inference receipt reports `VERIFIED (6 pass)`

Rust is covered by the focused service test added here and will run in the repository CI Rust 1.94 environment; this workstation does not have a Rust toolchain installed.

## Deployment

The Chutes receipt fix takes effect only after a gateway deployment is rebuilt from the merged commit. The npm runtime fix takes effect after publishing the coordinated `clients-v0.2.2` release.
