### PR TITLE
fix(clients): load Pi provider from host runtime

### DIFF
--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/opencode-provider-aci",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native OpenCode provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "1.18.23",

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-phala-cloud",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Phala Cloud provider for OpenCode with verified ACI transport and per-response receipt verification",
   "keywords": [
     "aci",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0",
-    "@phala/opencode-provider-aci": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1",
+    "@phala/opencode-provider-aci": "^0.4.1"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/opencode-provider/packages/opencode-provider-redpill/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-redpill",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "RedPill ACI provider for OpenCode",
   "keywords": [
     "aci",
@@ -51,8 +51,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0",
-    "@phala/opencode-provider-aci": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1",
+    "@phala/opencode-provider-aci": "^0.4.1"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-clients",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "workspaces": [
         "verifier-ts",
@@ -6115,10 +6115,10 @@
     },
     "opencode-provider/packages/opencode-provider-aci": {
       "name": "@phala/opencode-provider-aci",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "1.18.23",
@@ -6132,11 +6132,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-phala-cloud": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0",
-        "@phala/opencode-provider-aci": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1",
+        "@phala/opencode-provider-aci": "^0.4.1"
       },
       "engines": {
         "bun": ">=1.4.0"
@@ -6146,11 +6146,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-redpill": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0",
-        "@phala/opencode-provider-aci": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1",
+        "@phala/opencode-provider-aci": "^0.4.1"
       },
       "engines": {
         "bun": ">=1.4.0"
@@ -6161,10 +6161,10 @@
     },
     "pi-provider/packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6176,11 +6176,11 @@
       }
     },
     "pi-provider/packages/pi-provider-phala-cloud": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0",
-        "@phala/pi-provider-aci": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1",
+        "@phala/pi-provider-aci": "^0.4.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6192,11 +6192,11 @@
       }
     },
     "pi-provider/packages/pi-provider-redpill": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.4.0",
-        "@phala/pi-provider-aci": "^0.4.0"
+        "@phala/aci-provider": "^0.4.1",
+        "@phala/pi-provider-aci": "^0.4.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6209,10 +6209,10 @@
     },
     "provider": {
       "name": "@phala/aci-provider",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.4.0"
+        "@phala/aci-verifier": "^0.4.1"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -6227,7 +6227,7 @@
     },
     "verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/package-smoke.sh
+++ b/clients/package-smoke.sh
@@ -7,7 +7,8 @@ trap 'rm -rf "$scratch"' EXIT
 
 packs="$scratch/packs"
 consumer="$scratch/consumer"
-mkdir -p "$packs" "$consumer"
+pi_npm="$scratch/pi-agent/npm"
+mkdir -p "$packs" "$consumer" "$pi_npm"
 
 for package in \
   @phala/aci-verifier \
@@ -85,3 +86,28 @@ for (const name of [
   }
 }
 '
+
+# Pi deliberately omits host-provided peer dependencies when it installs an
+# extension. Load the packaged extension with Pi's own loader in that layout.
+npm init --yes --silent --prefix "$pi_npm" >/dev/null
+npm install --prefix "$pi_npm" --legacy-peer-deps --ignore-scripts --no-audit --no-fund \
+  "$packs"/phala-aci-verifier-*.tgz \
+  "$packs"/phala-aci-provider-*.tgz \
+  "$packs"/phala-pi-provider-aci-*.tgz \
+  "$packs"/pi-provider-phala-cloud-*.tgz
+
+for peer in pi-ai pi-coding-agent pi-tui; do
+  if [[ -e "$pi_npm/node_modules/@earendil-works/$peer" ]]; then
+    echo "Pi smoke unexpectedly installed host peer @earendil-works/$peer" >&2
+    exit 1
+  fi
+done
+
+PI_CODING_AGENT_DIR="$scratch/pi-agent" \
+  "$repo_root/clients/node_modules/.bin/pi" \
+  --offline \
+  --no-context-files \
+  --no-skills \
+  --no-themes \
+  --extension "$pi_npm/node_modules/pi-provider-phala-cloud/dist/index.js" \
+  --list-models >/dev/null

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "ACI TypeScript clients and coding-agent providers",
   "license": "MIT",

--- a/clients/pi-provider/packages/pi-provider-aci/index.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/index.ts
@@ -23,8 +23,8 @@ import type {
   ExtensionCommandContext,
   ExtensionFactory,
 } from "@earendil-works/pi-coding-agent";
+import * as piAi from "@earendil-works/pi-ai";
 import type { Model, Provider } from "@earendil-works/pi-ai";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { type SettingItem, SettingsList, truncateToWidth } from "@earendil-works/pi-tui";
 import { createAciProvider, type AciProvider } from "@phala/aci-provider";
 import os from "node:os";
@@ -68,6 +68,36 @@ interface AciRuntimeState {
 interface AciConnectionSetup {
   configKey: string;
   promise: Promise<void>;
+}
+
+type OpenAICompletionsApi = ReturnType<
+  typeof import("@earendil-works/pi-ai/compat").openAICompletionsApi
+>;
+
+function isOpenAICompletionsApi(api: unknown): api is OpenAICompletionsApi {
+  return (
+    typeof api === "object" &&
+    api !== null &&
+    "stream" in api &&
+    typeof api.stream === "function" &&
+    "streamSimple" in api &&
+    typeof api.streamSimple === "function"
+  );
+}
+
+function openAICompletionsApi(): OpenAICompletionsApi {
+  if (!("openAICompletionsApi" in piAi)) {
+    throw new Error("Pi does not provide the OpenAI Completions API");
+  }
+  const factory = piAi.openAICompletionsApi;
+  if (typeof factory !== "function") {
+    throw new Error("Pi provides an invalid OpenAI Completions API factory");
+  }
+  const api: unknown = factory();
+  if (!isOpenAICompletionsApi(api)) {
+    throw new Error("Pi provides an invalid OpenAI Completions API");
+  }
+  return api;
 }
 
 function modelsFromState(state: AciRuntimeState) {

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0",
-    "@phala/pi-provider-aci": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1",
+    "@phala/pi-provider-aci": "^0.4.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Redpill AI for Pi with verified ACI transport and per-response receipt verification",
   "keywords": [
     "ai-provider",
@@ -52,8 +52,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.4.0",
-    "@phala/pi-provider-aci": "^0.4.0"
+    "@phala/aci-provider": "^0.4.1",
+    "@phala/pi-provider-aci": "^0.4.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/provider/package.json
+++ b/clients/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-provider",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Framework-neutral model provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -62,7 +62,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.4.0"
+    "@phala/aci-verifier": "^0.4.1"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- load the OpenAI Completions adapter through Pi's host-provided root runtime instead of an extension-local `pi-ai` subpath
- validate the host adapter boundary before registering the native ACI provider
- add a release smoke test that installs the packaged Phala Cloud extension with Pi's real `--legacy-peer-deps` layout and loads it through the bundled Pi CLI
- bump the coordinated client release to `0.4.1`

## Root cause

Pi intentionally omits `@earendil-works/pi-*` peer dependencies from managed extension installs and supplies those APIs through loader virtual modules. The previous smoke test auto-installed peers in a generic npm consumer, so the private subpath import appeared to work but failed in `~/.pi/agent/npm`.

## Verification

- `npm run check`
- `npm test`
- `npm run test:bun`
- `npm run lint`
- `npm run format:check`
- `npm run lint:packages`
- `bash package-smoke.sh`

The package smoke test asserts the managed extension directory contains no Pi host peers, then runs the real bundled `pi --offline --list-models` against `pi-provider-phala-cloud`.
