### PR TITLE
release(clients): publish 0.7.3 and expose Pi packages

### DIFF
--- a/clients/opencode-provider/packages/opencode-provider-aci/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/opencode-provider-aci",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Native OpenCode provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -52,7 +52,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "1.18.24",

--- a/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-phala-cloud",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Phala Cloud provider for OpenCode with verified ACI transport and per-response receipt verification",
   "keywords": [
     "aci",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2",
-    "@phala/opencode-provider-aci": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3",
+    "@phala/opencode-provider-aci": "^0.7.3"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/opencode-provider/packages/opencode-provider-redpill/package.json
+++ b/clients/opencode-provider/packages/opencode-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-provider-redpill",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "RedPill ACI provider for OpenCode",
   "keywords": [
     "aci",
@@ -51,8 +51,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2",
-    "@phala/opencode-provider-aci": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3",
+    "@phala/opencode-provider-aci": "^0.7.3"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.18.23 <2"

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "private-ai-gateway-clients",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "workspaces": [
         "verifier-ts",
@@ -6315,10 +6315,10 @@
     },
     "opencode-provider/packages/opencode-provider-aci": {
       "name": "@phala/opencode-provider-aci",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "1.18.24",
@@ -6333,11 +6333,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-phala-cloud": {
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2",
-        "@phala/opencode-provider-aci": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3",
+        "@phala/opencode-provider-aci": "^0.7.3"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6348,11 +6348,11 @@
       }
     },
     "opencode-provider/packages/opencode-provider-redpill": {
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2",
-        "@phala/opencode-provider-aci": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3",
+        "@phala/opencode-provider-aci": "^0.7.3"
       },
       "engines": {
         "bun": ">=1.4.0",
@@ -6364,10 +6364,10 @@
     },
     "pi-provider/packages/pi-provider-aci": {
       "name": "@phala/pi-provider-aci",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6379,11 +6379,11 @@
       }
     },
     "pi-provider/packages/pi-provider-phala-cloud": {
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2",
-        "@phala/pi-provider-aci": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3",
+        "@phala/pi-provider-aci": "^0.7.3"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6395,11 +6395,11 @@
       }
     },
     "pi-provider/packages/pi-provider-redpill": {
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-provider": "^0.7.2",
-        "@phala/pi-provider-aci": "^0.7.2"
+        "@phala/aci-provider": "^0.7.3",
+        "@phala/pi-provider-aci": "^0.7.3"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6412,10 +6412,10 @@
     },
     "provider": {
       "name": "@phala/aci-provider",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@phala/aci-verifier": "^0.7.2"
+        "@phala/aci-verifier": "^0.7.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -6430,7 +6430,7 @@
     },
     "verifier-ts": {
       "name": "@phala/aci-verifier",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@phala/dcap-qvl": "^0.6.2",

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-ai-gateway-clients",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "ACI TypeScript clients and coding-agent providers",
   "license": "MIT",

--- a/clients/pi-provider/packages/pi-provider-aci/package.json
+++ b/clients/pi-provider/packages/pi-provider-aci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/pi-provider-aci",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Vendor-neutral Pi provider for private-ai-gateway using an instance-scoped verified ACI transport",
   "keywords": [
     "aci",
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-phala-cloud",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Phala Cloud Confidential AI for Pi with verified ACI transport and signed receipt auditing",
   "keywords": [
     "ai-provider",
@@ -54,8 +54,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2",
-    "@phala/pi-provider-aci": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3",
+    "@phala/pi-provider-aci": "^0.7.3"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
+++ b/clients/pi-provider/packages/pi-provider-phala-cloud/package.json
@@ -9,6 +9,7 @@
     "phala",
     "phala-cloud",
     "pi",
+    "pi-package",
     "pi-provider",
     "tee",
     "verifiable"

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-redpill",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "RedPill AI for Pi with verified ACI transport and per-response receipt verification",
   "keywords": [
     "ai-provider",
@@ -53,8 +53,8 @@
     "prepublishOnly": "npm run check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-provider": "^0.7.2",
-    "@phala/pi-provider-aci": "^0.7.2"
+    "@phala/aci-provider": "^0.7.3",
+    "@phala/pi-provider-aci": "^0.7.3"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.84.3 <0.85.0",

--- a/clients/pi-provider/packages/pi-provider-redpill/package.json
+++ b/clients/pi-provider/packages/pi-provider-redpill/package.json
@@ -7,6 +7,7 @@
     "attestation",
     "confidential-ai",
     "pi",
+    "pi-package",
     "pi-provider",
     "redpill",
     "tee",

--- a/clients/provider/package.json
+++ b/clients/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-provider",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Framework-neutral model provider for Attested Confidential Inference gateways",
   "keywords": [
     "aci",
@@ -62,7 +62,7 @@
     "prepublishOnly": "npm run check && npm test && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@phala/aci-verifier": "^0.7.2"
+    "@phala/aci-verifier": "^0.7.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/clients/verifier-ts/package.json
+++ b/clients/verifier-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/aci-verifier",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TypeScript ACI verifier and verified fetch client for browsers, Node.js, and Bun.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## What

Prepare the coordinated `0.7.3` release for all eight client packages.

- bump all package versions and internal dependency ranges to `0.7.3`
- update the workspace lockfile
- add `pi-package` discovery metadata to the RedPill and Phala Cloud Pi packages so they enter the searchable pi.dev catalog after publication

## Verification

- build and typecheck all workspaces
- Node and Bun test suites
- lint and format checks
- publint and Are The Types Wrong checks
- clean-project tarball install/import smoke test for all eight packages
- Pi offline dynamic-catalog and command-registration smoke test
- OpenCode provider-loading smoke tests