### PR TITLE
fix(clients): normalize RedPill casing and prepare 0.7.0

### DIFF
--- a/clients/architecture.md
+++ b/clients/architecture.md
@@ -63,7 +63,7 @@ flowchart LR
   channel -->|verified, SPKI-pinned TLS| api
   backend --> provider[TEE or private model provider]:::external
 
-  pipeline[Redpill and Phala release pipeline<br/>publish reviewed compose hashes<br/>product work still pending]:::pending
+  pipeline[RedPill and Phala release pipeline<br/>publish reviewed compose hashes<br/>product work still pending]:::pending
   pipeline -. supplies policy .-> release
 ```
 
@@ -97,12 +97,12 @@ were hardened in place:
 | Direct OpenCode integration through its provider `options.fetch` hook | Current refactor |
 | Fail-closed OpenCode provider ownership, live model discovery, end-of-stream receipt audit and read-only inspection tool | Current OpenCode work |
 | Coding-agent integration guide around the shared transport boundary | Current refactor |
-| Reviewed compose publication from Redpill and Phala release pipelines | Pending product work |
+| Reviewed compose publication from RedPill and Phala release pipelines | Pending product work |
 
-Account authentication is outside the ACI trust protocol. Redpill adapters
+Account authentication is outside the ACI trust protocol. RedPill adapters
 currently accept API keys only. Phala Cloud's device authorization and account
 metadata live in the explicit `@phala/aci-provider/phala-cloud` subpath and are
-attached only by the Phala Cloud adapters. A future Redpill Clerk OAuth flow
+attached only by the Phala Cloud adapters. A future RedPill Clerk OAuth flow
 should be added when that product endpoint exists, without changing the
 verifier.
 
@@ -122,9 +122,9 @@ attestation, receipt verification, device polling, credential storage, or
 another model catalog.
 
 Account authorization is a product capability, not part of ACI. Phala Cloud
-currently implements `AccountApiKeyAuth` with its device grant. Redpill does
+currently implements `AccountApiKeyAuth` with its device grant. RedPill does
 not advertise account authorization, so both hosts expose only its API-key
-method. A future Redpill Clerk integration should implement the same shared
+method. A future RedPill Clerk integration should implement the same shared
 contract once its real authorization endpoints exist; Pi and OpenCode adapters
 will not need brand-specific login code.
 
@@ -186,7 +186,7 @@ hash is the value bound into RTMR3 and is therefore the value a verifier pins.
 Clients obtain accepted compose hashes from authenticated release metadata.
 
 The neutral SDK may intentionally use hardware-bound mode for self-hosted and
-development deployments. A production Redpill or Phala branded client should
+development deployments. A production RedPill or Phala branded client should
 ship or securely obtain a reviewed compose allowlist and use reviewed-release
 mode by default.
 
@@ -205,7 +205,7 @@ deployment release process must still close the trust loop:
 
 The repository can publish all eight npm packages in dependency order from a
 signed GitHub Release. Publishing alone does not create a reviewed-release
-claim: the Redpill and Phala deployment pipelines still need to supply the
+claim: the RedPill and Phala deployment pipelines still need to supply the
 independently reviewed compose hashes consumed by the branded policies.
 
 The local agent sees plaintext prompts and responses. This architecture covers

--- a/clients/coding-agents.md
+++ b/clients/coding-agents.md
@@ -32,7 +32,7 @@ Then use Pi's native login and model picker:
 
 ```text
 /login redpill
-# paste the Redpill API key
+# paste the RedPill API key
 
 # or
 /login phala
@@ -54,7 +54,7 @@ credential store; use `/login` when the key must survive a restart.
 
 The provider-scoped commands expose ACI-specific state that Pi does not know
 about: settings, attestation, retained receipts, and content-addressed sessions.
-For example, Redpill registers `/redpill-settings`, `/redpill-attestation`,
+For example, RedPill registers `/redpill-settings`, `/redpill-attestation`,
 `/redpill-receipts`, `/redpill-receipt`, and `/redpill-session`.
 
 Pi keeps the latest 32 receipt-bearing wire digests by default. That local audit
@@ -76,7 +76,7 @@ native TUI flow:
 
 ```text
 /connect
-# select Redpill AI or Phala Cloud and complete login
+# select RedPill AI or Phala Cloud and complete login
 /models
 # select a redpill/ or phala/ model
 ```
@@ -86,7 +86,7 @@ The plugin command persists the plugin entry in OpenCode configuration, and
 separate provider block: the plugin owns the provider, verified fetch, live
 models, and auth loader.
 
-Redpill currently supports API keys only. Phala Cloud offers both its device
+RedPill currently supports API keys only. Phala Cloud offers both its device
 account flow and an API-key method. The device flow returns the issued
 Confidential AI key through OpenCode's documented browser-authorization hook;
 the plugin does not create a parallel OAuth token lifecycle or credential file.
@@ -103,7 +103,7 @@ The branded plugins register matching inspection commands:
 /phala-session <session-id>
 ```
 
-Replace `phala` with `redpill` for Redpill. These OpenCode custom commands
+Replace `phala` with `redpill` for RedPill. These OpenCode custom commands
 use OpenCode's official prompt-command mechanism to ask the selected model to
 call the provider-scoped read-only inspect tool. The tool itself performs the
 local inspection; no second verifier is involved. Pi can render the same data
@@ -168,7 +168,7 @@ lifecycle, credentials, and dynamic models. Create one `AciProvider`, map its
 reuse `inspectAciProvider()` for audit UI. If a product supplies an
 `AccountApiKeyAuth`, map its authorization presentation and returned key into
 the host's native auth API; manual API-key entry and all persistence stay in
-the host. Phala Cloud already supplies this contract. Redpill should add one
+the host. Phala Cloud already supplies this contract. RedPill should add one
 only after its Clerk endpoints are defined. If the host cannot inject a
 per-provider fetch, changing only its base URL cannot provide ACI channel
 binding.

--- a/clients/opencode-provider/README.md
+++ b/clients/opencode-provider/README.md
@@ -8,7 +8,7 @@
   supplies the Phala Cloud endpoint and identity.
 
 Both branded packages support direct API keys. Only the Phala Cloud package
-adds its device login; Redpill does not currently expose account OAuth. All
+adds its device login; RedPill does not currently expose account OAuth. All
 packages use OpenCode's v1 server-plugin manifest and run on Bun. The provider
 is created by the plugin, so plugin installation or initialization failure
 cannot leave a separately configured ordinary HTTPS provider behind.
@@ -20,9 +20,9 @@ opencode plugin opencode-provider-redpill --global
 opencode plugin opencode-provider-phala-cloud --global
 ```
 
-Restart OpenCode after installing. Run `/connect`, select Redpill AI or Phala
+Restart OpenCode after installing. Run `/connect`, select RedPill AI or Phala
 Cloud, then run `/models` and select a `redpill/` or `phala/` model. Phala Cloud
-offers both its account device flow and manual API-key entry; Redpill currently
+offers both its account device flow and manual API-key entry; RedPill currently
 offers API-key entry. OpenCode persists the plugin entry and credential in its
 own stores. No hand-written provider block or adapter-owned credential file is
 required.

--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/opencode-provider-aci",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Native OpenCode provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "1.18.24",

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-phala-cloud",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Phala Cloud provider for OpenCode with verified ACI transport and per-response receipt verification",
   "keywords": [
     "aci",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0",
-    "@phala/opencode-provider-aci": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0",
+    "@phala/opencode-provider-aci": "^0.7.0"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/opencode-provider/packages/opencode-provider-redpill/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/README.md
@@ -12,14 +12,14 @@ pickers:
 
 ```text
 /connect
-# search for Redpill AI and enter the API key
+# search for RedPill AI and enter the API key
 /models
 # search for redpill/ and select a model
 ```
 
 OpenCode persists the plugin entry and credential in its own configuration and
 auth store. `REDPILL_AI_API_KEY` is also supported for the current process, but
-environment variables are not copied into the auth store. Redpill does not
+environment variables are not copied into the auth store. RedPill does not
 currently expose account OAuth. Select `redpill/<model-id>` in OpenCode. The
 plugin discovers current TEE models and sends
 inference only through an attested, TLS-pinned connection. Every response

--- a/clients/opencode-provider/packages/opencode-provider-redpill/index.ts
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/index.ts
@@ -2,13 +2,13 @@ import type { PluginModule } from "@opencode-ai/plugin";
 import { REDPILL_ACI_PROFILE } from "@phala/aci-provider/profiles";
 import { createOpenCodeAciPlugin } from "@phala/opencode-provider-aci";
 
-export const RedpillProviderPlugin = createOpenCodeAciPlugin({
+export const RedPillProviderPlugin = createOpenCodeAciPlugin({
   profile: REDPILL_ACI_PROFILE,
 });
 
 const plugin: PluginModule = {
   id: "opencode-provider-redpill",
-  server: RedpillProviderPlugin,
+  server: RedPillProviderPlugin,
 };
 
 export default plugin;

--- a/clients/opencode-provider/packages/opencode-provider-redpill/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-redpill",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "RedPill ACI provider for OpenCode",
   "keywords": [
     "aci",
@@ -51,8 +51,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0",
-    "@phala/opencode-provider-aci": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0",
+    "@phala/opencode-provider-aci": "^0.7.0"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-clients",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "verifier-ts",
@@ -6315,10 +6315,10 @@
     },
     "opencode-provider/packages/opencode-provider-aci": {
       "name": "@phala/opencode-provider-aci",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "1.18.24",
@@ -6333,11 +6333,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-phala-cloud": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0",
-        "@phala/opencode-provider-aci": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0",
+        "@phala/opencode-provider-aci": "^0.7.0"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6348,11 +6348,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-redpill": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0",
-        "@phala/opencode-provider-aci": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0",
+        "@phala/opencode-provider-aci": "^0.7.0"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6364,10 +6364,10 @@
     },
     "pi-provider/packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6379,11 +6379,11 @@
       }
     },
     "pi-provider/packages/pi-provider-phala-cloud": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0",
-        "@phala/pi-provider-aci": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0",
+        "@phala/pi-provider-aci": "^0.7.0"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6395,11 +6395,11 @@
       }
     },
     "pi-provider/packages/pi-provider-redpill": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.6.0",
-        "@phala/pi-provider-aci": "^0.6.0"
+        "@phala/aci-provider": "^0.7.0",
+        "@phala/pi-provider-aci": "^0.7.0"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6412,10 +6412,10 @@
     },
     "provider": {
       "name": "@phala/aci-provider",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.6.0"
+        "@phala/aci-verifier": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -6430,7 +6430,7 @@
     },
     "verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "ACI TypeScript clients and coding-agent providers",
   "license": "MIT",

--- a/clients/pi-provider/README.md
+++ b/clients/pi-provider/README.md
@@ -6,7 +6,7 @@ with **attested TLS (SPKI) pinning** as the security control.
 This is the neutral Pi adapter. Branded distributions add their identity on top and
 publish their own npm packages:
 
-- [`pi-provider-redpill`](https://www.npmjs.com/package/pi-provider-redpill) — Redpill AI
+- [`pi-provider-redpill`](https://www.npmjs.com/package/pi-provider-redpill) — RedPill AI
 - [`pi-provider-phala-cloud`](https://www.npmjs.com/package/pi-provider-phala-cloud) — Phala Cloud
 
 Both are thin skins over this package (`createProvider` with an instance-scoped

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0",
-    "@phala/pi-provider-aci": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0",
+    "@phala/pi-provider-aci": "^0.7.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/README.md
+++ b/clients/pi-provider/packages/pi-provider-redpill/README.md
@@ -2,7 +2,7 @@
 
 Attested AI for Pi, powered by [private-ai-gateway].
 
-A thin, Redpill-branded distribution of the vendor-neutral
+A thin, RedPill-branded distribution of the vendor-neutral
 [`@phala/pi-provider-aci`](https://www.npmjs.com/package/@phala/pi-provider-aci): standard
 chat plus **attested TLS (SPKI) pinning** — the prompt and reply are readable
 only by the attested workload. Every response receipt is verified before Pi
@@ -20,7 +20,7 @@ connection, then save a default model from the native model picker:
 
 ```text
 /login redpill
-# paste the Redpill API key and wait for the footer to show aci-verified
+# paste the RedPill API key and wait for the footer to show aci-verified
 /model
 # search for redpill/, select a model, and press Ctrl+S
 ```

--- a/clients/pi-provider/packages/pi-provider-redpill/index.ts
+++ b/clients/pi-provider/packages/pi-provider-redpill/index.ts
@@ -1,9 +1,9 @@
 /**
- * pi-provider-redpill — Redpill AI branded distribution of the
+ * pi-provider-redpill — RedPill AI branded distribution of the
  * vendor-neutral private-ai-gateway (ACI) Pi provider.
  *
  * This package is a thin skin: it imports the core `@phala/pi-provider-aci` and
- * registers it with the Redpill identity (provider id, endpoint, env vars).
+ * registers it with the RedPill identity (provider id, endpoint, env vars).
  * All protocol logic — attestation, TLS SPKI pinning,
  * model discovery — lives in the core.
  *

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "RedPill AI for Pi with verified ACI transport and per-response receipt verification",
   "keywords": [
     "ai-provider",
@@ -52,8 +52,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.6.0",
-    "@phala/pi-provider-aci": "^0.6.0"
+    "@phala/aci-provider": "^0.7.0",
+    "@phala/pi-provider-aci": "^0.7.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-provider-redpill",
   "version": "0.6.0",
-  "description": "Redpill AI for Pi with verified ACI transport and per-response receipt verification",
+  "description": "RedPill AI for Pi with verified ACI transport and per-response receipt verification",
   "keywords": [
     "ai-provider",
     "attestation",

--- a/clients/provider/README.md
+++ b/clients/provider/README.md
@@ -9,7 +9,7 @@ audit semantics.
 
 Host adapters such as Pi and OpenCode supply their native configuration and UI.
 Applications normally install a host adapter rather than this package directly.
-Shared Redpill and Phala Cloud profiles are exported from
+Shared RedPill and Phala Cloud profiles are exported from
 `@phala/aci-provider/profiles`. Phala Cloud's account API and device
 authorization flow are isolated under `@phala/aci-provider/phala-cloud`; they
 are not part of the ACI protocol or verifier.
@@ -75,5 +75,5 @@ const accountAuth = createPhalaCloudAccountAuth({
 ```
 
 This product authentication contract is separate from ACI verification.
-Redpill currently has no account authorization implementation and remains
+RedPill currently has no account authorization implementation and remains
 API-key-only.

--- a/clients/provider/package.json
+++ b/clients/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-provider",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Framework-neutral model provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -62,7 +62,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.6.0"
+    "@phala/aci-verifier": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/clients/provider/src/profiles.ts
+++ b/clients/provider/src/profiles.ts
@@ -2,7 +2,7 @@ import type { AciProviderProfile } from "./profile.ts";
 
 export const REDPILL_ACI_PROFILE = {
   providerId: "redpill",
-  label: "Redpill AI",
+  label: "RedPill AI",
   defaultBaseURL: "https://tee.redpill.ai/v1",
   apiKeyEnv: "REDPILL_AI_API_KEY",
   envPrefix: "REDPILL",

--- a/clients/provider/test/profiles.test.ts
+++ b/clients/provider/test/profiles.test.ts
@@ -6,4 +6,5 @@ import { PHALA_CLOUD_ACI_PROFILE, REDPILL_ACI_PROFILE } from "../src/profiles.ts
 test("branded profiles expose their product API key environment", () => {
   assert.equal(PHALA_CLOUD_ACI_PROFILE.apiKeyEnv, "PHALA_AI_API_KEY");
   assert.equal(REDPILL_ACI_PROFILE.apiKeyEnv, "REDPILL_AI_API_KEY");
+  assert.equal(REDPILL_ACI_PROFILE.label, "RedPill AI");
 });

--- a/clients/releasing.md
+++ b/clients/releasing.md
@@ -68,5 +68,5 @@ move or reuse a release tag after publication; npm versions are immutable.
 
 Package publication and reviewed deployment approval are separate operations.
 The branded release claims a reviewed gateway deployment after the
-Redpill/Phala release pipeline independently publishes the accepted compose
+RedPill/Phala release pipeline independently publishes the accepted compose
 hashes through an authenticated release channel.

--- a/clients/verifier-ts/README.md
+++ b/clients/verifier-ts/README.md
@@ -165,7 +165,7 @@ await aci.close();
 
 Install the two ESM packages with `npm install openai @phala/aci-verifier`.
 Run the same source under Node 20.18.1+ or Bun 1.4.0+; the `/runtime` export
-selects the matching pinned transport. Set `ACI_API_KEY` to the Redpill key.
+selects the matching pinned transport. Set `ACI_API_KEY` to the RedPill key.
 The SDK adds it to the inference request; `aci.fetch` retains that request's
 authorization in its bounded exchange history and reuses it only for the
 matching private receipt lookup.

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -33,11 +33,11 @@ merged. The framework and cross-cutting reviews:
 As observed on 2026-07-13, Private AI Gateway does not guarantee per-tenant
 prefix-cache partitioning for the active Kimi-K2.6 providers. The gateway
 preserves a caller's `cache_salt` but does not derive one from the authenticated
-Redpill tenant.
+RedPill tenant.
 
 - Tinfoil [replaces `cache_salt`](https://github.com/tinfoilsh/confidential-model-router/blob/v0.0.118/cache_salt.go)
-  with a value derived from Redpill's shared upstream credential. The gateway
-  does not set `user_cache_secret`, so Redpill tenants share one namespace.
+  with a value derived from RedPill's shared upstream credential. The gateway
+  does not set `user_cache_secret`, so RedPill tenants share one namespace.
 - Chutes passes `cache_salt` to vLLM but does not generate it. Unsalted requests
   share the serving instance's namespace.
 
@@ -45,7 +45,7 @@ Tinfoil's behavior is attestation-backed. Chutes configuration is control-plane
 evidence and is not bound by its current attestation. The intended interface is
 caller-controlled: preserve `cache_salt` for Chutes and translate it to
 `user_cache_secret` for Tinfoil. The gateway should not derive or override the
-partition from Redpill tenant identity.
+partition from RedPill tenant identity.
 
 ## The shared verification model
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -154,7 +154,7 @@ backend-owned `response.received`, frontend-owned `response.returned`).
   baseline commit in `VENDOR.md`.
 - Deferred: standalone / self-hosted Phala dstack-vLLM node verification through the
   deep verifier and the live harness. The bridge today only dispatches
-  `tinfoil`/`near-ai`/`chutes`, and the vendored verifier's Phala/Redpill paths go
+  `tinfoil`/`near-ai`/`chutes`, and the vendored verifier's Phala/RedPill paths go
   through the hosted `api.redpill.ai` / `cloud-api.phala.network` endpoints, not a raw
   node's `/v1/attestation/report`. The gateway already verifies first-party
   ACI-service workers natively in Rust (`AciServiceUpstreamVerifier`); the follow-up is a `phala`
@@ -200,7 +200,7 @@ backend-owned `response.received`, frontend-owned `response.returned`).
   hashes. Verifiers should not compare `request.received.body_hash` with the
   original encrypted HTTP body.
 - Write neutral docs with `{API_KEY_ENV_VAR}` and product wrappers that render
-  `REDPILL_AI_API_KEY` for Redpill and `PHALA_AI_API_KEY` for Phala.
+  `REDPILL_AI_API_KEY` for RedPill and `PHALA_AI_API_KEY` for Phala.
 
 ### P1: Local Backend Proxy Mode
 

--- a/scripts/confidential_verifier/__init__.py
+++ b/scripts/confidential_verifier/__init__.py
@@ -1,6 +1,6 @@
 from .types import AttestationReport, VerificationResult
 from .sdk import TeeVerifier
-from .providers import TinfoilProvider, RedpillProvider, NearaiProvider
+from .providers import TinfoilProvider, RedPillProvider, NearaiProvider
 from .verifiers import IntelTdxVerifier, NvidiaGpuVerifier
 
 __all__ = [
@@ -8,7 +8,7 @@ __all__ = [
     "VerificationResult",
     "TeeVerifier",
     "TinfoilProvider",
-    "RedpillProvider",
+    "RedPillProvider",
     "NearaiProvider",
     "IntelTdxVerifier",
     "NvidiaGpuVerifier",

--- a/scripts/confidential_verifier/providers/__init__.py
+++ b/scripts/confidential_verifier/providers/__init__.py
@@ -1,7 +1,7 @@
 from .base import ServiceProvider
 from .tinfoil import TinfoilProvider
-from .redpill import RedpillProvider
+from .redpill import RedPillProvider
 from .nearai import NearaiProvider
 from .chutes import ChutesProvider
 
-__all__ = ["ServiceProvider", "TinfoilProvider", "RedpillProvider", "NearaiProvider", "ChutesProvider"]
+__all__ = ["ServiceProvider", "TinfoilProvider", "RedPillProvider", "NearaiProvider", "ChutesProvider"]

--- a/scripts/confidential_verifier/providers/redpill.py
+++ b/scripts/confidential_verifier/providers/redpill.py
@@ -6,12 +6,12 @@ from .base import ServiceProvider
 from ..types import AttestationReport
 
 
-class RedpillProvider(ServiceProvider):
+class RedPillProvider(ServiceProvider):
     """
-    Provider for Redpill AI models.
+    Provider for RedPill AI models.
 
-    Redpill models are Phala Cloud apps. The SDK handles verification
-    specially using RedpillVerifier which uses PhalaCloudVerifier internally.
+    RedPill models are Phala Cloud apps. The SDK handles verification
+    specially using RedPillVerifier which uses PhalaCloudVerifier internally.
     """
 
     def __init__(self):
@@ -21,7 +21,7 @@ class RedpillProvider(ServiceProvider):
         url = f"{self.api_base}/attestation/report"
         nonce = secrets.token_hex(32)
         print(
-            f"[Redpill] Fetching from {url} for model {model_id} with nonce {nonce[:8]}..."
+            f"[RedPill] Fetching from {url} for model {model_id} with nonce {nonce[:8]}..."
         )
 
         response = requests.get(url, params={"model": model_id, "nonce": nonce})
@@ -34,7 +34,7 @@ class RedpillProvider(ServiceProvider):
             intel_quote = model_atts[0].get("intel_quote")
 
         if not intel_quote:
-            raise Exception("Redpill report missing intel_quote")
+            raise Exception("RedPill report missing intel_quote")
 
         nvidia_payload = data.get("nvidia_payload")
         if isinstance(nvidia_payload, str):
@@ -57,7 +57,7 @@ class RedpillProvider(ServiceProvider):
 
     def list_models(self) -> List[str]:
         url = f"{self.api_base}/models"
-        print(f"[Redpill] Fetching models from {url}")
+        print(f"[RedPill] Fetching models from {url}")
         response = requests.get(url)
         response.raise_for_status()
         data = response.json()

--- a/scripts/confidential_verifier/sdk.py
+++ b/scripts/confidential_verifier/sdk.py
@@ -3,15 +3,15 @@ import time
 import asyncio
 from typing import List, Optional
 from .types import AttestationReport, VerificationResult
-from .providers import TinfoilProvider, RedpillProvider, NearaiProvider, ChutesProvider
-from .verifiers import NvidiaGpuVerifier, NearAICloudVerifier, RedpillVerifier, ChutesVerifier
+from .providers import TinfoilProvider, RedPillProvider, NearaiProvider, ChutesProvider
+from .verifiers import NvidiaGpuVerifier, NearAICloudVerifier, RedPillVerifier, ChutesVerifier
 
 
 class TeeVerifier:
     def __init__(self, chutes_api_key: Optional[str] = None):
         self.providers = {
             "tinfoil": TinfoilProvider(),
-            "redpill": RedpillProvider(),
+            "redpill": RedPillProvider(),
             "nearai": NearaiProvider(),
         }
         # Chutes requires API key, only add if available
@@ -21,7 +21,7 @@ class TeeVerifier:
 
         self.nvidia_verifier = NvidiaGpuVerifier()
         self.nearai_verifier = NearAICloudVerifier()
-        self.redpill_verifier = RedpillVerifier()
+        self.redpill_verifier = RedPillVerifier()
         self.chutes_verifier = ChutesVerifier()
 
     async def fetch_report(
@@ -54,7 +54,7 @@ class TeeVerifier:
                 model_id=report.model_id,
             )
 
-        # Special handling for Redpill which uses PhalaCloudVerifier internally
+        # Special handling for RedPill which uses PhalaCloudVerifier internally
         if provider_name == "redpill":
             if not report.raw:
                 return VerificationResult(
@@ -63,7 +63,7 @@ class TeeVerifier:
                     timestamp=time.time(),
                     hardware_type=["INTEL_TDX"],
                     claims={},
-                    error="Missing raw report data for Redpill verification",
+                    error="Missing raw report data for RedPill verification",
                 )
             # Build report data with all required fields
             report_data = {

--- a/scripts/confidential_verifier/verifiers/__init__.py
+++ b/scripts/confidential_verifier/verifiers/__init__.py
@@ -3,7 +3,7 @@ from .nvidia import NvidiaGpuVerifier
 from .tinfoil import TinfoilTdxVerifier, TinfoilSevVerifier
 from .base import Verifier
 from .dstack import DstackVerifier, verify_report_data
-from .redpill import RedpillVerifier
+from .redpill import RedPillVerifier
 from .nearai import NearAICloudVerifier
 from .chutes import ChutesVerifier
 
@@ -15,7 +15,7 @@ from .chutes import ChutesVerifier
 # User-facing verifiers (what users should call)
 # - TinfoilSevVerifier: Unified verifier for TDX + SEV-SNP with Sigstore manifest
 # - TinfoilTdxVerifier: Legacy TDX verifier (use TinfoilSevVerifier instead)
-# - RedpillVerifier: Full Phala app verification for Redpill models
+# - RedPillVerifier: Full Phala app verification for RedPill models
 # - NearAICloudVerifier: Multi-component (Gateway + Models) verification
 # - ChutesVerifier: Intel TDX + NVIDIA CC with E2E public key binding
 
@@ -26,7 +26,7 @@ __all__ = [
     "TinfoilSevVerifier",
     "TinfoilTdxVerifier",
     "DstackVerifier",
-    "RedpillVerifier",
+    "RedPillVerifier",
     "NearAICloudVerifier",
     "ChutesVerifier",
     "verify_report_data",

--- a/scripts/confidential_verifier/verifiers/dstack.py
+++ b/scripts/confidential_verifier/verifiers/dstack.py
@@ -25,7 +25,7 @@ def verify_report_data(
         report_data[0:32] = SHA256(signing_address || tls_cert_fingerprint)
         report_data[32:64] = nonce (32 bytes)
 
-    This is a shared helper used by dstack-based verifiers (Redpill, NearAI).
+    This is a shared helper used by dstack-based verifiers (RedPill, NearAI).
 
     Args:
         tdx_report_data_hex: The 64-byte report_data from TDX quote (hex string)

--- a/scripts/confidential_verifier/verifiers/phala.py
+++ b/scripts/confidential_verifier/verifiers/phala.py
@@ -19,8 +19,8 @@ class PhalaCloudVerifier(Verifier):
     Internal verifier for Phala Cloud Apps.
     Verifies dstack TEE environment (App/KMS/Gateway components) and optionally GPU.
 
-    This is an internal class used by RedpillVerifier. Users should call
-    RedpillVerifier directly for Redpill model verification.
+    This is an internal class used by RedPillVerifier. Users should call
+    RedPillVerifier directly for RedPill model verification.
     """
 
     def __init__(

--- a/scripts/confidential_verifier/verifiers/redpill.py
+++ b/scripts/confidential_verifier/verifiers/redpill.py
@@ -13,11 +13,11 @@ from ..types import VerificationResult
 logger = logging.getLogger(__name__)
 
 
-class RedpillVerifier(Verifier):
+class RedPillVerifier(Verifier):
     """
-    Verifier for Redpill models.
+    Verifier for RedPill models.
 
-    Redpill models are Phala Cloud apps, so this verifier uses PhalaCloudVerifier
+    RedPill models are Phala Cloud apps, so this verifier uses PhalaCloudVerifier
     internally to verify the dstack TEE environment (App/KMS/Gateway components).
     Additionally verifies nvidia GPU attestation and report data binding.
     """
@@ -29,7 +29,7 @@ class RedpillVerifier(Verifier):
     def _extract_report_data_from_quote(intel_quote: str) -> Optional[str]:
         """
         Extract report_data (64 bytes) from TDX quote for nonce/address binding check.
-        The Redpill intel_quote contains the nonce/address that was passed to the API.
+        The RedPill intel_quote contains the nonce/address that was passed to the API.
         """
         try:
             quote_bytes = bytes.fromhex(intel_quote)
@@ -42,7 +42,7 @@ class RedpillVerifier(Verifier):
 
     @staticmethod
     def get_redpill_models() -> List[Dict[str, Any]]:
-        """Fetches running models from Redpill API."""
+        """Fetches running models from RedPill API."""
         url = "https://api.redpill.ai/v1/models"
         try:
             response = requests.get(url)
@@ -50,11 +50,11 @@ class RedpillVerifier(Verifier):
             data = response.json()
             return data.get("data", [])
         except Exception as e:
-            logger.warning(f"Failed to fetch Redpill models: {e}")
+            logger.warning(f"Failed to fetch RedPill models: {e}")
             return []
 
     def _get_model_info(self, model_id: str) -> Optional[Dict[str, Any]]:
-        """Look up the model info for a given Redpill model_id."""
+        """Look up the model info for a given RedPill model_id."""
         models = self.get_redpill_models()
         for model in models:
             if model.get("id") == model_id:
@@ -62,7 +62,7 @@ class RedpillVerifier(Verifier):
         return None
 
     def _get_app_id_for_model(self, model_id: str) -> Optional[str]:
-        """Look up the Phala app_id for a given Redpill model_id."""
+        """Look up the Phala app_id for a given RedPill model_id."""
         model = self._get_model_info(model_id)
         if model:
             return model.get("metadata", {}).get("appid")
@@ -70,10 +70,10 @@ class RedpillVerifier(Verifier):
 
     async def verify(self, report_data: Dict[str, Any]) -> VerificationResult:
         """
-        Verify a Redpill model attestation report.
+        Verify a RedPill model attestation report.
 
         Args:
-            report_data: Raw attestation report from Redpill API containing:
+            report_data: Raw attestation report from RedPill API containing:
                 - model_id or model: The model identifier
                 - intel_quote: TDX quote (optional, for report data verification)
                 - nvidia_payload: GPU attestation payload
@@ -179,7 +179,7 @@ class RedpillVerifier(Verifier):
                 # NearAI verifier expects the raw data from NearAI API
                 raw_data = report_data.get("raw") or report_data
 
-                # For NearAI resold via Redpill, we only care about the first model attestation
+                # For NearAI resold via RedPill, we only care about the first model attestation
                 if isinstance(raw_data, dict) and "model_attestations" in raw_data:
                     model_atts = raw_data.get("model_attestations", [])
                     if len(model_atts) > 1:
@@ -234,12 +234,12 @@ class RedpillVerifier(Verifier):
                 if not result.model_verified:
                     return result
 
-                # 4. Verify report data binding (nonce/address) against the Redpill intel_quote
+                # 4. Verify report data binding (nonce/address) against the RedPill intel_quote
                 request_nonce = report_data.get("request_nonce")
                 signing_address = report_data.get("signing_address")
                 intel_quote = report_data.get("intel_quote")
 
-                # Extract report_data from the Redpill intel_quote
+                # Extract report_data from the RedPill intel_quote
                 report_data_hex = None
                 if intel_quote:
                     report_data_hex = self._extract_report_data_from_quote(intel_quote)
@@ -278,7 +278,7 @@ class RedpillVerifier(Verifier):
             )
 
         except Exception as e:
-            logger.exception("Redpill verification failed")
+            logger.exception("RedPill verification failed")
             # Try to get model provider from model_info if available
             model_provider = None
             try:

--- a/spec/related-work.md
+++ b/spec/related-work.md
@@ -11,7 +11,7 @@ comparison:
    intended for independent implementation.
 2. **Per-request signed receipts are rare.** Big-tech systems bind responses
    only implicitly to an attested session; among public APIs, only the
-   dstack lineage (Phala vllm-proxy, NEAR AI, 0G, Redpill) and Nillion sign
+   dstack lineage (Phala vllm-proxy, NEAR AI, 0G, RedPill) and Nillion sign
    individual responses. ACI's structured receipt — event log, upstream
    verification, session references — has no published counterpart.
 


### PR DESCRIPTION
## Summary

- normalize the RedPill brand across package metadata, docs, runtime labels, and legacy verifier messages
- rename public code symbols to `RedPillProviderPlugin`, `RedPillProvider`, and `RedPillVerifier`
- preserve lowercase compatibility identifiers such as npm package names, provider IDs, URLs, environment variables, and wire fields
- coordinate all eight published client packages and internal dependency ranges at `0.7.0`

## Verification

- `npm run build`
- `npm run check`
- `npm test`
- `npm run test:bun`
- `npm run lint`
- `npm run format:check`
- `npm run lint:packages`
- `bash package-smoke.sh`
- `python3 -m compileall -q scripts/confidential_verifier`
- repository and built-artifact scan for stale `Redpill` spelling