### PR TITLE
refactor(clients): trust gateway model capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Start here:
 - [ACI client architecture](clients/architecture.md) — the framework-neutral
   client product, existing versus new components, release policy, and coding
   agent integration boundary.
+- [Coding agent integrations](clients/coding-agents.md) — native Pi and
+  OpenCode installation, login, model selection, and ACI inspection.
 
 ## Audience
 
@@ -586,7 +588,9 @@ tests/                         unit and integration coverage
 
 - [ACI spec, quickstart, and test vectors](spec/README.md)
 - [Client verifiers](clients/README.md)
-- [PI provider extension (use the gateway from pi)](clients/pi-provider/README.md)
+- [Coding agent integrations](clients/coding-agents.md)
+- [Pi provider](clients/pi-provider/README.md)
+- [OpenCode provider](clients/opencode-provider/README.md)
 - [Deployment guide](deploy/README.md)
 - [Configuration reference](docs/configuration-reference.md)
 - [Live E2E test suite](docs/live-e2e-test-suite.md)

--- a/clients/README.md
+++ b/clients/README.md
@@ -61,7 +61,7 @@ and native coding-agent integrations:
   [`releasing.md`](releasing.md).
 - [`opencode-provider`](opencode-provider) — the native OpenCode v1 server
   plugin. `@phala/opencode-provider-aci` maps the shared provider into
-  OpenCode's config, auth, model, reasoning, and lifecycle hooks;
+  OpenCode's config, auth, model, and lifecycle hooks;
   `opencode-provider-redpill` supplies API-key authentication, while
   `opencode-provider-phala-cloud` also adds Phala Cloud device login. Both use
   shared branded profiles. It verifies every receipt before the response stream

--- a/clients/architecture.md
+++ b/clients/architecture.md
@@ -112,7 +112,7 @@ verified transport:
 | Contract | Shared responsibility | Host responsibility |
 | --- | --- | --- |
 | Provider lifecycle | Resolve policy, establish the verified connection, expose one scoped `fetch`, and fail closed | Create and close the provider through native lifecycle hooks |
-| Model catalog | Discover `/v1/models` once and normalize filtering, capabilities, pricing, and thinking format into `AciModel` | Map `AciModel` into the host's model type and let the host persist selection/catalog state |
+| Model catalog | Strictly validate `/v1/models` and map its declared capabilities, pricing, limits, and modalities into `AciModel` | Map `AciModel` into the host's model type and let the host persist selection/catalog state |
 | Account authorization | Describe one browser/device flow with `AccountApiKeyAuth` and return one API key plus optional metadata | Map the flow into native auth UI and persist the key |
 | ACI inspection | Return structured status, attestation, receipt, and session results and format them for text UIs | Register native commands/tools and render the result |
 
@@ -120,6 +120,15 @@ This is the extension boundary for another coding agent. A new adapter should
 map these contracts into official host APIs. It should not implement
 attestation, receipt verification, device polling, credential storage, or
 another model catalog.
+
+Model metadata has one authority: the gateway catalog. `supported_features`
+drives reasoning and tool support, while `supported_sampling_parameters`
+drives temperature support. Empty capability arrays are treated conservatively
+and never expanded from a model id. Required limits, modalities, base prices,
+and capability arrays are validated instead of replaced with client defaults.
+Optional cache prices remain absent.
+Provider-specific reasoning dialects remain a gateway routing concern; clients
+use the gateway's public reasoning fields.
 
 Account authorization is a product capability, not part of ACI. Phala Cloud
 currently implements `AccountApiKeyAuth` with its device grant. RedPill does

--- a/clients/opencode-provider/packages/opencode-provider-aci/README.md
+++ b/clients/opencode-provider/packages/opencode-provider-aci/README.md
@@ -42,6 +42,12 @@ attaches it to model requests through its native auth loader. The plugin uses
 OpenCode's server-plugin, provider config, auth, model, and disposal hooks; it
 does not maintain parallel config or credential files.
 
+Capability flags come only from the catalog. The plugin does not create
+model-family variants or rewrite reasoning parameters; OpenCode's official
+OpenAI-compatible provider handles its standard reasoning request and response
+fields.
+Optional cache prices stay absent when the catalog does not publish them.
+
 The plugin registers `/aci-attestation`, `/aci-receipts`, `/aci-receipt [id]`,
 and `/aci-session <id>` as native OpenCode custom commands. They dispatch the
 read-only `aci_inspect` tool, whose five actions are `status`, `attestation`,

--- a/clients/opencode-provider/packages/opencode-provider-aci/src/index.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/src/index.ts
@@ -17,28 +17,7 @@ const OPENAI_COMPATIBLE_PACKAGE = "@ai-sdk/openai-compatible";
 
 type OpenCodeProviderConfig = NonNullable<Config["provider"]>[string];
 type OpenCodeCommandConfig = NonNullable<Config["command"]>[string];
-
-export interface OpenCodeModelConfig {
-  name: string;
-  family?: string;
-  attachment: boolean;
-  reasoning: boolean;
-  temperature: boolean;
-  tool_call: boolean;
-  interleaved: false | { field: "reasoning_content" };
-  cost: {
-    input: number;
-    output: number;
-    cache_read: number;
-    cache_write: number;
-  };
-  limit: { context: number; output: number };
-  modalities: {
-    input: ("text" | "audio" | "image" | "video" | "pdf")[];
-    output: ("text" | "audio" | "image" | "video" | "pdf")[];
-  };
-  variants?: Record<string, Record<string, unknown>>;
-}
+export type OpenCodeModelConfig = NonNullable<OpenCodeProviderConfig["models"]>[string];
 
 type AciReceiptOptions = NonNullable<AciProviderConfigInput["receipts"]>;
 
@@ -71,28 +50,18 @@ function pluginConfig(options: PluginOptions | undefined): OpenCodeAciPluginOpti
 export function mapOpenCodeModel(model: AciModel): OpenCodeModelConfig {
   return {
     name: model.name,
-    ...(model.family ? { family: model.family } : {}),
     attachment: model.input.some((modality) => modality !== "text"),
     reasoning: model.reasoning,
     temperature: model.temperature,
     tool_call: model.toolCall,
-    interleaved: model.reasoning ? { field: "reasoning_content" } : false,
     cost: {
       input: model.cost.input,
       output: model.cost.output,
-      cache_read: model.cost.cacheRead,
-      cache_write: model.cost.cacheWrite,
+      ...(model.cost.cacheRead === undefined ? {} : { cache_read: model.cost.cacheRead }),
+      ...(model.cost.cacheWrite === undefined ? {} : { cache_write: model.cost.cacheWrite }),
     },
     limit: { context: model.contextWindow, output: model.maxOutputTokens },
     modalities: { input: [...model.input], output: [...model.output] },
-    ...(model.thinkingFormat === "qwen"
-      ? {
-          variants: {
-            off: { enable_thinking: false },
-            high: { enable_thinking: true },
-          },
-        }
-      : {}),
   };
 }
 
@@ -247,18 +216,6 @@ export function createOpenCodeAciPlugin({
           };
         },
         methods,
-      },
-      async "chat.params"(request, output) {
-        if (request.model.providerID !== profile.providerId) return;
-        const model = active?.models().find((item) => item.id === request.model.id);
-        if (!model) return;
-        if (model.thinkingFormat === "qwen" && output.options.enable_thinking === undefined) {
-          output.options.enable_thinking = true;
-        }
-        if (model.thinkingFormat === "off") {
-          delete output.options.enable_thinking;
-          delete output.options.reasoningEffort;
-        }
       },
       async dispose() {
         const provider = active;

--- a/clients/opencode-provider/packages/opencode-provider-aci/test/models.test.ts
+++ b/clients/opencode-provider/packages/opencode-provider-aci/test/models.test.ts
@@ -2,17 +2,16 @@ import { expect, test } from "bun:test";
 
 import { mapOpenCodeModel } from "../src/index.ts";
 
-test("maps provider capabilities and Qwen thinking variants into OpenCode", () => {
+test("maps only catalog-declared capabilities into OpenCode", () => {
   const model = mapOpenCodeModel({
-    id: "qwen/qwen3-coder",
-    name: "Qwen3 Coder",
+    id: "provider/model",
+    name: "Provider Model",
     reasoning: true,
-    thinkingFormat: "qwen",
     toolCall: true,
     temperature: true,
     input: ["text", "image"],
     output: ["text"],
-    cost: { input: 0.2, output: 0.8, cacheRead: 0.1, cacheWrite: 0 },
+    cost: { input: 0.2, output: 0.8 },
     contextWindow: 262_144,
     maxOutputTokens: 65_536,
   });
@@ -20,10 +19,6 @@ test("maps provider capabilities and Qwen thinking variants into OpenCode", () =
   expect(model.reasoning).toBe(true);
   expect(model.attachment).toBe(true);
   expect(model.tool_call).toBe(true);
-  expect(model.interleaved).toEqual({ field: "reasoning_content" });
+  expect(model.cost).toEqual({ input: 0.2, output: 0.8 });
   expect(model.limit).toEqual({ context: 262_144, output: 65_536 });
-  expect(model.variants).toEqual({
-    off: { enable_thinking: false },
-    high: { enable_thinking: true },
-  });
 });

--- a/clients/package-smoke.sh
+++ b/clients/package-smoke.sh
@@ -134,10 +134,6 @@ await Promise.all([
     join(agentDir, "models-store.json"),
     JSON.stringify({ phala: { models: [model], checkedAt: Date.now() } }, null, 2),
   ),
-  writeFile(
-    join(agentDir, "settings.json"),
-    JSON.stringify({ defaultProvider: "phala", defaultModel: "smoke/model" }, null, 2),
-  ),
 ]);
 NODE
 
@@ -154,6 +150,8 @@ printf '%s\n' \
   --no-context-files \
   --no-skills \
   --no-themes \
+  --provider phala \
+  --model smoke/model \
   --extension "$pi_npm/node_modules/pi-provider-phala-cloud/dist/index.js" \
   >"$scratch/pi-rpc.jsonl"
 
@@ -184,7 +182,7 @@ if (
   state.data?.model?.id !== "smoke/model"
 ) {
   throw new Error(
-    `Pi did not restore its stored dynamic catalog and default model offline: ${JSON.stringify({ state, available })}`,
+    `Pi did not select the restored dynamic model offline: ${JSON.stringify({ state, available })}`,
   );
 }
 const response = records.find(

--- a/clients/pi-provider/packages/pi-provider-aci/README.md
+++ b/clients/pi-provider/packages/pi-provider-aci/README.md
@@ -31,6 +31,12 @@ environment variables into its credential store.
 The provider fails closed when workload or channel verification fails. For a
 production reviewed-release claim, configure `ACI_ACCEPTED_COMPOSE_HASHES` with
 the comma-separated compose hashes published by the deployment operator.
+Model capabilities come only from the gateway catalog. Pi reasoning levels use
+the gateway's public normalized reasoning field; upstream model dialects are
+handled by the gateway, not by this extension.
+Pi requires numeric rates for every token category, so an omitted cache rate is
+represented at the ordinary input rate rather than as a free cache operation.
+
 `/aci-receipts` lists retained exchanges. `/aci-receipt [id]` displays or
 re-verifies the latest or selected exchange's signed receipt, exact wire body
 hashes, and cited attested session. `/aci-session <id>` fetches the public

--- a/clients/pi-provider/packages/pi-provider-aci/index.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/index.ts
@@ -13,7 +13,7 @@
  * Source layout:
  *   src/config.ts        — layered config (default/home/project/env/runtime)
  *   src/project-trust.ts — project-scope config trust gate
- *   src/models.ts        — /v1/models discovery + thinkingFormat inference
+ *   src/models.ts        — strict /v1/models mapping into Pi models
  *   src/settings-ui.ts   — SettingsList helpers for the settings command
  */
 
@@ -64,7 +64,6 @@ import {
 } from "./src/connection.ts";
 import {
   type AciConfigScope,
-  THINKING_FORMAT_VALUES,
   buildSettingsTheme,
   formatScopeDescription,
   modelRegistrationSummary,
@@ -236,7 +235,6 @@ async function openSettingsMenu(
     const refreshValues = () => {
       list.updateValue("scope", scope);
       list.updateValue("isTeeOnly", drafts[scope].models.isTeeOnly ? "true" : "false");
-      list.updateValue("thinkingFormat", drafts[scope].models.thinkingFormat);
     };
 
     const save = () => {
@@ -269,13 +267,6 @@ async function openSettingsMenu(
         save();
         return;
       }
-      if (id === "thinkingFormat") {
-        drafts[scope].models.thinkingFormat =
-          newValue as AciCloudConfig["models"]["thinkingFormat"];
-        list.updateValue(id, newValue);
-        save();
-        return;
-      }
     };
 
     const scopeItem: SettingItem = {
@@ -296,13 +287,6 @@ async function openSettingsMenu(
         description: "Only register models served confidentially (is_tee === true)",
         currentValue: drafts[scope].models.isTeeOnly ? "true" : "false",
         values: ["true", "false"],
-      },
-      {
-        id: "thinkingFormat",
-        label: "Thinking format",
-        description: "How pi thinking levels map to provider parameters",
-        currentValue: drafts[scope].models.thinkingFormat,
-        values: [...THINKING_FORMAT_VALUES],
       },
     ];
 
@@ -414,13 +398,17 @@ export function createProvider({
     const receiptCommand = `${state.profile.providerId}-receipt`;
     const sessionCommand = `${state.profile.providerId}-session`;
     pi.registerCommand(settingsCommand, {
-      description: `Configure ${state.profile.label} models and thinking format`,
+      description: `Configure ${state.profile.label} model discovery`,
       handler: async (_args, ctx) => {
         if (ctx.mode !== "tui") {
           ctx.ui.notify(`${settingsCommand} requires TUI mode`, "error");
           return;
         }
-        await openSettingsMenu(pi, ctx, state);
+        try {
+          await openSettingsMenu(pi, ctx, state);
+        } catch (error) {
+          ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+        }
       },
     });
 
@@ -469,10 +457,5 @@ export const PROVIDER_ID = DEFAULT_PROFILE.providerId;
 export { PROVIDER_VERSION };
 export { resolveProfile as getProviderProfile } from "./src/profile.ts";
 export { loadAciCloudConfig } from "./src/config.ts";
-export {
-  discoverAciModels,
-  inferThinkingFormat,
-  mapAciModelToPi,
-  mapAciServerModel,
-} from "./src/models.ts";
+export { discoverAciModels, mapAciModelToPi, mapAciServerModel } from "./src/models.ts";
 export { createAciProvider } from "@phala/aci-provider";

--- a/clients/pi-provider/packages/pi-provider-aci/src/config.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/src/config.ts
@@ -29,13 +29,9 @@ import {
 
 import { DEFAULT_PROFILE, type ProviderProfile } from "./profile.ts";
 
-export type ThinkingFormat = "auto" | "qwen" | "openai" | "off";
-
 export interface AciModelsConfig {
   /** Only register models whose /v1/models entry has is_tee === true. */
   isTeeOnly: boolean;
-  /** How to map pi thinking levels onto provider request parameters. */
-  thinkingFormat: ThinkingFormat;
   /** Optional model-id allowlist. When set, only these ids are registered. */
   allowlist?: string[];
 }
@@ -64,7 +60,6 @@ export type AciCloudConfigPatch = {
   baseUrl?: unknown;
   models?: Partial<{
     isTeeOnly: unknown;
-    thinkingFormat: unknown;
     allowlist: unknown;
   }>;
   trust?: Partial<{
@@ -99,7 +94,6 @@ export const DEFAULT_ACI_CLOUD_CONFIG: AciCloudConfig = {
   baseUrl: DEFAULT_PROFILE.defaultBaseURL,
   models: {
     isTeeOnly: true,
-    thinkingFormat: "auto",
   },
   trust: {},
 };
@@ -175,15 +169,6 @@ function readConfigFile(path: string): Record<string, unknown> {
   }
 }
 
-function readConfigFileQuiet(path: string, logPrefix: string): Record<string, unknown> {
-  try {
-    return readConfigFile(path);
-  } catch (error) {
-    console.error(`${logPrefix} failed to read config file ${path}:`, error);
-    return {};
-  }
-}
-
 function envConfigPatch(
   env: NodeJS.ProcessEnv,
   providerProfile: ProviderProfile,
@@ -220,7 +205,6 @@ export function validateAciCloudConfig(
   for (const [record, field, pointer] of [
     [config, "baseUrl", "/baseUrl"],
     [models, "isTeeOnly", "/models/isTeeOnly"],
-    [models, "thinkingFormat", "/models/thinkingFormat"],
   ] as const) {
     if (!(field in record)) fail(configPath, pointer, "required field is missing");
   }
@@ -231,7 +215,6 @@ export function validateAciCloudConfig(
         baseURL: config.baseUrl,
         models: {
           isTeeOnly: models.isTeeOnly,
-          thinkingFormat: models.thinkingFormat,
           allowlist: models.allowlist,
         },
         trust: {
@@ -246,7 +229,6 @@ export function validateAciCloudConfig(
       baseUrl: resolved.baseURL,
       models: {
         isTeeOnly: resolved.models.isTeeOnly,
-        thinkingFormat: resolved.models.thinkingFormat,
         ...(resolved.models.allowlist ? { allowlist: [...resolved.models.allowlist] } : {}),
       },
       trust: {
@@ -302,10 +284,7 @@ export function loadProjectAciCloudConfig(
   return validateAciCloudConfig(
     mergeConfigPatch(
       defaultAciCloudConfig(providerProfile),
-      readConfigFileQuiet(
-        getProjectAciCloudConfigPath(cwd, providerProfile.providerId),
-        providerProfile.logPrefix,
-      ),
+      readConfigFile(getProjectAciCloudConfigPath(cwd, providerProfile.providerId)),
     ),
     "<aci-config>",
     providerProfile,
@@ -319,10 +298,7 @@ export function loadHomeAciCloudConfig(
   return validateAciCloudConfig(
     mergeConfigPatch(
       defaultAciCloudConfig(providerProfile),
-      readConfigFileQuiet(
-        getGlobalAciCloudConfigPath(home, providerProfile.providerId),
-        providerProfile.logPrefix,
-      ),
+      readConfigFile(getGlobalAciCloudConfigPath(home, providerProfile.providerId)),
     ),
     "<aci-config>",
     providerProfile,

--- a/clients/pi-provider/packages/pi-provider-aci/src/models.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/src/models.ts
@@ -1,7 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   discoverAciModelCatalog,
-  inferThinkingFormat as inferAciThinkingFormat,
   mapAciModel,
   type AciModel,
   type AciServerModel,
@@ -11,60 +10,42 @@ import { toAciProviderConfig, type AciCloudConfig } from "./config.ts";
 
 export type AciPiModel = Omit<Model<"openai-completions">, "api" | "provider" | "baseUrl">;
 
-interface InferredThinking {
-  reasoning: boolean;
-  format: "qwen" | "openai" | "off";
-  maxTokensField: "max_tokens" | "max_completion_tokens";
-  supportsReasoningEffort: boolean;
+function piInput(model: AciModel): Array<"text" | "image"> {
+  const input = model.input.filter(
+    (modality): modality is "text" | "image" => modality === "text" || modality === "image",
+  );
+  if (input.length === 0) {
+    throw new Error(`Pi does not support the input modalities declared by model "${model.id}"`);
+  }
+  return input;
 }
 
-function piThinking(modelId: string, format: InferredThinking["format"]): InferredThinking {
-  if (format === "qwen") {
-    return {
-      reasoning: true,
-      format,
-      maxTokensField: "max_tokens",
-      supportsReasoningEffort: false,
-    };
-  }
-  if (format === "openai") {
-    return {
-      reasoning: true,
-      format,
-      maxTokensField: modelId.toLowerCase().includes("gpt-oss")
-        ? "max_completion_tokens"
-        : "max_tokens",
-      supportsReasoningEffort: true,
-    };
-  }
+function piCost(model: AciModel): AciPiModel["cost"] {
   return {
-    reasoning: false,
-    format,
-    maxTokensField: "max_tokens",
-    supportsReasoningEffort: false,
+    input: model.cost.input,
+    output: model.cost.output,
+    cacheRead: model.cost.cacheRead ?? model.cost.input,
+    cacheWrite: model.cost.cacheWrite ?? model.cost.input,
   };
 }
 
-export function inferThinkingFormat(modelId: string): InferredThinking {
-  return piThinking(modelId, inferAciThinkingFormat(modelId));
-}
-
 export function mapAciModelToPi(model: AciModel): AciPiModel {
-  const thinking = piThinking(model.id, model.thinkingFormat);
   return {
     id: model.id,
     name: model.name,
     reasoning: model.reasoning,
-    input: model.input.includes("image") ? ["text", "image"] : ["text"],
-    cost: model.cost,
+    input: piInput(model),
+    cost: piCost(model),
     contextWindow: model.contextWindow,
     maxTokens: model.maxOutputTokens,
     compat: {
-      thinkingFormat: thinking.format === "off" ? "openai" : thinking.format,
-      maxTokensField: thinking.maxTokensField,
-      supportsReasoningEffort: thinking.supportsReasoningEffort,
+      thinkingFormat: "openrouter",
+      maxTokensField: "max_tokens",
+      supportsStore: true,
+      supportsDeveloperRole: true,
       supportsStrictMode: false,
       supportsUsageInStreaming: true,
+      supportsLongCacheRetention: false,
     },
   };
 }

--- a/clients/pi-provider/packages/pi-provider-aci/src/settings-ui.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/src/settings-ui.ts
@@ -15,7 +15,6 @@ import { PROVIDER_VERSION } from "./constants.ts";
 
 export type AciConfigScope = "project" | "home";
 
-export const THINKING_FORMAT_VALUES = ["auto", "qwen", "openai", "off"] as const;
 export const BOOLEAN_VALUES = ["true", "false"] as const;
 
 export function buildSettingsTheme(theme: Theme): SettingsListTheme {
@@ -62,5 +61,5 @@ export function modelRegistrationSummary(config: AciCloudConfig): string {
   const allow = config.models.allowlist?.length
     ? `, allowlist: ${config.models.allowlist.length}`
     : "";
-  return `Models: ${tee}${allow} | thinking: ${config.models.thinkingFormat}`;
+  return `Models: ${tee}${allow}`;
 }

--- a/clients/pi-provider/packages/pi-provider-aci/tests/config.test.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/tests/config.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
 
 import {
   DEFAULT_ACI_CLOUD_CONFIG,
+  getGlobalAciCloudConfigPath,
+  loadHomeAciCloudConfig,
   toAciProviderConfig,
   validateAciCloudConfig,
   type AciCloudConfig,
@@ -19,7 +24,6 @@ test("validating a concrete config passes and preserves values", () => {
   const validated = validateAciCloudConfig(BASE);
   assert.equal(validated.baseUrl, "https://gateway.test/v1");
   assert.equal(validated.models.isTeeOnly, true);
-  assert.equal(validated.models.thinkingFormat, "auto");
   assert.deepEqual(validated.trust, {});
   assert.equal(toAciProviderConfig(validated).receipts.verification, "response");
 });
@@ -57,11 +61,6 @@ test("validateAciCloudConfig: accepts only canonical attested-session ids", () =
   assert.throws(() => validateAciCloudConfig(bad), /lowercase session id/);
 });
 
-test("validateAciCloudConfig: rejects invalid thinkingFormat", () => {
-  const bad = { ...BASE, models: { ...BASE.models, thinkingFormat: "bogus" } };
-  assert.throws(() => validateAciCloudConfig(bad), /expected "auto", "qwen", "openai", or "off"/);
-});
-
 test("validateAciCloudConfig: rejects non-boolean isTeeOnly", () => {
   const bad = { ...BASE, models: { ...BASE.models, isTeeOnly: "yes" } };
   assert.throws(() => validateAciCloudConfig(bad), /expected a boolean/);
@@ -94,4 +93,14 @@ test("validateAciCloudConfig: allowlist with empty string is rejected", () => {
     models: { ...BASE.models, allowlist: [""] },
   };
   assert.throws(() => validateAciCloudConfig(bad), /expected a non-empty string/);
+});
+
+test("loadHomeAciCloudConfig rejects a malformed persisted config", (t) => {
+  const home = mkdtempSync(join(tmpdir(), "pi-provider-aci-"));
+  t.after(() => rmSync(home, { recursive: true, force: true }));
+  const path = getGlobalAciCloudConfigPath(home);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "{");
+
+  assert.throws(() => loadHomeAciCloudConfig(home), /invalid JSON/);
 });

--- a/clients/pi-provider/packages/pi-provider-aci/tests/models.test.ts
+++ b/clients/pi-provider/packages/pi-provider-aci/tests/models.test.ts
@@ -2,167 +2,45 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { DEFAULT_ACI_CLOUD_CONFIG } from "../src/config.ts";
-import { inferThinkingFormat, mapAciServerModel } from "../src/models.ts";
+import { mapAciServerModel } from "../src/models.ts";
 import type { AciServerModel } from "../src/models.ts";
 
-test("inferThinkingFormat: qwen models use qwen format with enable_thinking", () => {
-  const result = inferThinkingFormat("phala/qwen3.5-27b");
-  assert.equal(result.reasoning, true);
-  assert.equal(result.format, "qwen");
-  assert.equal(result.maxTokensField, "max_tokens");
+const catalogModel: AciServerModel = {
+  id: "provider/model",
+  name: "Provider Model",
+  is_tee: true,
+  context_length: 262_144,
+  max_output_length: 65_536,
+  pricing: { prompt: "0.0000003", completion: "0.0000024" },
+  input_modalities: ["text", "image"],
+  output_modalities: ["text"],
+  supported_features: ["reasoning", "tools"],
+  supported_sampling_parameters: ["temperature"],
+};
+
+test("maps the shared catalog contract into Pi without model-specific rules", () => {
+  const model = mapAciServerModel(catalogModel, DEFAULT_ACI_CLOUD_CONFIG);
+
+  assert.ok(model);
+  assert.equal(model.reasoning, true);
+  assert.deepEqual(model.input, ["text", "image"]);
+  assert.deepEqual(model.cost, { input: 0.3, output: 2.4, cacheRead: 0.3, cacheWrite: 0.3 });
+  assert.equal(model.contextWindow, 262_144);
+  assert.equal(model.maxTokens, 65_536);
+  assert.deepEqual(model.compat, {
+    thinkingFormat: "openrouter",
+    maxTokensField: "max_tokens",
+    supportsStore: true,
+    supportsDeveloperRole: true,
+    supportsStrictMode: false,
+    supportsUsageInStreaming: true,
+    supportsLongCacheRetention: false,
+  });
 });
 
-test("inferThinkingFormat: gpt-oss models use openai reasoning_effort", () => {
-  const result = inferThinkingFormat("phala/gpt-oss-20b");
-  assert.equal(result.reasoning, true);
-  assert.equal(result.format, "openai");
-  assert.equal(result.maxTokensField, "max_completion_tokens");
-  assert.equal(result.supportsReasoningEffort, true);
-});
-
-test("inferThinkingFormat: gemma and other non-reasoning models default to off", () => {
-  const result = inferThinkingFormat("phala/gemma-3-27b-it");
-  assert.equal(result.reasoning, false);
-  assert.equal(result.format, "off");
-});
-
-test("inferThinkingFormat: deepseek-r1 treated as openai reasoning", () => {
-  const result = inferThinkingFormat("deepseek/deepseek-r1");
-  assert.equal(result.reasoning, true);
-  assert.equal(result.format, "openai");
-});
-
-test("mapAciServerModel: drops non-TEE models when isTeeOnly is true", () => {
-  const model: AciServerModel = {
-    id: "some/plain-model",
-    name: "Plain",
-    is_tee: false,
-    context_length: 32768,
-    max_output_length: 8192,
-    pricing: { prompt: "0.00000010", completion: "0.00000020" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
-  assert.equal(mapped, null);
-});
-
-test("mapAciServerModel: keeps non-TEE models when isTeeOnly is false", () => {
-  const config = {
-    ...DEFAULT_ACI_CLOUD_CONFIG,
-    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models, isTeeOnly: false },
-  };
-  const model: AciServerModel = {
-    id: "some/plain-model",
-    name: "Plain",
-    is_tee: false,
-    context_length: 32768,
-    max_output_length: 8192,
-    pricing: { prompt: "0.00000010", completion: "0.00000020" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, config);
-  assert.ok(mapped);
-  assert.equal(mapped.id, "some/plain-model");
-});
-
-test("mapAciServerModel: excludes embedding models", () => {
-  const model: AciServerModel = {
-    id: "qwen/qwen3-embedding-8b",
-    name: "Embedding",
-    is_tee: true,
-    context_length: 32000,
-    output_modalities: ["embeddings"],
-    input_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
-  assert.equal(mapped, null);
-});
-
-test("mapAciServerModel: converts per-token pricing to per-million", () => {
-  const model: AciServerModel = {
-    id: "phala/qwen3.5-27b",
-    name: "Qwen3.5 27B",
-    is_tee: true,
-    context_length: 262144,
-    max_output_length: 262144,
-    pricing: { prompt: "0.00000030", completion: "0.00000240" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
-  assert.ok(mapped);
-  assert.equal(mapped.cost.input, 0.3);
-  assert.equal(mapped.cost.output, 2.4);
-  assert.equal(mapped.cost.cacheRead, 0);
-});
-
-test("mapAciServerModel: maps image input modality", () => {
-  const model: AciServerModel = {
-    id: "phala/qwen3-vl-30b",
-    name: "Qwen3 VL",
-    is_tee: true,
-    context_length: 128000,
-    pricing: { prompt: "0.00000020", completion: "0.00000070" },
-    input_modalities: ["text", "image"],
-    output_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
-  assert.ok(mapped);
-  assert.deepEqual(mapped.input, ["text", "image"]);
-});
-
-test("mapAciServerModel: allowlist filters out unlisted ids", () => {
-  const config = {
-    ...DEFAULT_ACI_CLOUD_CONFIG,
-    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models, allowlist: ["phala/qwen3.5-27b"] },
-  };
-  const kept: AciServerModel = {
-    id: "phala/qwen3.5-27b",
-    is_tee: true,
-    context_length: 1000,
-    pricing: { prompt: "0", completion: "0" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  const dropped: AciServerModel = {
-    id: "phala/other-model",
-    is_tee: true,
-    context_length: 1000,
-    pricing: { prompt: "0", completion: "0" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  assert.ok(mapAciServerModel(kept, config));
-  assert.equal(mapAciServerModel(dropped, config), null);
-});
-
-test("mapAciServerModel: qwen model gets qwen thinkingFormat compat", () => {
-  const model: AciServerModel = {
-    id: "phala/qwen3.5-27b",
-    is_tee: true,
-    context_length: 262144,
-    pricing: { prompt: "0", completion: "0" },
-    input_modalities: ["text"],
-    output_modalities: ["text"],
-  };
-  const mapped = mapAciServerModel(model, DEFAULT_ACI_CLOUD_CONFIG);
-  assert.ok(mapped);
-  assert.equal(mapped.reasoning, true);
-  assert.equal((mapped.compat as { thinkingFormat?: string } | undefined)?.thinkingFormat, "qwen");
+test("keeps shared TEE filtering", () => {
   assert.equal(
-    (mapped.compat as { maxTokensField?: string } | undefined)?.maxTokensField,
-    "max_tokens",
+    mapAciServerModel({ ...catalogModel, is_tee: false }, DEFAULT_ACI_CLOUD_CONFIG),
+    null,
   );
-});
-
-test("explicit openai thinking keeps the model-specific max-token field", () => {
-  const config = {
-    ...DEFAULT_ACI_CLOUD_CONFIG,
-    models: { ...DEFAULT_ACI_CLOUD_CONFIG.models, thinkingFormat: "openai" as const },
-  };
-  const mapped = mapAciServerModel({ id: "deepseek/deepseek-r1", is_tee: true }, config);
-  assert.ok(mapped);
-  assert.equal(mapped.compat?.maxTokensField, "max_tokens");
 });

--- a/clients/provider/README.md
+++ b/clients/provider/README.md
@@ -43,6 +43,13 @@ Model discovery uses the verified connection but sends no inference API key;
 the gateway's `/v1/models` catalog is public. Host adapters own credentials and
 attach them only to inference requests.
 
+The catalog is authoritative. The provider maps reasoning and tools only from
+`supported_features`, and temperature only from
+`supported_sampling_parameters`. It does not infer capabilities, family,
+limits, modalities, or request dialects from model ids. Malformed required
+metadata fails discovery instead of being replaced with guessed defaults.
+Optional cache prices remain absent when the catalog omits them.
+
 `provider.receipts()` returns the bounded in-process exchange history, newest
 first. `provider.verifyReceipt()` verifies the latest exchange when no id is
 given, while `provider.verifySession(id)` fetches the public session artifact

--- a/clients/provider/src/config.ts
+++ b/clients/provider/src/config.ts
@@ -1,15 +1,11 @@
 import type { AciProviderProfile } from "./profile.ts";
 
-export type AciThinkingFormat = "auto" | "qwen" | "openai" | "off";
 export type AciReceiptVerification = "on-demand" | "response";
-
-const THINKING_FORMATS: ReadonlySet<unknown> = new Set(["auto", "qwen", "openai", "off"]);
 
 export interface AciProviderConfig {
   baseURL: string;
   models: {
     isTeeOnly: boolean;
-    thinkingFormat: AciThinkingFormat;
     allowlist?: readonly string[];
   };
   trust: {
@@ -26,7 +22,6 @@ export interface AciProviderConfigInput {
   baseURL?: unknown;
   models?: {
     isTeeOnly?: unknown;
-    thinkingFormat?: unknown;
     allowlist?: unknown;
   };
   trust?: {
@@ -90,10 +85,6 @@ function validateSessionIds(value: unknown): readonly string[] | undefined {
   });
 }
 
-function isThinkingFormat(value: unknown): value is AciThinkingFormat {
-  return THINKING_FORMATS.has(value);
-}
-
 function envValue(env: Record<string, string | undefined>, ...names: string[]): string | undefined {
   for (const name of names) {
     const value = env[name]?.trim();
@@ -120,26 +111,18 @@ export function aciProviderConfigInputFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): AciProviderConfigInput {
   const prefix = profile.envPrefix;
-  const baseURL = envValue(
-    env,
-    `${prefix}_BASE_URL`,
-    `${prefix}_CLOUD_API_PREFIX`,
-    `${prefix}_CLOUD_BASE_URL`,
-    ...(profile.baseURLAliases ?? []),
-  );
-  const isTeeOnly = booleanEnv(envValue(env, `${prefix}_IS_TEE_ONLY`, `${prefix}_TEE_ONLY`));
-  const thinkingFormat = envValue(env, `${prefix}_THINKING_FORMAT`);
+  const baseURL = envValue(env, `${prefix}_BASE_URL`);
+  const isTeeOnly = booleanEnv(envValue(env, `${prefix}_IS_TEE_ONLY`));
   const allowlist = commaSeparated(envValue(env, `${prefix}_MODEL_ALLOWLIST`));
   const acceptedComposeHashes = commaSeparated(envValue(env, `${prefix}_ACCEPTED_COMPOSE_HASHES`));
   const acceptedSessionIds = commaSeparated(envValue(env, `${prefix}_ACCEPTED_SESSION_IDS`));
 
   return {
     ...(baseURL ? { baseURL } : {}),
-    ...(isTeeOnly !== undefined || thinkingFormat !== undefined || allowlist !== undefined
+    ...(isTeeOnly !== undefined || allowlist !== undefined
       ? {
           models: {
             ...(isTeeOnly !== undefined ? { isTeeOnly } : {}),
-            ...(thinkingFormat !== undefined ? { thinkingFormat } : {}),
             ...(allowlist !== undefined ? { allowlist } : {}),
           },
         }
@@ -181,14 +164,6 @@ export function resolveAciProviderConfig(
       : input.models.isTeeOnly;
   if (typeof isTeeOnly !== "boolean") fail("/models/isTeeOnly", "expected a boolean");
 
-  const thinkingFormat =
-    input.models?.thinkingFormat === undefined
-      ? (envInput.models?.thinkingFormat ?? "auto")
-      : input.models.thinkingFormat;
-  if (!isThinkingFormat(thinkingFormat)) {
-    fail("/models/thinkingFormat", 'expected "auto", "qwen", "openai", or "off"');
-  }
-
   const allowlist = optionalStringArray(
     input.models?.allowlist === undefined ? envInput.models?.allowlist : input.models.allowlist,
     "/models/allowlist",
@@ -223,7 +198,6 @@ export function resolveAciProviderConfig(
     baseURL,
     models: {
       isTeeOnly,
-      thinkingFormat,
       ...(allowlist ? { allowlist } : {}),
     },
     trust: {

--- a/clients/provider/src/index.ts
+++ b/clients/provider/src/index.ts
@@ -20,13 +20,11 @@ export {
   type AciProviderConfig,
   type AciProviderConfigInput,
   type AciReceiptVerification,
-  type AciThinkingFormat,
 } from "./config.ts";
 export {
   AciModelDiscoveryError,
   discoverAciModelCatalog,
   discoverAciModels,
-  inferThinkingFormat,
   mapAciModel,
   type AciModel,
   type AciModelCatalog,

--- a/clients/provider/src/models.ts
+++ b/clients/provider/src/models.ts
@@ -1,4 +1,4 @@
-import type { AciProviderConfig, AciThinkingFormat } from "./config.ts";
+import type { AciProviderConfig } from "./config.ts";
 import type { AciFetch } from "@phala/aci-verifier/runtime";
 
 export type AciModality = "text" | "audio" | "image" | "video" | "pdf";
@@ -8,10 +8,8 @@ const ACI_MODALITIES: ReadonlySet<unknown> = new Set(["text", "audio", "image", 
 export interface AciModel {
   id: string;
   name: string;
-  family?: string;
   description?: string;
   reasoning: boolean;
-  thinkingFormat: Exclude<AciThinkingFormat, "auto">;
   toolCall: boolean;
   temperature: boolean;
   input: readonly AciModality[];
@@ -19,8 +17,8 @@ export interface AciModel {
   cost: {
     input: number;
     output: number;
-    cacheRead: number;
-    cacheWrite: number;
+    cacheRead?: number;
+    cacheWrite?: number;
   };
   contextWindow: number;
   maxOutputTokens: number;
@@ -35,7 +33,9 @@ export interface AciServerModel {
   pricing?: unknown;
   input_modalities?: unknown;
   output_modalities?: unknown;
+  supported_features?: unknown;
   supported_parameters?: unknown;
+  supported_sampling_parameters?: unknown;
   description?: unknown;
 }
 
@@ -46,91 +46,102 @@ export class AciModelDiscoveryError extends Error {
   }
 }
 
-export function inferThinkingFormat(modelId: string): Exclude<AciThinkingFormat, "auto"> {
-  const id = modelId.toLowerCase();
-  if (id.includes("qwen")) return "qwen";
-  if (
-    id.includes("gpt-oss") ||
-    (id.includes("deepseek") && (id.includes("r1") || id.includes("v4"))) ||
-    id.includes("reasoner") ||
-    id.includes("glm-5")
-  ) {
-    return "openai";
-  }
-  return "off";
+function invalidModel(id: string, field: string, expected: string): never {
+  throw new AciModelDiscoveryError(`model "${id}" ${field} must be ${expected}`);
 }
 
-function price(value: unknown): number {
-  if (typeof value !== "string" && typeof value !== "number") return 0;
+function nonEmptyString(value: unknown, id: string, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    return invalidModel(id, field, "a non-empty string");
+  }
+  return value;
+}
+
+function price(value: unknown, id: string, field: string): number {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return invalidModel(id, field, "a non-negative number");
+  }
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  if (
+    (typeof value === "string" && value.trim() === "") ||
+    !Number.isFinite(parsed) ||
+    parsed < 0
+  ) {
+    return invalidModel(id, field, "a non-negative number");
+  }
   return Math.round(parsed * 1_000_000 * 1_000_000_000) / 1_000_000_000;
 }
 
-function modalities(value: unknown, fallback: readonly AciModality[]): readonly AciModality[] {
-  if (!Array.isArray(value)) return fallback;
-  const result = value.filter((item): item is AciModality => ACI_MODALITIES.has(item));
-  return result.length > 0 ? result : fallback;
+function modalities(value: unknown, id: string, field: string): readonly AciModality[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return invalidModel(id, field, "a non-empty array of supported modalities");
+  }
+  return value.map((item) => {
+    if (!ACI_MODALITIES.has(item)) {
+      return invalidModel(id, field, "an array of supported modalities");
+    }
+    return item as AciModality;
+  });
 }
 
-function positiveInteger(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : fallback;
+function positiveInteger(value: unknown, id: string, field: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    return invalidModel(id, field, "a positive safe integer");
+  }
+  return value;
 }
 
-function supportedParameters(value: unknown): Set<string> {
-  return new Set(
-    Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [],
-  );
+function stringSet(value: unknown, id: string, field: string): ReadonlySet<string> {
+  if (!Array.isArray(value)) return invalidModel(id, field, "an array of strings");
+  return new Set(value.map((item) => nonEmptyString(item, id, field)));
+}
+
+function pricing(value: unknown, id: string): AciModel["cost"] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalidModel(id, "pricing", "an object");
+  }
+  const raw = value as Record<string, unknown>;
+  return {
+    input: price(raw.prompt, id, "pricing.prompt"),
+    output: price(raw.completion, id, "pricing.completion"),
+    ...(raw.input_cache_read === undefined
+      ? {}
+      : { cacheRead: price(raw.input_cache_read, id, "pricing.input_cache_read") }),
+    ...(raw.input_cache_write === undefined
+      ? {}
+      : { cacheWrite: price(raw.input_cache_write, id, "pricing.input_cache_write") }),
+  };
 }
 
 export function mapAciModel(
   model: AciServerModel,
   config: AciProviderConfig,
 ): AciModel | undefined {
-  if (typeof model.id !== "string" || model.id.length === 0) return undefined;
-  if (
-    Array.isArray(model.output_modalities) &&
-    model.output_modalities.length === 1 &&
-    model.output_modalities[0] === "embeddings"
-  ) {
-    return undefined;
-  }
-  const output = modalities(model.output_modalities, ["text"]);
+  const id = nonEmptyString(model.id, "<unknown>", "id");
   if (config.models.isTeeOnly && model.is_tee !== true) return undefined;
-  if (config.models.allowlist?.length && !config.models.allowlist.includes(model.id))
-    return undefined;
+  if (config.models.allowlist?.length && !config.models.allowlist.includes(id)) return undefined;
 
-  const contextWindow = positiveInteger(model.context_length, 32_768);
-  const maxOutputTokens = positiveInteger(model.max_output_length, Math.min(contextWindow, 8_192));
-  const rawPricing =
-    model.pricing && typeof model.pricing === "object"
-      ? (model.pricing as Record<string, unknown>)
-      : {};
-  const parameters = supportedParameters(model.supported_parameters);
-  const thinkingFormat =
-    config.models.thinkingFormat === "auto"
-      ? inferThinkingFormat(model.id)
-      : config.models.thinkingFormat;
+  const contextWindow = positiveInteger(model.context_length, id, "context_length");
+  const maxOutputTokens = positiveInteger(model.max_output_length, id, "max_output_length");
+  const features = stringSet(model.supported_features, id, "supported_features");
+  const sampling = stringSet(
+    model.supported_sampling_parameters,
+    id,
+    "supported_sampling_parameters",
+  );
 
   return {
-    id: model.id,
-    name: typeof model.name === "string" && model.name ? model.name : model.id,
-    family: model.id.split("/").at(-1)?.split(/[-:]/)[0],
-    ...(typeof model.description === "string" && model.description
-      ? { description: model.description }
-      : {}),
-    reasoning: thinkingFormat !== "off",
-    thinkingFormat,
-    toolCall: parameters.size === 0 || parameters.has("tools") || parameters.has("tool_choice"),
-    temperature: parameters.size === 0 || parameters.has("temperature"),
-    input: modalities(model.input_modalities, ["text"]),
-    output,
-    cost: {
-      input: price(rawPricing.prompt),
-      output: price(rawPricing.completion),
-      cacheRead: price(rawPricing.input_cache_read ?? rawPricing.cache_read),
-      cacheWrite: price(rawPricing.input_cache_write ?? rawPricing.cache_write),
-    },
+    id,
+    name: nonEmptyString(model.name, id, "name"),
+    ...(model.description === undefined
+      ? {}
+      : { description: nonEmptyString(model.description, id, "description") }),
+    reasoning: features.has("reasoning"),
+    toolCall: features.has("tools"),
+    temperature: sampling.has("temperature"),
+    input: modalities(model.input_modalities, id, "input_modalities"),
+    output: modalities(model.output_modalities, id, "output_modalities"),
+    cost: pricing(model.pricing, id),
     contextWindow,
     maxOutputTokens,
   };
@@ -174,12 +185,22 @@ export async function discoverAciModelCatalog({
     if (!value || typeof value !== "object" || !Array.isArray((value as { data?: unknown }).data)) {
       throw new AciModelDiscoveryError("model discovery returned an invalid catalog");
     }
-    const raw = (value as { data: AciServerModel[] }).data.filter(
-      (model) => model && typeof model === "object" && !Array.isArray(model),
-    );
+    const raw = (value as { data: unknown[] }).data.map((model, index) => {
+      if (!model || typeof model !== "object" || Array.isArray(model)) {
+        throw new AciModelDiscoveryError(`model catalog entry ${index} must be an object`);
+      }
+      return model as AciServerModel;
+    });
     const models = raw
       .map((model) => mapAciModel(model, config))
       .filter((model): model is AciModel => model !== undefined);
+    const ids = new Set<string>();
+    for (const model of models) {
+      if (ids.has(model.id)) {
+        throw new AciModelDiscoveryError(`model catalog contains duplicate id "${model.id}"`);
+      }
+      ids.add(model.id);
+    }
     return { raw, models };
   } catch (error) {
     if (error instanceof AciModelDiscoveryError) throw error;

--- a/clients/provider/src/profile.ts
+++ b/clients/provider/src/profile.ts
@@ -7,7 +7,6 @@ export interface AciProviderProfile {
   logPrefix: string;
   acceptedComposeHashes?: readonly string[];
   acceptedSessionIds?: readonly string[];
-  baseURLAliases?: readonly string[];
 }
 
 export const DEFAULT_ACI_PROVIDER_PROFILE: AciProviderProfile = {

--- a/clients/provider/src/profiles.ts
+++ b/clients/provider/src/profiles.ts
@@ -7,7 +7,6 @@ export const REDPILL_ACI_PROFILE = {
   apiKeyEnv: "REDPILL_AI_API_KEY",
   envPrefix: "REDPILL",
   logPrefix: "[redpill]",
-  baseURLAliases: ["REDPILL_CLOUD_API_PREFIX", "REDPILL_BASE_URL"],
 } as const satisfies AciProviderProfile;
 
 export const PHALA_CLOUD_ACI_PROFILE = {
@@ -17,5 +16,4 @@ export const PHALA_CLOUD_ACI_PROFILE = {
   apiKeyEnv: "PHALA_AI_API_KEY",
   envPrefix: "PHALA",
   logPrefix: "[phala]",
-  baseURLAliases: ["PHALA_CLOUD_API_PREFIX", "PHALA_BASE_URL", "PHALA_CLOUD_BASE_URL"],
 } as const satisfies AciProviderProfile;

--- a/clients/provider/test/config.test.ts
+++ b/clients/provider/test/config.test.ts
@@ -11,7 +11,7 @@ test("resolves provider policy from profile, environment, and explicit options",
   const config = resolveAciProviderConfig(
     profile,
     {
-      models: { allowlist: ["qwen/qwen3"] },
+      models: { allowlist: ["provider/model"] },
       receipts: { verification: "response", historySize: 8 },
     },
     {
@@ -21,7 +21,7 @@ test("resolves provider policy from profile, environment, and explicit options",
   );
 
   assert.equal(config.baseURL, "https://custom.example/v1");
-  assert.deepEqual(config.models.allowlist, ["qwen/qwen3"]);
+  assert.deepEqual(config.models.allowlist, ["provider/model"]);
   assert.deepEqual(config.trust.acceptedComposeHashes, [composeHash]);
   assert.deepEqual(config.receipts, { verification: "response", historySize: 8 });
 });
@@ -33,12 +33,8 @@ test("rejects a non-HTTPS model endpoint", () => {
   );
 });
 
-test("uses one deterministic base URL environment priority for every adapter", () => {
-  const env = {
-    ACI_BASE_URL: "https://base.example/v1",
-    ACI_CLOUD_API_PREFIX: "https://prefix.example/v1",
-    ACI_CLOUD_BASE_URL: "https://cloud.example/v1",
-  };
+test("uses the canonical base URL environment variable for every adapter", () => {
+  const env = { ACI_BASE_URL: "https://base.example/v1" };
 
   assert.equal(aciProviderConfigInputFromEnv(profile, env).baseURL, env.ACI_BASE_URL);
   assert.equal(resolveAciProviderConfig(profile, {}, env).baseURL, env.ACI_BASE_URL);

--- a/clients/provider/test/models.test.ts
+++ b/clients/provider/test/models.test.ts
@@ -7,61 +7,65 @@ import { resolveAciProviderProfile } from "../src/profile.ts";
 
 const profile = resolveAciProviderProfile({ defaultBaseURL: "https://gateway.example/v1" });
 const config = resolveAciProviderConfig(profile, {
-  models: { isTeeOnly: true, thinkingFormat: "auto", allowlist: ["qwen/qwen3-coder"] },
+  models: { isTeeOnly: true, allowlist: ["provider/model"] },
 });
 
+const catalogModel = {
+  id: "provider/model",
+  name: "Provider Model",
+  is_tee: true,
+  context_length: 262_144,
+  max_output_length: 65_536,
+  input_modalities: ["text", "image"],
+  output_modalities: ["text"],
+  supported_features: ["reasoning", "tools"],
+  supported_sampling_parameters: ["temperature"],
+  pricing: { prompt: "0.0000002", completion: "0.0000008" },
+};
+
 test("maps an ACI catalog entry into framework-neutral provider capabilities", () => {
-  const model = mapAciModel(
-    {
-      id: "qwen/qwen3-coder",
-      name: "Qwen3 Coder",
-      is_tee: true,
-      context_length: 262_144,
-      max_output_length: 65_536,
-      input_modalities: ["text", "image"],
-      output_modalities: ["text"],
-      supported_parameters: ["tools", "temperature"],
-      pricing: { prompt: "0.0000002", completion: "0.0000008" },
-    },
-    config,
-  );
+  const model = mapAciModel(catalogModel, config);
 
   assert.ok(model);
-  assert.equal(model.thinkingFormat, "qwen");
   assert.equal(model.reasoning, true);
   assert.equal(model.toolCall, true);
+  assert.equal(model.temperature, true);
   assert.deepEqual(model.input, ["text", "image"]);
-  assert.deepEqual(model.cost, { input: 0.2, output: 0.8, cacheRead: 0, cacheWrite: 0 });
+  assert.deepEqual(model.cost, { input: 0.2, output: 0.8 });
   assert.equal(model.contextWindow, 262_144);
   assert.equal(model.maxOutputTokens, 65_536);
 });
 
-test("filters non-TEE, disallowed, and embedding-only models", () => {
-  assert.equal(mapAciModel({ id: "qwen/qwen3-coder", is_tee: false }, config), undefined);
+test("filters non-TEE and disallowed models", () => {
+  assert.equal(mapAciModel({ id: "provider/model", is_tee: false }, config), undefined);
   assert.equal(mapAciModel({ id: "other/model", is_tee: true }, config), undefined);
-  assert.equal(
-    mapAciModel(
-      { id: "qwen/qwen3-coder", is_tee: true, output_modalities: ["embeddings"] },
-      config,
-    ),
-    undefined,
-  );
 });
 
-test("uses safe defaults for invalid model limits", () => {
+test("does not advertise capabilities that the catalog does not declare", () => {
   const model = mapAciModel(
     {
-      id: "qwen/qwen3-coder",
-      is_tee: true,
-      context_length: Number.POSITIVE_INFINITY,
-      max_output_length: 1.5,
+      ...catalogModel,
+      supported_features: [],
+      supported_sampling_parameters: [],
     },
     config,
   );
 
   assert.ok(model);
-  assert.equal(model.contextWindow, 32_768);
-  assert.equal(model.maxOutputTokens, 8_192);
+  assert.equal(model.reasoning, false);
+  assert.equal(model.toolCall, false);
+  assert.equal(model.temperature, false);
+});
+
+test("rejects malformed catalog facts instead of inventing defaults", () => {
+  assert.throws(
+    () => mapAciModel({ ...catalogModel, context_length: Number.POSITIVE_INFINITY }, config),
+    /context_length must be a positive safe integer/,
+  );
+  assert.throws(
+    () => mapAciModel({ ...catalogModel, output_modalities: ["embeddings"] }, config),
+    /output_modalities must be an array of supported modalities/,
+  );
 });
 
 test("discovers the public model catalog without an authorization header", async () => {


### PR DESCRIPTION
## Summary

- make `/v1/models` the only source of model capability metadata and reject malformed catalog entries instead of inventing defaults
- remove model-name inference, reasoning request rewrites, legacy URL aliases, and silent persisted-config fallback
- keep Pi and OpenCode adapters thin and host-native while preserving their required protocol mappings
- document the capability contract, cache-pricing behavior, configuration errors, and Pi/OpenCode entry points

## Verification

- `npm run format:check`
- `npm run build`
- `npm run check`
- `npm test`
- `npm run test:bun`
- `npm run lint`
- `npm run lint:packages`
- `npm run pack:check`
- isolated Pi/OpenCode tarball smoke tests
