### PR TITLE
test(clients): verify packaged agent plugins in host CLIs

### DIFF
--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -62,9 +62,7 @@
     "@opencode-ai/plugin": ">=1.18.23 <2"
   },
   "engines": {
-    "bun": ">=1.4.0"
-  },
-  "opencode": {
-    "type": "plugin"
+    "bun": ">=1.4.0",
+    "opencode": ">=1.18.23 <2"
   }
 }

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
@@ -1,15 +1,13 @@
 # `opencode-provider-phala-cloud`
 
-Phala Cloud's native OpenCode provider. Install it in `opencode.json`:
+Phala Cloud's native OpenCode provider. Install it for the current project:
 
-```jsonc
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-provider-phala-cloud"],
-}
+```sh
+opencode plugin opencode-provider-phala-cloud
 ```
 
-Run `opencode providers login` and choose Phala Cloud, or set
+Pass `--global` to install it in the global OpenCode config. Then run
+`opencode providers login` and choose Phala Cloud, or set
 `PHALA_LLM_API_KEY`. Then select `phala/<model-id>`. Account login uses the
 Phala Cloud device flow to issue a Confidential AI key; inference still travels
 only through the attested, TLS-pinned ACI connection. OpenCode calls browser

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -60,9 +60,7 @@
     "@opencode-ai/plugin": ">=1.18.23 <2"
   },
   "engines": {
-    "bun": ">=1.4.0"
-  },
-  "opencode": {
-    "type": "plugin"
+    "bun": ">=1.4.0",
+    "opencode": ">=1.18.23 <2"
   }
 }

--- a/clients/opencode-provider/packages/opencode-provider-redpill/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/README.md
@@ -1,15 +1,13 @@
 # `opencode-provider-redpill`
 
-RedPill's native OpenCode provider. Install it in your OpenCode configuration:
+RedPill's native OpenCode provider. Install it for the current project:
 
-```jsonc
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-provider-redpill"],
-}
+```sh
+opencode plugin opencode-provider-redpill
 ```
 
-Run `opencode providers login` and paste a Redpill API key, or set
+Pass `--global` to install it in the global OpenCode config. Then run
+`opencode providers login` and paste a Redpill API key, or set
 `REDPILL_LLM_API_KEY`. Redpill does not currently expose account OAuth. Then
 select `redpill/<model-id>`. The plugin discovers current TEE models and sends
 inference only through an attested, TLS-pinned connection. Every response

--- a/clients/opencode-provider/packages/opencode-provider-redpill/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/package.json
@@ -58,9 +58,7 @@
     "@opencode-ai/plugin": ">=1.18.23 <2"
   },
   "engines": {
-    "bun": ">=1.4.0"
-  },
-  "opencode": {
-    "type": "plugin"
+    "bun": ">=1.4.0",
+    "opencode": ">=1.18.23 <2"
   }
 }

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -24,6 +24,7 @@
         "@types/bun": "^1.4.0",
         "@types/node": "^24.0.0",
         "esbuild": "^0.25.0",
+        "opencode-ai": "1.18.23",
         "oxfmt": "^0.44.0",
         "oxlint": "^1.80.0",
         "publint": "^0.3.24",
@@ -5410,6 +5411,166 @@
         }
       }
     },
+    "node_modules/opencode-ai": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.23.tgz",
+      "integrity": "sha512-3NkT0XINL7d0HYkTyGV1SPChHXhvRgKqNaTgKRTGb0TXUWszXA7MW/y3zMZw29y1AQuUDAzRvVYmQ9KGRQhroA==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.23",
+        "opencode-darwin-x64": "1.18.23",
+        "opencode-darwin-x64-baseline": "1.18.23",
+        "opencode-linux-arm64": "1.18.23",
+        "opencode-linux-arm64-musl": "1.18.23",
+        "opencode-linux-x64": "1.18.23",
+        "opencode-linux-x64-baseline": "1.18.23",
+        "opencode-linux-x64-baseline-musl": "1.18.23",
+        "opencode-linux-x64-musl": "1.18.23",
+        "opencode-windows-arm64": "1.18.23",
+        "opencode-windows-x64": "1.18.23",
+        "opencode-windows-x64-baseline": "1.18.23"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.23.tgz",
+      "integrity": "sha512-QP9PjwpHtZoLVXw2WvUmPZecz7mWbQkT4t3K36B//fCaDG+zWa+SsztIeaW5azujNwwtUemLA5icE/zINng48Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.23.tgz",
+      "integrity": "sha512-R9nWP3edz/0FnEfwmuxtiWBB7bS4NtZCyCffJyiMlrbwdDC+bIXYrWxWXVrzaP1mJujs6g2MAwTCUSx/qpBhDw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-QGx6I/nFYur7qJ/Nx2L3fC4XYQt44cyDsm7p8twNA+cdjGX3ndnPbMdAl5ikdZyAfSMUGYK8VWY2JMxv0rmfjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.23.tgz",
+      "integrity": "sha512-g1zDFhuE9FOYwjSGderlu69wfd4GQzS0xsDiIY11QUciuBmM6DrHqLvmhlLFsUVHYVnCPY1YeN1pq5ewE3x72Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.23.tgz",
+      "integrity": "sha512-VyDkzUJfJgkx9h9RhazTW9xeTgSXBmVFPblsbPGBW9tR612f6gjQxfOfu4cpHnQHK1qjuW9ClzLKHWqv3EcJTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.23.tgz",
+      "integrity": "sha512-5x9d1Cm/YtqzR6lAlNbgVprTQ3R3hx7qGTWCzm5l5u6lBNkhYTrhy2s8k25dxKKuxqZ9Kngqz9JYWvSVHy2Lmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-yUhBOXfTQour2JCdAkwD3DDqSnyxB0grefwdPqEhYmJHIkYxfJIIzyy6V//pyouvkE0XMouFtiuZXw8S6Wo0iQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.23.tgz",
+      "integrity": "sha512-c1DPxauhzAurlIBhJBr/rokDpc65l084T4qTl36gDDT9Xzc/Nk5Q5yMDaPm1DDI3WeHKDt11MDlxT5AjQW5gtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.23.tgz",
+      "integrity": "sha512-t/5mlnTBZKdZpqKHwdwxlWqGakntauvMSmXtyJc17M7XJRmZaaGHtNSaSefbbYFIL4agoQCXTvIkhhyxOvr7zQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/opencode-provider-phala-cloud": {
       "resolved": "opencode-provider/packages/opencode-provider-phala-cloud",
       "link": true
@@ -5417,6 +5578,45 @@
     "node_modules/opencode-provider-redpill": {
       "resolved": "opencode-provider/packages/opencode-provider-redpill",
       "link": true
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.23.tgz",
+      "integrity": "sha512-QtJQcLU0yPz6on3jjks3f/EHgZuIDFw7FvAKu3wsHhL09NYDh7GczfRXDPRHa3NgqnU8dkB8p9mhqgaPRPogoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.23.tgz",
+      "integrity": "sha512-mMaIITuXzkNfjdcYL8uZaZuMDjulFyH/UCq9bxblam2mUZf9uWisoi5J6CXFsS/mkN7CZfTAt6PttSp4n3PH4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.23.tgz",
+      "integrity": "sha512-AqXsTKaPcDx3rrid5bLUwJbQ/3vr9rJ6fvOStIznTzwrbOgP8wy5G4jCoIzu6KB/WxGx/d1MrV4cGaJ73qnjBA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/oxfmt": {
       "version": "0.44.0",
@@ -6125,7 +6325,8 @@
         "@opencode-ai/sdk": "1.18.23"
       },
       "engines": {
-        "bun": ">=1.4.0"
+        "bun": ">=1.4.0",
+        "opencode": ">=1.18.23 <2"
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.18.23 <2"
@@ -6139,7 +6340,8 @@
         "@phala/opencode-provider-aci": "^0.4.1"
       },
       "engines": {
-        "bun": ">=1.4.0"
+        "bun": ">=1.4.0",
+        "opencode": ">=1.18.23 <2"
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.18.23 <2"
@@ -6153,7 +6355,8 @@
         "@phala/opencode-provider-aci": "^0.4.1"
       },
       "engines": {
-        "bun": ">=1.4.0"
+        "bun": ">=1.4.0",
+        "opencode": ">=1.18.23 <2"
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/package-smoke.sh
+++ b/clients/package-smoke.sh
@@ -111,3 +111,36 @@ PI_CODING_AGENT_DIR="$scratch/pi-agent" \
   --no-themes \
   --extension "$pi_npm/node_modules/pi-provider-phala-cloud/dist/index.js" \
   --list-models >/dev/null
+
+smoke_opencode_provider() {
+  local package_name="$1"
+  local provider_id="$2"
+  local config
+  local models
+
+  config="$(
+    node --input-type=module - "$consumer/node_modules/$package_name" "$provider_id" <<'NODE'
+import { pathToFileURL } from "node:url";
+
+const plugin = pathToFileURL(process.argv[2]).href;
+process.stdout.write(JSON.stringify({ plugin: [plugin], enabled_providers: [process.argv[3]] }));
+NODE
+  )"
+
+  models="$(
+    XDG_CONFIG_HOME="$scratch/opencode/$provider_id/config" \
+    XDG_CACHE_HOME="$scratch/opencode/$provider_id/cache" \
+    XDG_DATA_HOME="$scratch/opencode/$provider_id/data" \
+    XDG_STATE_HOME="$scratch/opencode/$provider_id/state" \
+    OPENCODE_CONFIG_CONTENT="$config" \
+      "$repo_root/clients/node_modules/.bin/opencode" models "$provider_id"
+  )"
+
+  if ! rg -q "^$provider_id/" <<<"$models"; then
+    echo "OpenCode did not load any $provider_id models" >&2
+    exit 1
+  fi
+}
+
+smoke_opencode_provider opencode-provider-phala-cloud phala
+smoke_opencode_provider opencode-provider-redpill redpill

--- a/clients/package-smoke.sh
+++ b/clients/package-smoke.sh
@@ -136,7 +136,7 @@ NODE
       "$repo_root/clients/node_modules/.bin/opencode" models "$provider_id"
   )"
 
-  if ! rg -q "^$provider_id/" <<<"$models"; then
+  if ! grep -q "^$provider_id/" <<<"$models"; then
     echo "OpenCode did not load any $provider_id models" >&2
     exit 1
   fi

--- a/clients/package.json
+++ b/clients/package.json
@@ -33,6 +33,7 @@
     "@types/bun": "^1.4.0",
     "@types/node": "^24.0.0",
     "esbuild": "^0.25.0",
+    "opencode-ai": "1.18.23",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.80.0",
     "publint": "^0.3.24",

--- a/clients/pi-provider/packages/pi-provider-aci/index.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/index.ts
@@ -85,7 +85,9 @@ function isOpenAICompletionsApi(api: unknown): api is OpenAICompletionsApi {
   );
 }
 
-function openAICompletionsApi(): OpenAICompletionsApi {
+// Pi exposes compat stream factories at the root module for extensions while
+// managed installs intentionally omit Pi peer packages.
+function getHostOpenAICompletionsApi(): OpenAICompletionsApi {
   if (!("openAICompletionsApi" in piAi)) {
     throw new Error("Pi does not provide the OpenAI Completions API");
   }
@@ -205,7 +207,7 @@ function piModelsFromState(state: AciRuntimeState): Model<"openai-completions">[
 }
 
 function nativeAciProvider(state: AciRuntimeState): Provider<"openai-completions"> {
-  const streams = openAICompletionsApi();
+  const streams = getHostOpenAICompletionsApi();
   const fetch = providerFetch(state);
   return {
     id: state.profile.providerId,


### PR DESCRIPTION
## Summary

- run the packaged Pi provider through Pi's real extension loader without host peer packages
- run packaged Phala Cloud and RedPill providers through OpenCode 1.18.23 model discovery
- declare the official OpenCode compatibility range and document the native plugin installer

## Verification

- `npm run check`
- `npm test`
- `npm run test:bun`
- `npm run lint`
- `npm run format:check`
- `npm run lint:packages`
- `bash package-smoke.sh`
- `git diff --check`