### PR TITLE
fix(clients): use native Pi and OpenCode persistence

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -70,8 +70,10 @@ and native coding-agent integrations:
   receipt, and session status.
 
 SDKs that accept a function can use `connectAci().fetch` directly. Native Pi
-and OpenCode integrations use the provider packages above. Agents that only
-accept a base URL use `aci serve` as a local verification boundary.
+and OpenCode integrations use their official provider and plugin APIs through
+the packages above. A base URL alone cannot inject ACI's attested TLS transport;
+hosts without a custom-fetch or provider-plugin extension point are not claimed
+as native integrations in this release.
 
 [docs/quickstart.md](../docs/quickstart.md) exercises both verifier
 surfaces against a live deployment. The `pi-provider` extension is loaded

--- a/clients/architecture.md
+++ b/clients/architecture.md
@@ -28,11 +28,9 @@ flowchart LR
     core[ACI provider core<br/>new]:::refactor
     sdk[OpenAI, Agents, LangChain,<br/>Vercel AI SDK]:::external
     opencode[OpenCode on Bun]:::external
-    agents[Codex and Claude Code]:::external
     connect[connectAci shared runtime client<br/>current refactor]:::refactor
     node[Node fetch adapter<br/>current refactor]:::refactor
     bun[Bun fetch adapter<br/>current refactor]:::refactor
-    serve[aci serve local proxy<br/>existing upstream]:::upstream
 
     pi --> core
     opencode --> ocadapter --> core
@@ -40,7 +38,6 @@ flowchart LR
     sdk --> connect
     connect -->|Node host| node
     connect -->|Bun host| bun
-    agents --> serve
   end
 
   subgraph trust[Shared trust contract]
@@ -53,7 +50,6 @@ flowchart LR
 
   node --> identity
   bun --> identity
-  serve --> identity
 
   subgraph tee[Private AI Gateway inside the TEE - existing upstream]
     api[OpenAI, Responses and<br/>Anthropic API surfaces]:::upstream
@@ -110,20 +106,24 @@ attached only by the Phala Cloud adapters. A future Redpill Clerk OAuth flow
 should be added when that product endpoint exists, without changing the
 verifier.
 
-`aci serve` is not a new protocol translator and was not introduced by the Pi
-integration. It is the existing Rust local verifying proxy. It preserves the
-request path and body, so the gateway must implement the protocol spoken by the
-agent. `connectAci()` is the new runtime client for applications that accept a
-custom `fetch`. Node and Bun expose the same public API and differ only in how
-their native `fetch` receives the TLS identity callback.
+Pi and OpenCode integrate through their official host APIs. Pi owns credentials,
+dynamic-catalog persistence, default-model persistence, and the provider
+lifecycle. OpenCode owns plugin configuration and credential persistence; its
+server plugin supplies the provider config, auth loader, verified fetch, tools,
+and disposal hook. Neither adapter maintains a parallel host state store.
 
-## One trust contract, two integrations
+`connectAci()` is the runtime client for applications that accept a custom
+`fetch`. Node and Bun expose the same public API and differ only in how their
+native `fetch` receives the TLS identity callback.
 
-Fetch-aware Node and Bun applications inject `connectAci().fetch`. Software
-that exposes only a base URL points at `aci serve` on localhost. This is a
-capability split, not two competing ACI products: one side receives a function,
-the other can only receive a URL. Both paths must enforce the same security
-meaning:
+## One trust contract, host-native integrations
+
+Pi and OpenCode inject the shared verified fetch through their official provider
+extension points. Other fetch-aware Node and Bun applications inject
+`connectAci().fetch` directly. A base URL alone cannot inject the attested TLS
+transport, so clients without a supported custom-fetch or provider-plugin
+boundary are not native ACI integrations in this release. Every supported path
+enforces the same security meaning:
 
 1. Verify a fresh TDX quote and its nonce-bound workload keyset.
 2. Verify that `sha256(app_compose)` is measured into the quote's RTMR3.
@@ -186,7 +186,6 @@ signed GitHub Release. Publishing alone does not create a reviewed-release
 claim: the Redpill and Phala deployment pipelines still need to supply the
 independently reviewed compose hashes consumed by the branded policies.
 
-The local agent and `aci serve` see plaintext prompts and responses. This
-architecture covers the remote model HTTP path; MCP servers, tools, browser
-automation, shell commands, WebSockets, extensions, and telemetry have separate
-trust boundaries.
+The local agent sees plaintext prompts and responses. This architecture covers
+the remote model HTTP path; MCP servers, tools, browser automation, shell
+commands, WebSockets, extensions, and telemetry have separate trust boundaries.

--- a/clients/coding-agents.md
+++ b/clients/coding-agents.md
@@ -1,119 +1,89 @@
 # Coding agents over ACI
 
-Coding-agent integrations keep verification at the transport boundary. Native
-providers also own model discovery and host-specific lifecycle integration.
+Coding agents should integrate ACI through capabilities officially exposed by
+their host. The adapter owns only ACI-specific verification and model mapping;
+the host continues to own installation, authentication, model selection,
+persistence, and lifecycle.
+
+| Host | Official extension point | ACI integration |
+| --- | --- | --- |
+| Pi | Provider extension, auth API, model registry, commands, footer | `pi-provider-redpill`, `pi-provider-phala-cloud`, or `@phala/pi-provider-aci` |
+| OpenCode | Server plugin, provider config, auth hooks, tools, dispose | `opencode-provider-redpill`, `opencode-provider-phala-cloud`, or `@phala/opencode-provider-aci` |
+| Node/Bun SDK application | Per-client custom `fetch` | `connectAci().fetch` |
+| Base-URL-only coding agent | No transport injection point | No native ACI adapter in this release |
+
+All supported paths share `@phala/aci-provider` and
+`@phala/aci-verifier`. They verify the workload and TLS channel before sending
+model traffic, discover the live model catalog, require verified serving,
+retain bounded wire digests, and verify every signed receipt and cited session
+before an inference response finishes.
+
+## Pi
+
+Install one provider through Pi's package manager:
+
+```sh
+pi install npm:pi-provider-redpill
+# or
+pi install npm:pi-provider-phala-cloud
+```
+
+Then use Pi's native login and model picker:
 
 ```text
-fetch-aware Node/Bun client ---- connectAci() ---- ACI gateway
+/login redpill
+# paste the Redpill API key
 
-base-URL-only CLI ----------- aci serve ------- ACI gateway
-                            127.0.0.1:4180
+# or
+/login phala
+# approve the Phala Cloud device login
+
+# wait for the footer to show aci-verified
+/model
+# search for redpill/ or phala/, select a model, and press Ctrl+S
 ```
 
-`connectAci()` is the direct integration when an application accepts a custom
-`fetch`; its conditional runtime entry selects the Node or Bun adapter.
-Applications that expose only a base URL use `aci serve`: one local process
-verifies the hardware-backed workload identity, pins the remote TLS SPKI, and
-forwards the agent's protocol unchanged. The selected gateway route must serve
-that protocol.
+Pi owns persistence. It writes credentials to `~/.pi/agent/auth.json`, dynamic
+catalogs to `~/.pi/agent/models-store.json`, and a default selected with
+`Ctrl+S` to `~/.pi/agent/settings.json`. A normal model selection changes only
+the current session. Cached dynamic models are restored offline.
 
-Both paths demand `provider.aci_verified` on JSON inference requests by
-default, record exact request/response digests without buffering streams, and
-verify signed receipts plus cited sessions on demand. A configured session set
-is a local acceptance policy: request pins are intersected with it, and a
-disjoint request fails before reaching the gateway.
+`REDPILL_AI_API_KEY` and `PHALA_AI_API_KEY` can provide a credential to the
+current process. Pi intentionally does not copy environment variables into its
+credential store; use `/login` when the key must survive a restart.
 
-## Start the local verifier
+The provider-scoped commands expose ACI-specific state that Pi does not know
+about: settings, attestation, retained receipts, and content-addressed sessions.
+For example, Redpill registers `/redpill-settings`, `/redpill-attestation`,
+`/redpill-receipt`, and `/redpill-session`.
 
-From this repository:
+## OpenCode
 
-```bash
-cargo run --bin aci -- serve https://gateway.example.com \
-  --accept-compose <reviewed-sha256-app-compose>
+Install a branded provider through OpenCode's native plugin command:
+
+```sh
+opencode plugin opencode-provider-redpill --global
+opencode providers login --provider redpill
+
+# or
+opencode plugin opencode-provider-phala-cloud --global
+opencode providers login --provider phala
 ```
 
-The command verifies before listening and fails closed. `--accept-compose` is
-repeatable for a controlled release rotation. Omitting it verifies the measured
-compose without accepting a reviewed release. Populate it from authenticated
-release metadata, not the endpoint being verified.
-The agent-facing base URLs are:
+Omit `--global` for a project installation. The plugin command persists the
+plugin entry in OpenCode configuration, and provider login persists the
+credential in OpenCode's auth store. Do not add a separate provider block: the
+plugin owns the provider, verified fetch, live models, and auth loader.
 
-- OpenAI APIs: `http://127.0.0.1:4180/v1`
-- Anthropic Messages: `http://127.0.0.1:4180`
+Redpill currently supports API keys only. Phala Cloud offers both its device
+account flow and an API-key method. The device flow returns the issued
+Confidential AI key through OpenCode's documented browser-authorization hook;
+the plugin does not create a parallel OAuth token lifecycle or credential file.
 
-Keep the gateway key in an environment variable. Authentication passes through
-from the agent request; the `aci serve` command line contains no key.
+`REDPILL_AI_API_KEY` and `PHALA_AI_API_KEY` are supported for the current
+process. OpenCode does not copy environment variables into its auth store.
 
-## Compatibility
-
-| Agent | Agent protocol | Integration | Status |
-| --- | --- | --- | --- |
-| Pi | OpenAI Chat Completions | Inject `connectAci().fetch` | Native |
-| Codex CLI | OpenAI Responses | Point a custom model provider at `aci serve` | Supported when the selected gateway route serves `/v1/responses` |
-| Claude Code | Anthropic Messages | Set `ANTHROPIC_BASE_URL` to `aci serve` | Supported; `/v1/messages/count_tokens` is optional |
-| OpenCode | OpenAI Chat Completions or Responses | Plugin injects Bun `connectAci().fetch` | Native |
-
-The native Pi and OpenCode providers additionally hold each inference stream
-open until its signed receipt and cited session verify. The bounded receipt
-history remains available for later inspection.
-
-### Codex CLI
-
-Codex custom providers use the Responses API. Put the provider in the
-user-level `$CODEX_HOME/config.toml`; project-local config cannot override
-provider definitions.
-
-```toml
-model = "<model-id>"
-model_provider = "aci"
-
-[model_providers.aci]
-name = "ACI local verifier"
-base_url = "http://127.0.0.1:4180/v1"
-env_key = "ACI_API_KEY"
-wire_api = "responses"
-```
-
-The gateway model route must implement `/v1/responses`.
-
-### Claude Code
-
-Claude Code speaks Anthropic Messages to a custom gateway:
-
-```bash
-export ANTHROPIC_BASE_URL=http://127.0.0.1:4180
-export ANTHROPIC_AUTH_TOKEN="$ACI_API_KEY"
-export ANTHROPIC_MODEL=<model-id>
-claude
-```
-
-The gateway already exposes `/v1/messages`. Claude Code may also call
-`/v1/messages/count_tokens`; that endpoint is optional and Claude Code falls
-back when it is unavailable. New Claude Code releases may add beta headers and
-body fields, so compatibility should be exercised when either side upgrades.
-
-### OpenCode
-
-For RedPill, add one plugin entry to `opencode.json`:
-
-```jsonc
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-provider-redpill"],
-}
-```
-
-Run `opencode providers login`, paste a Redpill API key, or set
-`REDPILL_AI_API_KEY`, then choose `redpill/<model-id>`. Redpill does not
-currently expose account OAuth; a future Clerk OAuth integration is outside
-this release.
-
-For Phala Cloud, install `opencode-provider-phala-cloud`, then use its device
-login or set `PHALA_AI_API_KEY` and choose `phala/<model-id>`. The plugin
-creates the provider itself; do not add a separate provider block for the same
-id.
-
-For another ACI gateway, use the neutral plugin:
+For another ACI gateway, configure the neutral plugin:
 
 ```jsonc
 {
@@ -124,61 +94,71 @@ For another ACI gateway, use the neutral plugin:
       {
         "baseURL": "https://gateway.example.com/v1",
         "trust": {
-          "acceptedComposeHashes": ["<reviewed-compose-sha256>"],
-        },
-      },
-    ],
-  ],
+          "acceptedComposeHashes": ["<reviewed-compose-sha256>"]
+        }
+      }
+    ]
+  ]
 }
 ```
 
-The plugin discovers `/v1/models` over the verified connection, defaults to
-`is_tee: true`, excludes embedding-only entries, maps model limits, prices,
-modalities, tools and reasoning controls, and accepts an optional model
-allowlist. The provider is installed with a rejecting fetch before any async
-verification starts. OpenCode currently ignores `config()` hook errors, so
-this ordering is required to prevent an ordinary HTTPS downgrade. Each
-inference response is held open until its signed receipt and cited session
-verify.
+Then run `opencode providers login --provider aci` or set `ACI_API_KEY`.
+The read-only `aci_inspect`, `redpill_aci_inspect`, or `phala_aci_inspect` tool
+reports connection status, attestation, receipt history, receipt audits, and
+session audits without returning prompts, responses, or raw evidence.
 
-OpenCode server plugins cannot register Pi-style TUI settings panels or footer
-state. Instead, each provider exposes the native read-only inspection tool
-`aci_inspect` or `<provider>_aci_inspect`. Its `status`, `attestation`,
-`receipts`, `receipt`, and `session` actions expose the same verified state and
-bounded audit history without returning prompts, responses, or raw evidence.
-OpenCode configuration remains in `opencode.json`, and credentials remain in
-OpenCode's native auth store.
+## SDK applications
 
-For a route that specifically implements `/v1/responses`, OpenCode documents
-`@ai-sdk/openai` instead of `@ai-sdk/openai-compatible`.
+Applications that expose a per-client fetch hook can inject the verified
+transport directly:
 
-OpenCode can still point at `aci serve` when an operator wants one shared local
-process for several tools. That is an operational choice, not a Bun
-compatibility requirement.
+```ts
+import { connectAci } from "@phala/aci-verifier/runtime";
+
+const aci = await connectAci({
+  baseURL: "https://gateway.example.com/v1",
+  acceptedComposeHashes: ["<reviewed-compose-sha256>"],
+});
+
+const response = await aci.fetch("https://gateway.example.com/v1/models");
+```
+
+Node and Bun expose the same API. Conditional package exports select the
+runtime-specific TLS adapter; application and framework code should not branch
+on the runtime. Prefer `@phala/aci-provider` when the application also needs
+shared model discovery, capability mapping, receipt history, and response
+completion verification.
+
+## Unsupported hosts
+
+A custom API base URL is not enough to inject ACI's attested TLS transport. A
+coding agent without an official custom-fetch or provider-plugin extension
+point therefore has no native integration in this release. In particular, this
+guide does not claim native Codex CLI or Claude Code support. Add a dedicated
+adapter only when the host exposes a supported transport boundary and lifecycle
+contract.
 
 ## Trust boundary
 
-`aci serve` and `connectAci()` share the same trust contract: fresh quote and
-keyset binding, measured compose appraisal, optional reviewed compose
-allowlist, identity expiry, hostname/SPKI channel binding, verified-serving
-constraints, and receipt/session auditing. Agent adapters select the HTTP
-protocol and transport; verification remains in the shared client.
+The shared clients verify a fresh quote and nonce-bound keyset, measured
+compose, optional reviewed-release allowlist, identity expiry, hostname and TLS
+SPKI binding, verified-serving constraints, exact wire digests, signed receipts,
+and cited sessions. Any required failure blocks the request or response.
 
-Coverage ends at model HTTP traffic between the local verifier and attested
+Coverage ends at model HTTP traffic between the local client and the attested
 gateway. WebSockets, MCP servers, tools, browser automation, shell commands,
-extensions, and telemetry have separate trust boundaries. The local agent and
-`aci serve` see plaintext prompts and responses; ACI binds the remote network
-path to the attested TLS identity.
+extensions, and telemetry have separate trust boundaries. The local coding
+agent still sees plaintext prompts and responses; ACI binds the remote network
+path to the attested workload identity.
 
 ## Sources
 
-Checked 2026-08-27:
+Checked 2026-08-28:
 
-- [Codex custom model providers](https://learn.chatgpt.com/docs/config-file/config-advanced#custom-model-providers)
-  and [configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference#configtoml)
-- [Claude Code gateway connection](https://code.claude.com/docs/en/llm-gateway-connect)
-  and [protocol reference](https://code.claude.com/docs/en/llm-gateway-protocol)
+- [Pi providers](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/providers.md),
+  [custom providers](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/custom-provider.md),
+  and [models and thinking](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/keybindings.md#models-and-thinking)
 - [OpenCode providers](https://opencode.ai/docs/providers/) and
-  [plugins](https://opencode.ai/docs/plugins/), source commit
-  tag [`v1.18.23`](https://github.com/anomalyco/opencode/tree/v1.18.23)
-- [Bun fetch TLS and proxy options](https://bun.com/docs/runtime/networking/fetch)
+  [plugins](https://opencode.ai/docs/plugins/), source tag
+  [`v1.18.23`](https://github.com/anomalyco/opencode/tree/v1.18.23)
+- [Bun fetch TLS options](https://bun.com/docs/runtime/networking/fetch)

--- a/clients/opencode-provider/README.md
+++ b/clients/opencode-provider/README.md
@@ -13,6 +13,21 @@ packages use OpenCode's v1 server-plugin manifest and run on Bun. The provider
 is created by the plugin, so plugin installation or initialization failure
 cannot leave a separately configured ordinary HTTPS provider behind.
 
+Install and authenticate through OpenCode's native commands:
+
+```sh
+opencode plugin opencode-provider-redpill --global
+opencode providers login --provider redpill
+
+# or
+opencode plugin opencode-provider-phala-cloud --global
+opencode providers login --provider phala
+```
+
+The plugin command persists the plugin entry; the provider login persists the
+credential in OpenCode's auth store. No hand-written provider block or
+adapter-owned credential file is required.
+
 Each plugin also registers one provider-scoped, read-only inspection tool:
 `aci_inspect`, `redpill_aci_inspect`, or `phala_aci_inspect`. It reports the
 verified connection and attestation, lists retained receipts, verifies a

--- a/clients/opencode-provider/packages/opencode-provider-aci/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-aci/README.md
@@ -22,12 +22,23 @@ receipt before the response stream can finish.
 }
 ```
 
-Set `ACI_API_KEY` or run `opencode providers login`. Select a discovered model
-as `aci/<model-id>`.
+After adding the configured plugin tuple above, store the key through
+OpenCode's official provider login and select a discovered model as
+`aci/<model-id>`:
+
+```sh
+opencode providers login --provider aci
+```
+
+The neutral package has no default gateway, so `baseURL` must be configured.
+`ACI_API_KEY` is also supported for the current process, but environment
+variables are not copied into OpenCode's auth store.
 
 The plugin discovers the public `/v1/models` catalog over the verified
 connection without sending the inference API key. OpenCode stores the key and
-attaches it to model requests through its native auth loader.
+attaches it to model requests through its native auth loader. The plugin uses
+OpenCode's server-plugin, provider config, auth, model, and disposal hooks; it
+does not maintain parallel config or credential files.
 
 The read-only `aci_inspect` tool exposes five actions: `status`, `attestation`,
 `receipts`, `receipt`, and `session`. Receipt inspection verifies the latest

--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/opencode-provider-aci",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Native OpenCode provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "1.18.23",

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/README.md
@@ -1,18 +1,30 @@
 # `opencode-provider-phala-cloud`
 
-Phala Cloud's native OpenCode provider. Install it for the current project:
+Phala Cloud's native OpenCode provider. Install it through OpenCode's official
+plugin command:
 
 ```sh
 opencode plugin opencode-provider-phala-cloud
 ```
 
-Pass `--global` to install it in the global OpenCode config. Then run
-`opencode providers login` and choose Phala Cloud, or set
-`PHALA_AI_API_KEY`. Then select `phala/<model-id>`. Account login uses the
-Phala Cloud device flow to issue a Confidential AI key; inference still travels
-only through the attested, TLS-pinned ACI connection. OpenCode calls browser
-authorization methods `oauth`, but this flow returns and stores an API-key
-credential rather than fabricating refreshable OAuth tokens.
+Pass `--global` to install it in the global OpenCode config. Start the official
+provider login and choose the Phala Cloud account method or API-key method:
+
+```sh
+opencode providers login --provider phala
+```
+
+The account method uses Phala Cloud's device flow to issue a Confidential AI
+key. It returns that key through OpenCode's documented browser-authorization
+hook, and OpenCode stores it as its native API credential. The plugin does not
+implement its own token or credential store. `PHALA_AI_API_KEY` is also
+supported for the current process, but environment variables are not copied
+into the auth store. Select `phala/<model-id>` in OpenCode; inference travels
+only through the attested, TLS-pinned ACI connection.
 
 Use the read-only `phala_aci_inspect` tool to inspect the verified attestation,
 retained receipt history, a receipt audit, or a content-addressed session audit.
+
+Do not add a separate `provider.phala` block. The plugin registers the provider,
+model catalog, verified fetch, and auth loader through OpenCode's native
+server-plugin API.

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-phala-cloud",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Phala Cloud provider for OpenCode with verified ACI transport and per-response receipt verification",
   "keywords": [
     "aci",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0",
-    "@phala/opencode-provider-aci": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1",
+    "@phala/opencode-provider-aci": "^0.5.1"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/opencode-provider/packages/opencode-provider-redpill/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/README.md
@@ -1,15 +1,24 @@
 # `opencode-provider-redpill`
 
-RedPill's native OpenCode provider. Install it for the current project:
+RedPill's native OpenCode provider. Install it through OpenCode's official
+plugin command:
 
 ```sh
 opencode plugin opencode-provider-redpill
 ```
 
-Pass `--global` to install it in the global OpenCode config. Then run
-`opencode providers login` and paste a Redpill API key, or set
-`REDPILL_AI_API_KEY`. Redpill does not currently expose account OAuth. Then
-select `redpill/<model-id>`. The plugin discovers current TEE models and sends
+Pass `--global` to install it in the global OpenCode config. Store a key through
+OpenCode's official provider login:
+
+```sh
+opencode providers login --provider redpill
+```
+
+OpenCode persists the plugin entry and credential in its own configuration and
+auth store. `REDPILL_AI_API_KEY` is also supported for the current process, but
+environment variables are not copied into the auth store. Redpill does not
+currently expose account OAuth. Select `redpill/<model-id>` in OpenCode. The
+plugin discovers current TEE models and sends
 inference only through an attested, TLS-pinned connection. Every response
 receipt is verified before OpenCode can finish the model turn or continue its
 tool loop.
@@ -17,3 +26,7 @@ tool loop.
 Use the read-only `redpill_aci_inspect` tool to inspect the verified
 attestation, retained receipt history, a receipt audit, or a content-addressed
 session audit.
+
+Do not add a separate `provider.redpill` block. The plugin registers the
+provider, model catalog, verified fetch, and auth loader through OpenCode's
+native server-plugin API.

--- a/clients/opencode-provider/packages/opencode-provider-redpill/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-redpill",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "RedPill ACI provider for OpenCode",
   "keywords": [
     "aci",
@@ -51,8 +51,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0",
-    "@phala/opencode-provider-aci": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1",
+    "@phala/opencode-provider-aci": "^0.5.1"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-clients",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "workspaces": [
         "verifier-ts",
@@ -6315,10 +6315,10 @@
     },
     "opencode-provider/packages/opencode-provider-aci": {
       "name": "@phala/opencode-provider-aci",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "1.18.23",
@@ -6333,11 +6333,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-phala-cloud": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0",
-        "@phala/opencode-provider-aci": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1",
+        "@phala/opencode-provider-aci": "^0.5.1"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6348,11 +6348,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-redpill": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0",
-        "@phala/opencode-provider-aci": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1",
+        "@phala/opencode-provider-aci": "^0.5.1"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6364,10 +6364,10 @@
     },
     "pi-provider/packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6379,11 +6379,11 @@
       }
     },
     "pi-provider/packages/pi-provider-phala-cloud": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0",
-        "@phala/pi-provider-aci": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1",
+        "@phala/pi-provider-aci": "^0.5.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6395,11 +6395,11 @@
       }
     },
     "pi-provider/packages/pi-provider-redpill": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.5.0",
-        "@phala/pi-provider-aci": "^0.5.0"
+        "@phala/aci-provider": "^0.5.1",
+        "@phala/pi-provider-aci": "^0.5.1"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6412,10 +6412,10 @@
     },
     "provider": {
       "name": "@phala/aci-provider",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.5.0"
+        "@phala/aci-verifier": "^0.5.1"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -6430,7 +6430,7 @@
     },
     "verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/package-smoke.sh
+++ b/clients/package-smoke.sh
@@ -89,7 +89,11 @@ for (const name of [
 
 # Pi deliberately omits host-provided peer dependencies when it installs an
 # extension. Load the packaged extension with Pi's own loader in that layout.
-npm init --yes --silent --prefix "$pi_npm" >/dev/null
+node --input-type=module - "$pi_npm/package.json" <<'NODE'
+import { writeFile } from "node:fs/promises";
+
+await writeFile(process.argv[2], JSON.stringify({ private: true }, null, 2));
+NODE
 npm install --prefix "$pi_npm" --legacy-peer-deps --ignore-scripts --no-audit --no-fund \
   "$packs"/phala-aci-verifier-*.tgz \
   "$packs"/phala-aci-provider-*.tgz \
@@ -103,16 +107,41 @@ for peer in pi-ai pi-coding-agent pi-tui; do
   fi
 done
 
-PI_CODING_AGENT_DIR="$scratch/pi-agent" \
-  "$repo_root/clients/node_modules/.bin/pi" \
-  --offline \
-  --no-context-files \
-  --no-skills \
-  --no-themes \
-  --extension "$pi_npm/node_modules/pi-provider-phala-cloud/dist/index.js" \
-  --list-models >/dev/null
+node --input-type=module - "$scratch/pi-agent" <<'NODE'
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
-printf '%s\n' '{"type":"get_commands"}' | \
+const agentDir = process.argv[2];
+await mkdir(agentDir, { recursive: true });
+const model = {
+  id: "smoke/model",
+  name: "Smoke Model",
+  api: "openai-completions",
+  provider: "phala",
+  baseUrl: "https://inference.phala.com/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 4096,
+  maxTokens: 1024,
+};
+await Promise.all([
+  writeFile(
+    join(agentDir, "auth.json"),
+    JSON.stringify({ phala: { type: "api_key", key: "smoke-test-key" } }, null, 2),
+  ),
+  writeFile(
+    join(agentDir, "models-store.json"),
+    JSON.stringify({ phala: { models: [model], checkedAt: Date.now() } }, null, 2),
+  ),
+  writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({ defaultProvider: "phala", defaultModel: "smoke/model" }, null, 2),
+  ),
+]);
+NODE
+
+printf '%s\n' '{"type":"get_state"}' '{"type":"get_commands"}' | \
   PI_CODING_AGENT_DIR="$scratch/pi-agent" \
   "$repo_root/clients/node_modules/.bin/pi" \
   --mode rpc \
@@ -132,6 +161,16 @@ const records = (await readFile(process.argv[2], "utf8"))
   .trim()
   .split("\n")
   .map((line) => JSON.parse(line));
+const state = records.find(
+  (record) => record.type === "response" && record.command === "get_state",
+);
+if (
+  !state?.success ||
+  state.data?.model?.provider !== "phala" ||
+  state.data?.model?.id !== "smoke/model"
+) {
+  throw new Error("Pi did not restore its stored dynamic catalog and default model offline");
+}
 const response = records.find(
   (record) => record.type === "response" && record.command === "get_commands",
 );

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "ACI TypeScript clients and coding-agent providers",
   "license": "MIT",

--- a/clients/pi-provider/README.md
+++ b/clients/pi-provider/README.md
@@ -37,6 +37,22 @@ Install the published package:
 pi install npm:@phala/pi-provider-aci
 ```
 
+Pi owns login, model-catalog persistence, and default-model persistence. For a
+branded package, use the provider id shown below:
+
+```text
+/login redpill
+# or: /login phala
+# wait for the footer to show aci-verified
+/model
+# search for the provider, select a model, and press Ctrl+S
+```
+
+Pi stores credentials in `~/.pi/agent/auth.json`, dynamic catalogs in
+`~/.pi/agent/models-store.json`, and the saved default in
+`~/.pi/agent/settings.json`. Environment variables are process inputs and are
+not copied into these files.
+
 For a source checkout:
 
 ```bash
@@ -100,7 +116,9 @@ release pipeline publishes them. Until then the provider's attestation command
 reports `measurement verified, not pinned`.
 
 The extension registers Pi's native `Provider` and `ApiKeyAuth` interfaces.
-Pi owns credential storage and environment resolution; the
+Its provider uses Pi's native dynamic-catalog helper, so Pi owns catalog refresh,
+offline restoration, persistence, and publication ordering. Pi also owns
+credential storage, default-model selection, and environment resolution; the
 `openai-completions` adapter receives the connection's scoped fetch through
 `StreamOptions.fetch`. A failed or expired connection blocks model traffic,
 and a failed receipt audit fails the response stream. Each Pi session gets a
@@ -108,8 +126,10 @@ fresh connection and closes it on shutdown.
 
 The same `connectAci()` API works with other Node and Bun SDKs and agent
 frameworks; see the [verifier integration examples](../verifier-ts/README.md#runtime-sdk-and-agent-frameworks).
-Coding-agent CLIs without a custom fetch hook use the local `aci serve` proxy;
-see the [coding agent guide](../coding-agents.md).
+Pi and OpenCode use host-native provider adapters; see the
+[coding agent guide](../coding-agents.md). A base URL alone cannot inject ACI's
+attested TLS transport, so this release does not claim native support for hosts
+without a custom-fetch or provider-plugin extension point.
 
 ## Branding / profiles
 

--- a/clients/pi-provider/packages/pi-provider-aci/README.md
+++ b/clients/pi-provider/packages/pi-provider-aci/README.md
@@ -9,9 +9,24 @@ attestation, receipt, and session audit commands.
 ```bash
 pi install npm:@phala/pi-provider-aci
 export ACI_BASE_URL=https://gateway.example/v1
-export ACI_API_KEY=...
 pi
 ```
+
+In Pi, store the gateway key and save a default model through the native UI:
+
+```text
+/login aci
+# paste the API key and wait for the footer to show aci-verified
+/model
+# search for aci/, select a model, and press Ctrl+S
+```
+
+Pi owns all persistence: credentials are stored in
+`~/.pi/agent/auth.json`, refreshed catalogs in
+`~/.pi/agent/models-store.json`, and a default selected with `Ctrl+S` in
+`~/.pi/agent/settings.json`. The cached catalog remains available offline.
+`ACI_API_KEY` is also supported for the current process, but Pi does not copy
+environment variables into its credential store.
 
 The provider fails closed when workload or channel verification fails. For a
 production reviewed-release claim, configure `ACI_ACCEPTED_COMPOSE_HASHES` with

--- a/clients/pi-provider/packages/pi-provider-aci/index.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/index.ts
@@ -24,7 +24,11 @@ import type {
   ExtensionFactory,
 } from "@earendil-works/pi-coding-agent";
 import * as piAi from "@earendil-works/pi-ai";
-import type { Model, Provider } from "@earendil-works/pi-ai";
+import {
+  createProvider as createPiProvider,
+  type Model,
+  type Provider,
+} from "@earendil-works/pi-ai";
 import { type SettingItem, SettingsList, truncateToWidth } from "@earendil-works/pi-tui";
 import { createAciProvider, type AciProvider } from "@phala/aci-provider";
 import os from "node:os";
@@ -46,6 +50,11 @@ import { type AciServerModel, discoverAciModels, mapAciServerModel } from "./src
 import { isAciProjectConfigApproved } from "./src/project-trust.ts";
 import { summarizeReceipt, summarizeSession } from "./src/audit.ts";
 import {
+  closeAciProvider,
+  ensureAciConnection,
+  type AciConnectionState,
+} from "./src/connection.ts";
+import {
   type AciConfigScope,
   THINKING_FORMAT_VALUES,
   buildSettingsTheme,
@@ -54,20 +63,10 @@ import {
   settingsTitle,
 } from "./src/settings-ui.ts";
 
-interface AciRuntimeState {
+interface AciRuntimeState extends AciConnectionState<AciProvider> {
   profile: ProviderProfile;
   config: AciCloudConfig;
-  rawModels: AciServerModel[];
-  provider: AciProvider | undefined;
-  providerConfigKey: string | undefined;
-  connectionSetup: AciConnectionSetup | undefined;
-  connectionError: string | undefined;
   overrides?: AciCloudConfigPatch;
-}
-
-interface AciConnectionSetup {
-  configKey: string;
-  promise: Promise<void>;
 }
 
 type OpenAICompletionsApi = ReturnType<
@@ -102,76 +101,9 @@ function getHostOpenAICompletionsApi(): OpenAICompletionsApi {
   return api;
 }
 
-function modelsFromState(state: AciRuntimeState) {
-  return state.rawModels
-    .map((m) => mapAciServerModel(m, state.config))
-    .filter((m): m is NonNullable<typeof m> => m !== null);
-}
-
-/**
- * Establish an instance-scoped ACI connection for the configured gateway.
- * Default posture is fail closed: when verification or channel binding fails,
- * the provider stream receives a rejecting fetch implementation.
- */
-function connectionConfig(config: AciCloudConfig): string {
-  return JSON.stringify({
-    baseUrl: config.baseUrl,
-    acceptedComposeHashes: config.trust.acceptedComposeHashes,
-    acceptedSessionIds: config.trust.acceptedSessionIds,
-  });
-}
-
-async function ensureAciConnection(state: AciRuntimeState): Promise<void> {
-  const config = state.config;
-  const configKey = connectionConfig(config);
-  if (state.provider && state.providerConfigKey === configKey) {
-    return;
-  }
-
-  const activeSetup = state.connectionSetup;
-  if (activeSetup) {
-    await activeSetup.promise;
-    if (activeSetup.configKey === configKey) return;
-    return ensureAciConnection(state);
-  }
-
-  const setup = (async () => {
-    await closeAciProvider(state);
-    try {
-      const provider = createAciProvider(toAciProviderConfig(config));
-      await provider.connect();
-      state.provider = provider;
-      state.providerConfigKey = configKey;
-      state.connectionError = undefined;
-    } catch (error) {
-      state.connectionError = error instanceof Error ? error.message : String(error);
-      console.error(`${state.profile.logPrefix} ACI connection failed:`, error);
-    }
-  })();
-  const pending = { configKey, promise: setup };
-  state.connectionSetup = pending;
-  try {
-    await setup;
-  } finally {
-    if (state.connectionSetup === pending) state.connectionSetup = undefined;
-  }
-}
-
-async function closeAciProvider(state: AciRuntimeState): Promise<void> {
-  const provider = state.provider;
-  state.provider = undefined;
-  state.providerConfigKey = undefined;
-  if (!provider) return;
-  try {
-    await provider.close();
-  } catch (error) {
-    console.error(`${state.profile.logPrefix} ACI connection close failed:`, error);
-  }
-}
-
 function providerFetch(state: AciRuntimeState): typeof globalThis.fetch {
   return async (input, init) => {
-    await ensureAciConnection(state);
+    await ensureAciConnection(state, () => createAciProvider(toAciProviderConfig(state.config)));
     if (state.provider) return state.provider.fetch(input, init);
     throw new Error(
       `${state.profile.logPrefix} inference blocked because no verified ACI connection is available: ${state.connectionError ?? "verification has not completed"}`,
@@ -183,7 +115,7 @@ async function refreshAciModels(
   state: AciRuntimeState,
   signal: AbortSignal,
 ): Promise<AciServerModel[]> {
-  await ensureAciConnection(state);
+  await ensureAciConnection(state, () => createAciProvider(toAciProviderConfig(state.config)));
   if (!state.provider) {
     throw new Error(
       `${state.profile.logPrefix} model discovery blocked because no verified ACI connection is available: ${state.connectionError ?? "verification has not completed"}`,
@@ -197,37 +129,39 @@ async function refreshAciModels(
   return discovered.raw;
 }
 
-function piModelsFromState(state: AciRuntimeState): Model<"openai-completions">[] {
-  return modelsFromState(state).map((model) => ({
-    ...model,
-    api: "openai-completions",
-    provider: state.profile.providerId,
-    baseUrl: state.config.baseUrl,
-  }));
+function toPiModels(
+  state: AciRuntimeState,
+  rawModels: readonly AciServerModel[],
+): Model<"openai-completions">[] {
+  return rawModels
+    .map((model) => mapAciServerModel(model, state.config))
+    .filter((model): model is NonNullable<typeof model> => model !== null)
+    .map((model) => ({
+      ...model,
+      api: "openai-completions",
+      provider: state.profile.providerId,
+      baseUrl: state.config.baseUrl,
+    }));
 }
 
 function nativeAciProvider(state: AciRuntimeState): Provider<"openai-completions"> {
   const streams = getHostOpenAICompletionsApi();
   const fetch = providerFetch(state);
-  return {
+  return createPiProvider({
     id: state.profile.providerId,
     name: state.profile.label,
     baseUrl: state.config.baseUrl,
     auth: { apiKey: createApiKeyAuth(state.profile) },
-    getModels: () => piModelsFromState(state),
-    async refreshModels(context) {
-      if (!context.allowNetwork) return;
-      const rawModels = await refreshAciModels(state, context.signal);
-      await context.publish({
-        update: () => {
-          state.rawModels = rawModels;
-        },
-      });
+    models: [],
+    async fetchModels({ signal }) {
+      return toPiModels(state, await refreshAciModels(state, signal));
     },
-    stream: (model, context, options) => streams.stream(model, context, { ...options, fetch }),
-    streamSimple: (model, context, options) =>
-      streams.streamSimple(model, context, { ...options, fetch }),
-  };
+    api: {
+      stream: (model, context, options) => streams.stream(model, context, { ...options, fetch }),
+      streamSimple: (model, context, options) =>
+        streams.streamSimple(model, context, { ...options, fetch }),
+    },
+  });
 }
 
 function registerAciProvider(pi: ExtensionAPI, state: AciRuntimeState): void {
@@ -443,7 +377,7 @@ async function runSessionCommand(
   state: AciRuntimeState,
   args: string,
 ): Promise<void> {
-  await ensureAciConnection(state);
+  await ensureAciConnection(state, () => createAciProvider(toAciProviderConfig(state.config)));
   if (!state.provider) {
     ctx.ui.notify(
       `ACI connection unavailable: ${state.connectionError ?? "not verified"}`,
@@ -477,7 +411,7 @@ async function runAttestationCommand(
   ctx: ExtensionCommandContext,
   state: AciRuntimeState,
 ): Promise<void> {
-  await ensureAciConnection(state);
+  await ensureAciConnection(state, () => createAciProvider(toAciProviderConfig(state.config)));
   if (!state.provider) {
     ctx.ui.notify(
       `Attestation validation failed: ${state.connectionError ?? "no verified connection"}`,
@@ -536,26 +470,31 @@ export function createProvider(
     const state: AciRuntimeState = {
       profile: providerProfile,
       config,
-      rawModels: [],
       provider: undefined,
       providerConfigKey: undefined,
       connectionSetup: undefined,
       connectionError: undefined,
+      renderConnectionStatus: undefined,
       overrides,
     };
     registerAciProvider(pi, state);
 
     pi.on("session_start", async (_event, ctx) => {
+      state.renderConnectionStatus = () => updateFooter(ctx, state);
+      state.renderConnectionStatus?.();
       const projectTrusted = isAciProjectConfigApproved(ctx);
       applyEffectiveConfig(pi, state, ctx.cwd, projectTrusted);
-      await ctx.modelRegistry.refresh({
-        allowNetwork: true,
-        providers: [state.profile.providerId],
-      });
-      updateFooter(ctx, state);
+      try {
+        await ctx.modelRegistry.refresh({
+          providers: [state.profile.providerId],
+        });
+      } finally {
+        state.renderConnectionStatus?.();
+      }
     });
 
     pi.on("session_shutdown", async () => {
+      state.renderConnectionStatus = undefined;
       await state.connectionSetup?.promise;
       await closeAciProvider(state);
     });

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-aci/src/connection.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/src/connection.ts
@@ -1,0 +1,88 @@
+interface AciConnectionConfig {
+  baseUrl: string;
+  trust: {
+    acceptedComposeHashes?: readonly string[];
+    acceptedSessionIds?: readonly string[];
+  };
+}
+
+export interface ConnectableAciProvider {
+  connect(): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export interface AciConnectionSetup {
+  configKey: string;
+  promise: Promise<void>;
+}
+
+export interface AciConnectionState<TProvider extends ConnectableAciProvider> {
+  profile: { logPrefix: string };
+  config: AciConnectionConfig;
+  provider: TProvider | undefined;
+  providerConfigKey: string | undefined;
+  connectionSetup: AciConnectionSetup | undefined;
+  connectionError: string | undefined;
+  renderConnectionStatus: (() => void) | undefined;
+}
+
+function connectionConfig(config: AciConnectionConfig): string {
+  return JSON.stringify({
+    baseUrl: config.baseUrl,
+    acceptedComposeHashes: config.trust.acceptedComposeHashes,
+    acceptedSessionIds: config.trust.acceptedSessionIds,
+  });
+}
+
+export async function ensureAciConnection<TProvider extends ConnectableAciProvider>(
+  state: AciConnectionState<TProvider>,
+  createProvider: () => TProvider,
+): Promise<void> {
+  const configKey = connectionConfig(state.config);
+  if (state.provider && state.providerConfigKey === configKey) return;
+
+  const activeSetup = state.connectionSetup;
+  if (activeSetup) {
+    await activeSetup.promise;
+    if (activeSetup.configKey === configKey) return;
+    return ensureAciConnection(state, createProvider);
+  }
+
+  const setup = (async () => {
+    await closeAciProvider(state);
+    state.connectionError = undefined;
+    state.renderConnectionStatus?.();
+    try {
+      const provider = createProvider();
+      await provider.connect();
+      state.provider = provider;
+      state.providerConfigKey = configKey;
+    } catch (error) {
+      state.connectionError = error instanceof Error ? error.message : String(error);
+      console.error(`${state.profile.logPrefix} ACI connection failed:`, error);
+    } finally {
+      state.renderConnectionStatus?.();
+    }
+  })();
+  const pending = { configKey, promise: setup };
+  state.connectionSetup = pending;
+  try {
+    await setup;
+  } finally {
+    if (state.connectionSetup === pending) state.connectionSetup = undefined;
+  }
+}
+
+export async function closeAciProvider<TProvider extends ConnectableAciProvider>(
+  state: AciConnectionState<TProvider>,
+): Promise<void> {
+  const provider = state.provider;
+  state.provider = undefined;
+  state.providerConfigKey = undefined;
+  if (!provider) return;
+  try {
+    await provider.close();
+  } catch (error) {
+    console.error(`${state.profile.logPrefix} ACI connection close failed:`, error);
+  }
+}

--- a/clients/pi-provider/packages/pi-provider-aci/src/constants.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/src/constants.ts
@@ -1,1 +1,1 @@
-export const PROVIDER_VERSION = "0.4.0";
+export const PROVIDER_VERSION = "0.5.1";

--- a/clients/pi-provider/packages/pi-provider-aci/tests/connection.test.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/tests/connection.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  ensureAciConnection,
+  type AciConnectionState,
+  type ConnectableAciProvider,
+} from "../src/connection.ts";
+
+class DeferredProvider implements ConnectableAciProvider {
+  private readonly ready: Promise<void>;
+
+  constructor(ready: Promise<void>) {
+    this.ready = ready;
+  }
+
+  connect(): Promise<void> {
+    return this.ready;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+test("connection completion publishes the verified footer state", async () => {
+  let finishConnection: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    finishConnection = resolve;
+  });
+  const phases: string[] = [];
+  const state: AciConnectionState<DeferredProvider> = {
+    profile: { logPrefix: "[test]" },
+    config: { baseUrl: "https://gateway.example/v1", trust: {} },
+    provider: undefined,
+    providerConfigKey: undefined,
+    connectionSetup: undefined,
+    connectionError: undefined,
+    renderConnectionStatus: () => {
+      phases.push(state.provider ? "verified" : state.connectionError ? "blocked" : "pending");
+    },
+  };
+
+  const connection = ensureAciConnection(state, () => new DeferredProvider(ready));
+  await Promise.resolve();
+  assert.deepEqual(phases, ["pending"]);
+
+  finishConnection?.();
+  await connection;
+  assert.deepEqual(phases, ["pending", "verified"]);
+});

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/README.md
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/README.md
@@ -14,21 +14,23 @@ can finish the model turn or continue its tool loop.
 pi install npm:pi-provider-phala-cloud
 ```
 
-Sign in with a Phala Cloud account (`/login phala`, device authorization —
-no API key to manage), or set one directly:
-
-```bash
-export PHALA_AI_API_KEY=...
-```
+Start Pi, complete the native device login, wait for the verified connection,
+then save a default model from the native model picker:
 
 ```text
 /login phala
-/model phala/openai/gpt-oss-20b
+# approve the device login and wait for the footer to show aci-verified
+/model
+# search for phala/, select a model, and press Ctrl+S
 ```
 
-The device flow issues and stores a Confidential AI API key. When upgrading
-from 0.3, run `/login phala` once to replace the legacy OAuth-shaped
-credential.
+The device flow issues a Confidential AI API key and returns it to Pi's official
+API-key auth interface. Pi stores the credential in `~/.pi/agent/auth.json`, the
+refreshed catalog in `~/.pi/agent/models-store.json`, and the saved default in
+`~/.pi/agent/settings.json`. These values survive a restart and the cached
+catalog remains available offline. As an alternative for one process, set
+`PHALA_AI_API_KEY`; Pi does not copy environment variables into its credential
+store.
 
 Config: `/phala-settings` · Attestation status: `/phala-attestation` · Receipt
 history and audit: `/phala-receipt` · Session inspection: `/phala-session`

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0",
-    "@phala/pi-provider-aci": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1",
+    "@phala/pi-provider-aci": "^0.5.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/README.md
+++ b/clients/pi-provider/packages/pi-provider-redpill/README.md
@@ -12,17 +12,30 @@ can finish the model turn or continue its tool loop.
 
 ```bash
 pi install npm:pi-provider-redpill
-export REDPILL_AI_API_KEY=...
+pi
 ```
+
+In Pi, store the API key through the native login flow, wait for the verified
+connection, then save a default model from the native model picker:
+
+```text
+/login redpill
+# paste the Redpill API key and wait for the footer to show aci-verified
+/model
+# search for redpill/, select a model, and press Ctrl+S
+```
+
+Pi stores the credential in `~/.pi/agent/auth.json`, the refreshed catalog in
+`~/.pi/agent/models-store.json`, and the saved default in
+`~/.pi/agent/settings.json`. These values survive a restart and the cached
+catalog remains available offline. As an alternative for one process, set
+`REDPILL_AI_API_KEY`; Pi does not copy environment variables into its credential
+store.
 
 The default ACI gateway is `https://tee.redpill.ai/v1`; override with
 `REDPILL_BASE_URL`. `tee.redpill.ai` and `inference.phala.com` enforce TEE-only
 routing and accept the same key. `api.redpill.ai` is the general API endpoint,
 not the default verified transport.
-
-```text
-/model redpill/deepseek/deepseek-v4-flash
-```
 
 Config: `/redpill-settings` · Attestation status: `/redpill-attestation` · Receipt
 history and audit: `/redpill-receipt` · Session inspection: `/redpill-session`

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Redpill AI for Pi with verified ACI transport and per-response receipt verification",
   "keywords": [
     "ai-provider",
@@ -52,8 +52,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.5.0",
-    "@phala/pi-provider-aci": "^0.5.0"
+    "@phala/aci-provider": "^0.5.1",
+    "@phala/pi-provider-aci": "^0.5.1"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/provider/package.json
+++ b/clients/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-provider",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Framework-neutral model provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -62,7 +62,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.5.0"
+    "@phala/aci-verifier": "^0.5.1"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/clients/releasing.md
+++ b/clients/releasing.md
@@ -48,14 +48,8 @@ their respective runtimes, and imports every public ESM entry.
 
 ## Trusted publishing
 
-The four existing packages already publish through npm trusted publishing. The
-four new `0.4.0` packages require the same trusted-publisher configuration
-after their bootstrap publish:
-
-- `@phala/aci-provider`
-- `@phala/opencode-provider-aci`
-- `opencode-provider-redpill`
-- `opencode-provider-phala-cloud`
+All eight packages publish through npm trusted publishing. Their trusted
+publisher must use the same repository and release workflow settings:
 
 Use these settings for each package:
 
@@ -68,7 +62,7 @@ Use these settings for each package:
 The workflow authenticates with npm through a short-lived OIDC identity.
 
 Create and publish a GitHub Release whose tag is `clients-v<version>`, for
-example `clients-v0.4.0`. The workflow checks that the tag matches every package
+example `clients-v0.5.1`. The workflow checks that the tag matches every package
 manifest, runs all release gates, then publishes in dependency order. Do not
 move or reuse a release tag after publication; npm versions are immutable.
 

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- replace the Pi adapter model cache with the official `pi-ai` dynamic provider helper
- keep Pi credentials, cached models, and default model in the host-owned stores and respect offline mode
- update the footer when asynchronous ACI verification completes
- document the official Pi provider and OpenCode plugin/auth flows without a base-URL proxy recommendation
- release all eight coordinated npm packages as `0.5.1`
- extend the packaged Pi smoke test to restore a stored dynamic catalog and default model offline

## Verification

- `npm --prefix clients run build`
- `npm --prefix clients run check`
- `npm --prefix clients test`
- `npm --prefix clients run test:bun`
- `npm --prefix clients run lint`
- `npm --prefix clients run format:check`
- `npm --prefix clients run lint:packages`
- `bash clients/package-smoke.sh`
- packaged Pi offline restart restored credential, catalog, and default model
- OpenCode official plugin install, model listing, provider login, and native auth persistence verified