### PR TITLE
Keep the Chutes evidence bundle out of per-instance sessions

### DIFF
--- a/src/aggregator/service/claims.rs
+++ b/src/aggregator/service/claims.rs
@@ -71,8 +71,8 @@ pub(super) fn chutes_instance_id<'a>(
 }
 
 /// Typed claims for one Chutes instance: the verifier's facts for that instance
-/// only. The session separately retains the shared verification evidence bundle
-/// that proves those facts.
+/// only, so its session is content-addressed on its own data and survives fleet
+/// churn (a sibling instance joining or failing does not change it).
 pub(super) fn per_instance_session_claims(
     event: &UpstreamVerifiedEvent,
     instance_id: &str,
@@ -779,8 +779,8 @@ mod claim_mapping_tests {
             c1.extra.get("gpu_verified").and_then(Value::as_bool),
             Some(true)
         );
-        // Fleet-wide fields are dropped, so this claim slice does not change
-        // when a sibling instance does.
+        // Fleet-wide fields are dropped, so the slice (and the session content id)
+        // does not change when a sibling instance does (per-instance idempotency).
         assert!(!c1.extra.contains_key("verified_instance_ids"));
         assert!(!c1.extra.contains_key("instance_tcb_statuses"));
         assert!(!c1.extra.contains_key("instance_measurements"));

--- a/src/aggregator/service/forward.rs
+++ b/src/aggregator/service/forward.rs
@@ -699,15 +699,18 @@ impl AciService {
                 Some(instance_id) => per_instance_session_claims(event, instance_id),
                 None => session_claims_for_event(event),
             };
-            // Chutes verifies a fleet in one nonce-bound evidence bundle, then
-            // exposes one channel binding per instance. Each per-instance
-            // session must retain that bundle so a receipt citation remains
-            // independently auditable under ACI section 9.2.
-            let evidence = event
-                .evidence
-                .as_ref()
-                .map(EvidenceRef::from_value)
-                .unwrap_or_default();
+            // A per-instance (Chutes) binding excludes the shared, nonce-bound raw
+            // evidence so re-verifying the same instance is a no-op; a single
+            // channel keeps the event's evidence.
+            let evidence = if instance.is_some() {
+                EvidenceRef::default()
+            } else {
+                event
+                    .evidence
+                    .as_ref()
+                    .map(EvidenceRef::from_value)
+                    .unwrap_or_default()
+            };
             let session_id = self.seal_attested_session(
                 event,
                 identity.clone(),

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -302,18 +302,21 @@ async fn verified_upstream_binding_creates_attested_session() {
     );
 }
 
+/// Chutes verifies its whole fleet under one nonce, so the raw evidence bundle
+/// changes every round even when an instance's own material does not. That
+/// bundle must stay out of the per-instance session: sealing it in mints a
+/// fresh session per instance per round, so the store grows without bound
+/// relative to the live set.
 #[tokio::test]
-async fn chutes_instance_session_retains_verification_evidence() {
+async fn chutes_instance_session_is_stable_across_evidence_rounds() {
     let (svc, _) = make_service(br#"{"id":"chat-xyz","model":"x"}"#);
-    let evidence_data = "data:application/json;base64,YWJj";
-    let evidence_digest = private_ai_gateway::aci::digest::sha256_hex(b"abc");
-    let event = UpstreamVerifiedEvent {
+    let chutes_event = |round: &str| UpstreamVerifiedEvent {
         provider_type: Some("chutes".to_string()),
         url_origin: Some("https://stub-upstream".to_string()),
         verifier_id: "private-ai-verifier/chutes/v1".to_string(),
         evidence: Some(serde_json::json!({
-            "digest": evidence_digest,
-            "data": evidence_data,
+            "digest": private_ai_gateway::aci::digest::sha256_hex(round.as_bytes()),
+            "data": format!("data:application/json;base64,{}", round),
         })),
         channel_bindings: vec![ChannelBinding::E2eePublicKeySha256 {
             provider: "chutes".to_string(),
@@ -323,28 +326,43 @@ async fn chutes_instance_session_retains_verification_evidence() {
         }],
         ..verified_event("stub-upstream", "x")
     };
+    let session_for = |result: &private_ai_gateway::aggregator::service::ForwardResult| {
+        payload_event(&result.receipt, "upstream.verified")["session_id"]
+            .as_str()
+            .expect("verified Chutes binding should produce a session id")
+            .to_string()
+    };
 
-    let result = svc
-        .forward_chat_completion(br#"{"model":"x","messages":[]}"#, None, false, Some(event))
+    let first = svc
+        .forward_chat_completion(
+            br#"{"model":"x","messages":[]}"#,
+            None,
+            false,
+            Some(chutes_event("YWJj")),
+        )
         .await
         .unwrap();
-    let session_id = payload_event(&result.receipt, "upstream.verified")["session_id"]
-        .as_str()
-        .expect("verified Chutes binding should produce a session id")
-        .to_string();
+    let second = svc
+        .forward_chat_completion(
+            br#"{"model":"x","messages":[]}"#,
+            None,
+            false,
+            Some(chutes_event("ZGVm")),
+        )
+        .await
+        .unwrap();
+
+    let session_id = session_for(&first);
+    assert_eq!(
+        session_for(&second),
+        session_id,
+        "a new evidence round must resolve to the existing instance session"
+    );
     let session = svc
         .get_attested_session(&session_id)
         .expect("Chutes session should be queryable");
-
-    assert_eq!(
-        session.document().evidence.digest.as_deref(),
-        Some(evidence_digest.as_str())
-    );
-    assert_eq!(
-        session.document().evidence.data_uri.as_deref(),
-        Some(evidence_data)
-    );
-    assert!(session.document().evidence.digest_matches_data());
+    assert!(session.document().evidence.digest.is_none());
+    assert!(session.document().evidence.data_uri.is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Reverts the session half of 8dd8c1d, which re-applied the change #145 had already reverted.

Chutes verifies its whole fleet under one nonce and exposes one channel binding per instance. The session fingerprint commits to the evidence digest, so sealing that nonce-bound bundle into every instance session means a fresh verification round never resolves to the existing session. Each round mints a new session per instance, each carrying the whole fleet bundle, and every forwarded request copies that bundle for every binding before the dedup lookup. The store and its log grow without bound relative to the live set.

## Change

- `forward.rs`: per-instance (Chutes) sessions carry `EvidenceRef::default()` again; single-channel providers keep their evidence.
- `claims.rs`: comment-only, back to the #145 wording.
- `tests/service.rs`: the test that asserted the bundle was retained now asserts a second evidence round resolves to the same session id and that the session holds no raw evidence. It fails on `main` and passes here.

The §9.2 deep-audit gap for Chutes is real; the fix shape is recorded in `docs/reviews/aci-spec-conformance-gaps.md` item 4 (evidence retained under its own digest, referenced out of band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
