### PR TITLE
fix(provider): verify receipts on stream cancellation

### DIFF
--- a/clients/provider/README.md
+++ b/clients/provider/README.md
@@ -36,8 +36,8 @@ const response = await provider.fetch("https://gateway.example.com/v1/chat/compl
 
 The provider fails closed: model traffic is sent only after workload attestation
 and TLS SPKI binding succeed. Set `receipts.verification` to `"response"` to
-make a response stream finish only after its signed receipt and cited session
-have verified.
+make a response stream finish or settle consumer cancellation only after its
+signed receipt and cited session have verified.
 
 Model discovery uses the verified connection but sends no inference API key;
 the gateway's `/v1/models` catalog is public. Host adapters own credentials and

--- a/clients/provider/src/provider.ts
+++ b/clients/provider/src/provider.ts
@@ -198,16 +198,30 @@ export async function auditResponse(
     await verify();
     return response;
   }
-  const body = response.body.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        controller.enqueue(chunk);
-      },
-      async flush() {
-        await verify();
-      },
-    }),
-  );
+  const reader = response.body.getReader();
+  let verification: Promise<void> | undefined;
+  const verifyOnce = () => {
+    verification ??= Promise.resolve()
+      .then(verify)
+      .then(() => undefined);
+    return verification;
+  };
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (!done) {
+        controller.enqueue(value);
+        return;
+      }
+      await verifyOnce();
+      controller.close();
+    },
+    async cancel(reason) {
+      const [cancelled, verified] = await Promise.allSettled([reader.cancel(reason), verifyOnce()]);
+      if (verified.status === "rejected") throw verified.reason;
+      if (cancelled.status === "rejected") throw cancelled.reason;
+    },
+  });
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,

--- a/clients/provider/test/audit.test.ts
+++ b/clients/provider/test/audit.test.ts
@@ -21,6 +21,64 @@ test("turns a failed receipt audit into a response stream error", async () => {
   await assert.rejects(response.text(), /receipt rejected/);
 });
 
+test("waits for receipt verification when the consumer cancels the stream", async () => {
+  let verified = 0;
+  let releaseVerification = () => {};
+  let signalVerificationStarted = () => {};
+  const verificationBlocked = new Promise<void>((resolve) => {
+    releaseVerification = resolve;
+  });
+  const verificationStarted = new Promise<void>((resolve) => {
+    signalVerificationStarted = resolve;
+  });
+  let cancellationReason: unknown;
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("partial"));
+    },
+    cancel(reason) {
+      cancellationReason = reason;
+    },
+  });
+  const response = await auditResponse(new Response(source), async () => {
+    signalVerificationStarted();
+    await verificationBlocked;
+    verified += 1;
+  });
+  const reader = response.body?.getReader();
+  assert.ok(reader);
+
+  await reader.read();
+  let cancellationSettled = false;
+  const cancellation = reader.cancel("consumer finished").then(() => {
+    cancellationSettled = true;
+  });
+
+  await verificationStarted;
+  assert.equal(cancellationSettled, false);
+  releaseVerification();
+  await cancellation;
+
+  assert.equal(verified, 1);
+  assert.equal(cancellationReason, "consumer finished");
+});
+
+test("rejects stream cancellation when receipt verification fails", async () => {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("untrusted"));
+    },
+  });
+  const response = await auditResponse(new Response(source), async () => {
+    throw new Error("receipt rejected");
+  });
+  const reader = response.body?.getReader();
+  assert.ok(reader);
+
+  await reader.read();
+  await assert.rejects(reader.cancel(), /receipt rejected/);
+});
+
 test("verifies a bodyless response before returning it", async () => {
   let verified = false;
   const original = new Response(null, { status: 204 });


### PR DESCRIPTION
## Summary

- verify the signed receipt and cited session when a response consumer cancels early
- keep verification idempotent across normal EOF and cancellation
- propagate receipt failures from reader cancellation while preserving the original cancellation reason downstream

This closes the remaining early-cancellation gap in the shared provider implementation. It is transport- and payload-agnostic, so it covers Pi, OpenCode, parser aborts, and non-SSE responses without scanning for provider-specific finish markers.

## Verification

- npm --prefix clients run build
- npm --prefix clients test
- npm --prefix clients run test:bun
- npm --prefix clients run lint
- npm --prefix clients run format:check
- npm --prefix clients run lint:packages
- bash clients/package-smoke.sh