### PR TITLE
fix(desktop): align Windows and Linux native lifecycle and UI

### DIFF
--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -183,19 +183,19 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $sandbox = Join-Path $env:RUNNER_TEMP 'private-ai-gateway-windows-smoke'
           $health = Join-Path $sandbox 'gui-health.json'
-          $home = Join-Path $sandbox 'home'
-          $appData = Join-Path $home 'AppData\Roaming'
-          $localAppData = Join-Path $home 'AppData\Local'
+          $isolatedHome = Join-Path $sandbox 'home'
+          $appData = Join-Path $isolatedHome 'AppData\Roaming'
+          $localAppData = Join-Path $isolatedHome 'AppData\Local'
           $crashLog = Join-Path $localAppData 'Private AI Gateway\crash.log'
           $env:PRIVATE_AI_GATEWAY_HOME = Join-Path $sandbox 'gateway-home'
-          $env:HOME = $home
-          $env:USERPROFILE = $home
+          $env:HOME = $isolatedHome
+          $env:USERPROFILE = $isolatedHome
           $env:APPDATA = $appData
           $env:LOCALAPPDATA = $localAppData
           $env:PRIVATE_AI_GATEWAY_GUI_HEALTH = $health
           $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE = Join-Path $sandbox 'launch.log'
           $env:PRIVATE_AI_GATEWAY_CRASH_LOG = $crashLog
-          New-Item -ItemType Directory -Force -Path $env:PRIVATE_AI_GATEWAY_HOME, $home, $appData, $localAppData | Out-Null
+          New-Item -ItemType Directory -Force -Path $env:PRIVATE_AI_GATEWAY_HOME, $isolatedHome, $appData, $localAppData | Out-Null
           $process = $null
           try {
             $process = Start-Process -FilePath 'release/native-windows/Private-AI-Gateway/PrivateAIGateway.Windows.exe' -ArgumentList '--smoke-test' -PassThru

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -57,6 +57,8 @@ jobs:
   linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    env:
+      RUSTFLAGS: '-D warnings'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -81,30 +83,50 @@ jobs:
       - name: Install desktop dependencies
         working-directory: apps/desktop
         run: npm ci
+      - name: Test native Linux client
+        working-directory: apps/desktop
+        run: cargo test --locked --manifest-path native/linux/Cargo.toml -- --test-threads=1
       - name: Package native Linux client
         working-directory: apps/desktop
         run: npm run dist:native:linux
       - name: Smoke runtime protocol
         working-directory: apps/desktop
         run: dbus-run-session -- node scripts/native-runtime-smoke.mjs release/native-linux/Private-AI-Gateway/private-ai-gateway-desktop-service
-      - name: Launch native Linux client
+      - name: Verify native Linux GUI runtime lifecycle
         working-directory: apps/desktop
         shell: bash
         run: |
           set -euo pipefail
-          dbus-run-session -- bash -c '
-            export GTK_A11Y=none
-            log="$RUNNER_TEMP/private-ai-gateway-linux.log"
-            xvfb-run -a release/native-linux/Private-AI-Gateway/private-ai-gateway --autostart >"$log" 2>&1 &
-            pid=$!
-            sleep 5
-            if ! kill -0 "$pid" 2>/dev/null; then
-              cat "$log"
-              wait "$pid"
-            fi
-            kill "$pid"
-            wait "$pid" || true
-          '
+          sandbox="$(mktemp -d "$RUNNER_TEMP/private-ai-gateway-linux-smoke.XXXXXX")"
+          trap 'rm -rf "$sandbox"' EXIT
+          export HOME="$sandbox/home"
+          export XDG_CONFIG_HOME="$sandbox/config"
+          export XDG_DATA_HOME="$sandbox/data"
+          export XDG_RUNTIME_DIR="$sandbox/runtime"
+          export PRIVATE_AI_GATEWAY_HOME="$sandbox/gateway-home"
+          export GTK_A11Y=none
+          mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_RUNTIME_DIR" "$PRIVATE_AI_GATEWAY_HOME"
+          chmod 700 "$XDG_RUNTIME_DIR"
+
+          gui='release/native-linux/Private-AI-Gateway/private-ai-gateway'
+          healthy_log="$sandbox/healthy.log"
+          if ! dbus-run-session -- xvfb-run -a timeout --foreground 30s "$gui" --smoke-test >"$healthy_log" 2>&1; then
+            cat "$healthy_log"
+            exit 1
+          fi
+          grep -F 'SMOKE_TEST_OK' "$healthy_log"
+
+          missing_log="$sandbox/missing-runtime.log"
+          set +e
+          PRIVATE_AI_GATEWAY_RUNTIME="$sandbox/missing-runtime" \
+            dbus-run-session -- xvfb-run -a timeout --foreground 30s "$gui" --smoke-test >"$missing_log" 2>&1
+          missing_status=$?
+          set -e
+          if [[ "$missing_status" -ne 1 ]] || grep -Fq 'SMOKE_TEST_OK' "$missing_log"; then
+            cat "$missing_log"
+            echo "Expected missing runtime smoke to exit 1 without a success marker; got $missing_status" >&2
+            exit 1
+          fi
       - uses: actions/upload-artifact@v6
         with:
           name: private-ai-gateway-native-linux-${{ github.sha }}

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_BUILD_JOBS: '2'
+
 jobs:
   runtime:
     runs-on: ubuntu-24.04
@@ -133,21 +136,57 @@ jobs:
       - name: Install desktop dependencies
         working-directory: apps/desktop
         run: npm ci
+      - name: Test native Windows runtime client
+        shell: pwsh
+        run: |
+          $output = Join-Path $env:RUNNER_TEMP 'private-ai-gateway-windows-tests'
+          try {
+            dotnet publish apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/PrivateAIGateway.Windows.Tests.csproj -c Release -r win-x64 --self-contained false -m:2 -o $output
+            & (Join-Path $output 'PrivateAIGateway.Windows.Tests.exe')
+            if ($LASTEXITCODE -ne 0) { throw "Windows runtime client tests exited with status $LASTEXITCODE" }
+          } finally {
+            Remove-Item -Recurse -Force $output -ErrorAction SilentlyContinue
+          }
       - name: Package native Windows client
         working-directory: apps/desktop
         run: npm run dist:native:windows
       - name: Smoke runtime protocol
         working-directory: apps/desktop
         run: node scripts/native-runtime-smoke.mjs release/native-windows/Private-AI-Gateway/private-ai-gateway-desktop-service.exe
-      - name: Launch native Windows client
+      - name: Verify native Windows GUI runtime lifecycle
         working-directory: apps/desktop
         shell: pwsh
         run: |
-          $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE = Join-Path $env:RUNNER_TEMP 'private-ai-gateway-launch.log'
-          $process = Start-Process -FilePath 'release/native-windows/Private-AI-Gateway/PrivateAIGateway.Windows.exe' -ArgumentList '--autostart' -PassThru
-          Start-Sleep -Seconds 5
-          if ($process.HasExited) {
-            Write-Host "Native Windows client exit code: $($process.ExitCode)"
+          $ErrorActionPreference = 'Stop'
+          $sandbox = Join-Path $env:RUNNER_TEMP 'private-ai-gateway-windows-smoke'
+          $health = Join-Path $sandbox 'gui-health.json'
+          $env:PRIVATE_AI_GATEWAY_HOME = Join-Path $sandbox 'gateway-home'
+          $env:HOME = Join-Path $sandbox 'home'
+          $env:USERPROFILE = $env:HOME
+          $env:PRIVATE_AI_GATEWAY_GUI_HEALTH = $health
+          $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE = Join-Path $sandbox 'launch.log'
+          New-Item -ItemType Directory -Force -Path $env:PRIVATE_AI_GATEWAY_HOME, $env:HOME | Out-Null
+          $process = $null
+          try {
+            $process = Start-Process -FilePath 'release/native-windows/Private-AI-Gateway/PrivateAIGateway.Windows.exe' -ArgumentList '--smoke-test' -PassThru
+            $deadline = (Get-Date).AddSeconds(30)
+            while (!(Test-Path $health) -and !$process.HasExited -and (Get-Date) -lt $deadline) {
+              Start-Sleep -Milliseconds 250
+              $process.Refresh()
+            }
+            if (!(Test-Path $health)) { throw 'Native Windows GUI did not complete its runtime RPC handshake' }
+            $result = Get-Content $health -Raw | ConvertFrom-Json
+            if (!$result.ok -or !$result.runtimeAvailable -or $result.agents -ne 5 -or !$result.clientKeyPresent) {
+              throw "Native Windows GUI health check failed: $(Get-Content $health -Raw)"
+            }
+            $exitDeadline = (Get-Date).AddSeconds(15)
+            while (!$process.HasExited -and (Get-Date) -lt $exitDeadline) {
+              Start-Sleep -Milliseconds 250
+              $process.Refresh()
+            }
+            if (!$process.HasExited) { throw 'Native Windows GUI did not shut down within 15 seconds' }
+            if ($process.ExitCode -ne 0) { throw "Native Windows GUI exited with status $($process.ExitCode)" }
+          } catch {
             if (Test-Path $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE) { Get-Content $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE }
             $crashLog = Join-Path $env:LOCALAPPDATA 'Private AI Gateway\crash.log'
             if (Test-Path $crashLog) { Get-Content $crashLog }
@@ -155,9 +194,11 @@ jobs:
               Where-Object LevelDisplayName -eq 'Error' |
               Select-Object -First 5 TimeCreated, ProviderName, Id, Message |
               Format-List
-            throw "Native Windows client exited during launch smoke"
+            throw
+          } finally {
+            if ($process -and !$process.HasExited) { Stop-Process -Id $process.Id -Force }
+            Remove-Item -Recurse -Force $sandbox -ErrorAction SilentlyContinue
           }
-          Stop-Process -Id $process.Id -Force
       - uses: actions/upload-artifact@v6
         with:
           name: private-ai-gateway-native-windows-${{ github.sha }}

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: true
           workspaces: |
             . -> target
             apps/desktop/gateway -> target
@@ -160,12 +161,19 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $sandbox = Join-Path $env:RUNNER_TEMP 'private-ai-gateway-windows-smoke'
           $health = Join-Path $sandbox 'gui-health.json'
+          $home = Join-Path $sandbox 'home'
+          $appData = Join-Path $home 'AppData\Roaming'
+          $localAppData = Join-Path $home 'AppData\Local'
+          $crashLog = Join-Path $localAppData 'Private AI Gateway\crash.log'
           $env:PRIVATE_AI_GATEWAY_HOME = Join-Path $sandbox 'gateway-home'
-          $env:HOME = Join-Path $sandbox 'home'
-          $env:USERPROFILE = $env:HOME
+          $env:HOME = $home
+          $env:USERPROFILE = $home
+          $env:APPDATA = $appData
+          $env:LOCALAPPDATA = $localAppData
           $env:PRIVATE_AI_GATEWAY_GUI_HEALTH = $health
           $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE = Join-Path $sandbox 'launch.log'
-          New-Item -ItemType Directory -Force -Path $env:PRIVATE_AI_GATEWAY_HOME, $env:HOME | Out-Null
+          $env:PRIVATE_AI_GATEWAY_CRASH_LOG = $crashLog
+          New-Item -ItemType Directory -Force -Path $env:PRIVATE_AI_GATEWAY_HOME, $home, $appData, $localAppData | Out-Null
           $process = $null
           try {
             $process = Start-Process -FilePath 'release/native-windows/Private-AI-Gateway/PrivateAIGateway.Windows.exe' -ArgumentList '--smoke-test' -PassThru
@@ -188,7 +196,6 @@ jobs:
             if ($process.ExitCode -ne 0) { throw "Native Windows GUI exited with status $($process.ExitCode)" }
           } catch {
             if (Test-Path $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE) { Get-Content $env:PRIVATE_AI_GATEWAY_LAUNCH_TRACE }
-            $crashLog = Join-Path $env:LOCALAPPDATA 'Private AI Gateway\crash.log'
             if (Test-Path $crashLog) { Get-Content $crashLog }
             Get-WinEvent -FilterHashtable @{ LogName = 'Application'; StartTime = (Get-Date).AddMinutes(-2) } -ErrorAction SilentlyContinue |
               Where-Object LevelDisplayName -eq 'Error' |

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -206,7 +206,7 @@ jobs:
             }
             if (!(Test-Path $health)) { throw 'Native Windows GUI did not complete its runtime RPC handshake' }
             $result = Get-Content $health -Raw | ConvertFrom-Json
-            if (!$result.ok -or !$result.runtimeAvailable -or $result.agents -ne 5 -or !$result.clientKeyPresent) {
+            if (!$result.ok -or !$result.runtimeAvailable -or $result.agents -ne 5 -or !$result.clientKeyPresent -or !$result.navigationSucceeded -or !$result.pageLoaded) {
               throw "Native Windows GUI health check failed: $(Get-Content $health -Raw)"
             }
             $exitDeadline = (Get-Date).AddSeconds(15)

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -225,6 +225,10 @@ a Linux amd64 DEB plus tar.gz. Each contains the GUI, shared runtime service,
 as release-ready only after its platform CI runner compiles, packages, launches,
 and runs the real runtime protocol smoke test.
 
+Linux profile credentials require a running Secret Service implementation such
+as GNOME Keyring. Installing the `libsecret` client library alone does not
+provide that daemon.
+
 Tests sit at the boundaries. `cargo test --manifest-path gateway/Cargo.toml`
 covers the proxy (token scope, fail-closed session, revocation gate, and a
 relay check proving that each inference path carries method, path, query,

--- a/apps/desktop/native/ARCHITECTURE.md
+++ b/apps/desktop/native/ARCHITECTURE.md
@@ -90,6 +90,10 @@ Brand assets are generated from `brand/<id>/brand.json` and copied into the
 native platform asset catalog at build time. Runtime assets are local; no image,
 font, script, or stylesheet is loaded from the network.
 
+On Linux, credential-backed profile flows require a running Secret Service
+implementation such as GNOME Keyring. `libsecret` is the client library and
+does not provide the Secret Service daemon itself.
+
 ## Parity Contract
 
 All four clients must expose the same product behavior:

--- a/apps/desktop/native/ARCHITECTURE.md
+++ b/apps/desktop/native/ARCHITECTURE.md
@@ -113,5 +113,7 @@ All four clients must expose the same product behavior:
   and platform-standard confirmation dialogs.
 
 The native clients are release-ready only after their dedicated CI runner
-compiles, packages, launches, and smoke-tests the real runtime protocol. Source
-that has not passed its platform compiler is not counted as complete.
+compiles, packages, and completes a runtime RPC handshake through the packaged
+GUI client before exercising bounded shutdown. A standalone protocol smoke is
+supplementary and does not prove that the GUI owns a live runtime. Source that
+has not passed its platform compiler is not counted as complete.

--- a/apps/desktop/native/linux/Cargo.lock
+++ b/apps/desktop/native/linux/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "gtk4",
  "ksni",
  "libadwaita",
+ "libc",
  "private-ai-gateway-desktop-gateway",
  "private-ai-gateway-desktop-runtime",
  "serde",

--- a/apps/desktop/native/linux/Cargo.toml
+++ b/apps/desktop/native/linux/Cargo.toml
@@ -15,5 +15,6 @@ desktop-runtime = { package = "private-ai-gateway-desktop-runtime", path = "../.
 gtk = { package = "gtk4", version = "0.10.3", features = ["v4_8"] }
 adw = { package = "libadwaita", version = "0.8.0", features = ["v1_2"] }
 ksni = { version = "0.3.6", default-features = false, features = ["blocking", "tokio"] }
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/native/linux/src/app.rs
+++ b/apps/desktop/native/linux/src/app.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
+    collections::{HashMap, HashSet},
     rc::Rc,
     sync::mpsc,
 };
@@ -14,6 +15,7 @@ use desktop_runtime::{
     usage::{UsagePage, UsageQuery},
 };
 use gtk::{gdk, glib, Align, Orientation};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
 
 use crate::{
@@ -21,7 +23,28 @@ use crate::{
     tray::{self, TrayCommand},
 };
 
-pub fn run() {
+mod dialogs;
+mod views;
+
+use views::*;
+
+#[derive(Clone, Copy, Default)]
+struct LaunchOptions {
+    autostart: bool,
+    smoke_test: bool,
+}
+
+thread_local! {
+    static LAUNCH_OPTIONS: Cell<LaunchOptions> = Cell::new(LaunchOptions::default());
+    static SMOKE_RESULT: Cell<i32> = const { Cell::new(1) };
+}
+
+pub fn run() -> i32 {
+    let arguments = std::env::args().collect::<Vec<_>>();
+    LAUNCH_OPTIONS.set(LaunchOptions {
+        autostart: arguments.iter().any(|argument| argument == "--autostart"),
+        smoke_test: arguments.iter().any(|argument| argument == "--smoke-test"),
+    });
     adw::init().expect("libadwaita could not be initialized");
     let app = adw::Application::builder()
         .application_id("org.dstack.private-ai-gateway")
@@ -29,34 +52,36 @@ pub fn run() {
         .build();
     app.connect_startup(|_| install_css());
     app.connect_activate(build_app);
-    app.connect_command_line(|app, command| {
+    app.connect_command_line(|app, _| {
         app.activate();
-        if command
-            .arguments()
-            .iter()
-            .any(|value| value == "--autostart")
-        {
-            if let Some(window) = app.active_window() {
-                window.hide();
-            }
-        }
         0.into()
     });
     app.run();
+    if LAUNCH_OPTIONS.get().smoke_test {
+        SMOKE_RESULT.get()
+    } else {
+        0
+    }
 }
 
 struct Ui {
-    app: adw::Application,
-    window: adw::ApplicationWindow,
+    window: glib::WeakRef<adw::ApplicationWindow>,
     toast: adw::ToastOverlay,
-    content: gtk::Box,
+    stack: gtk::Stack,
+    sidebar: gtk::ListBox,
     title: gtk::Label,
     status: gtk::Label,
     dev: gtk::Label,
     protection: gtk::Switch,
+    restart: gtk::Button,
     syncing: Cell<bool>,
     page: Cell<usize>,
-    client: Rc<RuntimeClient>,
+    client: RefCell<Option<Rc<RuntimeClient>>>,
+    generation: Cell<u64>,
+    runtime_connected: Cell<bool>,
+    runtime_error: RefCell<Option<String>>,
+    handshake_remaining: Cell<u8>,
+    smoke_pending: Cell<bool>,
     state: RefCell<GatewayState>,
     agents: RefCell<Vec<AgentStatus>>,
     usage: RefCell<UsagePage>,
@@ -65,6 +90,9 @@ struct Ui {
     usage_model: RefCell<Option<String>>,
     usage_range: Cell<usize>,
     tray: RefCell<Option<ksni::blocking::Handle<tray::GatewayTray>>>,
+    tray_available: Cell<bool>,
+    views: RefCell<Option<UiViews>>,
+    shutting_down: Cell<bool>,
 }
 
 fn build_app(app: &adw::Application) {
@@ -72,13 +100,7 @@ fn build_app(app: &adw::Application) {
         window.present();
         return;
     }
-    let client = match RuntimeClient::start() {
-        Ok(client) => client,
-        Err(error) => {
-            show_startup_error(app, &error);
-            return;
-        }
-    };
+    let runtime = RuntimeClient::start();
     let window = adw::ApplicationWindow::builder()
         .application(app)
         .title("Private AI Gateway")
@@ -104,7 +126,7 @@ fn build_app(app: &adw::Application) {
         .label("Not protected")
         .css_classes(["dim-label"])
         .build();
-    let protected_label = gtk::Label::new(Some("Protected"));
+    let protected_label = gtk::Label::new(Some("Protection"));
     let protection = gtk::Switch::new();
     let switch_box = gtk::Box::new(Orientation::Horizontal, 8);
     switch_box.append(&protected_label);
@@ -112,6 +134,25 @@ fn build_app(app: &adw::Application) {
     header.pack_end(&switch_box);
     header.pack_end(&status);
     header.pack_end(&dev);
+    let restart = gtk::Button::with_label("Restart Runtime");
+    restart.set_visible(false);
+    header.pack_end(&restart);
+    let menu = gtk::MenuButton::builder()
+        .icon_name("open-menu-symbolic")
+        .tooltip_text("Application menu")
+        .build();
+    let menu_popover = gtk::Popover::new();
+    let menu_box = vbox(4);
+    menu_box.set_margin_start(6);
+    menu_box.set_margin_end(6);
+    menu_box.set_margin_top(6);
+    menu_box.set_margin_bottom(6);
+    let quit = gtk::Button::with_label("Quit Private AI Gateway");
+    quit.set_has_frame(false);
+    menu_box.append(&quit);
+    menu_popover.set_child(Some(&menu_box));
+    menu.set_popover(Some(&menu_popover));
+    header.pack_end(&menu);
 
     let sidebar = gtk::ListBox::new();
     sidebar.add_css_class("navigation-sidebar");
@@ -165,10 +206,10 @@ fn build_app(app: &adw::Application) {
     side.set_size_request(220, -1);
     side.append(&brand);
     side.append(&sidebar);
-    let content = vbox(0);
+    let stack = gtk::Stack::builder().hexpand(true).vexpand(true).build();
     let main = vbox(0);
     main.append(&header);
-    main.append(&content);
+    main.append(&stack);
     let paned = gtk::Paned::new(Orientation::Horizontal);
     paned.set_start_child(Some(&side));
     paned.set_end_child(Some(&main));
@@ -180,18 +221,27 @@ fn build_app(app: &adw::Application) {
     window.set_content(Some(&toast));
 
     let (tray_tx, tray_rx) = mpsc::channel();
+    let tray = tray::spawn(tray_tx);
+    let window_ref = glib::WeakRef::new();
+    window_ref.set(Some(&window));
     let ui = Rc::new(Ui {
-        app: app.clone(),
-        window: window.clone(),
+        window: window_ref,
         toast,
-        content,
+        stack,
+        sidebar: sidebar.clone(),
         title,
         status,
         dev,
         protection: protection.clone(),
+        restart: restart.clone(),
         syncing: Cell::new(false),
         page: Cell::new(0),
-        client: client.clone(),
+        client: RefCell::new(None),
+        generation: Cell::new(0),
+        runtime_connected: Cell::new(false),
+        runtime_error: RefCell::new(None),
+        handshake_remaining: Cell::new(0),
+        smoke_pending: Cell::new(false),
         state: RefCell::new(GatewayState::default()),
         agents: RefCell::new(Vec::new()),
         usage: RefCell::new(empty_usage()),
@@ -199,8 +249,12 @@ fn build_app(app: &adw::Application) {
         usage_agent: RefCell::new(None),
         usage_model: RefCell::new(None),
         usage_range: Cell::new(1),
-        tray: RefCell::new(tray::spawn(tray_tx)),
+        tray: RefCell::new(tray.ok()),
+        tray_available: Cell::new(false),
+        views: RefCell::new(None),
+        shutting_down: Cell::new(false),
     });
+    *ui.views.borrow_mut() = Some(ui.build_views());
     let weak = Rc::downgrade(&ui);
     glib::timeout_add_local(std::time::Duration::from_millis(40), move || {
         let Some(ui) = weak.upgrade() else {
@@ -212,22 +266,10 @@ fn build_app(app: &adw::Application) {
         glib::ControlFlow::Continue
     });
     let weak = Rc::downgrade(&ui);
-    client.on_state(move |state| {
-        if let Some(ui) = weak.upgrade() {
-            ui.accept_state(state);
-        }
-    });
-    let weak = Rc::downgrade(&ui);
-    client.on_error(move |error| {
-        if let Some(ui) = weak.upgrade() {
-            ui.error(&error);
-        }
-    });
-    let weak = Rc::downgrade(&ui);
     sidebar.connect_row_selected(move |_, row| {
         if let (Some(ui), Some(row)) = (weak.upgrade(), row) {
             ui.page.set(row.index() as usize);
-            ui.render();
+            ui.show_page();
         }
     });
     let weak = Rc::downgrade(&ui);
@@ -242,40 +284,249 @@ fn build_app(app: &adw::Application) {
     });
     let weak = Rc::downgrade(&ui);
     window.connect_close_request(move |window| {
-        if weak.upgrade().is_some() {
-            window.hide();
+        if let Some(ui) = weak.upgrade() {
+            if ui.tray_available.get() {
+                window.hide();
+            } else {
+                ui.quit();
+            }
         }
         glib::Propagation::Stop
     });
-    ui.reload();
+    let weak = Rc::downgrade(&ui);
+    restart.connect_clicked(move |_| {
+        if let Some(ui) = weak.upgrade() {
+            ui.restart_runtime();
+        }
+    });
+    let weak = Rc::downgrade(&ui);
+    quit.connect_clicked(move |_| {
+        if let Some(ui) = weak.upgrade() {
+            ui.quit();
+        }
+    });
+    let owner = ui.clone();
+    app.connect_shutdown(move |_| owner.shutdown());
+    match runtime {
+        Ok(client) => ui.install_client(client),
+        Err(error) => ui.disconnected(error),
+    }
     ui.render();
-    if !std::env::args().any(|argument| argument == "--autostart") {
+    let options = LAUNCH_OPTIONS.get();
+    if !options.autostart || !ui.tray_available.get() {
         window.present();
+    }
+    if options.smoke_test {
+        let weak = Rc::downgrade(&ui);
+        glib::idle_add_local_once(move || {
+            if let Some(ui) = weak.upgrade() {
+                ui.run_smoke_test();
+            }
+        });
     }
 }
 
 impl Ui {
-    fn reload(self: &Rc<Self>) {
+    fn window(&self) -> adw::ApplicationWindow {
+        self.window
+            .upgrade()
+            .expect("application window should outlive the UI")
+    }
+
+    fn install_client(self: &Rc<Self>, client: Rc<RuntimeClient>) {
+        let generation = self.generation.get().wrapping_add(1);
+        self.generation.set(generation);
+        self.runtime_connected.set(false);
+        self.runtime_error.borrow_mut().take();
+        self.handshake_remaining.set(4);
+        *self.state.borrow_mut() = GatewayState::default();
+        self.agents.borrow_mut().clear();
+        *self.usage.borrow_mut() = empty_usage();
+        self.client_key.borrow_mut().clear();
         let weak = Rc::downgrade(self);
-        self.client
-            .request::<GatewayState>("getState", json!({}), move |result| {
-                if let Some(ui) = weak.upgrade() {
-                    match result {
-                        Ok(state) => ui.accept_state(state),
-                        Err(error) => ui.error(&error),
-                    }
-                }
-            });
-        self.reload_agents();
-        self.reload_usage(true);
+        client.on_state(move |state| {
+            if let Some(ui) = weak
+                .upgrade()
+                .filter(|ui| ui.generation.get() == generation)
+            {
+                ui.accept_state(state);
+            }
+        });
         let weak = Rc::downgrade(self);
-        self.client
-            .request::<String>("getClientKey", json!({}), move |result| {
-                if let (Some(ui), Ok(key)) = (weak.upgrade(), result) {
-                    *ui.client_key.borrow_mut() = key;
-                    ui.render();
+        client.on_disconnect(move |error| {
+            if let Some(ui) = weak
+                .upgrade()
+                .filter(|ui| ui.generation.get() == generation)
+            {
+                ui.disconnected(error);
+            }
+        });
+        *self.client.borrow_mut() = Some(client);
+        self.render();
+        self.handshake();
+    }
+
+    fn disconnected(self: &Rc<Self>, error: String) {
+        self.runtime_connected.set(false);
+        self.handshake_remaining.set(0);
+        *self.runtime_error.borrow_mut() = Some(error.clone());
+        self.render();
+        if LAUNCH_OPTIONS.get().smoke_test || self.smoke_pending.get() {
+            eprintln!("SMOKE_TEST_FAILED {error}");
+            SMOKE_RESULT.set(1);
+            self.quit();
+        } else {
+            self.error(&error);
+        }
+    }
+
+    fn restart_runtime(self: &Rc<Self>) {
+        self.restart.set_sensitive(false);
+        self.generation.set(self.generation.get().wrapping_add(1));
+        self.runtime_connected.set(false);
+        *self.state.borrow_mut() = GatewayState::default();
+        self.agents.borrow_mut().clear();
+        *self.usage.borrow_mut() = empty_usage();
+        self.client_key.borrow_mut().clear();
+        self.render();
+        if let Some(client) = self.client.borrow_mut().take() {
+            client.shutdown_and_wait();
+        }
+        match RuntimeClient::start() {
+            Ok(client) => self.install_client(client),
+            Err(error) => self.disconnected(error),
+        }
+        self.restart.set_sensitive(true);
+        self.render();
+    }
+
+    fn request<T, P, F>(self: &Rc<Self>, method: &str, params: P, callback: F)
+    where
+        T: DeserializeOwned + 'static,
+        P: Serialize,
+        F: FnOnce(&Rc<Self>, Result<T, String>) + 'static,
+    {
+        let generation = self.generation.get();
+        let Some(client) = self.client.borrow().clone() else {
+            callback(self, Err("The desktop runtime is disconnected".to_string()));
+            return;
+        };
+        let weak = Rc::downgrade(self);
+        client.request(method, params, move |result| {
+            if let Some(ui) = weak
+                .upgrade()
+                .filter(|ui| ui.generation.get() == generation)
+            {
+                callback(&ui, result);
+            }
+        });
+    }
+
+    fn run_smoke_test(self: &Rc<Self>) {
+        self.smoke_pending.set(true);
+        if self.runtime_connected.get() {
+            self.finish_smoke_test();
+            return;
+        }
+        let error = self.runtime_error.borrow().clone();
+        if let Some(error) = error {
+            self.disconnected(error);
+        }
+    }
+
+    fn quit(&self) {
+        if let Some(application) = self.window().application() {
+            application.quit();
+        }
+    }
+
+    fn shutdown(&self) {
+        if self.shutting_down.replace(true) {
+            return;
+        }
+        self.generation.set(self.generation.get().wrapping_add(1));
+        if let Some(handle) = self.tray.borrow_mut().take() {
+            handle.shutdown().wait();
+        }
+        if let Some(client) = self.client.borrow_mut().take() {
+            client.shutdown_and_wait();
+        }
+    }
+
+    fn handshake(self: &Rc<Self>) {
+        self.request::<GatewayState, _, _>("getState", json!({}), |ui, result| match result {
+            Ok(state) => {
+                *ui.state.borrow_mut() = state;
+                ui.handshake_step();
+            }
+            Err(error) => ui.disconnected(error),
+        });
+        self.request::<Vec<AgentStatus>, _, _>(
+            "listAgents",
+            json!({}),
+            |ui, result| match result {
+                Ok(agents) => {
+                    *ui.agents.borrow_mut() = agents;
+                    ui.handshake_step();
                 }
-            });
+                Err(error) => ui.disconnected(error),
+            },
+        );
+        let query = UsageQuery {
+            agent: None,
+            model: None,
+            session_id: None,
+            since: Some(unix_now().saturating_sub(30 * 86_400)),
+            until: None,
+            cursor: None,
+            limit: Some(20),
+        };
+        self.request::<UsagePage, _, _>("queryUsage", json!({ "query": query }), |ui, result| {
+            match result {
+                Ok(usage) => {
+                    *ui.usage.borrow_mut() = usage;
+                    ui.handshake_step();
+                }
+                Err(error) => ui.disconnected(error),
+            }
+        });
+        self.request::<String, _, _>("getClientKey", json!({}), |ui, result| match result {
+            Ok(key) => {
+                *ui.client_key.borrow_mut() = key;
+                ui.handshake_step();
+            }
+            Err(error) => ui.disconnected(error),
+        });
+    }
+
+    fn handshake_step(self: &Rc<Self>) {
+        let remaining = self.handshake_remaining.get();
+        if remaining == 0 {
+            return;
+        }
+        self.handshake_remaining.set(remaining - 1);
+        if remaining == 1 {
+            let process_running = self
+                .client
+                .borrow()
+                .as_ref()
+                .is_some_and(|client| client.is_process_running());
+            if !process_running {
+                self.disconnected("The desktop runtime exited during startup".to_string());
+                return;
+            }
+            self.runtime_connected.set(true);
+            self.render();
+            if self.smoke_pending.get() {
+                self.finish_smoke_test();
+            }
+        }
+    }
+
+    fn finish_smoke_test(&self) {
+        println!("SMOKE_TEST_OK status={}", self.state.borrow().status);
+        SMOKE_RESULT.set(0);
+        self.quit();
     }
 
     fn accept_state(self: &Rc<Self>, state: GatewayState) {
@@ -285,410 +536,6 @@ impl Ui {
         if usage_changed {
             self.reload_usage(true);
         }
-    }
-
-    fn render(self: &Rc<Self>) {
-        let state = self.state.borrow();
-        self.syncing.set(true);
-        self.protection.set_active(is_running(&state));
-        self.protection.set_sensitive(true);
-        self.syncing.set(false);
-        self.status.set_label(status_label(&state));
-        self.dev
-            .set_visible(is_running(&state) && !state.config.require_production_os);
-        let title = ["Overview", "Agents", "Usage", "Settings"][self.page.get().min(3)];
-        self.title.set_label(title);
-        while let Some(child) = self.content.first_child() {
-            self.content.remove(&child);
-        }
-        let page = match self.page.get() {
-            1 => self.agents_page(),
-            2 => self.usage_page(),
-            3 => self.settings_page(),
-            _ => self.overview_page(),
-        };
-        self.content.append(&page);
-        if let Some(handle) = self.tray.borrow().as_ref() {
-            let running = is_running(&state);
-            let protected = state.status == "verified" && !state.configuration_verification;
-            let label = status_label(&state).to_string();
-            let open = tray::open_at_login();
-            handle.update(move |tray| {
-                tray.running = running;
-                tray.protected = protected;
-                tray.status = label;
-                tray.open_at_login = open;
-            });
-        }
-    }
-
-    fn overview_page(self: &Rc<Self>) -> gtk::Widget {
-        let root = page_box();
-        let state = self.state.borrow();
-        let summary = hbox(18);
-        let icon = gtk::Image::from_icon_name(if state.status == "verified" {
-            "security-high-symbolic"
-        } else {
-            "security-medium-symbolic"
-        });
-        icon.set_pixel_size(36);
-        summary.append(&icon);
-        let labels = vbox(4);
-        labels.append(
-            &gtk::Label::builder()
-                .label(
-                    if is_running(&state) && !state.config.require_production_os {
-                        "Protected in dev mode"
-                    } else {
-                        status_label(&state)
-                    },
-                )
-                .css_classes(["title-3"])
-                .halign(Align::Start)
-                .build(),
-        );
-        labels.append(
-            &gtk::Label::builder()
-                .label(
-                    state
-                        .progress
-                        .as_deref()
-                        .or(state.error.as_deref())
-                        .or_else(|| active_profile(&state).map(|profile| profile.name.as_str()))
-                        .unwrap_or("Choose a Confidential AI profile"),
-                )
-                .css_classes(["dim-label"])
-                .halign(Align::Start)
-                .wrap(true)
-                .build(),
-        );
-        summary.append(&labels);
-        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        summary.append(&spacer);
-        let profiles = gtk::Button::with_label("Profiles…");
-        let weak = Rc::downgrade(self);
-        profiles.connect_clicked(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_profiles();
-            }
-        });
-        summary.append(&profiles);
-        let privacy = gtk::Button::with_label("Privacy Verification…");
-        privacy.set_sensitive(state.identity.is_some());
-        let weak = Rc::downgrade(self);
-        privacy.connect_clicked(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_privacy();
-            }
-        });
-        summary.append(&privacy);
-        root.append(&card(&summary));
-        let columns = hbox(20);
-        columns.set_homogeneous(true);
-        columns.append(&self.local_api_card());
-        columns.append(&self.agents_card());
-        root.append(&columns);
-        root.append(&metrics(&state.session_usage, Some("This session")));
-        let recent = vbox(0);
-        recent.append(&section_title("Recent usage"));
-        if state.activity.is_empty() {
-            recent.append(&empty("No usage this session"));
-        } else {
-            for item in state.activity.iter().take(5) {
-                recent.append(&self.usage_row(item.clone()));
-            }
-        }
-        root.append(&card(&recent));
-        scrolled(&root).upcast()
-    }
-
-    fn local_api_card(self: &Rc<Self>) -> gtk::Widget {
-        let state = self.state.borrow();
-        let root = vbox(0);
-        root.append(&section_title("Local API"));
-        root.append(&copy_row(
-            "Endpoint",
-            state.proxy_url.as_deref().unwrap_or("Unavailable"),
-            state.proxy_url.clone(),
-        ));
-        let key = self.client_key.borrow().clone();
-        let row = hbox(8);
-        let copy = gtk::Button::new();
-        copy.set_hexpand(true);
-        copy.set_has_frame(false);
-        let value = gtk::Label::builder()
-            .label("pag_••••••••••••")
-            .halign(Align::Start)
-            .css_classes(["monospace"])
-            .build();
-        copy.set_child(Some(&labeled("Client key", &value)));
-        let key_copy = key.clone();
-        copy.connect_clicked(move |_| clipboard(&key_copy));
-        row.append(&copy);
-        let eye = gtk::ToggleButton::builder()
-            .icon_name("view-reveal-symbolic")
-            .tooltip_text("Reveal client key")
-            .build();
-        let masked = value.clone();
-        eye.connect_toggled(move |button| {
-            masked.set_label(if button.is_active() {
-                &key
-            } else {
-                "pag_••••••••••••"
-            });
-            button.set_icon_name(if button.is_active() {
-                "view-conceal-symbolic"
-            } else {
-                "view-reveal-symbolic"
-            });
-        });
-        row.append(&eye);
-        root.append(&row);
-        card(&root).upcast()
-    }
-
-    fn agents_card(self: &Rc<Self>) -> gtk::Widget {
-        let root = vbox(0);
-        root.append(&section_title("Agents"));
-        for agent in self.agents.borrow().iter().take(5) {
-            root.append(&self.agent_row(agent.clone()));
-        }
-        card(&root).upcast()
-    }
-    fn agents_page(self: &Rc<Self>) -> gtk::Widget {
-        let root = page_box();
-        let group = vbox(0);
-        for agent in self.agents.borrow().iter() {
-            group.append(&self.agent_row(agent.clone()));
-        }
-        root.append(&card(&group));
-        scrolled(&root).upcast()
-    }
-
-    fn agent_row(self: &Rc<Self>, agent: AgentStatus) -> gtk::Widget {
-        let row = adw::ActionRow::builder()
-            .title(&agent.name)
-            .subtitle(
-                agent
-                    .error
-                    .as_deref()
-                    .or(agent.attention.as_deref())
-                    .unwrap_or(if agent.installed {
-                        &agent.config_path
-                    } else {
-                        "CLI not found"
-                    }),
-            )
-            .build();
-        row.add_prefix(&asset_picture(&format!("agents/{}.svg", agent.id), 28));
-        let toggle = gtk::Switch::builder()
-            .active(agent.connected)
-            .valign(Align::Center)
-            .sensitive(agent.installed || agent.recorded)
-            .build();
-        let original = agent.connected;
-        let weak = Rc::downgrade(self);
-        toggle.connect_active_notify(move |toggle| {
-            if toggle.is_active() != original {
-                if let Some(ui) = weak.upgrade() {
-                    ui.set_agent(agent.clone(), toggle.is_active());
-                }
-            }
-        });
-        row.add_suffix(&toggle);
-        row.set_activatable_widget(Some(&toggle));
-        row.upcast()
-    }
-
-    fn usage_page(self: &Rc<Self>) -> gtk::Widget {
-        let root = page_box();
-        let usage = self.usage.borrow();
-        let filters = hbox(10);
-        filters.append(&self.filter_combo(
-            "Agent",
-            "All agents",
-            &usage.agents,
-            self.usage_agent.borrow().clone(),
-            true,
-        ));
-        filters.append(&self.filter_combo(
-            "Model",
-            "All models",
-            &usage.models,
-            self.usage_model.borrow().clone(),
-            false,
-        ));
-        let range = gtk::ComboBoxText::new();
-        for label in ["7 days", "30 days", "All time"] {
-            range.append_text(label);
-        }
-        range.set_active(Some(self.usage_range.get() as u32));
-        let weak = Rc::downgrade(self);
-        range.connect_changed(move |combo| {
-            if let Some(ui) = weak.upgrade() {
-                ui.usage_range.set(combo.active().unwrap_or(1) as usize);
-                ui.reload_usage(true);
-            }
-        });
-        filters.append(&range);
-        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        filters.append(&spacer);
-        let export = gtk::Button::with_label("Export CSV…");
-        let weak = Rc::downgrade(self);
-        export.connect_clicked(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.export_usage();
-            }
-        });
-        filters.append(&export);
-        let clear = gtk::Button::with_label("Clear History…");
-        clear.add_css_class("destructive-action");
-        let weak = Rc::downgrade(self);
-        clear.connect_clicked(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.confirm_clear_usage();
-            }
-        });
-        filters.append(&clear);
-        root.append(&filters);
-        root.append(&metrics(&usage.summary, None));
-        root.append(&usage_chart(&usage.series));
-        let list = vbox(0);
-        list.append(&section_title("Usage history"));
-        if usage.items.is_empty() {
-            list.append(&empty("No usage matches these filters"));
-        } else {
-            for item in &usage.items {
-                list.append(&self.usage_row(item.clone()));
-            }
-        }
-        root.append(&card(&list));
-        if usage.next_cursor.is_some() {
-            let more = gtk::Button::with_label("Load More");
-            more.set_halign(Align::Center);
-            let weak = Rc::downgrade(self);
-            more.connect_clicked(move |_| {
-                if let Some(ui) = weak.upgrade() {
-                    ui.reload_usage(false);
-                }
-            });
-            root.append(&more);
-        }
-        scrolled(&root).upcast()
-    }
-
-    fn settings_page(self: &Rc<Self>) -> gtk::Widget {
-        let root = page_box();
-        let state = self.state.borrow();
-        let profiles = adw::PreferencesGroup::builder()
-            .title("Confidential AI")
-            .build();
-        let row = adw::ActionRow::builder()
-            .title("Profile")
-            .subtitle(
-                active_profile(&state)
-                    .map(|profile| profile.name.as_str())
-                    .unwrap_or("Not configured"),
-            )
-            .activatable(true)
-            .build();
-        let weak = Rc::downgrade(self);
-        row.connect_activated(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_profiles();
-            }
-        });
-        profiles.add(&row);
-        root.append(&profiles);
-        let local = adw::PreferencesGroup::builder().title("Local API").build();
-        let settings = adw::ActionRow::builder()
-            .title("Local API Settings")
-            .activatable(true)
-            .build();
-        settings.add_suffix(&gtk::Image::from_icon_name("go-next-symbolic"));
-        let weak = Rc::downgrade(self);
-        settings.connect_activated(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_local_api();
-            }
-        });
-        local.add(&settings);
-        let rotate = adw::ActionRow::builder()
-            .title("Rotate Client Key")
-            .activatable(true)
-            .build();
-        let weak = Rc::downgrade(self);
-        rotate.connect_activated(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.rotate_client_key();
-            }
-        });
-        local.add(&rotate);
-        root.append(&local);
-        let advanced = adw::ExpanderRow::builder().title("Advanced").build();
-        let policy = adw::ActionRow::builder()
-            .title("OS policy")
-            .subtitle(if state.config.require_production_os {
-                "Production OS required"
-            } else {
-                "Development OS allowed"
-            })
-            .build();
-        advanced.add_row(&policy);
-        let restore = adw::ActionRow::builder()
-            .title("Restore All Agent Configurations")
-            .activatable(true)
-            .build();
-        restore.add_css_class("error");
-        let weak = Rc::downgrade(self);
-        restore.connect_activated(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.confirm_restore();
-            }
-        });
-        advanced.add_row(&restore);
-        let group = adw::PreferencesGroup::new();
-        group.add(&advanced);
-        root.append(&group);
-        scrolled(&root).upcast()
-    }
-
-    fn usage_row(self: &Rc<Self>, item: RequestActivity) -> gtk::Widget {
-        let row = adw::ActionRow::builder()
-            .title(item.model.as_deref().unwrap_or(&item.path))
-            .subtitle(format!(
-                "{} · {}",
-                item.agent.as_deref().unwrap_or("Unknown"),
-                item.path
-            ))
-            .activatable(true)
-            .build();
-        row.add_prefix(&gtk::Image::from_icon_name(
-            if item.verified == Some(true) {
-                "security-high-symbolic"
-            } else if item.left_device {
-                "dialog-warning-symbolic"
-            } else {
-                "action-unavailable-symbolic"
-            },
-        ));
-        let tokens = item.input_tokens.unwrap_or(0) + item.output_tokens.unwrap_or(0);
-        row.add_suffix(
-            &gtk::Label::builder()
-                .label(format_number(tokens))
-                .css_classes(["dim-label", "monospace"])
-                .build(),
-        );
-        row.add_suffix(&gtk::Image::from_icon_name("go-next-symbolic"));
-        let weak = Rc::downgrade(self);
-        row.connect_activated(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_proof(item.clone());
-            }
-        });
-        row.upcast()
     }
 
     fn set_protection(self: &Rc<Self>, enabled: bool) {
@@ -702,24 +549,19 @@ impl Ui {
             return;
         }
         let params = if enabled {
-            serde_json::to_value(json!({ "config": state.config })).unwrap()
+            json!({ "config": state.config })
         } else {
             json!({})
         };
         drop(state);
-        let weak = Rc::downgrade(self);
-        self.client.request::<GatewayState>(
+        self.request::<GatewayState, _, _>(
             if enabled { "start" } else { "stop" },
             params,
-            move |result| {
-                if let Some(ui) = weak.upgrade() {
-                    match result {
-                        Ok(state) => ui.accept_state(state),
-                        Err(error) => {
-                            ui.error(&error);
-                            ui.render();
-                        }
-                    }
+            |ui, result| match result {
+                Ok(state) => ui.accept_state(state),
+                Err(error) => {
+                    ui.error(&error);
+                    ui.render();
                 }
             },
         );
@@ -737,24 +579,40 @@ impl Ui {
             None
         };
         let options = ConnectOptions { default_model };
-        let weak = Rc::downgrade(self);
         let id = agent.id.clone();
-        self.client.request::<AgentPreview>("previewAgent", json!({ "agentId": id, "connect": connect, "options": options }), move |result| { let Some(ui) = weak.upgrade() else { return; }; match result { Ok(preview) => { let weak = Rc::downgrade(&ui); ui.client.request::<AgentStatus>("applyAgent", json!({ "agentId": preview.agent.id, "connect": connect, "revision": preview.revision, "options": options }), move |result| if let Some(ui) = weak.upgrade() { match result { Ok(_) => ui.reload_agents(), Err(error) => ui.error(&error) } }); }, Err(error) => ui.error(&error) } });
+        self.request::<AgentPreview, _, _>(
+            "previewAgent",
+            json!({ "agentId": id, "connect": connect, "options": options }),
+            move |ui, result| match result {
+                Ok(preview) => ui.request::<AgentStatus, _, _>(
+                    "applyAgent",
+                    json!({
+                        "agentId": preview.agent.id,
+                        "connect": connect,
+                        "revision": preview.revision,
+                        "options": options
+                    }),
+                    |ui, result| match result {
+                        Ok(_) => ui.reload_agents(),
+                        Err(error) => ui.error(&error),
+                    },
+                ),
+                Err(error) => ui.error(&error),
+            },
+        );
     }
     fn reload_agents(self: &Rc<Self>) {
-        let weak = Rc::downgrade(self);
-        self.client
-            .request::<Vec<AgentStatus>>("listAgents", json!({}), move |result| {
-                if let Some(ui) = weak.upgrade() {
-                    match result {
-                        Ok(agents) => {
-                            *ui.agents.borrow_mut() = agents;
-                            ui.render();
-                        }
-                        Err(error) => ui.error(&error),
-                    }
+        self.request::<Vec<AgentStatus>, _, _>(
+            "listAgents",
+            json!({}),
+            |ui, result| match result {
+                Ok(agents) => {
+                    *ui.agents.borrow_mut() = agents;
+                    ui.render();
                 }
-            });
+                Err(error) => ui.error(&error),
+            },
+        );
     }
     fn reload_usage(self: &Rc<Self>, reset: bool) {
         let usage = self.usage.borrow();
@@ -775,638 +633,22 @@ impl Ui {
             cursor,
             limit: Some(20),
         };
-        let weak = Rc::downgrade(self);
-        self.client
-            .request::<UsagePage>("queryUsage", json!({ "query": query }), move |result| {
-                if let Some(ui) = weak.upgrade() {
-                    match result {
-                        Ok(mut page) => {
-                            if !reset {
-                                let mut items = ui.usage.borrow().items.clone();
-                                items.append(&mut page.items);
-                                page.items = items;
-                            }
-                            *ui.usage.borrow_mut() = page;
-                            ui.render();
-                        }
-                        Err(error) => ui.error(&error),
+        self.request::<UsagePage, _, _>(
+            "queryUsage",
+            json!({ "query": query }),
+            move |ui, result| match result {
+                Ok(mut page) => {
+                    if !reset {
+                        let mut items = ui.usage.borrow().items.clone();
+                        items.append(&mut page.items);
+                        page.items = items;
                     }
+                    *ui.usage.borrow_mut() = page;
+                    ui.render();
                 }
-            });
-    }
-    fn filter_combo(
-        self: &Rc<Self>,
-        tooltip: &str,
-        all: &str,
-        values: &[String],
-        selected: Option<String>,
-        agent: bool,
-    ) -> gtk::ComboBoxText {
-        let combo = gtk::ComboBoxText::new();
-        combo.set_tooltip_text(Some(tooltip));
-        combo.append_text(all);
-        for value in values {
-            combo.append_text(value);
-        }
-        combo.set_active(Some(
-            selected
-                .as_ref()
-                .and_then(|selected| values.iter().position(|value| value == selected))
-                .map_or(0, |index| index + 1) as u32,
-        ));
-        let weak = Rc::downgrade(self);
-        combo.connect_changed(move |combo| {
-            if let Some(ui) = weak.upgrade() {
-                let value = combo
-                    .active_text()
-                    .and_then(|value| (combo.active() != Some(0)).then(|| value.to_string()));
-                if agent {
-                    *ui.usage_agent.borrow_mut() = value;
-                } else {
-                    *ui.usage_model.borrow_mut() = value;
-                }
-                ui.reload_usage(true);
-            }
-        });
-        combo
-    }
-
-    fn show_profiles(self: &Rc<Self>) {
-        if self.state.borrow().profiles.is_empty() {
-            self.show_profile_editor(None);
-            return;
-        }
-        let dialog = dialog(&self.window, "Profiles", 620, 500);
-        let body = vbox(10);
-        let list = gtk::ListBox::new();
-        list.set_selection_mode(gtk::SelectionMode::Single);
-        let profiles = Rc::new(self.state.borrow().profiles.clone());
-        for profile in profiles.iter() {
-            let row = adw::ActionRow::builder()
-                .title(&profile.name)
-                .subtitle(&profile.remote_url)
-                .build();
-            list.append(&row);
-        }
-        body.append(&list);
-        let buttons = hbox(8);
-        let new = gtk::Button::with_label("New");
-        let edit = gtk::Button::with_label("Edit");
-        let delete = gtk::Button::with_label("Delete");
-        delete.add_css_class("destructive-action");
-        let use_profile = gtk::Button::with_label("Use Profile");
-        buttons.append(&new);
-        buttons.append(&edit);
-        buttons.append(&delete);
-        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        buttons.append(&spacer);
-        buttons.append(&use_profile);
-        body.append(&buttons);
-        dialog.content_area().append(&body);
-        dialog.add_button("Done", gtk::ResponseType::Close);
-        let weak = Rc::downgrade(self);
-        new.connect_clicked(move |_| {
-            if let Some(ui) = weak.upgrade() {
-                ui.show_profile_editor(None);
-            }
-        });
-        let weak = Rc::downgrade(self);
-        let list_edit = list.clone();
-        let profiles_edit = profiles.clone();
-        edit.connect_clicked(move |_| {
-            if let (Some(ui), Some(profile)) =
-                (weak.upgrade(), selected_profile(&list_edit, &profiles_edit))
-            {
-                ui.show_profile_editor(Some(profile));
-            }
-        });
-        let weak = Rc::downgrade(self);
-        let list_delete = list.clone();
-        let profiles_delete = profiles.clone();
-        delete.connect_clicked(move |_| {
-            if let (Some(ui), Some(profile)) = (
-                weak.upgrade(),
-                selected_profile(&list_delete, &profiles_delete),
-            ) {
-                ui.confirm_delete_profile(profile);
-            }
-        });
-        let weak = Rc::downgrade(self);
-        let profiles_use = profiles.clone();
-        use_profile.connect_clicked(move |_| {
-            if let (Some(ui), Some(profile)) =
-                (weak.upgrade(), selected_profile(&list, &profiles_use))
-            {
-                let weak = Rc::downgrade(&ui);
-                ui.client.request::<GatewayState>(
-                    "activateProfile",
-                    json!({ "profileId": profile.id }),
-                    move |result| {
-                        if let Some(ui) = weak.upgrade() {
-                            match result {
-                                Ok(state) => ui.accept_state(state),
-                                Err(error) => ui.error(&error),
-                            }
-                        }
-                    },
-                );
-            }
-        });
-        dialog.connect_response(|dialog, _| dialog.close());
-        dialog.present();
-    }
-
-    fn show_profile_editor(self: &Rc<Self>, profile: Option<ConfidentialProfile>) {
-        let dialog = dialog(
-            &self.window,
-            if profile.is_some() {
-                "Edit Profile"
-            } else {
-                "New Profile"
-            },
-            620,
-            480,
-        );
-        let body = vbox(12);
-        let name = gtk::Entry::new();
-        name.set_placeholder_text(Some("Name"));
-        name.set_text(
-            profile
-                .as_ref()
-                .map(|profile| profile.name.as_str())
-                .unwrap_or("RedPill"),
-        );
-        let provider = gtk::ComboBoxText::new();
-        for label in ["Phala", "RedPill", "Custom"] {
-            provider.append_text(label);
-        }
-        provider.set_active(Some(
-            match profile.as_ref().map(|profile| &profile.provider) {
-                Some(ServiceProvider::Phala) => 0,
-                Some(ServiceProvider::Custom) => 2,
-                _ => 1,
-            },
-        ));
-        let endpoint = gtk::Entry::new();
-        endpoint.set_placeholder_text(Some("Endpoint"));
-        endpoint.set_text(
-            profile
-                .as_ref()
-                .map(|profile| profile.remote_url.as_str())
-                .unwrap_or("https://tee.redpill.ai"),
-        );
-        endpoint.set_sensitive(provider.active() == Some(2));
-        let key = gtk::PasswordEntry::new();
-        key.set_placeholder_text(Some(
-            if profile
-                .as_ref()
-                .and_then(|profile| profile.verified_at)
-                .is_some()
-            {
-                "API key (leave blank to keep)"
-            } else {
-                "API key"
-            },
-        ));
-        key.set_show_peek_icon(true);
-        let allow_dev = gtk::Switch::builder()
-            .active(!self.state.borrow().config.require_production_os)
-            .build();
-        let dev_row = adw::ActionRow::builder()
-            .title("Allow development OS")
-            .subtitle(
-                "Weakens the production attestation policy and is shown in yellow while running.",
-            )
-            .build();
-        dev_row.add_suffix(&allow_dev);
-        dev_row.set_activatable_widget(Some(&allow_dev));
-        body.append(&name);
-        body.append(&provider);
-        body.append(&endpoint);
-        body.append(&key);
-        let verify = gtk::Button::with_label("Verify and Save");
-        verify.add_css_class("suggested-action");
-        verify.set_halign(Align::End);
-        body.append(&verify);
-        if profile
-            .as_ref()
-            .and_then(|profile| profile.verified_at)
-            .is_some()
-        {
-            body.append(
-                &gtk::Label::builder()
-                    .label("✓ Verified configuration")
-                    .css_classes(["success"])
-                    .halign(Align::Start)
-                    .build(),
-            );
-        }
-        body.append(&dev_row);
-        dialog.content_area().append(&body);
-        dialog.add_button("Cancel", gtk::ResponseType::Cancel);
-        let endpoint_change = endpoint.clone();
-        let name_change = name.clone();
-        let is_new = profile.is_none();
-        provider.connect_changed(move |provider| {
-            match provider.active() {
-                Some(0) => {
-                    endpoint_change.set_text("https://inference.phala.com");
-                    if is_new {
-                        name_change.set_text("Phala");
-                    }
-                }
-                Some(1) => {
-                    endpoint_change.set_text("https://tee.redpill.ai");
-                    if is_new {
-                        name_change.set_text("RedPill");
-                    }
-                }
-                _ => {
-                    if is_new {
-                        endpoint_change.set_text("");
-                        name_change.set_text("Custom");
-                    }
-                }
-            }
-            endpoint_change.set_sensitive(provider.active() == Some(2));
-        });
-        let weak = Rc::downgrade(self);
-        let profile_id = profile.as_ref().map(|profile| profile.id.clone());
-        let verify_dialog = dialog.clone();
-        verify.connect_clicked(move |button| {
-            let Some(ui) = weak.upgrade() else { return };
-            button.set_sensitive(false);
-            let input = ConfidentialProfileInput {
-                id: profile_id
-                    .clone()
-                    .unwrap_or_else(|| format!("profile-{}", unix_now())),
-                name: name.text().to_string(),
-                provider: match provider.active() {
-                    Some(0) => ServiceProvider::Phala,
-                    Some(2) => ServiceProvider::Custom,
-                    _ => ServiceProvider::Redpill,
-                },
-                remote_url: endpoint.text().to_string(),
-            };
-            let params = json!({
-                "profile": input,
-                "requireProductionOs": !allow_dev.is_active(),
-                "key": (!key.text().is_empty()).then(|| key.text().to_string())
-            });
-            let weak = Rc::downgrade(&ui);
-            let dialog = verify_dialog.clone();
-            let button = button.clone();
-            ui.client
-                .request::<GatewayState>("verifyConfiguration", params, move |result| {
-                    if let Some(ui) = weak.upgrade() {
-                        button.set_sensitive(true);
-                        match result {
-                            Ok(state) => {
-                                ui.accept_state(state);
-                                dialog.close();
-                            }
-                            Err(error) => ui.error(&error),
-                        }
-                    }
-                });
-        });
-        dialog.connect_response(|dialog, _| dialog.close());
-        dialog.present();
-    }
-
-    fn confirm_delete_profile(self: &Rc<Self>, profile: ConfidentialProfile) {
-        let weak = Rc::downgrade(self);
-        confirm(
-            &self.window,
-            "Delete profile?",
-            "The profile credential will be removed from the system credential store.",
-            "Delete",
-            move || {
-                if let Some(ui) = weak.upgrade() {
-                    let weak = Rc::downgrade(&ui);
-                    ui.client.request::<GatewayState>(
-                        "deleteProfile",
-                        json!({ "profileId": profile.id }),
-                        move |result| {
-                            if let Some(ui) = weak.upgrade() {
-                                match result {
-                                    Ok(state) => ui.accept_state(state),
-                                    Err(error) => ui.error(&error),
-                                }
-                            }
-                        },
-                    );
-                }
+                Err(error) => ui.error(&error),
             },
         );
-    }
-    fn show_local_api(self: &Rc<Self>) {
-        let config = self.state.borrow().local_api.clone();
-        let dialog = dialog(&self.window, "Local API Settings", 580, 440);
-        let body = vbox(12);
-        let address = gtk::Entry::new();
-        address.set_text(&config.listen_address);
-        let network = gtk::Switch::builder()
-            .active(config.allow_network_access)
-            .build();
-        let network_row = adw::ActionRow::builder()
-            .title("Allow network access")
-            .subtitle("Exposes the Local API beyond this computer.")
-            .build();
-        network_row.add_suffix(&network);
-        let port = gtk::SpinButton::with_range(1024.0, 65535.0, 1.0);
-        port.set_value(config.port as f64);
-        let host = gtk::Entry::new();
-        host.set_text(config.client_host.as_deref().unwrap_or(""));
-        body.append(&labeled("Listen address", &address));
-        body.append(&network_row);
-        body.append(&labeled("Port", &port));
-        body.append(&labeled("Client host", &host));
-        dialog.content_area().append(&body);
-        dialog.add_button("Cancel", gtk::ResponseType::Cancel);
-        dialog.add_button("Save", gtk::ResponseType::Accept);
-        let weak = Rc::downgrade(self);
-        dialog.connect_response(move |dialog, response| {
-            if response != gtk::ResponseType::Accept {
-                dialog.close();
-                return;
-            }
-            let Some(ui) = weak.upgrade() else {
-                dialog.close();
-                return;
-            };
-            let config = LocalApiConfig {
-                listen_address: address.text().to_string(),
-                allow_network_access: network.is_active(),
-                port: port.value_as_int() as u16,
-                client_host: (!host.text().is_empty()).then(|| host.text().to_string()),
-            };
-            let weak = Rc::downgrade(&ui);
-            let dialog = dialog.clone();
-            ui.client.request::<GatewayState>(
-                "saveLocalApiConfig",
-                json!({ "config": config }),
-                move |result| {
-                    if let Some(ui) = weak.upgrade() {
-                        match result {
-                            Ok(state) => {
-                                ui.accept_state(state);
-                                dialog.close();
-                            }
-                            Err(error) => ui.error(&error),
-                        }
-                    }
-                },
-            );
-        });
-        dialog.present();
-    }
-
-    fn show_proof(self: &Rc<Self>, item: RequestActivity) {
-        let dialog = dialog(&self.window, proof_verdict(&item), 700, 620);
-        let body = vbox(9);
-        let state = self.state.borrow();
-        for (label, value) in [
-            ("Request", item.id.clone()),
-            (
-                "Agent",
-                item.agent.clone().unwrap_or_else(|| "Unknown".into()),
-            ),
-            (
-                "Model",
-                item.model.clone().unwrap_or_else(|| "Not reported".into()),
-            ),
-            ("Path", format!("{} {}", item.method, item.path)),
-            ("Status", item.status.to_string()),
-            (
-                "Receipt",
-                item.receipt_id
-                    .clone()
-                    .unwrap_or_else(|| "No receipt".into()),
-            ),
-            (
-                "Policy",
-                if item.locally_constrained == Some(true) {
-                    "Applied before forwarding".into()
-                } else {
-                    "Not reported".into()
-                },
-            ),
-            (
-                "Rewrite",
-                if item.rewritten == Some(true) {
-                    "Service rewrote the request".into()
-                } else {
-                    "No rewrite reported".into()
-                },
-            ),
-            (
-                "Delivery",
-                if item.left_device {
-                    "Request may have left this computer".into()
-                } else {
-                    "Blocked locally before delivery".into()
-                },
-            ),
-            (
-                "Input tokens",
-                item.input_tokens
-                    .map(format_number)
-                    .unwrap_or_else(|| "Not reported".into()),
-            ),
-            (
-                "Output tokens",
-                item.output_tokens
-                    .map(format_number)
-                    .unwrap_or_else(|| "Not reported".into()),
-            ),
-            (
-                "Cost",
-                item.cost_usd
-                    .map(|cost| format!("${cost:.4}"))
-                    .unwrap_or_else(|| "Not reported".into()),
-            ),
-            (
-                "Gateway keyset",
-                state
-                    .identity
-                    .as_ref()
-                    .map(|identity| identity.keyset_digest.clone())
-                    .unwrap_or_else(|| "Not available".into()),
-            ),
-            (
-                "Detail",
-                if item.detail.is_empty() {
-                    "No additional detail".into()
-                } else {
-                    item.detail.clone()
-                },
-            ),
-        ] {
-            body.append(&detail_row(label, &value));
-        }
-        dialog.content_area().append(&scrolled(&body));
-        dialog.add_button("Done", gtk::ResponseType::Close);
-        dialog.connect_response(|dialog, _| dialog.close());
-        dialog.present();
-    }
-    fn show_privacy(self: &Rc<Self>) {
-        let state = self.state.borrow();
-        let dialog = dialog(&self.window, "Privacy Verification", 740, 660);
-        let body = vbox(14);
-        body.append(&wrapped("The gateway verifies the workload identity and model catalog before forwarding requests. Each response receipt binds the request, verified upstream session, and returned response."));
-        if let Some(identity) = &state.identity {
-            body.append(&section_title("Workload identity"));
-            for (label, value) in [
-                ("TEE", identity.tee_type.as_str()),
-                ("Trust level", identity.trust_level.as_str()),
-                ("Keyset digest", identity.keyset_digest.as_str()),
-                ("Serving mode", identity.serving.as_str()),
-                (
-                    "TLS SPKI",
-                    identity.tls_spki.as_deref().unwrap_or("Not published"),
-                ),
-            ] {
-                body.append(&detail_row(label, value));
-            }
-            body.append(&section_title("Source provenance"));
-            for (label, value) in [
-                (
-                    "Repository",
-                    identity
-                        .source
-                        .repo_url
-                        .as_deref()
-                        .unwrap_or("Not published"),
-                ),
-                (
-                    "Commit",
-                    identity
-                        .source
-                        .repo_commit
-                        .as_deref()
-                        .unwrap_or("Not published"),
-                ),
-                (
-                    "Image digest",
-                    identity
-                        .source
-                        .image_digest
-                        .as_deref()
-                        .unwrap_or("Not published"),
-                ),
-            ] {
-                body.append(&detail_row(label, value));
-            }
-        }
-        body.append(&section_title("Verification checks"));
-        for check in &state.checks {
-            let row = hbox(10);
-            row.append(&gtk::Image::from_icon_name(if check.status == "pass" {
-                "emblem-ok-symbolic"
-            } else if check.status == "fail" {
-                "dialog-error-symbolic"
-            } else {
-                "dialog-information-symbolic"
-            }));
-            let text = vbox(2);
-            text.append(
-                &gtk::Label::builder()
-                    .label(&check.title)
-                    .halign(Align::Start)
-                    .build(),
-            );
-            text.append(
-                &gtk::Label::builder()
-                    .label(&check.detail)
-                    .css_classes(["dim-label", "caption"])
-                    .halign(Align::Start)
-                    .wrap(true)
-                    .build(),
-            );
-            row.append(&text);
-            body.append(&row);
-        }
-        dialog.content_area().append(&scrolled(&body));
-        dialog.add_button("Done", gtk::ResponseType::Close);
-        dialog.connect_response(|dialog, _| dialog.close());
-        dialog.present();
-    }
-    fn confirm_clear_usage(self: &Rc<Self>) {
-        let weak = Rc::downgrade(self);
-        confirm(&self.window, "Clear all usage history?", "This permanently deletes the local usage database. It does not affect provider records.", "Clear History", move || if let Some(ui) = weak.upgrade() { let weak = Rc::downgrade(&ui); ui.client.request::<u64>("clearUsage", json!({}), move |result| if let Some(ui) = weak.upgrade() { match result { Ok(_) => ui.reload_usage(true), Err(error) => ui.error(&error) } }); });
-    }
-    fn confirm_restore(self: &Rc<Self>) {
-        let weak = Rc::downgrade(self);
-        confirm(&self.window, "Restore all agent configurations?", "Private AI Gateway will revoke every managed agent token and restore its previous configuration where possible.", "Restore All", move || if let Some(ui) = weak.upgrade() { let weak = Rc::downgrade(&ui); ui.client.request::<Vec<AgentStatus>>("disconnectAllAgents", json!({}), move |result| if let Some(ui) = weak.upgrade() { match result { Ok(agents) => { *ui.agents.borrow_mut() = agents; ui.render(); }, Err(error) => ui.error(&error) } }); });
-    }
-    fn rotate_client_key(self: &Rc<Self>) {
-        let weak = Rc::downgrade(self);
-        self.client
-            .request::<String>("rotateClientKey", json!({}), move |result| {
-                if let Some(ui) = weak.upgrade() {
-                    match result {
-                        Ok(key) => {
-                            *ui.client_key.borrow_mut() = key;
-                            ui.toast.add_toast(adw::Toast::new("Client key rotated"));
-                            ui.render();
-                        }
-                        Err(error) => ui.error(&error),
-                    }
-                }
-            });
-    }
-    fn export_usage(self: &Rc<Self>) {
-        let chooser = gtk::FileChooserNative::builder()
-            .title("Export Usage CSV")
-            .transient_for(&self.window)
-            .action(gtk::FileChooserAction::Save)
-            .accept_label("Export")
-            .cancel_label("Cancel")
-            .build();
-        chooser.set_current_name("private-ai-gateway-usage.csv");
-        let weak = Rc::downgrade(self);
-        chooser.connect_response(move |chooser, response| {
-            if response == gtk::ResponseType::Accept {
-                if let (Some(ui), Some(path)) =
-                    (weak.upgrade(), chooser.file().and_then(|file| file.path()))
-                {
-                    let now = unix_now();
-                    let since = match ui.usage_range.get() {
-                        0 => Some(now.saturating_sub(7 * 86_400)),
-                        1 => Some(now.saturating_sub(30 * 86_400)),
-                        _ => None,
-                    };
-                    let query = UsageQuery {
-                        agent: ui.usage_agent.borrow().clone(),
-                        model: ui.usage_model.borrow().clone(),
-                        session_id: None,
-                        since,
-                        until: None,
-                        cursor: None,
-                        limit: None,
-                    };
-                    let weak = Rc::downgrade(&ui);
-                    ui.client.request::<usize>(
-                        "exportUsageCsv",
-                        json!({ "query": query, "path": path }),
-                        move |result| {
-                            if let Some(ui) = weak.upgrade() {
-                                match result {
-                                    Ok(count) => ui.toast.add_toast(adw::Toast::new(&format!(
-                                        "Exported {count} records"
-                                    ))),
-                                    Err(error) => ui.error(&error),
-                                }
-                            }
-                        },
-                    );
-                }
-            }
-            chooser.destroy();
-        });
-        chooser.show();
     }
 
     fn handle_tray(self: &Rc<Self>, command: TrayCommand) {
@@ -1415,19 +657,24 @@ impl Ui {
                 let enabled = !is_running(&self.state.borrow());
                 self.set_protection(enabled);
             }
-            TrayCommand::Open => self.window.present(),
+            TrayCommand::Open => self.window().present(),
             TrayCommand::Settings => {
                 self.page.set(3);
-                self.window.present();
-                self.render();
+                self.sidebar
+                    .select_row(self.sidebar.row_at_index(3).as_ref());
+                self.window().present();
             }
+            TrayCommand::RestartRuntime => self.restart_runtime(),
             TrayCommand::OpenAtLogin => match tray::set_open_at_login(!tray::open_at_login()) {
                 Ok(()) => self.render(),
                 Err(error) => self.error(&error),
             },
-            TrayCommand::Quit => {
-                self.client.shutdown();
-                self.app.quit();
+            TrayCommand::Quit => self.quit(),
+            TrayCommand::Availability(available) => {
+                self.tray_available.set(available);
+                if !available {
+                    self.window().present();
+                }
             }
         }
     }
@@ -1446,19 +693,6 @@ fn install_css() {
             gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
     }
-}
-fn show_startup_error(app: &adw::Application, message: &str) {
-    let window = adw::ApplicationWindow::builder()
-        .application(app)
-        .title("Private AI Gateway")
-        .default_width(520)
-        .default_height(220)
-        .build();
-    let box_ = page_box();
-    box_.append(&section_title("Private AI Gateway could not start"));
-    box_.append(&wrapped(message));
-    window.set_content(Some(&box_));
-    window.present();
 }
 fn empty_usage() -> UsagePage {
     UsagePage {
@@ -1479,274 +713,24 @@ fn active_profile(state: &GatewayState) -> Option<&ConfidentialProfile> {
 fn is_running(state: &GatewayState) -> bool {
     matches!(state.status.as_str(), "verifying" | "verified" | "blocked")
 }
+fn is_protected(state: &GatewayState) -> bool {
+    state.status == "verified" && !state.configuration_verification
+}
 fn status_label(state: &GatewayState) -> &'static str {
+    if is_protected(state) {
+        return "Protected";
+    }
     match state.status.as_str() {
         "verifying" if state.configuration_verification => "Verifying configuration",
         "verifying" => "Starting",
-        "verified" if !state.config.require_production_os => "Protected · Dev mode",
-        "verified" => "Protected",
+        "verified" => "Verifying configuration",
         "blocked" => "Blocked",
         "error" => "Needs attention",
         _ => "Not protected",
-    }
-}
-fn page_box() -> gtk::Box {
-    let root = vbox(24);
-    root.set_margin_start(28);
-    root.set_margin_end(28);
-    root.set_margin_top(28);
-    root.set_margin_bottom(28);
-    root
-}
-fn vbox(spacing: i32) -> gtk::Box {
-    gtk::Box::new(Orientation::Vertical, spacing)
-}
-fn hbox(spacing: i32) -> gtk::Box {
-    gtk::Box::new(Orientation::Horizontal, spacing)
-}
-fn card(child: &impl IsA<gtk::Widget>) -> gtk::Box {
-    let card = vbox(0);
-    card.add_css_class("card");
-    card.append(child);
-    card
-}
-fn section_title(title: &str) -> gtk::Label {
-    gtk::Label::builder()
-        .label(title)
-        .css_classes(["heading"])
-        .halign(Align::Start)
-        .margin_bottom(8)
-        .build()
-}
-fn wrapped(text: &str) -> gtk::Label {
-    gtk::Label::builder()
-        .label(text)
-        .wrap(true)
-        .halign(Align::Start)
-        .xalign(0.0)
-        .build()
-}
-fn empty(text: &str) -> gtk::Label {
-    gtk::Label::builder()
-        .label(text)
-        .css_classes(["dim-label"])
-        .margin_top(24)
-        .margin_bottom(24)
-        .build()
-}
-fn scrolled(child: &impl IsA<gtk::Widget>) -> gtk::ScrolledWindow {
-    gtk::ScrolledWindow::builder()
-        .hscrollbar_policy(gtk::PolicyType::Never)
-        .vexpand(true)
-        .child(child)
-        .build()
-}
-fn labeled(label: &str, widget: &impl IsA<gtk::Widget>) -> gtk::Box {
-    let box_ = vbox(3);
-    box_.append(
-        &gtk::Label::builder()
-            .label(label)
-            .css_classes(["dim-label", "caption"])
-            .halign(Align::Start)
-            .build(),
-    );
-    box_.append(widget);
-    box_
-}
-fn detail_row(label: &str, value: &str) -> gtk::Grid {
-    let grid = gtk::Grid::builder()
-        .column_spacing(18)
-        .row_spacing(4)
-        .build();
-    let name = gtk::Label::builder()
-        .label(label)
-        .css_classes(["dim-label"])
-        .halign(Align::End)
-        .build();
-    let value = gtk::Label::builder()
-        .label(value)
-        .selectable(true)
-        .wrap(true)
-        .halign(Align::Start)
-        .xalign(0.0)
-        .hexpand(true)
-        .build();
-    grid.attach(&name, 0, 0, 1, 1);
-    grid.attach(&value, 1, 0, 1, 1);
-    grid
-}
-fn copy_row(label: &str, value: &str, copy_value: Option<String>) -> gtk::Button {
-    let button = gtk::Button::new();
-    button.set_has_frame(false);
-    let row = hbox(8);
-    let value_label = gtk::Label::builder()
-        .label(value)
-        .halign(Align::Start)
-        .hexpand(true)
-        .ellipsize(gtk::pango::EllipsizeMode::End)
-        .css_classes(["monospace"])
-        .build();
-    row.append(&labeled(label, &value_label));
-    row.append(&gtk::Image::from_icon_name("edit-copy-symbolic"));
-    button.set_child(Some(&row));
-    button.set_sensitive(copy_value.is_some());
-    button.connect_clicked(move |_| {
-        if let Some(value) = &copy_value {
-            clipboard(value);
-        }
-    });
-    button
-}
-fn clipboard(value: &str) {
-    if let Some(display) = gdk::Display::default() {
-        display.clipboard().set_text(value);
-    }
-}
-fn asset_picture(relative: &str, size: i32) -> gtk::Picture {
-    let path = std::env::var_os("PRIVATE_AI_GATEWAY_ASSETS")
-        .map(std::path::PathBuf::from)
-        .or_else(|| {
-            std::env::current_exe()
-                .ok()
-                .and_then(|path| path.parent().map(|parent| parent.join("Assets")))
-        })
-        .unwrap_or_default()
-        .join(relative);
-    let picture = gtk::Picture::for_filename(path);
-    picture.set_content_fit(gtk::ContentFit::Contain);
-    picture.set_size_request(size, size);
-    picture
-}
-fn metrics(summary: &UsageSummary, title: Option<&str>) -> gtk::Box {
-    let root = vbox(10);
-    if let Some(title) = title {
-        root.append(&section_title(title));
-    }
-    let grid = gtk::Grid::builder()
-        .column_spacing(28)
-        .column_homogeneous(true)
-        .build();
-    let protected = if summary.requests == 0 {
-        "—".into()
-    } else {
-        format!("{}%", summary.protected * 100 / summary.requests)
-    };
-    for (index, (label, value)) in [
-        ("Requests", format_number(summary.requests)),
-        (
-            "Tokens",
-            format_number(summary.input_tokens + summary.output_tokens),
-        ),
-        ("Cost", format!("${:.4}", summary.cost_usd)),
-        ("Protected", protected),
-    ]
-    .into_iter()
-    .enumerate()
-    {
-        grid.attach(
-            &labeled(
-                label,
-                &gtk::Label::builder()
-                    .label(value)
-                    .css_classes(["title-3", "monospace"])
-                    .halign(Align::Start)
-                    .build(),
-            ),
-            index as i32,
-            0,
-            1,
-            1,
-        );
-    }
-    root.append(&grid);
-    card(&root)
-}
-fn usage_chart(points: &[desktop_runtime::usage::UsagePoint]) -> gtk::Box {
-    let chart = gtk::DrawingArea::builder()
-        .content_height(170)
-        .hexpand(true)
-        .build();
-    let points = points.iter().map(|point| point.tokens).collect::<Vec<_>>();
-    chart.set_draw_func(move |_, cr, width, height| {
-        let max = points.iter().copied().max().unwrap_or(1).max(1) as f64;
-        let gap = 3.0;
-        let bar = (width as f64 / points.len().max(1) as f64 - gap).max(2.0);
-        cr.set_source_rgb(0.17, 0.43, 0.29);
-        for (index, value) in points.iter().enumerate() {
-            let h = (*value as f64 / max * (height as f64 - 16.0)).max(2.0);
-            cr.rectangle(index as f64 * (bar + gap), height as f64 - h, bar, h);
-            let _ = cr.fill();
-        }
-    });
-    card(&chart)
-}
-fn dialog(parent: &adw::ApplicationWindow, title: &str, width: i32, height: i32) -> gtk::Dialog {
-    gtk::Dialog::builder()
-        .transient_for(parent)
-        .modal(true)
-        .title(title)
-        .default_width(width)
-        .default_height(height)
-        .use_header_bar(1)
-        .build()
-}
-fn confirm(
-    parent: &adw::ApplicationWindow,
-    title: &str,
-    message: &str,
-    action: &str,
-    accept: impl Fn() + 'static,
-) {
-    let dialog = gtk::MessageDialog::builder()
-        .transient_for(parent)
-        .modal(true)
-        .message_type(gtk::MessageType::Warning)
-        .buttons(gtk::ButtonsType::None)
-        .text(title)
-        .secondary_text(message)
-        .build();
-    dialog.add_button("Cancel", gtk::ResponseType::Cancel);
-    let button = dialog.add_button(action, gtk::ResponseType::Accept);
-    button.add_css_class("destructive-action");
-    dialog.connect_response(move |dialog, response| {
-        if response == gtk::ResponseType::Accept {
-            accept();
-        }
-        dialog.close();
-    });
-    dialog.present();
-}
-fn selected_profile(
-    list: &gtk::ListBox,
-    profiles: &[ConfidentialProfile],
-) -> Option<ConfidentialProfile> {
-    let index = usize::try_from(list.selected_row()?.index()).ok()?;
-    profiles.get(index).cloned()
-}
-fn proof_verdict(item: &RequestActivity) -> &'static str {
-    if item.verified == Some(true) {
-        "Proof verified"
-    } else if !item.left_device {
-        "Blocked locally"
-    } else if item.verified == Some(false) {
-        "Proof failed"
-    } else {
-        "Proof unavailable"
     }
 }
 fn unix_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |duration| duration.as_secs())
-}
-fn format_number(value: u64) -> String {
-    let text = value.to_string();
-    let mut result = String::new();
-    for (index, character) in text.chars().rev().enumerate() {
-        if index > 0 && index % 3 == 0 {
-            result.push(',');
-        }
-        result.push(character);
-    }
-    result.chars().rev().collect()
 }

--- a/apps/desktop/native/linux/src/app/dialogs.rs
+++ b/apps/desktop/native/linux/src/app/dialogs.rs
@@ -1,0 +1,605 @@
+use super::*;
+
+impl Ui {
+    pub(super) fn show_profiles(self: &Rc<Self>) {
+        if self.state.borrow().profiles.is_empty() {
+            self.show_profile_editor(None);
+            return;
+        }
+        let dialog = dialog(&self.window(), "Profiles", 620, 500);
+        let body = vbox(10);
+        let list = gtk::ListBox::new();
+        list.set_selection_mode(gtk::SelectionMode::Single);
+        let profiles = Rc::new(self.state.borrow().profiles.clone());
+        for profile in profiles.iter() {
+            let row = adw::ActionRow::builder()
+                .title(&profile.name)
+                .subtitle(&profile.remote_url)
+                .build();
+            list.append(&row);
+        }
+        body.append(&list);
+        let buttons = hbox(8);
+        let new = gtk::Button::with_label("New");
+        let edit = gtk::Button::with_label("Edit");
+        let delete = gtk::Button::with_label("Delete");
+        delete.add_css_class("destructive-action");
+        let use_profile = gtk::Button::with_label("Use Profile");
+        buttons.append(&new);
+        buttons.append(&edit);
+        buttons.append(&delete);
+        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
+        spacer.set_hexpand(true);
+        buttons.append(&spacer);
+        buttons.append(&use_profile);
+        body.append(&buttons);
+        dialog.content_area().append(&body);
+        dialog.add_button("Done", gtk::ResponseType::Close);
+        let weak = Rc::downgrade(self);
+        new.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_profile_editor(None);
+            }
+        });
+        let weak = Rc::downgrade(self);
+        let list_edit = list.clone();
+        let profiles_edit = profiles.clone();
+        edit.connect_clicked(move |_| {
+            if let (Some(ui), Some(profile)) =
+                (weak.upgrade(), selected_profile(&list_edit, &profiles_edit))
+            {
+                ui.show_profile_editor(Some(profile));
+            }
+        });
+        let weak = Rc::downgrade(self);
+        let list_delete = list.clone();
+        let profiles_delete = profiles.clone();
+        delete.connect_clicked(move |_| {
+            if let (Some(ui), Some(profile)) = (
+                weak.upgrade(),
+                selected_profile(&list_delete, &profiles_delete),
+            ) {
+                ui.confirm_delete_profile(profile);
+            }
+        });
+        let weak = Rc::downgrade(self);
+        let profiles_use = profiles.clone();
+        use_profile.connect_clicked(move |_| {
+            if let (Some(ui), Some(profile)) =
+                (weak.upgrade(), selected_profile(&list, &profiles_use))
+            {
+                ui.request::<GatewayState, _, _>(
+                    "activateProfile",
+                    json!({ "profileId": profile.id }),
+                    |ui, result| match result {
+                        Ok(state) => ui.accept_state(state),
+                        Err(error) => ui.error(&error),
+                    },
+                );
+            }
+        });
+        dialog.connect_response(|dialog, _| dialog.close());
+        dialog.present();
+    }
+
+    pub(super) fn show_profile_editor(self: &Rc<Self>, profile: Option<ConfidentialProfile>) {
+        let dialog = dialog(
+            &self.window(),
+            if profile.is_some() {
+                "Edit Profile"
+            } else {
+                "New Profile"
+            },
+            620,
+            480,
+        );
+        let body = vbox(12);
+        let name = gtk::Entry::new();
+        name.set_placeholder_text(Some("Name"));
+        name.set_text(
+            profile
+                .as_ref()
+                .map(|profile| profile.name.as_str())
+                .unwrap_or("RedPill"),
+        );
+        let provider = gtk::ComboBoxText::new();
+        for label in ["Phala", "RedPill", "Custom"] {
+            provider.append_text(label);
+        }
+        provider.set_active(Some(
+            match profile.as_ref().map(|profile| &profile.provider) {
+                Some(ServiceProvider::Phala) => 0,
+                Some(ServiceProvider::Custom) => 2,
+                _ => 1,
+            },
+        ));
+        let endpoint = gtk::Entry::new();
+        endpoint.set_placeholder_text(Some("Endpoint"));
+        endpoint.set_text(
+            profile
+                .as_ref()
+                .map(|profile| profile.remote_url.as_str())
+                .unwrap_or("https://tee.redpill.ai"),
+        );
+        endpoint.set_sensitive(provider.active() == Some(2));
+        let key = gtk::PasswordEntry::new();
+        key.set_placeholder_text(Some(
+            if profile
+                .as_ref()
+                .and_then(|profile| profile.verified_at)
+                .is_some()
+            {
+                "API key (leave blank to keep)"
+            } else {
+                "API key"
+            },
+        ));
+        key.set_show_peek_icon(true);
+        let allow_dev = gtk::Switch::builder()
+            .active(!self.state.borrow().config.require_production_os)
+            .build();
+        let dev_row = adw::ActionRow::builder()
+            .title("Allow development OS")
+            .subtitle(
+                "Weakens the production attestation policy and is shown in yellow while running.",
+            )
+            .build();
+        dev_row.add_suffix(&allow_dev);
+        dev_row.set_activatable_widget(Some(&allow_dev));
+        body.append(&name);
+        body.append(&provider);
+        body.append(&endpoint);
+        body.append(&key);
+        let verify = gtk::Button::with_label("Verify and Save");
+        verify.add_css_class("suggested-action");
+        verify.set_halign(Align::End);
+        body.append(&verify);
+        if profile
+            .as_ref()
+            .and_then(|profile| profile.verified_at)
+            .is_some()
+        {
+            body.append(
+                &gtk::Label::builder()
+                    .label("✓ Verified configuration")
+                    .css_classes(["success"])
+                    .halign(Align::Start)
+                    .build(),
+            );
+        }
+        body.append(&dev_row);
+        dialog.content_area().append(&body);
+        dialog.add_button("Cancel", gtk::ResponseType::Cancel);
+        let endpoint_change = endpoint.clone();
+        let name_change = name.clone();
+        let is_new = profile.is_none();
+        provider.connect_changed(move |provider| {
+            match provider.active() {
+                Some(0) => {
+                    endpoint_change.set_text("https://inference.phala.com");
+                    if is_new {
+                        name_change.set_text("Phala");
+                    }
+                }
+                Some(1) => {
+                    endpoint_change.set_text("https://tee.redpill.ai");
+                    if is_new {
+                        name_change.set_text("RedPill");
+                    }
+                }
+                _ => {
+                    if is_new {
+                        endpoint_change.set_text("");
+                        name_change.set_text("Custom");
+                    }
+                }
+            }
+            endpoint_change.set_sensitive(provider.active() == Some(2));
+        });
+        let weak = Rc::downgrade(self);
+        let profile_id = profile.as_ref().map(|profile| profile.id.clone());
+        let verify_dialog = dialog.clone();
+        verify.connect_clicked(move |button| {
+            let Some(ui) = weak.upgrade() else { return };
+            button.set_sensitive(false);
+            let input = ConfidentialProfileInput {
+                id: profile_id
+                    .clone()
+                    .unwrap_or_else(|| format!("profile-{}", unix_now())),
+                name: name.text().to_string(),
+                provider: match provider.active() {
+                    Some(0) => ServiceProvider::Phala,
+                    Some(2) => ServiceProvider::Custom,
+                    _ => ServiceProvider::Redpill,
+                },
+                remote_url: endpoint.text().to_string(),
+            };
+            let params = json!({
+                "profile": input,
+                "requireProductionOs": !allow_dev.is_active(),
+                "key": (!key.text().is_empty()).then(|| key.text().to_string())
+            });
+            let dialog = verify_dialog.clone();
+            let button = button.clone();
+            ui.request::<GatewayState, _, _>("verifyConfiguration", params, move |ui, result| {
+                button.set_sensitive(true);
+                match result {
+                    Ok(state) => {
+                        ui.accept_state(state);
+                        dialog.close();
+                    }
+                    Err(error) => ui.error(&error),
+                }
+            });
+        });
+        dialog.connect_response(|dialog, _| dialog.close());
+        dialog.present();
+    }
+
+    pub(super) fn confirm_delete_profile(self: &Rc<Self>, profile: ConfidentialProfile) {
+        let weak = Rc::downgrade(self);
+        confirm(
+            &self.window(),
+            "Delete profile?",
+            "The profile credential will be removed from the system credential store.",
+            "Delete",
+            move || {
+                if let Some(ui) = weak.upgrade() {
+                    ui.request::<GatewayState, _, _>(
+                        "deleteProfile",
+                        json!({ "profileId": profile.id }),
+                        |ui, result| match result {
+                            Ok(state) => ui.accept_state(state),
+                            Err(error) => ui.error(&error),
+                        },
+                    );
+                }
+            },
+        );
+    }
+    pub(super) fn show_local_api(self: &Rc<Self>) {
+        let config = self.state.borrow().local_api.clone();
+        let dialog = dialog(&self.window(), "Local API Settings", 580, 440);
+        let body = vbox(12);
+        let address = gtk::Entry::new();
+        address.set_text(&config.listen_address);
+        let network = gtk::Switch::builder()
+            .active(config.allow_network_access)
+            .build();
+        let network_row = adw::ActionRow::builder()
+            .title("Allow network access")
+            .subtitle("Exposes the Local API beyond this computer.")
+            .build();
+        network_row.add_suffix(&network);
+        let port = gtk::SpinButton::with_range(1024.0, 65535.0, 1.0);
+        port.set_value(config.port as f64);
+        let host = gtk::Entry::new();
+        host.set_text(config.client_host.as_deref().unwrap_or(""));
+        body.append(&labeled("Listen address", &address));
+        body.append(&network_row);
+        body.append(&labeled("Port", &port));
+        body.append(&labeled("Client host", &host));
+        dialog.content_area().append(&body);
+        dialog.add_button("Cancel", gtk::ResponseType::Cancel);
+        dialog.add_button("Save", gtk::ResponseType::Accept);
+        let weak = Rc::downgrade(self);
+        dialog.connect_response(move |dialog, response| {
+            if response != gtk::ResponseType::Accept {
+                dialog.close();
+                return;
+            }
+            let Some(ui) = weak.upgrade() else {
+                dialog.close();
+                return;
+            };
+            let config = LocalApiConfig {
+                listen_address: address.text().to_string(),
+                allow_network_access: network.is_active(),
+                port: port.value_as_int() as u16,
+                client_host: (!host.text().is_empty()).then(|| host.text().to_string()),
+            };
+            let dialog = dialog.clone();
+            ui.request::<GatewayState, _, _>(
+                "saveLocalApiConfig",
+                json!({ "config": config }),
+                move |ui, result| match result {
+                    Ok(state) => {
+                        ui.accept_state(state);
+                        dialog.close();
+                    }
+                    Err(error) => ui.error(&error),
+                },
+            );
+        });
+        dialog.present();
+    }
+
+    pub(super) fn show_proof(self: &Rc<Self>, item: RequestActivity) {
+        let dialog = dialog(&self.window(), proof_verdict(&item), 700, 620);
+        let body = vbox(9);
+        let state = self.state.borrow();
+        for (label, value) in [
+            ("Request", item.id.clone()),
+            (
+                "Agent",
+                item.agent.clone().unwrap_or_else(|| "Unknown".into()),
+            ),
+            (
+                "Model",
+                item.model.clone().unwrap_or_else(|| "Not reported".into()),
+            ),
+            ("Path", format!("{} {}", item.method, item.path)),
+            ("Status", item.status.to_string()),
+            (
+                "Receipt",
+                item.receipt_id
+                    .clone()
+                    .unwrap_or_else(|| "No receipt".into()),
+            ),
+            (
+                "Policy",
+                if item.locally_constrained == Some(true) {
+                    "Applied before forwarding".into()
+                } else {
+                    "Not reported".into()
+                },
+            ),
+            (
+                "Rewrite",
+                if item.rewritten == Some(true) {
+                    "Service rewrote the request".into()
+                } else {
+                    "No rewrite reported".into()
+                },
+            ),
+            (
+                "Delivery",
+                if item.left_device {
+                    "Request may have left this computer".into()
+                } else {
+                    "Blocked locally before delivery".into()
+                },
+            ),
+            (
+                "Input tokens",
+                item.input_tokens
+                    .map(format_number)
+                    .unwrap_or_else(|| "Not reported".into()),
+            ),
+            (
+                "Output tokens",
+                item.output_tokens
+                    .map(format_number)
+                    .unwrap_or_else(|| "Not reported".into()),
+            ),
+            (
+                "Cost",
+                item.cost_usd
+                    .map(|cost| format!("${cost:.4}"))
+                    .unwrap_or_else(|| "Not reported".into()),
+            ),
+            (
+                "Gateway keyset",
+                state
+                    .identity
+                    .as_ref()
+                    .map(|identity| identity.keyset_digest.clone())
+                    .unwrap_or_else(|| "Not available".into()),
+            ),
+            (
+                "Detail",
+                if item.detail.is_empty() {
+                    "No additional detail".into()
+                } else {
+                    item.detail.clone()
+                },
+            ),
+        ] {
+            body.append(&detail_row(label, &value));
+        }
+        dialog.content_area().append(&scrolled(&body));
+        dialog.add_button("Done", gtk::ResponseType::Close);
+        dialog.connect_response(|dialog, _| dialog.close());
+        dialog.present();
+    }
+    pub(super) fn show_privacy(self: &Rc<Self>) {
+        let state = self.state.borrow();
+        let dialog = dialog(&self.window(), "Privacy Verification", 740, 660);
+        let body = vbox(14);
+        body.append(&wrapped("The gateway verifies the workload identity and model catalog before forwarding requests. Each response receipt binds the request, verified upstream session, and returned response."));
+        if let Some(identity) = &state.identity {
+            body.append(&section_title("Workload identity"));
+            for (label, value) in [
+                ("TEE", identity.tee_type.as_str()),
+                ("Trust level", identity.trust_level.as_str()),
+                ("Keyset digest", identity.keyset_digest.as_str()),
+                ("Serving mode", identity.serving.as_str()),
+                (
+                    "TLS SPKI",
+                    identity.tls_spki.as_deref().unwrap_or("Not published"),
+                ),
+            ] {
+                body.append(&detail_row(label, value));
+            }
+            body.append(&section_title("Source provenance"));
+            for (label, value) in [
+                (
+                    "Repository",
+                    identity
+                        .source
+                        .repo_url
+                        .as_deref()
+                        .unwrap_or("Not published"),
+                ),
+                (
+                    "Commit",
+                    identity
+                        .source
+                        .repo_commit
+                        .as_deref()
+                        .unwrap_or("Not published"),
+                ),
+                (
+                    "Image digest",
+                    identity
+                        .source
+                        .image_digest
+                        .as_deref()
+                        .unwrap_or("Not published"),
+                ),
+            ] {
+                body.append(&detail_row(label, value));
+            }
+        }
+        body.append(&section_title("Verification checks"));
+        for check in &state.checks {
+            let row = hbox(10);
+            row.append(&gtk::Image::from_icon_name(if check.status == "pass" {
+                "emblem-ok-symbolic"
+            } else if check.status == "fail" {
+                "dialog-error-symbolic"
+            } else {
+                "dialog-information-symbolic"
+            }));
+            let text = vbox(2);
+            text.append(
+                &gtk::Label::builder()
+                    .label(&check.title)
+                    .halign(Align::Start)
+                    .build(),
+            );
+            text.append(
+                &gtk::Label::builder()
+                    .label(&check.detail)
+                    .css_classes(["dim-label", "caption"])
+                    .halign(Align::Start)
+                    .wrap(true)
+                    .build(),
+            );
+            row.append(&text);
+            body.append(&row);
+        }
+        dialog.content_area().append(&scrolled(&body));
+        dialog.add_button("Done", gtk::ResponseType::Close);
+        dialog.connect_response(|dialog, _| dialog.close());
+        dialog.present();
+    }
+    pub(super) fn confirm_clear_usage(self: &Rc<Self>) {
+        let weak = Rc::downgrade(self);
+        confirm(&self.window(), "Clear all usage history?", "This permanently deletes the local usage database. It does not affect provider records.", "Clear History", move || if let Some(ui) = weak.upgrade() { ui.request::<u64, _, _>("clearUsage", json!({}), |ui, result| match result { Ok(_) => ui.reload_usage(true), Err(error) => ui.error(&error) }); });
+    }
+    pub(super) fn confirm_restore(self: &Rc<Self>) {
+        let weak = Rc::downgrade(self);
+        confirm(&self.window(), "Restore all agent configurations?", "Private AI Gateway will revoke every managed agent token and restore its previous configuration where possible.", "Restore All", move || if let Some(ui) = weak.upgrade() { ui.request::<Vec<AgentStatus>, _, _>("disconnectAllAgents", json!({}), |ui, result| match result { Ok(agents) => { *ui.agents.borrow_mut() = agents; ui.render(); }, Err(error) => ui.error(&error) }); });
+    }
+    pub(super) fn rotate_client_key(self: &Rc<Self>) {
+        self.request::<String, _, _>("rotateClientKey", json!({}), |ui, result| match result {
+            Ok(key) => {
+                *ui.client_key.borrow_mut() = key;
+                ui.toast.add_toast(adw::Toast::new("Client key rotated"));
+                ui.render();
+            }
+            Err(error) => ui.error(&error),
+        });
+    }
+    pub(super) fn export_usage(self: &Rc<Self>) {
+        let chooser = gtk::FileChooserNative::builder()
+            .title("Export Usage CSV")
+            .transient_for(&self.window())
+            .action(gtk::FileChooserAction::Save)
+            .accept_label("Export")
+            .cancel_label("Cancel")
+            .build();
+        chooser.set_current_name("private-ai-gateway-usage.csv");
+        let weak = Rc::downgrade(self);
+        chooser.connect_response(move |chooser, response| {
+            if response == gtk::ResponseType::Accept {
+                if let (Some(ui), Some(path)) =
+                    (weak.upgrade(), chooser.file().and_then(|file| file.path()))
+                {
+                    let now = unix_now();
+                    let since = match ui.usage_range.get() {
+                        0 => Some(now.saturating_sub(7 * 86_400)),
+                        1 => Some(now.saturating_sub(30 * 86_400)),
+                        _ => None,
+                    };
+                    let query = UsageQuery {
+                        agent: ui.usage_agent.borrow().clone(),
+                        model: ui.usage_model.borrow().clone(),
+                        session_id: None,
+                        since,
+                        until: None,
+                        cursor: None,
+                        limit: None,
+                    };
+                    ui.request::<usize, _, _>(
+                        "exportUsageCsv",
+                        json!({ "query": query, "path": path }),
+                        |ui, result| match result {
+                            Ok(count) => ui
+                                .toast
+                                .add_toast(adw::Toast::new(&format!("Exported {count} records"))),
+                            Err(error) => ui.error(&error),
+                        },
+                    );
+                }
+            }
+            chooser.destroy();
+        });
+        chooser.show();
+    }
+}
+fn dialog(parent: &adw::ApplicationWindow, title: &str, width: i32, height: i32) -> gtk::Dialog {
+    gtk::Dialog::builder()
+        .transient_for(parent)
+        .modal(true)
+        .title(title)
+        .default_width(width)
+        .default_height(height)
+        .use_header_bar(1)
+        .build()
+}
+fn confirm(
+    parent: &adw::ApplicationWindow,
+    title: &str,
+    message: &str,
+    action: &str,
+    accept: impl Fn() + 'static,
+) {
+    let dialog = gtk::MessageDialog::builder()
+        .transient_for(parent)
+        .modal(true)
+        .message_type(gtk::MessageType::Warning)
+        .buttons(gtk::ButtonsType::None)
+        .text(title)
+        .secondary_text(message)
+        .build();
+    dialog.add_button("Cancel", gtk::ResponseType::Cancel);
+    let button = dialog.add_button(action, gtk::ResponseType::Accept);
+    button.add_css_class("destructive-action");
+    dialog.connect_response(move |dialog, response| {
+        if response == gtk::ResponseType::Accept {
+            accept();
+        }
+        dialog.close();
+    });
+    dialog.present();
+}
+fn selected_profile(
+    list: &gtk::ListBox,
+    profiles: &[ConfidentialProfile],
+) -> Option<ConfidentialProfile> {
+    let index = usize::try_from(list.selected_row()?.index()).ok()?;
+    profiles.get(index).cloned()
+}
+fn proof_verdict(item: &RequestActivity) -> &'static str {
+    if item.verified == Some(true) {
+        "Proof verified"
+    } else if !item.left_device {
+        "Blocked locally"
+    } else if item.verified == Some(false) {
+        "Proof failed"
+    } else {
+        "Proof unavailable"
+    }
+}

--- a/apps/desktop/native/linux/src/app/views.rs
+++ b/apps/desktop/native/linux/src/app/views.rs
@@ -1,0 +1,926 @@
+use super::*;
+
+pub(super) struct UiViews {
+    overview_icon: gtk::Image,
+    overview_title: gtk::Label,
+    overview_detail: gtk::Label,
+    privacy: gtk::Button,
+    endpoint: gtk::Label,
+    endpoint_copy: gtk::Button,
+    client_key: gtk::Label,
+    client_key_reveal: gtk::ToggleButton,
+    overview_agents: StableAgentList,
+    session_metrics: MetricsView,
+    recent: StableUsageList,
+    agents: StableAgentList,
+    usage_agent: gtk::ComboBoxText,
+    usage_model: gtk::ComboBoxText,
+    usage_agents: Vec<String>,
+    usage_models: Vec<String>,
+    usage_metrics: MetricsView,
+    usage_chart: UsageChartView,
+    usage_list: StableUsageList,
+    load_more: gtk::Button,
+    profile: adw::ActionRow,
+    local_api_settings: adw::ActionRow,
+    policy: adw::ActionRow,
+}
+
+struct MetricsView {
+    root: gtk::Box,
+    values: [gtk::Label; 4],
+}
+
+struct UsageChartView {
+    root: gtk::Box,
+    area: gtk::DrawingArea,
+    points: Rc<RefCell<Vec<u64>>>,
+}
+
+struct StableAgentList {
+    root: gtk::Box,
+    rows: HashMap<String, AgentRowView>,
+    limit: Option<usize>,
+}
+
+struct AgentRowView {
+    row: adw::ActionRow,
+    toggle: gtk::Switch,
+    agent: Rc<RefCell<AgentStatus>>,
+    syncing: Rc<Cell<bool>>,
+}
+
+struct StableUsageList {
+    root: gtk::Box,
+    rows: HashMap<String, UsageRowView>,
+    limit: Option<usize>,
+    empty_text: &'static str,
+    empty: Option<gtk::Label>,
+}
+
+struct UsageRowView {
+    row: adw::ActionRow,
+    icon: gtk::Image,
+    tokens: gtk::Label,
+    item: Rc<RefCell<RequestActivity>>,
+}
+
+impl Ui {
+    pub(super) fn render(self: &Rc<Self>) {
+        let state = self.state.borrow();
+        let connected = self.runtime_connected.get();
+        self.syncing.set(true);
+        self.protection.set_active(connected && is_running(&state));
+        self.protection.set_sensitive(connected);
+        self.syncing.set(false);
+        let status = if connected {
+            status_label(&state)
+        } else {
+            "Runtime disconnected"
+        };
+        self.status.set_label(status);
+        self.restart.set_visible(!connected);
+        self.dev
+            .set_visible(connected && is_running(&state) && !state.config.require_production_os);
+        self.show_page();
+        let protected = connected && is_protected(&state);
+        let running = connected && is_running(&state);
+        if let Some(handle) = self.tray.borrow().as_ref() {
+            let label = status.to_string();
+            let open = tray::open_at_login();
+            handle.update(move |tray| {
+                tray.running = running;
+                tray.protected = protected;
+                tray.runtime_connected = connected;
+                tray.status = label;
+                tray.open_at_login = open;
+            });
+        }
+
+        let mut views_ref = self.views.borrow_mut();
+        let Some(views) = views_ref.as_mut() else {
+            return;
+        };
+        views.overview_icon.set_icon_name(Some(if protected {
+            "security-high-symbolic"
+        } else {
+            "security-medium-symbolic"
+        }));
+        views.overview_title.set_label(status);
+        let detail = if connected {
+            state
+                .progress
+                .as_deref()
+                .or(state.error.as_deref())
+                .or_else(|| active_profile(&state).map(|profile| profile.name.as_str()))
+                .unwrap_or("Choose a Confidential AI profile")
+                .to_string()
+        } else {
+            self.runtime_error
+                .borrow()
+                .clone()
+                .unwrap_or_else(|| "Restart the desktop runtime to continue".to_string())
+        };
+        views.overview_detail.set_label(&detail);
+        views
+            .privacy
+            .set_sensitive(connected && state.identity.is_some());
+        views
+            .endpoint
+            .set_label(state.proxy_url.as_deref().unwrap_or("Unavailable"));
+        views
+            .endpoint_copy
+            .set_sensitive(connected && state.proxy_url.is_some());
+        update_client_key(views, &self.client_key.borrow());
+        views.overview_agents.update(self, &self.agents.borrow());
+        views.session_metrics.update(&state.session_usage);
+        views.recent.update(self, &state.activity);
+        views.agents.update(self, &self.agents.borrow());
+
+        let usage = self.usage.borrow();
+        self.syncing.set(true);
+        update_combo(
+            &views.usage_agent,
+            "All agents",
+            &mut views.usage_agents,
+            &usage.agents,
+            self.usage_agent.borrow().as_deref(),
+        );
+        update_combo(
+            &views.usage_model,
+            "All models",
+            &mut views.usage_models,
+            &usage.models,
+            self.usage_model.borrow().as_deref(),
+        );
+        self.syncing.set(false);
+        views.usage_metrics.update(&usage.summary);
+        views.usage_chart.update(&usage.series);
+        views.usage_list.update(self, &usage.items);
+        views.load_more.set_visible(usage.next_cursor.is_some());
+        views.profile.set_subtitle(
+            active_profile(&state)
+                .map(|profile| profile.name.as_str())
+                .unwrap_or("Not configured"),
+        );
+        views.profile.set_sensitive(connected && !running);
+        views
+            .local_api_settings
+            .set_sensitive(connected && !running);
+        views
+            .policy
+            .set_subtitle(if state.config.require_production_os {
+                "Production OS required"
+            } else {
+                "Development OS allowed"
+            });
+    }
+
+    pub(super) fn show_page(&self) {
+        let title = ["Overview", "Agents", "Usage", "Settings"][self.page.get().min(3)];
+        self.title.set_label(title);
+        self.stack.set_visible_child_name(
+            ["overview", "agents", "usage", "settings"][self.page.get().min(3)],
+        );
+    }
+
+    pub(super) fn build_views(self: &Rc<Self>) -> UiViews {
+        let root = page_box();
+        let summary = hbox(18);
+        let icon = gtk::Image::from_icon_name("security-medium-symbolic");
+        icon.set_pixel_size(36);
+        summary.append(&icon);
+        let labels = vbox(4);
+        let overview_title = gtk::Label::builder()
+            .label("Not protected")
+            .css_classes(["title-3"])
+            .halign(Align::Start)
+            .build();
+        let overview_detail = gtk::Label::builder()
+            .label("Choose a Confidential AI profile")
+            .css_classes(["dim-label"])
+            .halign(Align::Start)
+            .wrap(true)
+            .build();
+        labels.append(&overview_title);
+        labels.append(&overview_detail);
+        summary.append(&labels);
+        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
+        spacer.set_hexpand(true);
+        summary.append(&spacer);
+        let profiles = gtk::Button::with_label("Profiles…");
+        let weak = Rc::downgrade(self);
+        profiles.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_profiles();
+            }
+        });
+        summary.append(&profiles);
+        let privacy = gtk::Button::with_label("Privacy Verification…");
+        let weak = Rc::downgrade(self);
+        privacy.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_privacy();
+            }
+        });
+        summary.append(&privacy);
+        root.append(&card(&summary));
+        let columns = hbox(20);
+        columns.set_homogeneous(true);
+        let local = vbox(0);
+        local.append(&section_title("Local API"));
+        let endpoint_copy = gtk::Button::new();
+        endpoint_copy.set_has_frame(false);
+        let endpoint = gtk::Label::builder()
+            .label("Unavailable")
+            .halign(Align::Start)
+            .hexpand(true)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .css_classes(["monospace"])
+            .build();
+        let endpoint_row = hbox(8);
+        endpoint_row.append(&labeled("Endpoint", &endpoint));
+        endpoint_row.append(&gtk::Image::from_icon_name("edit-copy-symbolic"));
+        endpoint_copy.set_child(Some(&endpoint_row));
+        let weak = Rc::downgrade(self);
+        endpoint_copy.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                if let Some(endpoint) = ui.state.borrow().proxy_url.as_deref() {
+                    clipboard(endpoint);
+                }
+            }
+        });
+        local.append(&endpoint_copy);
+        let key_row = hbox(8);
+        let key_copy = gtk::Button::new();
+        key_copy.set_hexpand(true);
+        key_copy.set_has_frame(false);
+        let client_key = gtk::Label::builder()
+            .label("pag_••••••••••••")
+            .halign(Align::Start)
+            .css_classes(["monospace"])
+            .build();
+        key_copy.set_child(Some(&labeled("Client key", &client_key)));
+        let weak = Rc::downgrade(self);
+        key_copy.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                clipboard(&ui.client_key.borrow());
+            }
+        });
+        key_row.append(&key_copy);
+        let client_key_reveal = gtk::ToggleButton::builder()
+            .icon_name("view-reveal-symbolic")
+            .tooltip_text("Reveal client key")
+            .build();
+        let weak = Rc::downgrade(self);
+        let key_label = client_key.clone();
+        client_key_reveal.connect_toggled(move |button| {
+            if let Some(ui) = weak.upgrade() {
+                let key = if button.is_active() {
+                    ui.client_key.borrow().clone()
+                } else {
+                    "pag_••••••••••••".to_string()
+                };
+                key_label.set_label(&key);
+            }
+            button.set_icon_name(if button.is_active() {
+                "view-conceal-symbolic"
+            } else {
+                "view-reveal-symbolic"
+            });
+        });
+        key_row.append(&client_key_reveal);
+        local.append(&key_row);
+        columns.append(&card(&local));
+        let overview_agents = StableAgentList::new(self, Some(5));
+        let agents_card = vbox(0);
+        agents_card.append(&section_title("Agents"));
+        agents_card.append(&overview_agents.root);
+        columns.append(&card(&agents_card));
+        root.append(&columns);
+        let session_metrics = MetricsView::new(Some("This session"));
+        root.append(&session_metrics.root);
+        let recent = StableUsageList::new(self, Some(5), "No usage this session");
+        let recent_card = vbox(0);
+        recent_card.append(&section_title("Recent usage"));
+        recent_card.append(&recent.root);
+        root.append(&card(&recent_card));
+        self.stack.add_named(&scrolled(&root), Some("overview"));
+
+        let agents_root = page_box();
+        let agents = StableAgentList::new(self, None);
+        agents_root.append(&card(&agents.root));
+        self.stack
+            .add_named(&scrolled(&agents_root), Some("agents"));
+
+        let usage_root = page_box();
+        let filters = hbox(10);
+        let usage_agent = self.filter_combo("Agent", "All agents", true);
+        let usage_model = self.filter_combo("Model", "All models", false);
+        filters.append(&usage_agent);
+        filters.append(&usage_model);
+        let range = gtk::ComboBoxText::new();
+        for label in ["7 days", "30 days", "All time"] {
+            range.append_text(label);
+        }
+        range.set_active(Some(self.usage_range.get() as u32));
+        let weak = Rc::downgrade(self);
+        range.connect_changed(move |combo| {
+            if let Some(ui) = weak.upgrade() {
+                if ui.syncing.get() {
+                    return;
+                }
+                ui.usage_range.set(combo.active().unwrap_or(1) as usize);
+                ui.reload_usage(true);
+            }
+        });
+        filters.append(&range);
+        let spacer = gtk::Box::new(Orientation::Horizontal, 0);
+        spacer.set_hexpand(true);
+        filters.append(&spacer);
+        let export = gtk::Button::with_label("Export CSV…");
+        let weak = Rc::downgrade(self);
+        export.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.export_usage();
+            }
+        });
+        filters.append(&export);
+        let clear = gtk::Button::with_label("Clear History…");
+        clear.add_css_class("destructive-action");
+        let weak = Rc::downgrade(self);
+        clear.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.confirm_clear_usage();
+            }
+        });
+        filters.append(&clear);
+        usage_root.append(&filters);
+        let usage_metrics = MetricsView::new(None);
+        usage_root.append(&usage_metrics.root);
+        let usage_chart = UsageChartView::new();
+        usage_root.append(&usage_chart.root);
+        let usage_list = StableUsageList::new(self, None, "No usage matches these filters");
+        let usage_card = vbox(0);
+        usage_card.append(&section_title("Usage history"));
+        usage_card.append(&usage_list.root);
+        usage_root.append(&card(&usage_card));
+        let load_more = gtk::Button::with_label("Load More");
+        load_more.set_halign(Align::Center);
+        let weak = Rc::downgrade(self);
+        load_more.connect_clicked(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.reload_usage(false);
+            }
+        });
+        usage_root.append(&load_more);
+        self.stack.add_named(&scrolled(&usage_root), Some("usage"));
+
+        let settings_root = page_box();
+        let profiles = adw::PreferencesGroup::builder()
+            .title("Confidential AI")
+            .build();
+        let profile = adw::ActionRow::builder()
+            .title("Profile")
+            .subtitle("Not configured")
+            .activatable(true)
+            .build();
+        let weak = Rc::downgrade(self);
+        profile.connect_activated(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_profiles();
+            }
+        });
+        profiles.add(&profile);
+        settings_root.append(&profiles);
+        let local = adw::PreferencesGroup::builder().title("Local API").build();
+        let local_api_settings = adw::ActionRow::builder()
+            .title("Local API Settings")
+            .activatable(true)
+            .build();
+        local_api_settings.add_suffix(&gtk::Image::from_icon_name("go-next-symbolic"));
+        let weak = Rc::downgrade(self);
+        local_api_settings.connect_activated(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_local_api();
+            }
+        });
+        local.add(&local_api_settings);
+        let rotate = adw::ActionRow::builder()
+            .title("Rotate Client Key")
+            .activatable(true)
+            .build();
+        let weak = Rc::downgrade(self);
+        rotate.connect_activated(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.rotate_client_key();
+            }
+        });
+        local.add(&rotate);
+        settings_root.append(&local);
+        let advanced = adw::ExpanderRow::builder().title("Advanced").build();
+        let policy = adw::ActionRow::builder()
+            .title("OS policy")
+            .subtitle("Production OS required")
+            .build();
+        advanced.add_row(&policy);
+        let restore = adw::ActionRow::builder()
+            .title("Restore All Agent Configurations")
+            .activatable(true)
+            .build();
+        restore.add_css_class("error");
+        let weak = Rc::downgrade(self);
+        restore.connect_activated(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.confirm_restore();
+            }
+        });
+        advanced.add_row(&restore);
+        let group = adw::PreferencesGroup::new();
+        group.add(&advanced);
+        settings_root.append(&group);
+        self.stack
+            .add_named(&scrolled(&settings_root), Some("settings"));
+
+        UiViews {
+            overview_icon: icon,
+            overview_title,
+            overview_detail,
+            privacy,
+            endpoint,
+            endpoint_copy,
+            client_key,
+            client_key_reveal,
+            overview_agents,
+            session_metrics,
+            recent,
+            agents,
+            usage_agent,
+            usage_model,
+            usage_agents: Vec::new(),
+            usage_models: Vec::new(),
+            usage_metrics,
+            usage_chart,
+            usage_list,
+            load_more,
+            profile,
+            local_api_settings,
+            policy,
+        }
+    }
+
+    fn filter_combo(self: &Rc<Self>, tooltip: &str, all: &str, agent: bool) -> gtk::ComboBoxText {
+        let combo = gtk::ComboBoxText::new();
+        combo.set_tooltip_text(Some(tooltip));
+        combo.append_text(all);
+        combo.set_active(Some(0));
+        let weak = Rc::downgrade(self);
+        combo.connect_changed(move |combo| {
+            if let Some(ui) = weak.upgrade() {
+                if ui.syncing.get() {
+                    return;
+                }
+                let value = combo
+                    .active_text()
+                    .and_then(|value| (combo.active() != Some(0)).then(|| value.to_string()));
+                if agent {
+                    *ui.usage_agent.borrow_mut() = value;
+                } else {
+                    *ui.usage_model.borrow_mut() = value;
+                }
+                ui.reload_usage(true);
+            }
+        });
+        combo
+    }
+}
+
+impl StableAgentList {
+    fn new(_ui: &Rc<Ui>, limit: Option<usize>) -> Self {
+        Self {
+            root: vbox(0),
+            rows: HashMap::new(),
+            limit,
+        }
+    }
+
+    fn update(&mut self, ui: &Rc<Ui>, agents: &[AgentStatus]) {
+        let agents = agents
+            .iter()
+            .take(self.limit.unwrap_or(usize::MAX))
+            .collect::<Vec<_>>();
+        let ids = agents
+            .iter()
+            .map(|agent| agent.id.as_str())
+            .collect::<HashSet<_>>();
+        let removed = self
+            .rows
+            .keys()
+            .filter(|id| !ids.contains(id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        for id in removed {
+            if let Some(row) = self.rows.remove(&id) {
+                self.root.remove(&row.row);
+            }
+        }
+        let mut previous: Option<gtk::Widget> = None;
+        for agent in agents {
+            if !self.rows.contains_key(&agent.id) {
+                let row = AgentRowView::new(ui, agent.clone());
+                self.root.append(&row.row);
+                self.rows.insert(agent.id.clone(), row);
+            }
+            let row = self.rows.get(&agent.id).expect("agent row was inserted");
+            row.update(agent);
+            let widget: gtk::Widget = row.row.clone().upcast();
+            self.root.reorder_child_after(&widget, previous.as_ref());
+            previous = Some(widget);
+        }
+    }
+}
+
+impl AgentRowView {
+    fn new(ui: &Rc<Ui>, agent: AgentStatus) -> Self {
+        let row = adw::ActionRow::builder().build();
+        row.add_prefix(&asset_picture(&format!("agents/{}.svg", agent.id), 28));
+        let toggle = gtk::Switch::builder().valign(Align::Center).build();
+        let current = Rc::new(RefCell::new(agent));
+        let syncing = Rc::new(Cell::new(false));
+        let weak = Rc::downgrade(ui);
+        let callback_agent = current.clone();
+        let callback_syncing = syncing.clone();
+        toggle.connect_active_notify(move |toggle| {
+            if callback_syncing.get() {
+                return;
+            }
+            let agent = callback_agent.borrow().clone();
+            if toggle.is_active() != agent.connected {
+                if let Some(ui) = weak.upgrade() {
+                    ui.set_agent(agent, toggle.is_active());
+                }
+            }
+        });
+        row.add_suffix(&toggle);
+        row.set_activatable_widget(Some(&toggle));
+        Self {
+            row,
+            toggle,
+            agent: current,
+            syncing,
+        }
+    }
+
+    fn update(&self, agent: &AgentStatus) {
+        self.row.set_title(&agent.name);
+        self.row.set_subtitle(
+            agent
+                .error
+                .as_deref()
+                .or(agent.attention.as_deref())
+                .unwrap_or(if agent.installed {
+                    &agent.config_path
+                } else {
+                    "CLI not found"
+                }),
+        );
+        self.syncing.set(true);
+        self.toggle.set_active(agent.connected);
+        self.toggle.set_sensitive(agent.installed || agent.recorded);
+        self.syncing.set(false);
+        *self.agent.borrow_mut() = agent.clone();
+    }
+}
+
+impl StableUsageList {
+    fn new(_ui: &Rc<Ui>, limit: Option<usize>, empty_text: &'static str) -> Self {
+        Self {
+            root: vbox(0),
+            rows: HashMap::new(),
+            limit,
+            empty_text,
+            empty: None,
+        }
+    }
+
+    fn update(&mut self, ui: &Rc<Ui>, items: &[RequestActivity]) {
+        let items = items
+            .iter()
+            .take(self.limit.unwrap_or(usize::MAX))
+            .collect::<Vec<_>>();
+        let ids = items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<HashSet<_>>();
+        let removed = self
+            .rows
+            .keys()
+            .filter(|id| !ids.contains(id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        for id in removed {
+            if let Some(row) = self.rows.remove(&id) {
+                self.root.remove(&row.row);
+            }
+        }
+        if items.is_empty() {
+            if self.empty.is_none() {
+                let label = empty(self.empty_text);
+                self.root.append(&label);
+                self.empty = Some(label);
+            }
+            return;
+        }
+        if let Some(label) = self.empty.take() {
+            self.root.remove(&label);
+        }
+        let mut previous: Option<gtk::Widget> = None;
+        for item in items {
+            if !self.rows.contains_key(&item.id) {
+                let row = UsageRowView::new(ui, item.clone());
+                self.root.append(&row.row);
+                self.rows.insert(item.id.clone(), row);
+            }
+            let row = self.rows.get(&item.id).expect("usage row was inserted");
+            row.update(item);
+            let widget: gtk::Widget = row.row.clone().upcast();
+            self.root.reorder_child_after(&widget, previous.as_ref());
+            previous = Some(widget);
+        }
+    }
+}
+
+impl UsageRowView {
+    fn new(ui: &Rc<Ui>, item: RequestActivity) -> Self {
+        let row = adw::ActionRow::builder().activatable(true).build();
+        let icon = gtk::Image::new();
+        row.add_prefix(&icon);
+        let tokens = gtk::Label::builder()
+            .css_classes(["dim-label", "monospace"])
+            .build();
+        row.add_suffix(&tokens);
+        row.add_suffix(&gtk::Image::from_icon_name("go-next-symbolic"));
+        let current = Rc::new(RefCell::new(item));
+        let weak = Rc::downgrade(ui);
+        let selected = current.clone();
+        row.connect_activated(move |_| {
+            if let Some(ui) = weak.upgrade() {
+                ui.show_proof(selected.borrow().clone());
+            }
+        });
+        Self {
+            row,
+            icon,
+            tokens,
+            item: current,
+        }
+    }
+
+    fn update(&self, item: &RequestActivity) {
+        self.row
+            .set_title(item.model.as_deref().unwrap_or(&item.path));
+        self.row.set_subtitle(&format!(
+            "{} · {}",
+            item.agent.as_deref().unwrap_or("Unknown"),
+            item.path
+        ));
+        self.icon
+            .set_icon_name(Some(if item.verified == Some(true) {
+                "security-high-symbolic"
+            } else if item.left_device {
+                "dialog-warning-symbolic"
+            } else {
+                "action-unavailable-symbolic"
+            }));
+        self.tokens.set_label(&format_number(
+            item.input_tokens.unwrap_or(0) + item.output_tokens.unwrap_or(0),
+        ));
+        *self.item.borrow_mut() = item.clone();
+    }
+}
+
+impl MetricsView {
+    fn new(title: Option<&str>) -> Self {
+        let root = vbox(10);
+        if let Some(title) = title {
+            root.append(&section_title(title));
+        }
+        let grid = gtk::Grid::builder()
+            .column_spacing(28)
+            .column_homogeneous(true)
+            .build();
+        let values = std::array::from_fn(|index| {
+            let value = gtk::Label::builder()
+                .label("0")
+                .css_classes(["title-3", "monospace"])
+                .halign(Align::Start)
+                .build();
+            grid.attach(
+                &labeled(["Requests", "Tokens", "Cost", "Protected"][index], &value),
+                index as i32,
+                0,
+                1,
+                1,
+            );
+            value
+        });
+        root.append(&grid);
+        Self {
+            root: card(&root),
+            values,
+        }
+    }
+
+    fn update(&self, summary: &UsageSummary) {
+        self.values[0].set_label(&format_number(summary.requests));
+        self.values[1].set_label(&format_number(summary.input_tokens + summary.output_tokens));
+        self.values[2].set_label(&format!("${:.4}", summary.cost_usd));
+        self.values[3].set_label(&if summary.requests == 0 {
+            "—".to_string()
+        } else {
+            format!("{}%", summary.protected * 100 / summary.requests)
+        });
+    }
+}
+
+impl UsageChartView {
+    fn new() -> Self {
+        let area = gtk::DrawingArea::builder()
+            .content_height(170)
+            .hexpand(true)
+            .build();
+        let points = Rc::new(RefCell::new(Vec::<u64>::new()));
+        let draw_points = points.clone();
+        area.set_draw_func(move |_, cr, width, height| {
+            let points = draw_points.borrow();
+            let max = points.iter().copied().max().unwrap_or(1).max(1) as f64;
+            let gap = 3.0;
+            let bar = (width as f64 / points.len().max(1) as f64 - gap).max(2.0);
+            cr.set_source_rgb(0.17, 0.43, 0.29);
+            for (index, value) in points.iter().enumerate() {
+                let h = (*value as f64 / max * (height as f64 - 16.0)).max(2.0);
+                cr.rectangle(index as f64 * (bar + gap), height as f64 - h, bar, h);
+                let _ = cr.fill();
+            }
+        });
+        Self {
+            root: card(&area),
+            area,
+            points,
+        }
+    }
+
+    fn update(&self, points: &[desktop_runtime::usage::UsagePoint]) {
+        *self.points.borrow_mut() = points.iter().map(|point| point.tokens).collect();
+        self.area.queue_draw();
+    }
+}
+
+fn update_combo(
+    combo: &gtk::ComboBoxText,
+    all: &str,
+    current_values: &mut Vec<String>,
+    values: &[String],
+    selected: Option<&str>,
+) {
+    if current_values != values {
+        combo.remove_all();
+        combo.append_text(all);
+        for value in values {
+            combo.append_text(value);
+        }
+        *current_values = values.to_vec();
+    }
+    combo.set_active(Some(
+        selected
+            .and_then(|selected| values.iter().position(|value| value == selected))
+            .map_or(0, |index| index + 1) as u32,
+    ));
+}
+
+fn update_client_key(views: &UiViews, key: &str) {
+    views
+        .client_key
+        .set_label(if views.client_key_reveal.is_active() {
+            key
+        } else {
+            "pag_••••••••••••"
+        });
+}
+
+pub(super) fn page_box() -> gtk::Box {
+    let root = vbox(24);
+    root.set_margin_start(28);
+    root.set_margin_end(28);
+    root.set_margin_top(28);
+    root.set_margin_bottom(28);
+    root
+}
+pub(super) fn vbox(spacing: i32) -> gtk::Box {
+    gtk::Box::new(Orientation::Vertical, spacing)
+}
+pub(super) fn hbox(spacing: i32) -> gtk::Box {
+    gtk::Box::new(Orientation::Horizontal, spacing)
+}
+pub(super) fn card(child: &impl IsA<gtk::Widget>) -> gtk::Box {
+    let card = vbox(0);
+    card.add_css_class("card");
+    card.append(child);
+    card
+}
+pub(super) fn section_title(title: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .label(title)
+        .css_classes(["heading"])
+        .halign(Align::Start)
+        .margin_bottom(8)
+        .build()
+}
+pub(super) fn wrapped(text: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .label(text)
+        .wrap(true)
+        .halign(Align::Start)
+        .xalign(0.0)
+        .build()
+}
+pub(super) fn empty(text: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .label(text)
+        .css_classes(["dim-label"])
+        .margin_top(24)
+        .margin_bottom(24)
+        .build()
+}
+pub(super) fn scrolled(child: &impl IsA<gtk::Widget>) -> gtk::ScrolledWindow {
+    gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .child(child)
+        .build()
+}
+pub(super) fn labeled(label: &str, widget: &impl IsA<gtk::Widget>) -> gtk::Box {
+    let box_ = vbox(3);
+    box_.append(
+        &gtk::Label::builder()
+            .label(label)
+            .css_classes(["dim-label", "caption"])
+            .halign(Align::Start)
+            .build(),
+    );
+    box_.append(widget);
+    box_
+}
+pub(super) fn detail_row(label: &str, value: &str) -> gtk::Grid {
+    let grid = gtk::Grid::builder()
+        .column_spacing(18)
+        .row_spacing(4)
+        .build();
+    let name = gtk::Label::builder()
+        .label(label)
+        .css_classes(["dim-label"])
+        .halign(Align::End)
+        .build();
+    let value = gtk::Label::builder()
+        .label(value)
+        .selectable(true)
+        .wrap(true)
+        .halign(Align::Start)
+        .xalign(0.0)
+        .hexpand(true)
+        .build();
+    grid.attach(&name, 0, 0, 1, 1);
+    grid.attach(&value, 1, 0, 1, 1);
+    grid
+}
+pub(super) fn clipboard(value: &str) {
+    if let Some(display) = gdk::Display::default() {
+        display.clipboard().set_text(value);
+    }
+}
+pub(super) fn asset_picture(relative: &str, size: i32) -> gtk::Picture {
+    let path = std::env::var_os("PRIVATE_AI_GATEWAY_ASSETS")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|path| path.parent().map(|parent| parent.join("Assets")))
+        })
+        .unwrap_or_default()
+        .join(relative);
+    let picture = gtk::Picture::for_filename(path);
+    picture.set_content_fit(gtk::ContentFit::Contain);
+    picture.set_size_request(size, size);
+    picture
+}
+pub(super) fn format_number(value: u64) -> String {
+    let text = value.to_string();
+    let mut result = String::new();
+    for (index, character) in text.chars().rev().enumerate() {
+        if index > 0 && index % 3 == 0 {
+            result.push(',');
+        }
+        result.push(character);
+    }
+    result.chars().rev().collect()
+}

--- a/apps/desktop/native/linux/src/main.rs
+++ b/apps/desktop/native/linux/src/main.rs
@@ -3,5 +3,5 @@ mod runtime_client;
 mod tray;
 
 fn main() {
-    app::run();
+    std::process::exit(app::run());
 }

--- a/apps/desktop/native/linux/src/runtime_client.rs
+++ b/apps/desktop/native/linux/src/runtime_client.rs
@@ -1,15 +1,19 @@
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::HashMap,
-    io::{BufRead, BufReader, Write},
-    path::PathBuf,
+    io::{Read, Write},
+    os::fd::AsRawFd,
+    os::unix::process::CommandExt,
+    path::{Path, PathBuf},
     process::{Child, ChildStdin, Command, Stdio},
     rc::Rc,
     sync::{
-        atomic::{AtomicU64, Ordering},
-        mpsc, Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError},
+        Arc,
     },
-    thread,
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
 };
 
 use desktop_runtime::contracts::GatewayState;
@@ -18,21 +22,64 @@ use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 
 const MAX_MESSAGE_BYTES: usize = 1024 * 1024;
+const OUTBOUND_CAPACITY: usize = 64;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(75);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 type Callback = Box<dyn FnOnce(Result<Value, String>)>;
 
+struct PendingRequest {
+    deadline: Instant,
+    callback: Callback,
+}
+
+enum Outbound {
+    Message(Vec<u8>),
+    Stop,
+}
+
+enum Incoming {
+    Message(Value),
+    Disconnected(String),
+}
+
 pub struct RuntimeClient {
-    input: Arc<Mutex<ChildStdin>>,
+    outbound: RefCell<Option<SyncSender<Outbound>>>,
+    incoming: Receiver<Incoming>,
     child: RefCell<Option<Child>>,
-    pending: Rc<RefCell<HashMap<String, Callback>>>,
+    reader: RefCell<Option<JoinHandle<()>>>,
+    writer: RefCell<Option<JoinHandle<()>>>,
+    pending: RefCell<HashMap<String, PendingRequest>>,
     next_id: AtomicU64,
-    on_state: Rc<RefCell<Option<Box<dyn Fn(GatewayState)>>>>,
-    on_error: Rc<RefCell<Option<Box<dyn Fn(String)>>>>,
+    connected: Cell<bool>,
+    shutting_down: Cell<bool>,
+    request_timeout: Duration,
+    shutdown_timeout: Duration,
+    stop_threads: Arc<AtomicBool>,
+    on_state: RefCell<Option<Box<dyn Fn(GatewayState)>>>,
+    on_disconnect: RefCell<Option<Box<dyn Fn(String)>>>,
 }
 
 impl RuntimeClient {
     pub fn start() -> Result<Rc<Self>, String> {
-        let service = runtime_path()?;
-        let mut child = Command::new(&service)
+        Self::start_path(&runtime_path()?, REQUEST_TIMEOUT, SHUTDOWN_TIMEOUT)
+    }
+
+    fn start_path(
+        path: &Path,
+        request_timeout: Duration,
+        shutdown_timeout: Duration,
+    ) -> Result<Rc<Self>, String> {
+        Self::start_command(&mut Command::new(path), request_timeout, shutdown_timeout)
+    }
+
+    fn start_command(
+        command: &mut Command,
+        request_timeout: Duration,
+        shutdown_timeout: Duration,
+    ) -> Result<Rc<Self>, String> {
+        let mut child = command
+            .process_group(0)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -42,28 +89,50 @@ impl RuntimeClient {
             .stdin
             .take()
             .ok_or_else(|| "Cannot write to the desktop runtime".to_string())?;
-        let output = child
-            .stdout
-            .take()
-            .ok_or_else(|| "Cannot read from the desktop runtime".to_string())?;
-        let (sender, receiver) = mpsc::channel::<Result<Value, String>>();
-        thread::spawn(move || read_messages(output, sender));
+        if let Err(error) = set_nonblocking(&input) {
+            force_stop_group(&mut child);
+            return Err(error);
+        }
+        let Some(output) = child.stdout.take() else {
+            force_stop_group(&mut child);
+            return Err("Cannot read from the desktop runtime".to_string());
+        };
+        if let Err(error) = set_nonblocking(&output) {
+            force_stop_group(&mut child);
+            return Err(error);
+        }
+
+        let (outbound, outbound_rx) = mpsc::sync_channel(OUTBOUND_CAPACITY);
+        let (incoming_tx, incoming) = mpsc::channel();
+        let stop_threads = Arc::new(AtomicBool::new(false));
+        let writer_events = incoming_tx.clone();
+        let writer_stop = stop_threads.clone();
+        let reader_stop = stop_threads.clone();
+        let writer =
+            thread::spawn(move || write_messages(input, outbound_rx, writer_events, writer_stop));
+        let reader = thread::spawn(move || read_messages(output, incoming_tx, reader_stop));
         let client = Rc::new(Self {
-            input: Arc::new(Mutex::new(input)),
+            outbound: RefCell::new(Some(outbound)),
+            incoming,
             child: RefCell::new(Some(child)),
-            pending: Rc::new(RefCell::new(HashMap::new())),
+            reader: RefCell::new(Some(reader)),
+            writer: RefCell::new(Some(writer)),
+            pending: RefCell::new(HashMap::new()),
             next_id: AtomicU64::new(1),
-            on_state: Rc::new(RefCell::new(None)),
-            on_error: Rc::new(RefCell::new(None)),
+            connected: Cell::new(true),
+            shutting_down: Cell::new(false),
+            request_timeout,
+            shutdown_timeout,
+            stop_threads,
+            on_state: RefCell::new(None),
+            on_disconnect: RefCell::new(None),
         });
         let weak = Rc::downgrade(&client);
-        glib::timeout_add_local(std::time::Duration::from_millis(30), move || {
+        glib::timeout_add_local(Duration::from_millis(30), move || {
             let Some(client) = weak.upgrade() else {
                 return glib::ControlFlow::Break;
             };
-            for message in receiver.try_iter() {
-                client.handle(message);
-            }
+            client.poll();
             glib::ControlFlow::Continue
         });
         Ok(client)
@@ -73,8 +142,8 @@ impl RuntimeClient {
         *self.on_state.borrow_mut() = Some(Box::new(callback));
     }
 
-    pub fn on_error(&self, callback: impl Fn(String) + 'static) {
-        *self.on_error.borrow_mut() = Some(Box::new(callback));
+    pub fn on_disconnect(&self, callback: impl Fn(String) + 'static) {
+        *self.on_disconnect.borrow_mut() = Some(Box::new(callback));
     }
 
     pub fn request<T: DeserializeOwned + 'static>(
@@ -83,95 +152,393 @@ impl RuntimeClient {
         params: impl Serialize,
         callback: impl FnOnce(Result<T, String>) + 'static,
     ) {
+        if !self.connected.get() {
+            callback(Err("The desktop runtime is disconnected".to_string()));
+            return;
+        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed).to_string();
-        self.pending.borrow_mut().insert(
-            id.clone(),
-            Box::new(move |result| {
-                callback(result.and_then(|value| {
-                    serde_json::from_value(value)
-                        .map_err(|_| "The desktop runtime returned an invalid response".to_string())
-                }));
-            }),
-        );
         let message = json!({ "schemaVersion": 1, "id": id, "method": method, "params": params });
         let mut bytes = match serde_json::to_vec(&message) {
             Ok(bytes) if bytes.len() <= MAX_MESSAGE_BYTES => bytes,
             _ => {
-                self.fail_request(&id, "Desktop runtime request is too large");
+                callback(Err("Desktop runtime request is too large".to_string()));
                 return;
             }
         };
         bytes.push(b'\n');
+        self.pending.borrow_mut().insert(
+            id.clone(),
+            PendingRequest {
+                deadline: Instant::now() + self.request_timeout,
+                callback: Box::new(move |result| {
+                    callback(result.and_then(|value| {
+                        serde_json::from_value(value).map_err(|_| {
+                            "The desktop runtime returned an invalid response".to_string()
+                        })
+                    }));
+                }),
+            },
+        );
         let result = self
-            .input
-            .lock()
-            .map_err(|_| "The desktop runtime input is unavailable".to_string())
-            .and_then(|mut input| {
-                input
-                    .write_all(&bytes)
-                    .and_then(|()| input.flush())
-                    .map_err(|error| format!("Cannot write to the desktop runtime: {error}"))
+            .outbound
+            .borrow()
+            .as_ref()
+            .ok_or_else(|| "The desktop runtime is disconnected".to_string())
+            .and_then(|sender| {
+                sender
+                    .try_send(Outbound::Message(bytes))
+                    .map_err(|error| match error {
+                        TrySendError::Full(_) => "The desktop runtime is busy".to_string(),
+                        TrySendError::Disconnected(_) => {
+                            "The desktop runtime is disconnected".to_string()
+                        }
+                    })
             });
         if let Err(error) = result {
-            self.fail_request(&id, &error);
+            self.fail_request(&id, error);
         }
     }
 
-    pub fn shutdown(&self) {
-        self.request::<Value>("shutdown", json!({}), |_| {});
+    pub fn is_process_running(&self) -> bool {
+        self.child
+            .borrow()
+            .as_ref()
+            .is_some_and(|child| !child_has_exited(child))
     }
 
-    fn fail_request(&self, id: &str, error: &str) {
-        if let Some(callback) = self.pending.borrow_mut().remove(id) {
+    pub fn shutdown_and_wait(&self) {
+        if self.shutting_down.replace(true) {
+            return;
+        }
+        if self.connected.get() {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed).to_string();
+            if let Ok(mut bytes) = serde_json::to_vec(
+                &json!({ "schemaVersion": 1, "id": id, "method": "shutdown", "params": {} }),
+            ) {
+                bytes.push(b'\n');
+                if let Some(sender) = self.outbound.borrow().as_ref() {
+                    let _ = sender.try_send(Outbound::Message(bytes));
+                }
+            }
+        }
+
+        let deadline = Instant::now() + self.shutdown_timeout;
+        let mut child = self.child.borrow_mut().take();
+        while Instant::now() < deadline {
+            let exited = child.as_ref().is_none_or(child_has_exited);
+            if exited {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        if let Some(child) = child.as_mut() {
+            kill_process_group(child, libc::SIGKILL);
+            let _ = child.wait();
+        }
+        if let Some(sender) = self.outbound.borrow_mut().take() {
+            let _ = sender.try_send(Outbound::Stop);
+            drop(sender);
+        }
+        self.stop_threads.store(true, Ordering::Release);
+        join_thread(&self.writer);
+        join_thread(&self.reader);
+        self.connected.set(false);
+        self.fail_all("The desktop runtime stopped");
+    }
+
+    fn poll(&self) {
+        for incoming in self.incoming.try_iter() {
+            match incoming {
+                Incoming::Message(message) if self.connected.get() => self.handle(message),
+                Incoming::Message(_) => {}
+                Incoming::Disconnected(error) => self.disconnect(error),
+            }
+        }
+        let exited = self.child.borrow().as_ref().is_some_and(child_has_exited);
+        if self.connected.get() && exited {
+            self.disconnect("The desktop runtime exited unexpectedly".to_string());
+        }
+        let now = Instant::now();
+        let expired = self
+            .pending
+            .borrow()
+            .iter()
+            .filter_map(|(id, request)| (request.deadline <= now).then(|| id.clone()))
+            .collect::<Vec<_>>();
+        if !expired.is_empty() {
+            self.disconnect("The desktop runtime request timed out".to_string());
+        }
+    }
+
+    fn fail_request(&self, id: &str, error: String) {
+        let request = self.pending.borrow_mut().remove(id);
+        if let Some(request) = request {
+            (request.callback)(Err(error));
+        }
+    }
+
+    fn fail_all(&self, error: &str) {
+        let callbacks = self
+            .pending
+            .borrow_mut()
+            .drain()
+            .map(|(_, request)| request.callback)
+            .collect::<Vec<_>>();
+        for callback in callbacks {
             callback(Err(error.to_string()));
         }
     }
 
-    fn handle(&self, incoming: Result<Value, String>) {
-        let message = match incoming {
-            Ok(message) => message,
-            Err(error) => {
-                if let Some(callback) = self.on_error.borrow().as_ref() {
-                    callback(error);
-                }
+    fn disconnect(&self, error: String) {
+        if !self.connected.replace(false) {
+            return;
+        }
+        self.stop_threads.store(true, Ordering::Release);
+        self.outbound.borrow_mut().take();
+        if let Some(mut child) = self.child.borrow_mut().take() {
+            force_stop_group(&mut child);
+        }
+        join_thread(&self.writer);
+        join_thread(&self.reader);
+        self.fail_all(&error);
+        if !self.shutting_down.get() {
+            if let Some(callback) = self.on_disconnect.borrow().as_ref() {
+                callback(error);
+            }
+        }
+    }
+
+    fn handle(&self, message: Value) {
+        let Some(object) = message.as_object() else {
+            self.disconnect("The desktop runtime returned an invalid message".to_string());
+            return;
+        };
+        if object.get("schemaVersion").and_then(Value::as_u64) != Some(1) {
+            self.disconnect("The desktop runtime uses an unsupported protocol version".to_string());
+            return;
+        }
+        if object.contains_key("event") {
+            if !has_exact_keys(object, &["schemaVersion", "event", "payload"])
+                || object.get("event").and_then(Value::as_str) != Some("stateChanged")
+            {
+                self.disconnect("The desktop runtime returned an invalid event".to_string());
                 return;
             }
-        };
-        if message.get("event").and_then(Value::as_str) == Some("stateChanged") {
-            if let Ok(state) = serde_json::from_value::<GatewayState>(
-                message.get("payload").cloned().unwrap_or(Value::Null),
+            match serde_json::from_value::<GatewayState>(
+                object.get("payload").cloned().unwrap_or(Value::Null),
             ) {
-                if let Some(callback) = self.on_state.borrow().as_ref() {
-                    callback(state);
+                Ok(state) => {
+                    if let Some(callback) = self.on_state.borrow().as_ref() {
+                        callback(state);
+                    }
                 }
+                Err(_) => self
+                    .disconnect("The desktop runtime returned an invalid state event".to_string()),
             }
             return;
         }
-        let Some(id) = message.get("id").and_then(Value::as_str) else {
+        let result = object.get("result");
+        let error = object.get("error");
+        let valid_result = result.is_some()
+            && error.is_none()
+            && has_exact_keys(object, &["schemaVersion", "id", "result"]);
+        let valid_error = error.is_some_and(|error| {
+            error.get("code").and_then(Value::as_str).is_some()
+                && error.get("message").and_then(Value::as_str).is_some()
+        }) && result.is_none()
+            && has_exact_keys(object, &["schemaVersion", "id", "error"]);
+        if valid_result == valid_error {
+            self.disconnect("The desktop runtime returned an invalid response".to_string());
+            return;
+        }
+        let Some(id) = object.get("id").and_then(Value::as_str) else {
+            self.disconnect("The desktop runtime returned an invalid message".to_string());
             return;
         };
-        let Some(callback) = self.pending.borrow_mut().remove(id) else {
+        let request = self.pending.borrow_mut().remove(id);
+        let Some(request) = request else {
             return;
         };
-        if let Some(error) = message.get("error") {
-            callback(Err(error
+        if let Some(error) = error {
+            (request.callback)(Err(error
                 .get("message")
                 .and_then(Value::as_str)
-                .unwrap_or("The operation failed")
+                .expect("validated runtime error message")
                 .to_string()));
         } else {
-            callback(Ok(message.get("result").cloned().unwrap_or(Value::Null)));
+            (request.callback)(Ok(result.cloned().unwrap_or(Value::Null)));
         }
     }
 }
 
+fn has_exact_keys(object: &serde_json::Map<String, Value>, keys: &[&str]) -> bool {
+    object.len() == keys.len() && keys.iter().all(|key| object.contains_key(*key))
+}
+
 impl Drop for RuntimeClient {
     fn drop(&mut self) {
-        if let Some(mut child) = self.child.borrow_mut().take() {
-            let _ = child.kill();
-            let _ = child.wait();
+        self.shutdown_and_wait();
+    }
+}
+
+fn set_nonblocking(handle: &impl AsRawFd) -> Result<(), String> {
+    let fd = handle.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(format!(
+            "Cannot configure desktop runtime input: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
+fn write_messages(
+    mut input: ChildStdin,
+    receiver: Receiver<Outbound>,
+    events: mpsc::Sender<Incoming>,
+    stop: Arc<AtomicBool>,
+) {
+    while !stop.load(Ordering::Acquire) {
+        let outbound = match receiver.recv_timeout(Duration::from_millis(50)) {
+            Ok(outbound) => outbound,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        };
+        match outbound {
+            Outbound::Message(bytes) => {
+                if let Err(error) = write_frame(&mut input, &bytes, &stop) {
+                    if !stop.load(Ordering::Acquire) {
+                        let _ = events.send(Incoming::Disconnected(error));
+                    }
+                    break;
+                }
+            }
+            Outbound::Stop => break,
         }
     }
+}
+
+fn write_frame(input: &mut ChildStdin, bytes: &[u8], stop: &AtomicBool) -> Result<(), String> {
+    let deadline = Instant::now() + WRITE_TIMEOUT;
+    let mut written = 0;
+    while written < bytes.len() {
+        if stop.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        match input.write(&bytes[written..]) {
+            Ok(0) => return Err("The desktop runtime closed its input".to_string()),
+            Ok(count) => written += count,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err("Writing to the desktop runtime timed out".to_string());
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => return Err(format!("Cannot write to the desktop runtime: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn read_messages(mut output: impl Read, sender: mpsc::Sender<Incoming>, stop: Arc<AtomicBool>) {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        if stop.load(Ordering::Acquire) {
+            return;
+        }
+        match output.read(&mut chunk) {
+            Ok(0) => {
+                if !stop.load(Ordering::Acquire) {
+                    let _ = sender.send(Incoming::Disconnected(
+                        "The desktop runtime closed its output".to_string(),
+                    ));
+                }
+                return;
+            }
+            Ok(count) => buffer.extend_from_slice(&chunk[..count]),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(error) => {
+                let _ = sender.send(Incoming::Disconnected(format!(
+                    "Cannot read from the desktop runtime: {error}"
+                )));
+                return;
+            }
+        }
+        if buffer.len() > MAX_MESSAGE_BYTES && !buffer.contains(&b'\n') {
+            let _ = sender.send(Incoming::Disconnected(
+                "Desktop runtime response is too large".to_string(),
+            ));
+            return;
+        }
+        while let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
+            let line = buffer.drain(..=newline).collect::<Vec<_>>();
+            let line = &line[..line.len() - 1];
+            if line.is_empty() {
+                continue;
+            }
+            if line.len() > MAX_MESSAGE_BYTES {
+                let _ = sender.send(Incoming::Disconnected(
+                    "Desktop runtime response is too large".to_string(),
+                ));
+                return;
+            }
+            match serde_json::from_slice(line) {
+                Ok(message) => {
+                    if sender.send(Incoming::Message(message)).is_err() {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    let _ = sender.send(Incoming::Disconnected(
+                        "Desktop runtime returned invalid JSON".to_string(),
+                    ));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn join_thread(thread: &RefCell<Option<JoinHandle<()>>>) {
+    if let Some(thread) = thread.borrow_mut().take() {
+        let _ = thread.join();
+    }
+}
+
+fn kill_process_group(child: &Child, signal: libc::c_int) {
+    if let Ok(process_group) = i32::try_from(child.id()) {
+        unsafe {
+            libc::kill(-process_group, signal);
+        }
+    }
+}
+
+fn child_has_exited(child: &Child) -> bool {
+    let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+    let result = unsafe {
+        libc::waitid(
+            libc::P_PID,
+            child.id(),
+            info.as_mut_ptr(),
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        )
+    };
+    if result < 0 {
+        return std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD);
+    }
+    unsafe { info.assume_init().si_pid() != 0 }
+}
+
+fn force_stop_group(child: &mut Child) {
+    kill_process_group(child, libc::SIGKILL);
+    let _ = child.wait();
 }
 
 fn runtime_path() -> Result<PathBuf, String> {
@@ -186,19 +553,177 @@ fn runtime_path() -> Result<PathBuf, String> {
         .join("private-ai-gateway-desktop-service"))
 }
 
-fn read_messages(output: impl std::io::Read, sender: mpsc::Sender<Result<Value, String>>) {
-    for line in BufReader::new(output).lines() {
-        let message = line
-            .map_err(|error| format!("Cannot read from the desktop runtime: {error}"))
-            .and_then(|line| {
-                if line.len() > MAX_MESSAGE_BYTES {
-                    return Err("Desktop runtime response is too large".to_string());
-                }
-                serde_json::from_str(&line)
-                    .map_err(|_| "Desktop runtime returned invalid JSON".to_string())
-            });
-        if sender.send(message).is_err() {
-            break;
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+
+    struct TestRuntime {
+        script: PathBuf,
+        marker: PathBuf,
+    }
+
+    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(1);
+
+    impl TestRuntime {
+        fn new(body: impl FnOnce(&Path) -> String) -> Self {
+            let nonce = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+            let base = std::env::temp_dir().join(format!(
+                "private-ai-gateway-runtime-{}-{nonce}",
+                std::process::id()
+            ));
+            let script = base.with_extension("py");
+            let marker = base.with_extension("pid");
+            fs::write(&script, format!("{}\n", body(&marker))).expect("write runtime fixture");
+            Self { script, marker }
         }
+
+        fn client(&self, request_timeout: Duration) -> Rc<RuntimeClient> {
+            RuntimeClient::start_command(
+                Command::new("python3").arg(&self.script),
+                request_timeout,
+                Duration::from_millis(150),
+            )
+            .expect("start runtime fixture")
+        }
+    }
+
+    impl Drop for TestRuntime {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.script);
+            let _ = fs::remove_file(&self.marker);
+        }
+    }
+
+    fn poll_until(client: &RuntimeClient, condition: impl Fn() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !condition() && Instant::now() < deadline {
+            client.poll();
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(condition(), "condition did not complete");
+    }
+
+    #[test]
+    fn request_round_trip_and_graceful_shutdown() {
+        let runtime = TestRuntime::new(|marker| {
+            format!(
+                concat!(
+                    "import json, subprocess, sys\n",
+                    "child = subprocess.Popen(['sleep', '60'])\n",
+                    "open({marker:?}, 'w').write(str(child.pid))\n",
+                    "for line in sys.stdin:\n",
+                    "    request = json.loads(line)\n",
+                    "    result = None if request['method'] == 'shutdown' else {{'ok': True}}\n",
+                    "    print(json.dumps({{'schemaVersion': 1, 'id': request['id'], 'result': result}}), flush=True)\n",
+                    "    if request['method'] == 'shutdown':\n",
+                    "        break"
+                ),
+                marker = marker.display().to_string()
+            )
+        });
+        let client = runtime.client(Duration::from_secs(1));
+        poll_until(&client, || runtime.marker.is_file());
+        let descendant = fs::read_to_string(&runtime.marker)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        let result = Rc::new(RefCell::new(None));
+        let received = result.clone();
+        client.request::<Value>("getState", json!({}), move |value| {
+            *received.borrow_mut() = Some(value)
+        });
+        poll_until(&client, || result.borrow().is_some());
+        assert_eq!(
+            result.borrow().as_ref().unwrap().as_ref().unwrap()["ok"],
+            true
+        );
+        client.shutdown_and_wait();
+        assert!(!client.is_process_running());
+        assert!(!process_is_live(descendant));
+    }
+
+    #[test]
+    fn eof_disconnects_and_fails_pending_requests() {
+        let runtime = TestRuntime::new(|_| "raise SystemExit(7)".to_string());
+        let client = runtime.client(Duration::from_secs(1));
+        let disconnected = Rc::new(RefCell::new(None));
+        let observed = disconnected.clone();
+        client.on_disconnect(move |error| *observed.borrow_mut() = Some(error));
+        let result = Rc::new(RefCell::new(None));
+        let received = result.clone();
+        client.request::<Value>("getState", json!({}), move |value| {
+            *received.borrow_mut() = Some(value)
+        });
+        poll_until(&client, || disconnected.borrow().is_some());
+        assert!(result.borrow().as_ref().is_some_and(Result::is_err));
+        client.shutdown_and_wait();
+    }
+
+    #[test]
+    fn unsupported_protocol_version_disconnects() {
+        let runtime = TestRuntime::new(|_| {
+            concat!(
+                "import json, sys\n",
+                "request = json.loads(sys.stdin.readline())\n",
+                "print(json.dumps({'schemaVersion': 2, 'id': request['id'], 'result': None}), flush=True)"
+            )
+            .to_string()
+        });
+        let client = runtime.client(Duration::from_secs(1));
+        let disconnected = Rc::new(RefCell::new(None));
+        let observed = disconnected.clone();
+        client.on_disconnect(move |error| *observed.borrow_mut() = Some(error));
+        let result = Rc::new(RefCell::new(None));
+        let received = result.clone();
+        client.request::<Value>("getState", json!({}), move |value| {
+            *received.borrow_mut() = Some(value)
+        });
+        poll_until(&client, || disconnected.borrow().is_some());
+        assert!(disconnected
+            .borrow()
+            .as_deref()
+            .is_some_and(|error| error.contains("protocol version")));
+        assert!(result.borrow().as_ref().is_some_and(Result::is_err));
+        client.shutdown_and_wait();
+    }
+
+    #[test]
+    fn timeout_disconnects_and_stops_owned_process_group() {
+        let runtime = TestRuntime::new(|marker| {
+            format!(
+                "import subprocess, sys\nchild = subprocess.Popen(['sleep', '60'])\nopen({:?}, 'w').write(str(child.pid))\nfor _line in sys.stdin:\n    pass",
+                marker.display().to_string()
+            )
+        });
+        let client = runtime.client(Duration::from_millis(50));
+        poll_until(&client, || runtime.marker.is_file());
+        let result = Rc::new(RefCell::new(None));
+        let received = result.clone();
+        client.request::<Value>("getState", json!({}), move |value| {
+            *received.borrow_mut() = Some(value)
+        });
+        poll_until(&client, || result.borrow().is_some());
+        assert!(result.borrow().as_ref().is_some_and(Result::is_err));
+        let descendant = fs::read_to_string(&runtime.marker)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        poll_until(&client, || !process_is_live(descendant));
+        client.shutdown_and_wait();
+    }
+
+    fn process_is_live(pid: u32) -> bool {
+        fs::read_to_string(format!("/proc/{pid}/stat"))
+            .ok()
+            .and_then(|stat| stat.rsplit_once(") ").map(|(_, fields)| fields.to_string()))
+            .and_then(|fields| fields.chars().next())
+            .is_some_and(|state| state != 'Z')
     }
 }

--- a/apps/desktop/native/linux/src/tray.rs
+++ b/apps/desktop/native/linux/src/tray.rs
@@ -7,13 +7,16 @@ pub enum TrayCommand {
     Toggle,
     Open,
     Settings,
+    RestartRuntime,
     OpenAtLogin,
     Quit,
+    Availability(bool),
 }
 
 pub struct GatewayTray {
     pub running: bool,
     pub protected: bool,
+    pub runtime_connected: bool,
     pub status: String,
     pub open_at_login: bool,
     pub icon_path: String,
@@ -44,7 +47,7 @@ impl ksni::Tray for GatewayTray {
         use ksni::menu::{CheckmarkItem, StandardItem};
         vec![
             CheckmarkItem {
-                label: "Protected".into(),
+                label: "Protection".into(),
                 checked: self.running,
                 activate: Box::new(|tray: &mut GatewayTray| {
                     let _ = tray.commands.send(TrayCommand::Toggle);
@@ -55,6 +58,15 @@ impl ksni::Tray for GatewayTray {
             StandardItem {
                 label: self.status.clone(),
                 enabled: false,
+                ..Default::default()
+            }
+            .into(),
+            StandardItem {
+                label: "Restart Runtime".into(),
+                visible: !self.runtime_connected,
+                activate: Box::new(|tray: &mut GatewayTray| {
+                    let _ = tray.commands.send(TrayCommand::RestartRuntime);
+                }),
                 ..Default::default()
             }
             .into(),
@@ -96,20 +108,30 @@ impl ksni::Tray for GatewayTray {
             .into(),
         ]
     }
+
+    fn watcher_online(&self) {
+        let _ = self.commands.send(TrayCommand::Availability(true));
+    }
+
+    fn watcher_offline(&self, _reason: ksni::OfflineReason) -> bool {
+        let _ = self.commands.send(TrayCommand::Availability(false));
+        true
+    }
 }
 
-pub fn spawn(commands: Sender<TrayCommand>) -> Option<Handle<GatewayTray>> {
-    GatewayTray {
+pub fn spawn(commands: Sender<TrayCommand>) -> Result<Handle<GatewayTray>, String> {
+    let tray = GatewayTray {
         running: false,
         protected: false,
+        runtime_connected: false,
         status: "Not protected".into(),
         open_at_login: open_at_login(),
         icon_path: asset_dir().to_string_lossy().into_owned(),
         commands,
     }
-    .assume_sni_available(true)
     .spawn()
-    .ok()
+    .map_err(|error| format!("System tray is unavailable: {error}"))?;
+    Ok(tray)
 }
 
 pub fn set_open_at_login(enabled: bool) -> Result<(), String> {

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/PrivateAIGateway.Windows.Tests.csproj
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/PrivateAIGateway.Windows.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\PrivateAIGateway.Windows\Models.cs" Link="Models.cs" />
+    <Compile Include="..\PrivateAIGateway.Windows\RuntimeClient.cs" Link="RuntimeClient.cs" />
+    <Compile Include="..\PrivateAIGateway.Windows\RuntimePresentation.cs" Link="RuntimePresentation.cs" />
+  </ItemGroup>
+</Project>

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/Program.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using PrivateAIGateway.Windows;
 
 const string ChildMode = "PRIVATE_AI_GATEWAY_RUNTIME_TEST_CHILD";
@@ -15,6 +16,7 @@ var tests = new (string Name, Func<Task> Run)[]
     ("pending request fails on EOF", PendingRequestFailsOnEofAsync),
     ("malformed frame disconnects", () => InvalidFrameDisconnectsAsync("malformed")),
     ("oversized frame disconnects", () => InvalidFrameDisconnectsAsync("oversized")),
+    ("wrong protocol version disconnects", () => InvalidFrameDisconnectsAsync("wrong-version")),
     ("unresponsive shutdown is bounded", UnresponsiveShutdownIsBoundedAsync),
     ("status presentation distinguishes protection", StatusPresentationIsAccurateAsync),
 };
@@ -39,7 +41,12 @@ static async Task InvalidFrameDisconnectsAsync(string mode)
 {
     await using var client = await StartClientAsync(mode);
     var error = await ExpectRuntimeFailureAsync(client.RequestAsync<GatewayState>("getState", new { }));
-    var expected = mode == "oversized" ? "message_too_large" : "invalid_response";
+    var expected = mode switch
+    {
+        "oversized" => "message_too_large",
+        "wrong-version" => "unsupported_schema",
+        _ => "invalid_response",
+    };
     Assert(error.Code == expected, $"Expected {expected}, got {error.Code}");
     Assert(!client.IsAvailable, "Invalid runtime output did not disconnect the client");
 }
@@ -122,6 +129,13 @@ static void RunChild(string mode)
         case "oversized":
             Console.ReadLine();
             Console.Write(new string('x', 1024 * 1024 + 1));
+            Console.Out.Flush();
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+            return;
+        case "wrong-version":
+            var request = JsonDocument.Parse(Console.ReadLine() ?? throw new InvalidOperationException("Missing request"));
+            var id = request.RootElement.GetProperty("id").GetString();
+            Console.WriteLine(JsonSerializer.Serialize(new { schemaVersion = 2, id, result = new { } }));
             Console.Out.Flush();
             Thread.Sleep(TimeSpan.FromSeconds(30));
             return;

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/Program.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows.Tests/Program.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using System.Text;
+using PrivateAIGateway.Windows;
+
+const string ChildMode = "PRIVATE_AI_GATEWAY_RUNTIME_TEST_CHILD";
+
+if (Environment.GetEnvironmentVariable(ChildMode) is { } mode)
+{
+    RunChild(mode);
+    return;
+}
+
+var tests = new (string Name, Func<Task> Run)[]
+{
+    ("pending request fails on EOF", PendingRequestFailsOnEofAsync),
+    ("malformed frame disconnects", () => InvalidFrameDisconnectsAsync("malformed")),
+    ("oversized frame disconnects", () => InvalidFrameDisconnectsAsync("oversized")),
+    ("unresponsive shutdown is bounded", UnresponsiveShutdownIsBoundedAsync),
+    ("status presentation distinguishes protection", StatusPresentationIsAccurateAsync),
+};
+
+foreach (var test in tests)
+{
+    await test.Run();
+    Console.WriteLine($"PASS {test.Name}");
+}
+
+static async Task PendingRequestFailsOnEofAsync()
+{
+    await using var client = await StartClientAsync("eof-on-request");
+    var exited = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+    client.Exited += error => exited.TrySetResult(error);
+    var error = await ExpectRuntimeFailureAsync(client.RequestAsync<GatewayState>("getState", new { }));
+    Assert(error.Code is "runtime_eof" or "runtime_exited", $"Unexpected EOF error code: {error.Code}");
+    Assert(await exited.Task.WaitAsync(TimeSpan.FromSeconds(5)) is not null, "Runtime exit was not reported");
+}
+
+static async Task InvalidFrameDisconnectsAsync(string mode)
+{
+    await using var client = await StartClientAsync(mode);
+    var error = await ExpectRuntimeFailureAsync(client.RequestAsync<GatewayState>("getState", new { }));
+    var expected = mode == "oversized" ? "message_too_large" : "invalid_response";
+    Assert(error.Code == expected, $"Expected {expected}, got {error.Code}");
+    Assert(!client.IsAvailable, "Invalid runtime output did not disconnect the client");
+}
+
+static async Task UnresponsiveShutdownIsBoundedAsync()
+{
+    var client = await StartClientAsync("ignore-shutdown");
+    var elapsed = Stopwatch.StartNew();
+    await client.DisposeAsync();
+    elapsed.Stop();
+    Assert(elapsed.Elapsed < TimeSpan.FromSeconds(10), $"Shutdown took {elapsed.Elapsed.TotalSeconds:F1} seconds");
+}
+
+static Task StatusPresentationIsAccurateAsync()
+{
+    var development = GatewayState.Empty with
+    {
+        Status = "verified",
+        ConfigurationVerification = false,
+        Config = new StartGatewayConfig("https://example.test", false),
+    };
+    Assert(RuntimePresentation.IsProtected(development), "Verified runtime should be protected");
+    Assert(RuntimePresentation.ShowDevMode(development), "Verified development runtime should show dev mode");
+    Assert(RuntimePresentation.SummaryLabel(development) == "Protected in dev mode", "Development summary is incorrect");
+
+    var configuration = development with { ConfigurationVerification = true };
+    Assert(!RuntimePresentation.IsProtected(configuration), "Configuration verification must not be protected");
+    Assert(!RuntimePresentation.ShowDevMode(configuration), "Configuration verification must not show protected dev mode");
+    Assert(RuntimePresentation.StatusLabel(configuration) == "Configuration verified", "Configuration status is incorrect");
+
+    var blocked = development with { Status = "blocked", ConfigurationVerification = false };
+    Assert(!RuntimePresentation.IsProtected(blocked), "Blocked runtime must not be protected");
+    Assert(!RuntimePresentation.ShowDevMode(blocked), "Blocked runtime must not show protected dev mode");
+    Assert(RuntimePresentation.SummaryLabel(blocked) == "Blocked", "Blocked summary is incorrect");
+    return Task.CompletedTask;
+}
+
+static async Task<RuntimeClient> StartClientAsync(string mode)
+{
+    var executable = Environment.ProcessPath ?? throw new InvalidOperationException("Cannot locate the test executable");
+    Environment.SetEnvironmentVariable("PRIVATE_AI_GATEWAY_RUNTIME", executable);
+    Environment.SetEnvironmentVariable(ChildMode, mode);
+    var client = new RuntimeClient();
+    try
+    {
+        await client.StartAsync();
+        return client;
+    }
+    finally
+    {
+        Environment.SetEnvironmentVariable(ChildMode, null);
+        Environment.SetEnvironmentVariable("PRIVATE_AI_GATEWAY_RUNTIME", null);
+    }
+}
+
+static async Task<RuntimeException> ExpectRuntimeFailureAsync(Task operation)
+{
+    try
+    {
+        await operation.WaitAsync(TimeSpan.FromSeconds(5));
+        throw new InvalidOperationException("Runtime request unexpectedly succeeded");
+    }
+    catch (RuntimeException error) { return error; }
+}
+
+static void RunChild(string mode)
+{
+    Console.OutputEncoding = new UTF8Encoding(false);
+    switch (mode)
+    {
+        case "eof-on-request":
+            Console.ReadLine();
+            return;
+        case "malformed":
+            Console.ReadLine();
+            Console.WriteLine("{");
+            Console.Out.Flush();
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+            return;
+        case "oversized":
+            Console.ReadLine();
+            Console.Write(new string('x', 1024 * 1024 + 1));
+            Console.Out.Flush();
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+            return;
+        case "ignore-shutdown":
+            while (Console.ReadLine() is not null) { }
+            return;
+        default:
+            throw new InvalidOperationException($"Unknown child mode: {mode}");
+    }
+}
+
+static void Assert(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
@@ -35,7 +35,7 @@ public partial class App : Application
         Trace("app:activating");
         MainWindow.Activate();
         Trace("app:activated");
-        if (Environment.GetCommandLineArgs().Contains("--autostart") || IsSmokeTest) MainWindow.HideAfterLaunch();
+        if (Environment.GetCommandLineArgs().Contains("--autostart")) MainWindow.HideAfterLaunch();
     }
 
     private static void WriteCrashLog(Exception error)

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
@@ -6,6 +6,7 @@ namespace PrivateAIGateway.Windows;
 public partial class App : Application
 {
     public static MainWindow MainWindow { get; private set; } = null!;
+    public static bool IsSmokeTest { get; private set; }
     private static readonly Mutex Instance;
     private static readonly bool IsFirstInstance;
 
@@ -29,11 +30,12 @@ public partial class App : Application
             Exit();
             return;
         }
+        IsSmokeTest = Environment.GetCommandLineArgs().Contains("--smoke-test");
         MainWindow = new MainWindow();
         Trace("app:activating");
         MainWindow.Activate();
         Trace("app:activated");
-        if (Environment.GetCommandLineArgs().Contains("--autostart")) MainWindow.HideAfterLaunch();
+        if (Environment.GetCommandLineArgs().Contains("--autostart") || IsSmokeTest) MainWindow.HideAfterLaunch();
     }
 
     private static void WriteCrashLog(Exception error)

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/App.xaml.cs
@@ -42,9 +42,12 @@ public partial class App : Application
     {
         try
         {
-            var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Private AI Gateway");
-            Directory.CreateDirectory(directory);
-            File.AppendAllText(Path.Combine(directory, "crash.log"), $"{DateTimeOffset.UtcNow:O}{Environment.NewLine}{error}{Environment.NewLine}{Environment.NewLine}");
+            var path = Environment.GetEnvironmentVariable("PRIVATE_AI_GATEWAY_CRASH_LOG");
+            if (string.IsNullOrWhiteSpace(path))
+                path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Private AI Gateway", "crash.log");
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory)) Directory.CreateDirectory(directory);
+            File.AppendAllText(path, $"{DateTimeOffset.UtcNow:O}{Environment.NewLine}{error}{Environment.NewLine}{Environment.NewLine}");
         }
         catch { }
     }

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
@@ -22,6 +22,7 @@ public sealed class MainWindow : Window
     private readonly ContentPresenter pageHost = new();
     private readonly InfoBar errorBar = new() { Severity = InfoBarSeverity.Error, IsOpen = false, IsClosable = true };
     private readonly Button restartButton = new() { Content = "Restart Runtime", Visibility = Visibility.Collapsed };
+    private readonly TaskCompletionSource<bool> navigationInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private string page = "overview";
     private bool syncingSwitch;
     private bool initialized;
@@ -74,6 +75,7 @@ public sealed class MainWindow : Window
             navigation.SelectedItem = navigation.MenuItems[0];
             if (pageHost.Content is null) ShowPage("overview");
             App.Trace("navigation:selected");
+            navigationInitialized.TrySetResult(true);
         });
     }
 
@@ -162,8 +164,13 @@ public sealed class MainWindow : Window
         App.Trace("runtime:updating-ui");
         Update(null);
         App.Trace("runtime:ui-updated");
-        var passed = healthy && store.IsRuntimeAvailable && store.Agents.Length == 5;
-        WriteHealthResult(passed);
+        var navigationSucceeded = false;
+        var pageLoaded = false;
+        if (App.IsSmokeTest)
+            (navigationSucceeded, pageLoaded) = await VerifySmokeUiAsync();
+        var passed = healthy && store.IsRuntimeAvailable && store.Agents.Length == 5 &&
+            (!App.IsSmokeTest || navigationSucceeded && pageLoaded);
+        WriteHealthResult(passed, navigationSucceeded, pageLoaded);
         App.Trace(passed ? "health:passed" : "health:failed");
         if (App.IsSmokeTest)
         {
@@ -231,6 +238,59 @@ public sealed class MainWindow : Window
         }
         else UpdatePage(pageName);
         if (!ReferenceEquals(pageHost.Content, nativePage.Content)) pageHost.Content = nativePage.Content;
+    }
+
+    private async Task<(bool NavigationSucceeded, bool PageLoaded)> VerifySmokeUiAsync()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            await navigationInitialized.Task.WaitAsync(timeout.Token);
+            foreach (var pageName in new[] { "overview", "agents", "usage", "settings" })
+            {
+                App.Trace($"smoke:navigating:{pageName}");
+                navigation.SelectedItem = NavigationTarget(pageName);
+                if (page != pageName ||
+                    !pages.TryGetValue(pageName, out var nativePage) ||
+                    !ReferenceEquals(pageHost.Content, nativePage.Content) ||
+                    nativePage.Content is not FrameworkElement content)
+                {
+                    App.Trace($"smoke:navigation-failed:{pageName}");
+                    return (false, false);
+                }
+                await WaitForLoadedAsync(content, timeout.Token);
+                App.Trace($"smoke:page-loaded:{pageName}");
+            }
+            return (true, true);
+        }
+        catch (OperationCanceledException)
+        {
+            App.Trace("smoke:page-load-timeout");
+            return (false, false);
+        }
+        catch (Exception error)
+        {
+            App.Trace($"smoke:navigation-error:{error.GetType().Name}");
+            return (false, false);
+        }
+    }
+
+    private object NavigationTarget(string pageName)
+    {
+        if (pageName == "settings") return navigation.SettingsItem;
+        return navigation.MenuItems
+            .OfType<NavigationViewItem>()
+            .First(item => string.Equals(item.Tag?.ToString(), pageName, StringComparison.Ordinal));
+    }
+
+    private static async Task WaitForLoadedAsync(FrameworkElement content, CancellationToken cancellationToken)
+    {
+        if (content.IsLoaded) return;
+        var loaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        RoutedEventHandler handler = (_, _) => loaded.TrySetResult(true);
+        content.Loaded += handler;
+        try { await loaded.Task.WaitAsync(cancellationToken); }
+        finally { content.Loaded -= handler; }
     }
 
     private void Navigation_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -320,7 +380,7 @@ public sealed class MainWindow : Window
         restartButton.Visibility = Visibility.Collapsed;
     }
 
-    private void WriteHealthResult(bool healthy)
+    private void WriteHealthResult(bool healthy, bool navigationSucceeded, bool pageLoaded)
     {
         var path = Environment.GetEnvironmentVariable("PRIVATE_AI_GATEWAY_GUI_HEALTH");
         if (string.IsNullOrWhiteSpace(path)) return;
@@ -334,6 +394,8 @@ public sealed class MainWindow : Window
                 status = store.State.Status,
                 agents = store.Agents.Length,
                 clientKeyPresent = !string.IsNullOrEmpty(store.ClientKey),
+                navigationSucceeded,
+                pageLoaded,
             }));
             File.Move(temporary, path, true);
         }

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -12,15 +13,19 @@ public sealed class MainWindow : Window
 {
     private readonly RuntimeStore store = new();
     private readonly NativeTray tray;
-    private readonly NavigationView Navigation = new();
-    private readonly TextBlock PageTitle = new() { Text = "Overview", FontSize = 20, FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold, VerticalAlignment = VerticalAlignment.Center };
-    private readonly Border DevBadge = new() { Background = new SolidColorBrush(ColorHelper.FromArgb(0x33, 0xE9, 0xA4, 0)), CornerRadius = new CornerRadius(4), Padding = new Thickness(7, 3, 7, 3), Visibility = Visibility.Collapsed };
-    private readonly TextBlock StatusText = new() { VerticalAlignment = VerticalAlignment.Center, Opacity = 0.7 };
-    private readonly ToggleSwitch ProtectionSwitch = new();
-    private readonly ContentPresenter PageHost = new();
+    private readonly IReadOnlyDictionary<string, INativePage> pages;
+    private readonly NavigationView navigation = new();
+    private readonly TextBlock pageTitle = new() { Text = "Overview", FontSize = 20, FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold, VerticalAlignment = VerticalAlignment.Center };
+    private readonly Border devBadge = new() { Background = new SolidColorBrush(ColorHelper.FromArgb(0x33, 0xE9, 0xA4, 0)), CornerRadius = new CornerRadius(4), Padding = new Thickness(7, 3, 7, 3), Visibility = Visibility.Collapsed };
+    private readonly TextBlock statusText = new() { VerticalAlignment = VerticalAlignment.Center, Opacity = 0.7 };
+    private readonly ToggleSwitch protectionSwitch = new();
+    private readonly ContentPresenter pageHost = new();
+    private readonly InfoBar errorBar = new() { Severity = InfoBarSeverity.Error, IsOpen = false, IsClosable = true };
+    private readonly Button restartButton = new() { Content = "Restart Runtime", Visibility = Visibility.Collapsed };
     private string page = "overview";
     private bool syncingSwitch;
     private bool initialized;
+    private bool quitting;
     private AppWindow appWindow = null!;
 
     public MainWindow()
@@ -28,95 +33,95 @@ public sealed class MainWindow : Window
         App.Trace("window:constructing");
         Title = "Private AI Gateway";
         BuildShell();
+        pages = NativeViews.CreatePages(store, this);
+        pageHost.Content = pages[page].Content;
         App.Trace("window:shell-built");
         var hwnd = WindowNative.GetWindowHandle(this);
         appWindow = AppWindow.GetFromWindowId(Win32Interop.GetWindowIdFromWindow(hwnd));
         appWindow.Resize(new global::Windows.Graphics.SizeInt32(1052, 820));
         appWindow.SetIcon(Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico"));
-        appWindow.Closing += (_, args) => { args.Cancel = true; appWindow.Hide(); };
+        appWindow.Closing += (_, args) =>
+        {
+            args.Cancel = !quitting;
+            if (!quitting) appWindow.Hide();
+        };
         App.Trace("window:app-window-ready");
         tray = new NativeTray(hwnd, ShowMainWindow, ShowSettings, ToggleFromTray, QuitAsync);
         App.Trace("window:tray-ready");
-        store.PropertyChanged += (_, _) => DispatcherQueue.TryEnqueue(Render);
-        store.Error += message => DispatcherQueue.TryEnqueue(async () => await ShowErrorAsync(message));
-        Activated += async (_, _) => { if (!initialized) { initialized = true; await InitializeAsync(); } };
-        Navigation.Loaded += SelectInitialPage;
+        store.PropertyChanged += (_, args) => DispatcherQueue.TryEnqueue(() => Update(args.PropertyName));
+        store.Error += message => DispatcherQueue.TryEnqueue(() => ShowError(message));
+        restartButton.Click += async (_, _) => await RestartRuntimeAsync();
+        errorBar.ActionButton = restartButton;
+        Activated += async (_, _) =>
+        {
+            if (!initialized)
+            {
+                initialized = true;
+                await InitializeAsync();
+            }
+        };
+        navigation.Loaded += SelectInitialPage;
         App.Trace("window:constructed");
     }
 
     private void SelectInitialPage(object sender, RoutedEventArgs args)
     {
-        Navigation.Loaded -= SelectInitialPage;
-        App.Trace("navigation:loaded");
-        DispatcherQueue.TryEnqueue(() =>
-        {
-            App.Trace("navigation:selecting");
-            Navigation.SelectedItem = Navigation.MenuItems[0];
-            App.Trace("navigation:selected");
-        });
+        navigation.Loaded -= SelectInitialPage;
+        DispatcherQueue.TryEnqueue(() => navigation.SelectedItem = navigation.MenuItems[0]);
     }
 
     private void BuildShell()
     {
-        Navigation.IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
-        Navigation.IsSettingsVisible = true;
-        Navigation.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
-        Navigation.OpenPaneLength = 220;
-        Navigation.SelectionChanged += Navigation_SelectionChanged;
-        Navigation.MenuItems.Add(NavigationItem("Overview", "overview", new SymbolIcon(Symbol.Home)));
-        Navigation.MenuItems.Add(NavigationItem("Agents", "agents", new FontIcon { Glyph = "\uE756" }));
-        Navigation.MenuItems.Add(NavigationItem("Usage", "usage", new FontIcon { Glyph = "\uE9D2" }));
+        navigation.IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
+        navigation.IsSettingsVisible = true;
+        navigation.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
+        navigation.OpenPaneLength = 220;
+        navigation.SelectionChanged += Navigation_SelectionChanged;
+        navigation.MenuItems.Add(NavigationItem("Overview", "overview", new SymbolIcon(Symbol.Home)));
+        navigation.MenuItems.Add(NavigationItem("Agents", "agents", new FontIcon { Glyph = "\uE756" }));
+        navigation.MenuItems.Add(NavigationItem("Usage", "usage", new FontIcon { Glyph = "\uE9D2" }));
 
         var brand = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 10, Padding = new Thickness(4, 8, 0, 16) };
-        brand.Children.Add(new Image
-        {
-            Source = new SvgImageSource(new Uri("ms-appx:///Assets/brand/mark.svg")),
-            Width = 34,
-            Height = 34,
-        });
+        brand.Children.Add(new Image { Source = new SvgImageSource(new Uri("ms-appx:///Assets/brand/mark.svg")), Width = 34, Height = 34 });
         var brandText = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
         brandText.Children.Add(new TextBlock { Text = "Private AI Gateway", FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold });
         brandText.Children.Add(new TextBlock { Text = "Confidential inference", FontSize = 12, Opacity = 0.65 });
         brand.Children.Add(brandText);
-        Navigation.PaneHeader = brand;
+        navigation.PaneHeader = brand;
 
         var shell = new Grid();
         shell.RowDefinitions.Add(new RowDefinition { Height = new GridLength(58) });
+        shell.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
         shell.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
         var header = new Grid { Padding = new Thickness(24, 0, 24, 0) };
         header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        header.Children.Add(PageTitle);
-
-        DevBadge.Child = new TextBlock { Text = "Dev mode", Foreground = new SolidColorBrush(ColorHelper.FromArgb(0xFF, 0xB8, 0x78, 0)), FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold };
+        header.Children.Add(pageTitle);
+        devBadge.Child = new TextBlock { Text = "Dev mode", Foreground = new SolidColorBrush(ColorHelper.FromArgb(0xFF, 0xB8, 0x78, 0)), FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold };
         var controls = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 12, VerticalAlignment = VerticalAlignment.Center };
-        controls.Children.Add(DevBadge);
-        controls.Children.Add(StatusText);
+        controls.Children.Add(devBadge);
+        controls.Children.Add(statusText);
         controls.Children.Add(new TextBlock { Text = "Protected", VerticalAlignment = VerticalAlignment.Center });
-        ProtectionSwitch.Toggled += ProtectionSwitch_Toggled;
-        controls.Children.Add(ProtectionSwitch);
+        protectionSwitch.Toggled += ProtectionSwitch_Toggled;
+        controls.Children.Add(protectionSwitch);
         Grid.SetColumn(controls, 1);
         header.Children.Add(controls);
-
-        var headerBorder = new Border
+        shell.Children.Add(new Border
         {
             BorderBrush = new SolidColorBrush(ColorHelper.FromArgb(0x20, 0x80, 0x80, 0x80)),
             BorderThickness = new Thickness(0, 0, 0, 1),
             Child = header,
-        };
-        shell.Children.Add(headerBorder);
-        Grid.SetRow(PageHost, 1);
-        shell.Children.Add(PageHost);
-        Navigation.Content = shell;
-        Content = Navigation;
+        });
+        errorBar.Margin = new Thickness(24, 8, 24, 0);
+        Grid.SetRow(errorBar, 1);
+        shell.Children.Add(errorBar);
+        Grid.SetRow(pageHost, 2);
+        shell.Children.Add(pageHost);
+        navigation.Content = shell;
+        Content = navigation;
     }
 
-    private static NavigationViewItem NavigationItem(string title, string tag, IconElement icon) => new()
-    {
-        Content = title,
-        Tag = tag,
-        Icon = icon,
-    };
+    private static NavigationViewItem NavigationItem(string title, string tag, IconElement icon) => new() { Content = title, Tag = tag, Icon = icon };
 
     public void ShowMainWindow()
     {
@@ -124,112 +129,180 @@ public sealed class MainWindow : Window
         Activate();
     }
 
-    public void HideMainWindow() => appWindow.Hide();
-
-    public void HideAfterLaunch() => DispatcherQueue.TryEnqueue(() =>
-    {
-        App.Trace("window:hiding");
-        appWindow.Hide();
-        App.Trace("window:hidden");
-    });
+    public void HideAfterLaunch() => DispatcherQueue.TryEnqueue(appWindow.Hide);
 
     public void ShowSettings()
     {
         ShowMainWindow();
-        Navigation.SelectedItem = Navigation.SettingsItem;
+        navigation.SelectedItem = navigation.SettingsItem;
     }
 
     private async Task InitializeAsync()
     {
-        try { await store.InitializeAsync(); Render(); }
-        catch (Exception error) { await ShowErrorAsync(error.Message); }
+        var healthy = false;
+        try
+        {
+            healthy = await store.InitializeAsync();
+            if (healthy) ClearError();
+        }
+        catch (Exception error) { ShowError(error.Message); }
+        Update(null);
+        var passed = healthy && store.IsRuntimeAvailable && store.Agents.Length == 5;
+        WriteHealthResult(passed);
+        if (App.IsSmokeTest)
+        {
+            if (!passed) Environment.ExitCode = 1;
+            await QuitCoreAsync();
+        }
     }
 
-    private void Render()
+    private void Update(string? propertyName)
     {
         syncingSwitch = true;
-        ProtectionSwitch.IsOn = store.IsRunning;
-        ProtectionSwitch.IsEnabled = !store.IsBusy;
+        protectionSwitch.IsOn = store.IsRunning;
+        protectionSwitch.IsEnabled = store.IsRuntimeAvailable && !store.IsBusy;
         syncingSwitch = false;
-        StatusText.Text = StatusLabel(store.State);
-        DevBadge.Visibility = store.IsRunning && store.IsDevMode ? Visibility.Visible : Visibility.Collapsed;
-        tray.Update(store.IsRunning, store.IsProtected, StatusLabel(store.State));
-        PageHost.Content = page switch
+        statusText.Text = store.IsRuntimeAvailable ? RuntimePresentation.StatusLabel(store.State) : "Runtime unavailable";
+        devBadge.Visibility = RuntimePresentation.ShowDevMode(store.State) && store.IsRuntimeAvailable ? Visibility.Visible : Visibility.Collapsed;
+        tray.Update(store.IsProtected, statusText.Text);
+
+        switch (propertyName)
         {
-            "agents" => NativeViews.Agents(store),
-            "usage" => NativeViews.Usage(store, this),
-            "settings" => NativeViews.Settings(store, this),
-            _ => NativeViews.Overview(store, this),
-        };
+            case nameof(RuntimeStore.Agents):
+                pages["overview"].Update();
+                pages["agents"].Update();
+                break;
+            case nameof(RuntimeStore.Usage):
+                pages["usage"].Update();
+                break;
+            case nameof(RuntimeStore.ClientKey):
+                pages["overview"].Update();
+                break;
+            case nameof(RuntimeStore.State):
+                pages["overview"].Update();
+                pages["settings"].Update();
+                break;
+            case nameof(RuntimeStore.IsRuntimeAvailable):
+            case null:
+                foreach (var nativePage in pages.Values) nativePage.Update();
+                break;
+        }
     }
 
     private void Navigation_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
         page = args.IsSettingsSelected ? "settings" : (args.SelectedItemContainer?.Tag?.ToString() ?? "overview");
-        PageTitle.Text = page switch { "agents" => "Agents", "usage" => "Usage", "settings" => "Settings", _ => "Overview" };
-        Render();
+        pageTitle.Text = page switch { "agents" => "Agents", "usage" => "Usage", "settings" => "Settings", _ => "Overview" };
+        pages[page].Update();
+        if (!ReferenceEquals(pageHost.Content, pages[page].Content)) pageHost.Content = pages[page].Content;
     }
 
     private async void ProtectionSwitch_Toggled(object sender, RoutedEventArgs e)
     {
         if (syncingSwitch) return;
-        if (ProtectionSwitch.IsOn && (!store.State.ApiKeySaved || store.State.Profiles.Length == 0))
+        if (protectionSwitch.IsOn && (!store.State.ApiKeySaved || store.State.Profiles.Length == 0))
         {
             syncingSwitch = true;
-            ProtectionSwitch.IsOn = false;
+            protectionSwitch.IsOn = false;
             syncingSwitch = false;
             await ShowProfilesAsync();
             return;
         }
-        try { await store.SetProtectionAsync(ProtectionSwitch.IsOn); }
-        catch { Render(); }
+        try { await store.SetProtectionAsync(protectionSwitch.IsOn); }
+        catch (Exception) { Update(null); }
     }
 
     private async void ToggleFromTray()
     {
+        if (!store.IsRuntimeAvailable)
+        {
+            ShowMainWindow();
+            ShowError("The desktop runtime is not running. Restart it to continue.");
+            return;
+        }
         if (!store.IsRunning && (!store.State.ApiKeySaved || store.State.Profiles.Length == 0))
         {
             ShowMainWindow();
             await ShowProfilesAsync();
             return;
         }
-        try { await store.SetProtectionAsync(!store.IsRunning); } catch { }
+        try { await store.SetProtectionAsync(!store.IsRunning); }
+        catch (Exception) { }
     }
 
-    public async Task ShowProfilesAsync() => await NativeDialogs.ShowProfilesAsync(store, ContentRoot());
-    public async Task ShowLocalApiAsync() => await NativeDialogs.ShowLocalApiAsync(store, ContentRoot());
-    public async Task ShowProofAsync(RequestActivity item) => await NativeDialogs.ShowProofAsync(store.State, item, ContentRoot());
-    public async Task ShowPrivacyAsync() => await NativeDialogs.ShowPrivacyAsync(store.State, ContentRoot());
+    public Task ShowProfilesAsync() => NativeDialogs.ShowProfilesAsync(store, ContentRoot());
+    public Task ShowLocalApiAsync() => NativeDialogs.ShowLocalApiAsync(store, ContentRoot());
+    public Task ShowProofAsync(RequestActivity item) => NativeDialogs.ShowProofAsync(store.State, item, ContentRoot());
+    public Task ShowPrivacyAsync() => NativeDialogs.ShowPrivacyAsync(store.State, ContentRoot());
+
     public async Task ConfirmRestoreAsync()
     {
         if (await NativeDialogs.ConfirmAsync("Restore all agent configurations?", "Private AI Gateway will revoke every managed agent token and restore its previous configuration where possible.", "Restore All", ContentRoot()))
             await store.RestoreAllAgentsAsync();
     }
+
     public async Task ConfirmClearUsageAsync()
     {
         if (await NativeDialogs.ConfirmAsync("Clear all usage history?", "This permanently deletes the local usage database. It does not affect provider records.", "Clear History", ContentRoot()))
             await store.ClearUsageAsync();
     }
 
-    private async Task ShowErrorAsync(string message)
+    private async Task RestartRuntimeAsync()
     {
-        var dialog = new ContentDialog { Title = "Private AI Gateway", Content = message, CloseButtonText = "OK", XamlRoot = ContentRoot() };
-        await dialog.ShowAsync();
+        restartButton.IsEnabled = false;
+        var restarted = await store.RestartAsync();
+        restartButton.IsEnabled = true;
+        if (restarted) ClearError();
+    }
+
+    private void ShowError(string message)
+    {
+        errorBar.Title = store.IsRuntimeAvailable ? "Operation failed" : "Desktop runtime unavailable";
+        errorBar.Message = message;
+        restartButton.Visibility = store.IsRuntimeAvailable ? Visibility.Collapsed : Visibility.Visible;
+        errorBar.IsClosable = store.IsRuntimeAvailable;
+        errorBar.IsOpen = true;
+    }
+
+    private void ClearError()
+    {
+        errorBar.IsOpen = false;
+        restartButton.Visibility = Visibility.Collapsed;
+    }
+
+    private void WriteHealthResult(bool healthy)
+    {
+        var path = Environment.GetEnvironmentVariable("PRIVATE_AI_GATEWAY_GUI_HEALTH");
+        if (string.IsNullOrWhiteSpace(path)) return;
+        var temporary = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(temporary, JsonSerializer.Serialize(new
+            {
+                ok = healthy,
+                runtimeAvailable = store.IsRuntimeAvailable,
+                status = store.State.Status,
+                agents = store.Agents.Length,
+                clientKeyPresent = !string.IsNullOrEmpty(store.ClientKey),
+            }));
+            File.Move(temporary, path, true);
+        }
+        catch (Exception error) { App.Trace($"health-write-failed:{error.GetType().Name}"); }
+        finally
+        {
+            try { File.Delete(temporary); }
+            catch (Exception) { }
+        }
     }
 
     private XamlRoot ContentRoot() => Content.XamlRoot;
-    private static string StatusLabel(GatewayState state) => state.Status switch
-    {
-        "verifying" => state.ConfigurationVerification ? "Verifying configuration" : "Starting",
-        "verified" when !state.Config.RequireProductionOs => "Protected · Dev mode",
-        "verified" => "Protected",
-        "blocked" => "Blocked",
-        "error" => "Needs attention",
-        _ => "Not protected",
-    };
 
-    private async void QuitAsync()
+    private async void QuitAsync() => await QuitCoreAsync();
+
+    private async Task QuitCoreAsync()
     {
+        if (quitting) return;
+        quitting = true;
         tray.Dispose();
         await store.DisposeAsync();
         appWindow.Destroy();

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
@@ -13,7 +13,7 @@ public sealed class MainWindow : Window
 {
     private readonly RuntimeStore store = new();
     private readonly NativeTray tray;
-    private readonly IReadOnlyDictionary<string, INativePage> pages;
+    private readonly Dictionary<string, INativePage> pages = [];
     private readonly NavigationView navigation = new();
     private readonly TextBlock pageTitle = new() { Text = "Overview", FontSize = 20, FontWeight = global::Microsoft.UI.Text.FontWeights.SemiBold, VerticalAlignment = VerticalAlignment.Center };
     private readonly Border devBadge = new() { Background = new SolidColorBrush(ColorHelper.FromArgb(0x33, 0xE9, 0xA4, 0)), CornerRadius = new CornerRadius(4), Padding = new Thickness(7, 3, 7, 3), Visibility = Visibility.Collapsed };
@@ -25,6 +25,7 @@ public sealed class MainWindow : Window
     private string page = "overview";
     private bool syncingSwitch;
     private bool initialized;
+    private bool navigationReady;
     private bool quitting;
     private AppWindow appWindow = null!;
 
@@ -33,8 +34,6 @@ public sealed class MainWindow : Window
         App.Trace("window:constructing");
         Title = "Private AI Gateway";
         BuildShell();
-        pages = NativeViews.CreatePages(store, this);
-        pageHost.Content = pages[page].Content;
         App.Trace("window:shell-built");
         var hwnd = WindowNative.GetWindowHandle(this);
         appWindow = AppWindow.GetFromWindowId(Win32Interop.GetWindowIdFromWindow(hwnd));
@@ -67,7 +66,15 @@ public sealed class MainWindow : Window
     private void SelectInitialPage(object sender, RoutedEventArgs args)
     {
         navigation.Loaded -= SelectInitialPage;
-        DispatcherQueue.TryEnqueue(() => navigation.SelectedItem = navigation.MenuItems[0]);
+        App.Trace("navigation:loaded");
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            navigationReady = true;
+            App.Trace("navigation:selecting");
+            navigation.SelectedItem = navigation.MenuItems[0];
+            if (pageHost.Content is null) ShowPage("overview");
+            App.Trace("navigation:selected");
+        });
     }
 
     private void BuildShell()
@@ -139,25 +146,36 @@ public sealed class MainWindow : Window
 
     private async Task InitializeAsync()
     {
+        App.Trace("runtime:initializing");
         var healthy = false;
         try
         {
             healthy = await store.InitializeAsync();
+            App.Trace(healthy ? "runtime:initialized" : "runtime:unavailable");
             if (healthy) ClearError();
         }
-        catch (Exception error) { ShowError(error.Message); }
+        catch (Exception error)
+        {
+            App.Trace($"runtime:initialization-failed:{error.GetType().Name}");
+            ShowError(error.Message);
+        }
+        App.Trace("runtime:updating-ui");
         Update(null);
+        App.Trace("runtime:ui-updated");
         var passed = healthy && store.IsRuntimeAvailable && store.Agents.Length == 5;
         WriteHealthResult(passed);
+        App.Trace(passed ? "health:passed" : "health:failed");
         if (App.IsSmokeTest)
         {
             if (!passed) Environment.ExitCode = 1;
+            App.Trace("smoke:quitting");
             await QuitCoreAsync();
         }
     }
 
     private void Update(string? propertyName)
     {
+        App.Trace($"update:{propertyName ?? "all"}:starting");
         syncingSwitch = true;
         protectionSwitch.IsOn = store.IsRunning;
         protectionSwitch.IsEnabled = store.IsRuntimeAvailable && !store.IsBusy;
@@ -166,35 +184,67 @@ public sealed class MainWindow : Window
         devBadge.Visibility = RuntimePresentation.ShowDevMode(store.State) && store.IsRuntimeAvailable ? Visibility.Visible : Visibility.Collapsed;
         tray.Update(store.IsProtected, statusText.Text);
 
+        if (pages.Count == 0)
+        {
+            App.Trace($"update:{propertyName ?? "all"}:shell-only");
+            return;
+        }
+
         switch (propertyName)
         {
             case nameof(RuntimeStore.Agents):
-                pages["overview"].Update();
-                pages["agents"].Update();
+                UpdatePage("overview");
+                UpdatePage("agents");
                 break;
             case nameof(RuntimeStore.Usage):
-                pages["usage"].Update();
+                UpdatePage("usage");
                 break;
             case nameof(RuntimeStore.ClientKey):
-                pages["overview"].Update();
+                UpdatePage("overview");
                 break;
             case nameof(RuntimeStore.State):
-                pages["overview"].Update();
-                pages["settings"].Update();
+                UpdatePage("overview");
+                UpdatePage("settings");
                 break;
             case nameof(RuntimeStore.IsRuntimeAvailable):
             case null:
-                foreach (var nativePage in pages.Values) nativePage.Update();
+                foreach (var pageName in pages.Keys) UpdatePage(pageName);
                 break;
         }
+        App.Trace($"update:{propertyName ?? "all"}:completed");
+    }
+
+    private void UpdatePage(string pageName)
+    {
+        if (!pages.TryGetValue(pageName, out var nativePage)) return;
+        App.Trace($"page:{pageName}:updating");
+        nativePage.Update();
+        App.Trace($"page:{pageName}:updated");
+    }
+
+    private void ShowPage(string pageName)
+    {
+        if (!pages.TryGetValue(pageName, out var nativePage))
+        {
+            nativePage = NativeViews.CreatePage(pageName, store, this);
+            pages.Add(pageName, nativePage);
+        }
+        else UpdatePage(pageName);
+        if (!ReferenceEquals(pageHost.Content, nativePage.Content)) pageHost.Content = nativePage.Content;
     }
 
     private void Navigation_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
+        App.Trace("navigation:selection-changing");
         page = args.IsSettingsSelected ? "settings" : (args.SelectedItemContainer?.Tag?.ToString() ?? "overview");
         pageTitle.Text = page switch { "agents" => "Agents", "usage" => "Usage", "settings" => "Settings", _ => "Overview" };
-        pages[page].Update();
-        if (!ReferenceEquals(pageHost.Content, pages[page].Content)) pageHost.Content = pages[page].Content;
+        if (!navigationReady)
+        {
+            App.Trace("navigation:selection-deferred");
+            return;
+        }
+        ShowPage(page);
+        App.Trace($"navigation:selection-changed:{page}");
     }
 
     private async void ProtectionSwitch_Toggled(object sender, RoutedEventArgs e)
@@ -303,9 +353,13 @@ public sealed class MainWindow : Window
     {
         if (quitting) return;
         quitting = true;
+        App.Trace("quit:disposing-tray");
         tray.Dispose();
+        App.Trace("quit:disposing-runtime");
         await store.DisposeAsync();
+        App.Trace("quit:destroying-window");
         appWindow.Destroy();
+        App.Trace("quit:exiting");
         Application.Current.Exit();
     }
 }

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/MainWindow.cs
@@ -138,7 +138,7 @@ public sealed class MainWindow : Window
         Activate();
     }
 
-    public void HideAfterLaunch() => DispatcherQueue.TryEnqueue(appWindow.Hide);
+    public void HideAfterLaunch() => DispatcherQueue.TryEnqueue(() => appWindow.Hide());
 
     public void ShowSettings()
     {

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeDialogs.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeDialogs.cs
@@ -26,12 +26,18 @@ internal static class NativeDialogs
                 list.Items.Add(row);
                 if (profile.Id == selected?.Id) list.SelectedItem = row;
             }
-            list.SelectionChanged += (_, _) => selected = (list.SelectedItem as FrameworkElement)?.Tag as ConfidentialProfile;
             var actions = Horizontal(8);
             var add = new Button { Content = IconLabel("New", "\uE710") };
             var edit = new Button { Content = IconLabel("Edit", "\uE70F"), IsEnabled = selected is not null };
             var delete = new Button { Content = IconLabel("Delete", "\uE74D"), IsEnabled = selected is not null && store.State.Profiles.Length > 1 };
             var use = new Button { Content = "Use Profile", IsEnabled = selected?.VerifiedAt is not null && selected.Id != store.State.ActiveProfileId };
+            list.SelectionChanged += (_, _) =>
+            {
+                selected = (list.SelectedItem as FrameworkElement)?.Tag as ConfidentialProfile;
+                edit.IsEnabled = selected is not null;
+                delete.IsEnabled = selected is not null && store.State.Profiles.Length > 1;
+                use.IsEnabled = selected?.VerifiedAt is not null && selected.Id != store.State.ActiveProfileId;
+            };
             add.Click += (_, _) => nextAction = "new";
             edit.Click += (_, _) => nextAction = "edit";
             delete.Click += (_, _) => nextAction = "delete";
@@ -47,9 +53,15 @@ internal static class NativeDialogs
                 case "edit" when selected is not null: await ShowProfileEditorAsync(store, selected, root); break;
                 case "delete" when selected is not null:
                     if (await ConfirmAsync("Delete profile?", "The profile credential will be removed from Windows Credential Manager.", "Delete", root))
-                        await store.DeleteProfileAsync(selected.Id);
+                    {
+                        try { await store.DeleteProfileAsync(selected.Id); }
+                        catch (Exception) { return; }
+                    }
                     break;
-                case "use" when selected is not null: await store.ActivateProfileAsync(selected.Id); break;
+                case "use" when selected is not null:
+                    try { await store.ActivateProfileAsync(selected.Id); }
+                    catch (Exception) { return; }
+                    break;
                 default: return;
             }
         }
@@ -65,9 +77,10 @@ internal static class NativeDialogs
         var key = new PasswordBox { Header = profile?.VerifiedAt is null ? "API key" : "API key (leave blank to keep)", PasswordRevealMode = PasswordRevealMode.Peek };
         var verify = new Button { Content = "Verify and Save", HorizontalAlignment = HorizontalAlignment.Right };
         var verified = new InfoBar { Severity = InfoBarSeverity.Success, Title = "Verified configuration", IsOpen = profile?.VerifiedAt is not null, IsClosable = false };
+        var validation = new InfoBar { Severity = InfoBarSeverity.Error, Title = "Configuration could not be verified", IsOpen = false, IsClosable = true };
         var allowDev = new ToggleSwitch { Header = "Allow development OS", IsOn = !store.State.Config.RequireProductionOs };
         var explanation = new TextBlock { Text = "Development OS mode weakens the production attestation policy and is shown in yellow whenever protection is running.", TextWrapping = TextWrapping.Wrap, Opacity = 0.65 };
-        var content = Vertical(14); content.Children.Add(name); content.Children.Add(provider); content.Children.Add(endpoint); content.Children.Add(key); content.Children.Add(verify); content.Children.Add(verified); content.Children.Add(allowDev); content.Children.Add(explanation);
+        var content = Vertical(14); content.Children.Add(name); content.Children.Add(provider); content.Children.Add(endpoint); content.Children.Add(key); content.Children.Add(verify); content.Children.Add(verified); content.Children.Add(validation); content.Children.Add(allowDev); content.Children.Add(explanation);
         var dialog = Dialog(profile is null ? "New Profile" : "Edit Profile", content, root, "Cancel");
         provider.SelectionChanged += (_, _) =>
         {
@@ -80,9 +93,16 @@ internal static class NativeDialogs
         {
             verify.IsEnabled = false;
             verify.Content = "Verifying…";
+            validation.IsOpen = false;
             var providerId = provider.SelectedIndex switch { 0 => "phala", 2 => "custom", _ => "redpill" };
             var input = new ConfidentialProfileInput(profile?.Id ?? $"profile-{Guid.NewGuid():N}", name.Text, providerId, endpoint.Text);
-            if (await store.VerifyAndSaveAsync(input, allowDev.IsOn, key.Password)) dialog.Hide();
+            var result = await store.VerifyAndSaveAsync(input, allowDev.IsOn, key.Password);
+            if (result.Success) dialog.Hide();
+            else
+            {
+                validation.Message = result.Error ?? "The configuration could not be verified.";
+                validation.IsOpen = true;
+            }
             verify.IsEnabled = true;
             verify.Content = "Verify and Save";
         };
@@ -96,9 +116,10 @@ internal static class NativeDialogs
         var network = new ToggleSwitch { Header = "Allow network access", IsOn = current.AllowNetworkAccess };
         var port = new NumberBox { Header = "Port", Value = current.Port, Minimum = 1024, Maximum = 65535, SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact };
         var host = new TextBox { Header = "Client host", Text = current.ClientHost ?? "" };
-        var note = new InfoBar { Title = "Network access exposes the Local API beyond this PC.", Message = "Connected agents must be disconnected before changing the endpoint.", Severity = InfoBarSeverity.Warning, IsOpen = false, IsClosable = false };
+        var note = new InfoBar { Title = "Network access exposes the Local API beyond this PC.", Message = "Connected agents must be disconnected before changing the endpoint.", Severity = InfoBarSeverity.Warning, IsOpen = network.IsOn, IsClosable = false };
+        var validation = new InfoBar { Title = "Local API settings could not be saved", Severity = InfoBarSeverity.Error, IsOpen = false, IsClosable = true };
         network.Toggled += (_, _) => note.IsOpen = network.IsOn;
-        var content = Vertical(14); content.Children.Add(address); content.Children.Add(network); content.Children.Add(note); content.Children.Add(port); content.Children.Add(host);
+        var content = Vertical(14); content.Children.Add(address); content.Children.Add(network); content.Children.Add(note); content.Children.Add(port); content.Children.Add(host); content.Children.Add(validation);
         var dialog = new ContentDialog { Title = "Local API Settings", Content = content, PrimaryButtonText = "Save", CloseButtonText = "Cancel", DefaultButton = ContentDialogButton.Primary, XamlRoot = root, MinWidth = 540 };
         dialog.PrimaryButtonClick += async (_, args) =>
         {
@@ -106,11 +127,16 @@ internal static class NativeDialogs
             try
             {
                 args.Cancel = true;
+                validation.IsOpen = false;
                 var value = double.IsNaN(port.Value) ? 0 : port.Value;
                 await store.SaveLocalApiAsync(new(address.Text, network.IsOn, (ushort)value, string.IsNullOrWhiteSpace(host.Text) ? null : host.Text));
                 dialog.Hide();
             }
-            catch { }
+            catch (Exception error)
+            {
+                validation.Message = error.Message;
+                validation.IsOpen = true;
+            }
             finally { deferral.Complete(); }
         };
         await dialog.ShowAsync();

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeTray.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeTray.cs
@@ -37,7 +37,7 @@ internal sealed class NativeTray : IDisposable
     private readonly WindowProc callback;
     private readonly nint normalIcon;
     private readonly nint protectedIcon;
-    private bool running;
+    private bool protectedState;
     private string status = "Not protected";
 
     internal NativeTray(nint window, Action open, Action settings, Action toggle, Action quit)
@@ -69,9 +69,9 @@ internal sealed class NativeTray : IDisposable
         Notify(NimAdd, normalIcon, "Private AI Gateway - Not protected");
     }
 
-    internal void Update(bool running, bool protectedState, string status)
+    internal void Update(bool protectedState, string status)
     {
-        this.running = running;
+        this.protectedState = protectedState;
         this.status = status;
         Notify(NimModify, protectedState ? protectedIcon : normalIcon, $"Private AI Gateway - {status}");
     }
@@ -90,7 +90,7 @@ internal sealed class NativeTray : IDisposable
     private void ShowMenu()
     {
         var menu = CreatePopupMenu();
-        AppendMenu(menu, MfString | (running ? MfChecked : 0), 1, "Protected");
+        AppendMenu(menu, MfString | (protectedState ? MfChecked : 0), 1, "Protected");
         AppendMenu(menu, MfString | MfGray, 2, status);
         AppendMenu(menu, MfSeparator, 0, null);
         AppendMenu(menu, MfString, 3, "Open Private AI Gateway");

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
@@ -21,7 +21,7 @@ internal static class NativeViews
     internal static INativePage CreatePage(string pageName, RuntimeStore store, MainWindow window)
     {
         App.Trace($"page:{pageName}:creating");
-        var page = pageName switch
+        INativePage page = pageName switch
         {
             "agents" => new AgentsPage(store),
             "usage" => new UsagePageView(store, window),

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
@@ -18,14 +18,19 @@ internal static class NativeViews
     private static readonly SolidColorBrush Success = new(global::Windows.UI.Color.FromArgb(255, 44, 110, 73));
     private static readonly SolidColorBrush Warning = new(global::Windows.UI.Color.FromArgb(255, 184, 120, 0));
 
-    internal static IReadOnlyDictionary<string, INativePage> CreatePages(RuntimeStore store, MainWindow window) =>
-        new Dictionary<string, INativePage>
+    internal static INativePage CreatePage(string pageName, RuntimeStore store, MainWindow window)
+    {
+        App.Trace($"page:{pageName}:creating");
+        var page = pageName switch
         {
-            ["overview"] = new OverviewPage(store, window),
-            ["agents"] = new AgentsPage(store),
-            ["usage"] = new UsagePageView(store, window),
-            ["settings"] = new SettingsPage(store, window),
+            "agents" => new AgentsPage(store),
+            "usage" => new UsagePageView(store, window),
+            "settings" => new SettingsPage(store, window),
+            _ => new OverviewPage(store, window),
         };
+        App.Trace($"page:{pageName}:created");
+        return page;
+    }
 
     private sealed class OverviewPage : INativePage
     {

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/NativeViews.cs
@@ -7,182 +7,445 @@ using WinRT.Interop;
 
 namespace PrivateAIGateway.Windows;
 
+internal interface INativePage
+{
+    UIElement Content { get; }
+    void Update();
+}
+
 internal static class NativeViews
 {
     private static readonly SolidColorBrush Success = new(global::Windows.UI.Color.FromArgb(255, 44, 110, 73));
     private static readonly SolidColorBrush Warning = new(global::Windows.UI.Color.FromArgb(255, 184, 120, 0));
 
-    internal static UIElement Overview(RuntimeStore store, MainWindow window)
-    {
-        var content = Vertical(24);
-        content.Children.Add(ProtectionSummary(store, window));
-        var columns = new Grid { ColumnSpacing = 20 };
-        columns.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        columns.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        var local = Section("Local API");
-        local.Children.Add(CopyRow("Endpoint", store.State.ProxyUrl ?? "Unavailable", store.State.ProxyUrl));
-        local.Children.Add(new Border
+    internal static IReadOnlyDictionary<string, INativePage> CreatePages(RuntimeStore store, MainWindow window) =>
+        new Dictionary<string, INativePage>
         {
-            Height = 1,
-            Margin = new Thickness(0, 4, 0, 4),
-            Background = new SolidColorBrush(global::Windows.UI.Color.FromArgb(32, 128, 128, 128)),
-        });
-        local.Children.Add(ClientKeyRow(store));
-        var agents = Section("Agents");
-        foreach (var agent in store.Agents.Take(5)) agents.Children.Add(AgentRow(store, agent));
-        columns.Children.Add(Card(local));
-        Grid.SetColumn(CardInto(columns, agents), 1);
-        content.Children.Add(columns);
-        content.Children.Add(Metrics(store.State.SessionUsage, "This session"));
-        var recent = Section("Recent usage");
-        if (store.State.Activity.Length == 0) recent.Children.Add(Empty("No usage this session"));
-        else foreach (var item in store.State.Activity.Take(5)) recent.Children.Add(UsageRow(item, () => _ = window.ShowProofAsync(item)));
-        content.Children.Add(Card(recent));
-        return Scroll(content);
-    }
+            ["overview"] = new OverviewPage(store, window),
+            ["agents"] = new AgentsPage(store),
+            ["usage"] = new UsagePageView(store, window),
+            ["settings"] = new SettingsPage(store, window),
+        };
 
-    internal static UIElement Agents(RuntimeStore store)
+    private sealed class OverviewPage : INativePage
     {
-        var content = Vertical(0);
-        if (store.Agents.Length == 0) content.Children.Add(Empty("No supported agents were found"));
-        else foreach (var agent in store.Agents) content.Children.Add(AgentRow(store, agent));
-        return new ScrollViewer { Content = Card(content), Padding = new Thickness(24) };
-    }
+        private readonly RuntimeStore store;
+        private readonly MainWindow window;
+        private readonly FontIcon protectionIcon = new() { FontSize = 32 };
+        private readonly TextBlock summaryTitle = new() { FontSize = 18, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold };
+        private readonly TextBlock summaryDetail = new() { Opacity = 0.65, TextWrapping = TextWrapping.Wrap };
+        private readonly Button privacy = new() { Content = "Privacy Verification…" };
+        private readonly TextBlock endpoint = new() { FontFamily = new FontFamily("Consolas"), TextTrimming = TextTrimming.CharacterEllipsis };
+        private readonly Button endpointCopy = new() { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = Transparent, BorderThickness = new Thickness(0) };
+        private readonly TextBlock clientKey = new() { FontFamily = new FontFamily("Consolas") };
+        private readonly AgentList agentRows;
+        private readonly TextBlock[] sessionMetrics = MetricValues();
+        private readonly UsageList recentRows;
+        private bool revealKey;
 
-    internal static UIElement Usage(RuntimeStore store, MainWindow window)
-    {
-        var root = Vertical(18);
-        var toolbar = Horizontal(12);
-        toolbar.Children.Add(Filter("Agent", "All agents", store.Usage.Agents, store.UsageAgent, value => { store.UsageAgent = value; _ = store.ReloadUsageAsync(true); }));
-        toolbar.Children.Add(Filter("Model", "All models", store.Usage.Models, store.UsageModel, value => { store.UsageModel = value; _ = store.ReloadUsageAsync(true); }));
-        var range = new ComboBox { Header = "Time", MinWidth = 140 };
-        foreach (var option in new[] { "7 days", "30 days", "All time" }) range.Items.Add(option);
-        range.SelectedIndex = (int)store.UsageRange;
-        range.SelectionChanged += (_, _) => { store.UsageRange = (UsageRange)Math.Max(0, range.SelectedIndex); _ = store.ReloadUsageAsync(true); };
-        toolbar.Children.Add(range);
-        toolbar.Children.Add(new Border { Width = 10 });
-        var export = new Button { Content = "Export CSV…" };
-        export.Click += async (_, _) => await ExportAsync(store, window);
-        toolbar.Children.Add(export);
-        var clear = new Button { Content = "Clear History…" };
-        clear.Click += async (_, _) => await window.ConfirmClearUsageAsync();
-        toolbar.Children.Add(clear);
-        root.Children.Add(toolbar);
-        root.Children.Add(Metrics(store.Usage.Summary, null));
-        root.Children.Add(UsageChart(store.Usage.Series));
-        var list = Section("Usage history");
-        if (store.Usage.Items.Length == 0) list.Children.Add(Empty("No usage matches these filters"));
-        else foreach (var item in store.Usage.Items) list.Children.Add(UsageRow(item, () => _ = window.ShowProofAsync(item)));
-        root.Children.Add(Card(list));
-        if (store.Usage.NextCursor is not null)
+        internal OverviewPage(RuntimeStore store, MainWindow window)
         {
-            var more = new Button { Content = "Load More", HorizontalAlignment = HorizontalAlignment.Center };
-            more.Click += async (_, _) => await store.ReloadUsageAsync(false);
-            root.Children.Add(more);
+            this.store = store;
+            this.window = window;
+            agentRows = new AgentList(store, "Agents");
+            recentRows = new UsageList(window, "Recent usage");
+            var content = Vertical(24);
+            content.Children.Add(BuildSummary());
+            var columns = new Grid { ColumnSpacing = 20 };
+            columns.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            columns.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            columns.Children.Add(Card(BuildLocalApi()));
+            var agents = Card(agentRows.Content);
+            Grid.SetColumn(agents, 1);
+            columns.Children.Add(agents);
+            content.Children.Add(columns);
+            content.Children.Add(Metrics(sessionMetrics, "This session"));
+            content.Children.Add(Card(recentRows.Content));
+            Content = Scroll(content);
+            Update();
         }
-        return Scroll(root);
+
+        public UIElement Content { get; }
+
+        public void Update()
+        {
+            var state = store.State;
+            protectionIcon.Glyph = store.IsProtected ? "\uE83D" : "\uEA18";
+            protectionIcon.Foreground = store.IsRuntimeAvailable && RuntimePresentation.ShowDevMode(state) ? Warning : store.IsProtected ? Success : null;
+            summaryTitle.Text = store.IsRuntimeAvailable ? RuntimePresentation.SummaryLabel(state) : "Runtime unavailable";
+            summaryDetail.Text = state.Progress ?? state.Error ?? store.ActiveProfile?.Name ?? "Choose a Confidential AI profile";
+            privacy.IsEnabled = state.Identity is not null && store.IsRuntimeAvailable;
+            endpoint.Text = state.ProxyUrl ?? "Unavailable";
+            endpointCopy.IsEnabled = state.ProxyUrl is not null && store.IsRuntimeAvailable;
+            clientKey.Text = revealKey ? store.ClientKey : "pag_••••••••••••";
+            agentRows.Reconcile(store.Agents.Take(5));
+            SetMetrics(sessionMetrics, state.SessionUsage);
+            recentRows.Reconcile(state.Activity.Take(5), "No usage this session");
+        }
+
+        private UIElement BuildSummary()
+        {
+            var grid = new Grid { Padding = new Thickness(20), ColumnSpacing = 16 };
+            grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+            grid.Children.Add(protectionIcon);
+            var text = Vertical(4);
+            text.Children.Add(summaryTitle);
+            text.Children.Add(summaryDetail);
+            Grid.SetColumn(text, 1);
+            grid.Children.Add(text);
+            var actions = Horizontal(8);
+            var profiles = new Button { Content = "Profiles…" };
+            profiles.Click += async (_, _) => await window.ShowProfilesAsync();
+            privacy.Click += async (_, _) => await window.ShowPrivacyAsync();
+            actions.Children.Add(profiles);
+            actions.Children.Add(privacy);
+            Grid.SetColumn(actions, 2);
+            grid.Children.Add(actions);
+            return Card(grid);
+        }
+
+        private UIElement BuildLocalApi()
+        {
+            var local = Section("Local API");
+            var endpointGrid = new Grid();
+            endpointGrid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            endpointGrid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+            endpointGrid.Children.Add(Labeled("Endpoint", endpoint));
+            var copyIcon = new FontIcon { Glyph = "\uE8C8" };
+            Grid.SetColumn(copyIcon, 1);
+            endpointGrid.Children.Add(copyIcon);
+            endpointCopy.Content = endpointGrid;
+            endpointCopy.Click += (_, _) =>
+            {
+                if (store.State.ProxyUrl is { } value) global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(ClipboardContent(value));
+            };
+            local.Children.Add(endpointCopy);
+            local.Children.Add(Divider());
+
+            var keyCopy = new Button { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = Transparent, BorderThickness = new Thickness(0) };
+            keyCopy.Content = Labeled("Client key", clientKey);
+            keyCopy.Click += (_, _) => global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(ClipboardContent(store.ClientKey));
+            var eye = new Button { Content = new FontIcon { Glyph = "\uE890" } };
+            eye.Click += (_, _) =>
+            {
+                revealKey = !revealKey;
+                clientKey.Text = revealKey ? store.ClientKey : "pag_••••••••••••";
+                ToolTipService.SetToolTip(eye, revealKey ? "Hide client key" : "Reveal client key");
+            };
+            ToolTipService.SetToolTip(eye, "Reveal client key");
+            var row = new Grid { ColumnSpacing = 8 };
+            row.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            row.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+            row.Children.Add(keyCopy);
+            Grid.SetColumn(eye, 1);
+            row.Children.Add(eye);
+            local.Children.Add(row);
+            return local;
+        }
     }
 
-    internal static UIElement Settings(RuntimeStore store, MainWindow window)
+    private sealed class AgentsPage : INativePage
     {
-        var root = Vertical(18);
-        var profiles = Section("Confidential AI");
-        profiles.Children.Add(new TextBlock { Text = store.ActiveProfile?.Name ?? "Not configured", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-        var manage = new Button { Content = "Manage Profiles…", HorizontalAlignment = HorizontalAlignment.Left, IsEnabled = !store.IsRunning };
-        manage.Click += async (_, _) => await window.ShowProfilesAsync();
-        profiles.Children.Add(manage);
-        root.Children.Add(Card(profiles));
-        var local = Section("Local API");
-        var localSettings = new Button { Content = "Local API Settings…", HorizontalAlignment = HorizontalAlignment.Left, IsEnabled = !store.IsRunning };
-        localSettings.Click += async (_, _) => await window.ShowLocalApiAsync();
-        var rotate = new Button { Content = "Rotate Client Key…", HorizontalAlignment = HorizontalAlignment.Left };
-        rotate.Click += async (_, _) => await store.RotateClientKeyAsync();
-        local.Children.Add(localSettings);
-        local.Children.Add(rotate);
-        root.Children.Add(Card(local));
-        var advanced = new Expander { Header = "Advanced", IsExpanded = false };
-        var advancedContent = Vertical(10);
-        advancedContent.Children.Add(new TextBlock { Text = store.IsDevMode ? "Development OS allowed" : "Production OS required" });
-        var restore = new Button { Content = "Restore All Agent Configurations…", HorizontalAlignment = HorizontalAlignment.Left };
-        restore.Click += async (_, _) => await window.ConfirmRestoreAsync();
-        advancedContent.Children.Add(restore);
-        advanced.Content = advancedContent;
-        root.Children.Add(advanced);
-        return Scroll(root);
+        private readonly RuntimeStore store;
+        private readonly AgentList rows;
+
+        internal AgentsPage(RuntimeStore store)
+        {
+            this.store = store;
+            rows = new AgentList(store, null);
+            Content = new ScrollViewer { Content = Card(rows.Content), Padding = new Thickness(24), HorizontalScrollMode = ScrollMode.Disabled };
+            Update();
+        }
+
+        public UIElement Content { get; }
+        public void Update() => rows.Reconcile(store.Agents);
     }
 
-    private static UIElement ProtectionSummary(RuntimeStore store, MainWindow window)
+    private sealed class UsagePageView : INativePage
     {
-        var grid = new Grid { Padding = new Thickness(20), ColumnSpacing = 16 };
-        grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
-        var icon = new FontIcon { Glyph = store.IsProtected ? "\uE83D" : "\uEA18", FontSize = 32, Foreground = store.IsDevMode && store.IsRunning ? Warning : store.IsProtected ? Success : null };
-        grid.Children.Add(icon);
-        var text = Vertical(4);
-        text.Children.Add(new TextBlock { Text = store.IsDevMode && store.IsRunning ? "Protected in dev mode" : Status(store.State), FontSize = 18, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-        text.Children.Add(new TextBlock { Text = store.State.Progress ?? store.State.Error ?? store.ActiveProfile?.Name ?? "Choose a Confidential AI profile", Opacity = 0.65, TextWrapping = TextWrapping.Wrap });
-        Grid.SetColumn(text, 1); grid.Children.Add(text);
-        var actions = Horizontal(8);
-        var profile = new Button { Content = "Profiles…" }; profile.Click += async (_, _) => await window.ShowProfilesAsync();
-        var privacy = new Button { Content = "Privacy Verification…", IsEnabled = store.State.Identity is not null }; privacy.Click += async (_, _) => await window.ShowPrivacyAsync();
-        actions.Children.Add(profile); actions.Children.Add(privacy);
-        Grid.SetColumn(actions, 2); grid.Children.Add(actions);
-        return Card(grid);
+        private readonly RuntimeStore store;
+        private readonly MainWindow window;
+        private readonly ComboBox agentFilter = new() { Header = "Agent", MinWidth = 150 };
+        private readonly ComboBox modelFilter = new() { Header = "Model", MinWidth = 150 };
+        private readonly ComboBox rangeFilter = new() { Header = "Time", MinWidth = 140 };
+        private readonly TextBlock[] summaryMetrics = MetricValues();
+        private readonly ContentControl chart = new();
+        private readonly UsageList history;
+        private readonly Button more = new() { Content = "Load More", HorizontalAlignment = HorizontalAlignment.Center };
+        private bool syncingFilters;
+
+        internal UsagePageView(RuntimeStore store, MainWindow window)
+        {
+            this.store = store;
+            this.window = window;
+            history = new UsageList(window, "Usage history");
+            agentFilter.SelectionChanged += async (_, _) => await FilterChangedAsync(true);
+            modelFilter.SelectionChanged += async (_, _) => await FilterChangedAsync(false);
+            foreach (var option in new[] { "7 days", "30 days", "All time" }) rangeFilter.Items.Add(option);
+            rangeFilter.SelectionChanged += async (_, _) =>
+            {
+                if (syncingFilters) return;
+                store.UsageRange = (UsageRange)Math.Max(0, rangeFilter.SelectedIndex);
+                try { await store.ReloadUsageAsync(true); } catch (RuntimeException) { }
+            };
+            more.Click += async (_, _) =>
+            {
+                try { await store.ReloadUsageAsync(false); } catch (RuntimeException) { }
+            };
+
+            var root = Vertical(18);
+            var toolbar = Horizontal(12);
+            toolbar.Children.Add(agentFilter);
+            toolbar.Children.Add(modelFilter);
+            toolbar.Children.Add(rangeFilter);
+            toolbar.Children.Add(new Border { Width = 10 });
+            var export = new Button { Content = "Export CSV…" };
+            export.Click += async (_, _) => await ExportAsync(store, window);
+            var clear = new Button { Content = "Clear History…" };
+            clear.Click += async (_, _) => await window.ConfirmClearUsageAsync();
+            toolbar.Children.Add(export);
+            toolbar.Children.Add(clear);
+            root.Children.Add(toolbar);
+            root.Children.Add(Metrics(summaryMetrics, null));
+            root.Children.Add(chart);
+            root.Children.Add(Card(history.Content));
+            root.Children.Add(more);
+            Content = Scroll(root);
+            Update();
+        }
+
+        public UIElement Content { get; }
+
+        public void Update()
+        {
+            syncingFilters = true;
+            SetFilter(agentFilter, "All agents", store.Usage.Agents, store.UsageAgent);
+            SetFilter(modelFilter, "All models", store.Usage.Models, store.UsageModel);
+            rangeFilter.SelectedIndex = (int)store.UsageRange;
+            syncingFilters = false;
+            agentFilter.IsEnabled = store.IsRuntimeAvailable;
+            modelFilter.IsEnabled = store.IsRuntimeAvailable;
+            rangeFilter.IsEnabled = store.IsRuntimeAvailable;
+            SetMetrics(summaryMetrics, store.Usage.Summary);
+            chart.Content = UsageChart(store.Usage.Series);
+            history.Reconcile(store.Usage.Items, "No usage matches these filters");
+            more.Visibility = store.Usage.NextCursor is null ? Visibility.Collapsed : Visibility.Visible;
+            more.IsEnabled = store.IsRuntimeAvailable;
+        }
+
+        private async Task FilterChangedAsync(bool agent)
+        {
+            if (syncingFilters) return;
+            var box = agent ? agentFilter : modelFilter;
+            var value = box.SelectedIndex <= 0 ? null : box.SelectedItem?.ToString();
+            if (agent) store.UsageAgent = value;
+            else store.UsageModel = value;
+            try { await store.ReloadUsageAsync(true); } catch (RuntimeException) { }
+        }
     }
 
-    private static UIElement AgentRow(RuntimeStore store, AgentStatus agent)
+    private sealed class SettingsPage : INativePage
     {
-        var grid = new Grid { Padding = new Thickness(12, 8, 12, 8), ColumnSpacing = 12 };
-        grid.ColumnDefinitions.Add(new() { Width = new GridLength(30) });
-        grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
-        grid.Children.Add(AssetImage($"Assets/agents/{agent.Id}.svg", 26));
-        var labels = Vertical(2);
-        labels.Children.Add(new TextBlock { Text = agent.Name });
-        labels.Children.Add(new TextBlock { Text = agent.Error ?? agent.Attention ?? (agent.Installed ? agent.ConfigPath : "CLI not found"), FontSize = 12, Opacity = agent.Error is null ? 0.6 : 1, TextWrapping = TextWrapping.Wrap, MaxLines = 2 });
-        Grid.SetColumn(labels, 1); grid.Children.Add(labels);
-        var toggle = new ToggleSwitch { IsOn = agent.Connected, IsEnabled = agent.Installed || agent.Recorded, OffContent = "", OnContent = "" };
-        toggle.Toggled += async (_, _) => { if (toggle.IsOn != agent.Connected) await store.SetAgentAsync(agent, toggle.IsOn); };
-        Grid.SetColumn(toggle, 2); grid.Children.Add(toggle);
-        return grid;
+        private readonly RuntimeStore store;
+        private readonly TextBlock profile = new() { FontWeight = Microsoft.UI.Text.FontWeights.SemiBold };
+        private readonly Button manage = new() { Content = "Manage Profiles…", HorizontalAlignment = HorizontalAlignment.Left };
+        private readonly Button localSettings = new() { Content = "Local API Settings…", HorizontalAlignment = HorizontalAlignment.Left };
+        private readonly Button rotate = new() { Content = "Rotate Client Key…", HorizontalAlignment = HorizontalAlignment.Left };
+        private readonly TextBlock policy = new();
+        private readonly Button restore = new() { Content = "Restore All Agent Configurations…", HorizontalAlignment = HorizontalAlignment.Left };
+
+        internal SettingsPage(RuntimeStore store, MainWindow window)
+        {
+            this.store = store;
+            var root = Vertical(18);
+            var profiles = Section("Confidential AI");
+            profiles.Children.Add(profile);
+            manage.Click += async (_, _) => await window.ShowProfilesAsync();
+            profiles.Children.Add(manage);
+            root.Children.Add(Card(profiles));
+            var local = Section("Local API");
+            localSettings.Click += async (_, _) => await window.ShowLocalApiAsync();
+            rotate.Click += async (_, _) => await store.RotateClientKeyAsync();
+            local.Children.Add(localSettings);
+            local.Children.Add(rotate);
+            root.Children.Add(Card(local));
+            var advanced = new Expander { Header = "Advanced", IsExpanded = false };
+            var advancedContent = Vertical(10);
+            advancedContent.Children.Add(policy);
+            restore.Click += async (_, _) => await window.ConfirmRestoreAsync();
+            advancedContent.Children.Add(restore);
+            advanced.Content = advancedContent;
+            root.Children.Add(advanced);
+            Content = Scroll(root);
+            Update();
+        }
+
+        public UIElement Content { get; }
+
+        public void Update()
+        {
+            profile.Text = store.ActiveProfile?.Name ?? "Not configured";
+            manage.IsEnabled = store.IsRuntimeAvailable && !store.IsRunning;
+            localSettings.IsEnabled = store.IsRuntimeAvailable && !store.IsRunning;
+            rotate.IsEnabled = store.IsRuntimeAvailable;
+            restore.IsEnabled = store.IsRuntimeAvailable;
+            policy.Text = store.IsDevMode ? "Development OS allowed" : "Production OS required";
+        }
     }
 
-    private static UIElement ClientKeyRow(RuntimeStore store)
+    private sealed class AgentList
     {
-        var reveal = false;
-        var value = new TextBlock { Text = "pag_••••••••••••", FontFamily = new FontFamily("Consolas") };
-        var copy = new Button { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent), BorderThickness = new Thickness(0) };
-        copy.Content = Labeled("Client key", value);
-        copy.Click += (_, _) => global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(ClipboardContent(store.ClientKey));
-        var eye = new Button { Content = new FontIcon { Glyph = "\uE890" } };
-        eye.Click += (_, _) => { reveal = !reveal; value.Text = reveal ? store.ClientKey : "pag_••••••••••••"; };
-        var grid = new Grid { ColumnSpacing = 8 };
-        grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
-        grid.Children.Add(copy); Grid.SetColumn(eye, 1); grid.Children.Add(eye);
-        return grid;
+        private readonly RuntimeStore store;
+        private readonly int offset;
+        private readonly Dictionary<string, AgentRowView> rows = [];
+        private readonly TextBlock empty = Empty("No supported agents were found");
+
+        internal AgentList(RuntimeStore store, string? title)
+        {
+            this.store = store;
+            Content = title is null ? Vertical(0) : Section(title);
+            offset = title is null ? 0 : 1;
+        }
+
+        internal StackPanel Content { get; }
+
+        internal void Reconcile(IEnumerable<AgentStatus> agents)
+        {
+            var values = agents.ToArray();
+            var ids = values.Select(agent => agent.Id).ToHashSet(StringComparer.Ordinal);
+            foreach (var stale in rows.Keys.Where(id => !ids.Contains(id)).ToArray())
+            {
+                Content.Children.Remove(rows[stale].Content);
+                rows.Remove(stale);
+            }
+            Content.Children.Remove(empty);
+            for (var index = 0; index < values.Length; index++)
+            {
+                var agent = values[index];
+                if (!rows.TryGetValue(agent.Id, out var row)) rows[agent.Id] = row = new AgentRowView(store, agent);
+                row.Update(agent);
+                Place(Content, row.Content, offset + index);
+            }
+            if (values.Length == 0) Content.Children.Add(empty);
+        }
     }
 
-    private static UIElement CopyRow(string title, string value, string? copyValue)
+    private sealed class AgentRowView
     {
-        var button = new Button { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent), BorderThickness = new Thickness(0), IsEnabled = copyValue is not null };
-        var grid = new Grid(); grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) }); grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
-        grid.Children.Add(Labeled(title, new TextBlock { Text = value, FontFamily = new FontFamily("Consolas"), TextTrimming = TextTrimming.CharacterEllipsis }));
-        var icon = new FontIcon { Glyph = "\uE8C8" }; Grid.SetColumn(icon, 1); grid.Children.Add(icon); button.Content = grid;
-        button.Click += (_, _) => { if (copyValue is not null) global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(ClipboardContent(copyValue)); };
-        return button;
+        private readonly RuntimeStore store;
+        private readonly TextBlock name = new();
+        private readonly TextBlock detail = new() { FontSize = 12, TextWrapping = TextWrapping.Wrap, MaxLines = 2 };
+        private readonly ToggleSwitch toggle = new() { OffContent = "", OnContent = "" };
+        private AgentStatus agent;
+        private bool syncing;
+
+        internal AgentRowView(RuntimeStore store, AgentStatus agent)
+        {
+            this.store = store;
+            this.agent = agent;
+            var grid = new Grid { Padding = new Thickness(12, 8, 12, 8), ColumnSpacing = 12 };
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(30) });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+            grid.Children.Add(AssetImage($"Assets/agents/{agent.Id}.svg", 26));
+            var labels = Vertical(2);
+            labels.Children.Add(name);
+            labels.Children.Add(detail);
+            Grid.SetColumn(labels, 1);
+            grid.Children.Add(labels);
+            toggle.Toggled += async (_, _) =>
+            {
+                if (!syncing && toggle.IsOn != this.agent.Connected) await store.SetAgentAsync(this.agent, toggle.IsOn);
+            };
+            Grid.SetColumn(toggle, 2);
+            grid.Children.Add(toggle);
+            Content = grid;
+            Update(agent);
+        }
+
+        internal UIElement Content { get; }
+
+        internal void Update(AgentStatus next)
+        {
+            agent = next;
+            name.Text = next.Name;
+            detail.Text = next.Error ?? next.Attention ?? (next.Installed ? next.ConfigPath : "CLI not found");
+            detail.Opacity = next.Error is null ? 0.6 : 1;
+            syncing = true;
+            toggle.IsOn = next.Connected;
+            toggle.IsEnabled = store.IsRuntimeAvailable && (next.Installed || next.Recorded);
+            syncing = false;
+        }
     }
 
-    private static UIElement Metrics(UsageSummary summary, string? title)
+    private sealed class UsageList
+    {
+        private readonly MainWindow window;
+        private readonly int offset;
+        private readonly Dictionary<string, UsageRowView> rows = [];
+        private TextBlock? empty;
+
+        internal UsageList(MainWindow window, string? title)
+        {
+            this.window = window;
+            Content = title is null ? Vertical(0) : Section(title);
+            offset = title is null ? 0 : 1;
+        }
+
+        internal StackPanel Content { get; }
+
+        internal void Reconcile(IEnumerable<RequestActivity> items, string emptyText)
+        {
+            var values = items.ToArray();
+            var ids = values.Select(item => item.Id).ToHashSet(StringComparer.Ordinal);
+            foreach (var stale in rows.Keys.Where(id => !ids.Contains(id)).ToArray())
+            {
+                Content.Children.Remove(rows[stale].Content);
+                rows.Remove(stale);
+            }
+            if (empty is not null) Content.Children.Remove(empty);
+            for (var index = 0; index < values.Length; index++)
+            {
+                var item = values[index];
+                if (!rows.TryGetValue(item.Id, out var row)) rows[item.Id] = row = new UsageRowView(window, item);
+                row.Update(item);
+                Place(Content, row.Content, offset + index);
+            }
+            if (values.Length == 0)
+            {
+                empty = Empty(emptyText);
+                Content.Children.Add(empty);
+            }
+        }
+    }
+
+    private static TextBlock[] MetricValues() => Enumerable.Range(0, 4).Select(_ => new TextBlock { FontSize = 18 }).ToArray();
+
+    private static UIElement Metrics(TextBlock[] values, string? title)
     {
         var stack = Vertical(10);
         if (title is not null) stack.Children.Add(new TextBlock { Text = title, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
         var grid = new Grid { ColumnSpacing = 20 };
-        for (var index = 0; index < 4; index++) grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
-        var values = new[] { ("Requests", $"{summary.Requests:N0}"), ("Tokens", $"{summary.InputTokens + summary.OutputTokens:N0}"), ("Cost", $"{summary.CostUsd:C}"), ("Protected", summary.Requests == 0 ? "—" : $"{summary.Protected * 100 / summary.Requests}%") };
-        for (var index = 0; index < values.Length; index++) { var metric = Labeled(values[index].Item1, new TextBlock { Text = values[index].Item2, FontSize = 18 }); Grid.SetColumn(metric, index); grid.Children.Add(metric); }
-        stack.Children.Add(grid); return Card(stack);
+        for (var index = 0; index < values.Length; index++) grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+        var labels = new[] { "Requests", "Tokens", "Cost", "Protected" };
+        for (var index = 0; index < values.Length; index++)
+        {
+            var metric = Labeled(labels[index], values[index]);
+            Grid.SetColumn(metric, index);
+            grid.Children.Add(metric);
+        }
+        stack.Children.Add(grid);
+        return Card(stack);
+    }
+
+    private static void SetMetrics(TextBlock[] values, UsageSummary summary)
+    {
+        values[0].Text = $"{summary.Requests:N0}";
+        values[1].Text = $"{summary.InputTokens + summary.OutputTokens:N0}";
+        values[2].Text = $"{summary.CostUsd:C}";
+        values[3].Text = summary.Requests == 0 ? "—" : $"{summary.Protected * 100 / summary.Requests}%";
     }
 
     private static UIElement UsageChart(UsagePoint[] points)
@@ -195,42 +458,111 @@ internal static class NativeViews
             chart.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
             var column = new Grid { VerticalAlignment = VerticalAlignment.Bottom, Height = Math.Max(2, 120d * points[index].Tokens / max), Background = Success, CornerRadius = new CornerRadius(2) };
             ToolTipService.SetToolTip(column, $"{points[index].Day}: {points[index].Tokens:N0} tokens");
-            Grid.SetColumn(column, index); chart.Children.Add(column);
+            Grid.SetColumn(column, index);
+            chart.Children.Add(column);
         }
         return Card(chart);
     }
 
-    private static UIElement UsageRow(RequestActivity item, Action action)
+    private sealed class UsageRowView
     {
-        var button = new Button { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent), BorderThickness = new Thickness(0), Padding = new Thickness(12, 9, 12, 9) };
-        var grid = new Grid { ColumnSpacing = 12 };
-        grid.ColumnDefinitions.Add(new() { Width = new GridLength(24) }); grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) }); grid.ColumnDefinitions.Add(new() { Width = new GridLength(90) }); grid.ColumnDefinitions.Add(new() { Width = new GridLength(72) }); grid.ColumnDefinitions.Add(new() { Width = new GridLength(18) });
-        grid.Children.Add(new FontIcon { Glyph = item.Verified == true ? "\uE83D" : item.LeftDevice ? "\uE814" : "\uE711", Foreground = item.Verified == true ? Success : item.LeftDevice ? new SolidColorBrush(Microsoft.UI.Colors.IndianRed) : null });
-        var label = Vertical(2); label.Children.Add(new TextBlock { Text = item.Model ?? item.Path, TextTrimming = TextTrimming.CharacterEllipsis }); label.Children.Add(new TextBlock { Text = string.Join(" · ", new[] { item.Agent, item.Path }.Where(value => !string.IsNullOrEmpty(value))), FontSize = 12, Opacity = 0.6, TextTrimming = TextTrimming.CharacterEllipsis }); Grid.SetColumn(label, 1); grid.Children.Add(label);
-        var tokens = new TextBlock { Text = $"{(item.InputTokens ?? 0) + (item.OutputTokens ?? 0):N0}", Opacity = 0.65, HorizontalAlignment = HorizontalAlignment.Right }; Grid.SetColumn(tokens, 2); grid.Children.Add(tokens);
-        var time = new TextBlock { Text = DateTimeOffset.FromUnixTimeSeconds((long)item.At).ToLocalTime().ToString("t"), Opacity = 0.65, HorizontalAlignment = HorizontalAlignment.Right }; Grid.SetColumn(time, 3); grid.Children.Add(time);
-        var arrow = new FontIcon { Glyph = "\uE76C", FontSize = 12, Opacity = 0.5 }; Grid.SetColumn(arrow, 4); grid.Children.Add(arrow);
-        button.Content = grid; button.Click += (_, _) => action(); return button;
+        private readonly FontIcon verdict = new();
+        private readonly TextBlock title = new() { TextTrimming = TextTrimming.CharacterEllipsis };
+        private readonly TextBlock subtitle = new() { FontSize = 12, Opacity = 0.6, TextTrimming = TextTrimming.CharacterEllipsis };
+        private readonly TextBlock tokens = new() { Opacity = 0.65, HorizontalAlignment = HorizontalAlignment.Right };
+        private readonly TextBlock time = new() { Opacity = 0.65, HorizontalAlignment = HorizontalAlignment.Right };
+        private RequestActivity item;
+
+        internal UsageRowView(MainWindow window, RequestActivity item)
+        {
+            this.item = item;
+            var button = new Button { HorizontalContentAlignment = HorizontalAlignment.Stretch, Background = Transparent, BorderThickness = new Thickness(0), Padding = new Thickness(12, 9, 12, 9) };
+            var grid = new Grid { ColumnSpacing = 12 };
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(24) });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(90) });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(72) });
+            grid.ColumnDefinitions.Add(new() { Width = new GridLength(18) });
+            grid.Children.Add(verdict);
+            var label = Vertical(2);
+            label.Children.Add(title);
+            label.Children.Add(subtitle);
+            Grid.SetColumn(label, 1);
+            grid.Children.Add(label);
+            Grid.SetColumn(tokens, 2);
+            grid.Children.Add(tokens);
+            Grid.SetColumn(time, 3);
+            grid.Children.Add(time);
+            var arrow = new FontIcon { Glyph = "\uE76C", FontSize = 12, Opacity = 0.5 };
+            Grid.SetColumn(arrow, 4);
+            grid.Children.Add(arrow);
+            button.Content = grid;
+            button.Click += (_, _) => _ = window.ShowProofAsync(this.item);
+            Content = button;
+            Update(item);
+        }
+
+        internal UIElement Content { get; }
+
+        internal void Update(RequestActivity next)
+        {
+            item = next;
+            verdict.Glyph = next.Verified == true ? "\uE83D" : next.LeftDevice ? "\uE814" : "\uE711";
+            verdict.Foreground = next.Verified == true ? Success : next.LeftDevice ? new SolidColorBrush(Microsoft.UI.Colors.IndianRed) : null;
+            title.Text = next.Model ?? next.Path;
+            subtitle.Text = string.Join(" · ", new[] { next.Agent, next.Path }.Where(value => !string.IsNullOrEmpty(value)));
+            tokens.Text = $"{(next.InputTokens ?? 0) + (next.OutputTokens ?? 0):N0}";
+            time.Text = DateTimeOffset.FromUnixTimeSeconds((long)next.At).ToLocalTime().ToString("t");
+        }
     }
 
-    private static StackPanel Section(string title) { var stack = Vertical(0); stack.Children.Add(new TextBlock { Text = title, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Margin = new Thickness(12, 10, 12, 7) }); return stack; }
+    private static void Place(StackPanel parent, UIElement child, int index)
+    {
+        var current = parent.Children.IndexOf(child);
+        if (current == index) return;
+        if (current >= 0) parent.Children.RemoveAt(current);
+        parent.Children.Insert(Math.Min(index, parent.Children.Count), child);
+    }
+
+    private static void SetFilter(ComboBox box, string all, IEnumerable<string> options, string? selected)
+    {
+        var values = options.ToArray();
+        var desired = new[] { all }.Concat(values).ToArray();
+        if (!box.Items.Cast<object>().Select(item => item.ToString()).SequenceEqual(desired))
+        {
+            box.Items.Clear();
+            foreach (var value in desired) box.Items.Add(value);
+        }
+        box.SelectedIndex = selected is null ? 0 : Math.Max(0, Array.IndexOf(values, selected) + 1);
+    }
+
+    private static StackPanel Section(string title)
+    {
+        var stack = Vertical(0);
+        stack.Children.Add(new TextBlock { Text = title, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Margin = new Thickness(12, 10, 12, 7) });
+        return stack;
+    }
+
     private static Border Card(UIElement content) => new() { Child = content, Background = new SolidColorBrush(global::Windows.UI.Color.FromArgb(20, 128, 128, 128)), BorderBrush = new SolidColorBrush(global::Windows.UI.Color.FromArgb(35, 128, 128, 128)), BorderThickness = new Thickness(1), CornerRadius = new CornerRadius(6), Padding = new Thickness(12) };
-    private static Border CardInto(Grid grid, UIElement content) { var card = Card(content); grid.Children.Add(card); return card; }
+    private static Border Divider() => new() { Height = 1, Margin = new Thickness(0, 4, 0, 4), Background = new SolidColorBrush(global::Windows.UI.Color.FromArgb(32, 128, 128, 128)) };
     private static StackPanel Vertical(double spacing) => new() { Orientation = Orientation.Vertical, Spacing = spacing };
     private static StackPanel Horizontal(double spacing) => new() { Orientation = Orientation.Horizontal, Spacing = spacing, VerticalAlignment = VerticalAlignment.Center };
     private static ScrollViewer Scroll(UIElement content) => new() { Content = content, Padding = new Thickness(24), HorizontalScrollMode = ScrollMode.Disabled };
     private static TextBlock Empty(string text) => new() { Text = text, HorizontalAlignment = HorizontalAlignment.Center, Opacity = 0.6, Margin = new Thickness(18, 28, 18, 28) };
-    private static StackPanel Labeled(string title, UIElement value) { var stack = Vertical(3); stack.Children.Add(new TextBlock { Text = title, FontSize = 12, Opacity = 0.6 }); stack.Children.Add(value); return stack; }
-    private static Image AssetImage(string source, double size) => new() { Source = new SvgImageSource(new Uri($"ms-appx:///{source}")), Width = size, Height = size };
-    private static global::Windows.ApplicationModel.DataTransfer.DataPackage ClipboardContent(string value) { var package = new global::Windows.ApplicationModel.DataTransfer.DataPackage(); package.SetText(value); return package; }
-    private static string Status(GatewayState state) => state.Status switch { "verified" => "Protected", "verifying" => "Verifying…", "blocked" => "Blocked", "error" => "Needs attention", _ => "Not protected" };
-
-    private static ComboBox Filter(string header, string all, IEnumerable<string> options, string? selected, Action<string?> changed)
+    private static StackPanel Labeled(string title, UIElement value)
     {
-        var box = new ComboBox { Header = header, MinWidth = 150 };
-        box.Items.Add(all); foreach (var option in options) box.Items.Add(option);
-        box.SelectedIndex = selected is null ? 0 : Math.Max(0, Array.IndexOf(options.ToArray(), selected) + 1);
-        box.SelectionChanged += (_, _) => changed(box.SelectedIndex <= 0 ? null : box.SelectedItem?.ToString()); return box;
+        var stack = Vertical(3);
+        stack.Children.Add(new TextBlock { Text = title, FontSize = 12, Opacity = 0.6 });
+        stack.Children.Add(value);
+        return stack;
+    }
+    private static Image AssetImage(string source, double size) => new() { Source = new SvgImageSource(new Uri($"ms-appx:///{source}")), Width = size, Height = size };
+    private static readonly SolidColorBrush Transparent = new(Microsoft.UI.Colors.Transparent);
+    private static global::Windows.ApplicationModel.DataTransfer.DataPackage ClipboardContent(string value)
+    {
+        var package = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
+        package.SetText(value);
+        return package;
     }
 
     private static async Task ExportAsync(RuntimeStore store, MainWindow window)
@@ -238,6 +570,7 @@ internal static class NativeViews
         var picker = new FileSavePicker { SuggestedFileName = $"private-ai-gateway-usage-{DateTime.Now:yyyy-MM-dd}" };
         picker.FileTypeChoices.Add("CSV", new List<string> { ".csv" });
         InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(window));
-        var file = await picker.PickSaveFileAsync(); if (file is not null) await store.ExportUsageAsync(file.Path);
+        var file = await picker.PickSaveFileAsync();
+        if (file is not null) await store.ExportUsageAsync(file.Path);
     }
 }

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
@@ -173,25 +173,50 @@ public sealed class RuntimeClient : IAsyncDisposable
         {
             using var document = JsonDocument.Parse(utf8.GetString(frame));
             var root = document.RootElement;
-            if (!root.TryGetProperty("schemaVersion", out var schema) || schema.GetInt32() != 1)
+            if (root.ValueKind != JsonValueKind.Object)
+                throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid protocol envelope.");
+            if (!root.TryGetProperty("schemaVersion", out var schema) ||
+                schema.ValueKind != JsonValueKind.Number ||
+                !schema.TryGetInt32(out var version) ||
+                version != 1)
                 throw new RuntimeException("unsupported_schema", "The desktop runtime returned an unsupported protocol version.");
-            if (root.TryGetProperty("event", out var eventName) && eventName.GetString() == "stateChanged")
+            if (root.TryGetProperty("event", out var eventName))
             {
-                var state = root.GetProperty("payload").Deserialize<GatewayState>(json);
-                if (state is not null) StateChanged?.Invoke(state);
+                if (eventName.ValueKind != JsonValueKind.String ||
+                    eventName.GetString() != "stateChanged" ||
+                    !root.TryGetProperty("payload", out var payload) ||
+                    root.TryGetProperty("id", out _) ||
+                    root.TryGetProperty("result", out _) ||
+                    root.TryGetProperty("error", out _))
+                    throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid event envelope.");
+                var state = payload.Deserialize<GatewayState>(json) ??
+                    throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid state event.");
+                StateChanged?.Invoke(state);
                 return;
             }
-            if (!root.TryGetProperty("id", out var idValue))
+            if (!root.TryGetProperty("id", out var idValue) || idValue.ValueKind != JsonValueKind.String)
                 throw new RuntimeException("invalid_response", "The desktop runtime returned a response without an id.");
-            if (!pending.TryRemove(idValue.GetString() ?? "", out var completion)) return;
-            if (root.TryGetProperty("error", out var error))
+            var hasResult = root.TryGetProperty("result", out var result);
+            var hasError = root.TryGetProperty("error", out var error);
+            if (hasResult == hasError || root.TryGetProperty("payload", out _))
+                throw new RuntimeException("invalid_response", "The desktop runtime returned an ambiguous response envelope.");
+            var errorCode = "operation_failed";
+            var errorMessage = "The operation failed.";
+            if (hasError)
             {
-                completion.TrySetException(new RuntimeException(
-                    error.TryGetProperty("code", out var code) ? code.GetString() ?? "operation_failed" : "operation_failed",
-                    error.TryGetProperty("message", out var message) ? message.GetString() ?? "The operation failed." : "The operation failed."));
+                if (error.ValueKind != JsonValueKind.Object ||
+                    !error.TryGetProperty("code", out var code) || code.ValueKind != JsonValueKind.String ||
+                    !error.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.String)
+                    throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid error response.");
+                errorCode = code.GetString() ?? errorCode;
+                errorMessage = message.GetString() ?? errorMessage;
             }
-            else if (root.TryGetProperty("result", out var result)) completion.TrySetResult(result.Clone());
-            else throw new RuntimeException("invalid_response", "The desktop runtime returned a response without a result.");
+            if (!pending.TryRemove(idValue.GetString() ?? "", out var completion)) return;
+            if (hasError)
+            {
+                completion.TrySetException(new RuntimeException(errorCode, errorMessage));
+            }
+            else completion.TrySetResult(result.Clone());
         }
         catch (Exception error)
         {

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace PrivateAIGateway.Windows;
 
-public sealed class RuntimeException(string code, string message) : Exception(message)
+public sealed class RuntimeException(string code, string message, Exception? innerException = null) : Exception(message, innerException)
 {
     public string Code { get; } = code;
 }
@@ -13,24 +13,39 @@ public sealed class RuntimeException(string code, string message) : Exception(me
 public sealed class RuntimeClient : IAsyncDisposable
 {
     private const int MaxMessageBytes = 1024 * 1024;
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(75);
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(2);
     private readonly JsonSerializerOptions json = new(JsonSerializerDefaults.Web);
+    private readonly UTF8Encoding utf8 = new(false, true);
     private readonly ConcurrentDictionary<string, TaskCompletionSource<JsonElement>> pending = new();
     private readonly SemaphoreSlim writeLock = new(1, 1);
+    private readonly CancellationTokenSource lifetime = new();
+    private readonly object disposeLock = new();
     private Process? process;
     private StreamWriter? input;
+    private Task? readTask;
+    private Task? errorTask;
+    private Exception? failure;
+    private Task? disposeTask;
     private long nextId;
+    private int failed;
+    private int disposing;
 
     public event Action<GatewayState>? StateChanged;
     public event Action<Exception?>? Exited;
+    internal bool IsAvailable => Volatile.Read(ref failed) == 0 && IsRunning(process);
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var configured = Environment.GetEnvironmentVariable("PRIVATE_AI_GATEWAY_RUNTIME");
         var service = string.IsNullOrWhiteSpace(configured)
             ? Path.Combine(AppContext.BaseDirectory, "private-ai-gateway-desktop-service.exe")
             : configured;
         if (!File.Exists(service)) throw new RuntimeException("runtime_missing", "The bundled desktop runtime is missing.");
-        process = new Process
+
+        var started = new Process
         {
             StartInfo = new ProcessStartInfo(service)
             {
@@ -42,77 +57,224 @@ public sealed class RuntimeClient : IAsyncDisposable
             },
             EnableRaisingEvents = true,
         };
-        process.Exited += (_, _) => Exited?.Invoke(process.ExitCode == 0 ? null : new RuntimeException("runtime_exited", $"The desktop runtime exited with status {process.ExitCode}."));
-        if (!process.Start()) throw new RuntimeException("runtime_start_failed", "The desktop runtime could not be started.");
-        input = process.StandardInput;
-        _ = Task.Run(() => ReadAsync(process.StandardOutput, cancellationToken), cancellationToken);
-        _ = Task.Run(() => DrainErrorsAsync(process.StandardError, cancellationToken), cancellationToken);
+        started.Exited += ProcessExited;
+        process = started;
+        try
+        {
+            if (!started.Start()) throw new RuntimeException("runtime_start_failed", "The desktop runtime could not be started.");
+        }
+        catch (Exception error)
+        {
+            started.Exited -= ProcessExited;
+            process = null;
+            started.Dispose();
+            throw error is RuntimeException ? error : new RuntimeException("runtime_start_failed", "The desktop runtime could not be started.", error);
+        }
+
+        input = started.StandardInput;
+        readTask = Task.Run(() => ReadAsync(started.StandardOutput.BaseStream, lifetime.Token));
+        errorTask = Task.Run(() => DrainErrorsAsync(started.StandardError, lifetime.Token));
         await Task.Yield();
+        if (Volatile.Read(ref failed) != 0)
+            throw failure ?? new RuntimeException("runtime_exited", "The desktop runtime stopped during startup.");
     }
 
     public async Task<T> RequestAsync<T>(string method, object? parameters = null, CancellationToken cancellationToken = default)
     {
-        if (input is null) throw new RuntimeException("runtime_unavailable", "The desktop runtime is not running.");
         var id = Interlocked.Increment(ref nextId).ToString();
-        var completion = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!pending.TryAdd(id, completion)) throw new RuntimeException("request_conflict", "A runtime request id was reused.");
         var payload = JsonSerializer.Serialize(new { schemaVersion = 1, id, method, @params = parameters }, json);
         if (Encoding.UTF8.GetByteCount(payload) > MaxMessageBytes)
-        {
-            pending.TryRemove(id, out _);
             throw new RuntimeException("message_too_large", "Desktop runtime message exceeds the 1 MiB limit.");
+
+        var writer = input ?? throw new RuntimeException("runtime_unavailable", "The desktop runtime is not running.");
+        var completion = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!pending.TryAdd(id, completion)) throw new RuntimeException("request_conflict", "A runtime request id was reused.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lifetime.Token);
+        timeout.CancelAfter(RequestTimeout);
+        using var registration = timeout.Token.Register(() => completion.TrySetCanceled(timeout.Token));
+        try
+        {
+            if (Volatile.Read(ref failed) != 0)
+                throw failure ?? new RuntimeException("runtime_unavailable", "The desktop runtime is not running.");
+            await writeLock.WaitAsync(timeout.Token);
+            try
+            {
+                await writer.WriteLineAsync(payload.AsMemory(), timeout.Token);
+                await writer.FlushAsync(timeout.Token);
+            }
+            finally { writeLock.Release(); }
+            var element = await completion.Task;
+            if (typeof(T) == typeof(JsonElement)) return (T)(object)element;
+            return element.Deserialize<T>(json) ?? throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid response.");
         }
-        await writeLock.WaitAsync(cancellationToken);
-        try { await input.WriteLineAsync(payload.AsMemory(), cancellationToken); await input.FlushAsync(cancellationToken); }
-        catch { pending.TryRemove(id, out _); throw; }
-        finally { writeLock.Release(); }
-        using var registration = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
-        var element = await completion.Task;
-        if (typeof(T) == typeof(JsonElement)) return (T)(object)element;
-        return element.Deserialize<T>(json) ?? throw new RuntimeException("invalid_response", "The desktop runtime returned an invalid response.");
+        catch (OperationCanceledException) when (lifetime.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw failure ?? new RuntimeException("runtime_unavailable", "The desktop runtime is not running.");
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            var timeoutError = new RuntimeException("request_timeout", $"The desktop runtime did not answer {method} within {RequestTimeout.TotalSeconds:0} seconds.");
+            Fail(timeoutError);
+            throw timeoutError;
+        }
+        catch (Exception error) when (error is IOException or ObjectDisposedException)
+        {
+            var transport = new RuntimeException("runtime_write_failed", "The desktop runtime connection failed while sending a request.", error);
+            Fail(transport);
+            throw transport;
+        }
+        finally { pending.TryRemove(id, out _); }
     }
 
-    private async Task ReadAsync(StreamReader reader, CancellationToken cancellationToken)
+    private async Task ReadAsync(Stream stream, CancellationToken cancellationToken)
     {
         try
         {
-            while (!cancellationToken.IsCancellationRequested && await reader.ReadLineAsync(cancellationToken) is { } line)
+            var chunk = new byte[8192];
+            using var frame = new MemoryStream();
+            while (!cancellationToken.IsCancellationRequested)
             {
-                if (Encoding.UTF8.GetByteCount(line) > MaxMessageBytes) throw new RuntimeException("message_too_large", "Desktop runtime response exceeds the 1 MiB limit.");
-                using var document = JsonDocument.Parse(line);
-                var root = document.RootElement;
-                if (root.TryGetProperty("event", out var eventName) && eventName.GetString() == "stateChanged")
+                var count = await stream.ReadAsync(chunk, cancellationToken);
+                if (count == 0)
                 {
-                    var state = root.GetProperty("payload").Deserialize<GatewayState>(json);
-                    if (state is not null) StateChanged?.Invoke(state);
-                    continue;
+                    if (frame.Length != 0) throw new RuntimeException("invalid_response", "The desktop runtime closed its connection mid-message.");
+                    Fail(new RuntimeException("runtime_eof", "The desktop runtime closed its connection."));
+                    return;
                 }
-                if (!root.TryGetProperty("id", out var idValue) || !pending.TryRemove(idValue.GetString() ?? "", out var completion)) continue;
-                if (root.TryGetProperty("error", out var error))
+                var start = 0;
+                for (var index = 0; index < count; index++)
                 {
-                    completion.TrySetException(new RuntimeException(
-                        error.TryGetProperty("code", out var code) ? code.GetString() ?? "operation_failed" : "operation_failed",
-                        error.TryGetProperty("message", out var message) ? message.GetString() ?? "The operation failed." : "The operation failed."));
+                    if (chunk[index] != (byte)'\n') continue;
+                    AppendFrame(frame, chunk.AsSpan(start, index - start));
+                    if (frame.Length > 0) HandleFrame(frame.ToArray());
+                    frame.SetLength(0);
+                    start = index + 1;
                 }
-                else completion.TrySetResult(root.GetProperty("result").Clone());
+                AppendFrame(frame, chunk.AsSpan(start, count - start));
             }
         }
-        catch (Exception error) { Exited?.Invoke(error); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
+        catch (Exception error)
+        {
+            Fail(error is RuntimeException ? error : new RuntimeException("runtime_read_failed", "The desktop runtime connection failed while reading a response.", error));
+        }
+    }
+
+    private void AppendFrame(MemoryStream frame, ReadOnlySpan<byte> bytes)
+    {
+        if (frame.Length + bytes.Length > MaxMessageBytes)
+            throw new RuntimeException("message_too_large", "Desktop runtime response exceeds the 1 MiB limit.");
+        frame.Write(bytes);
+    }
+
+    private void HandleFrame(byte[] frame)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(utf8.GetString(frame));
+            var root = document.RootElement;
+            if (!root.TryGetProperty("schemaVersion", out var schema) || schema.GetInt32() != 1)
+                throw new RuntimeException("unsupported_schema", "The desktop runtime returned an unsupported protocol version.");
+            if (root.TryGetProperty("event", out var eventName) && eventName.GetString() == "stateChanged")
+            {
+                var state = root.GetProperty("payload").Deserialize<GatewayState>(json);
+                if (state is not null) StateChanged?.Invoke(state);
+                return;
+            }
+            if (!root.TryGetProperty("id", out var idValue))
+                throw new RuntimeException("invalid_response", "The desktop runtime returned a response without an id.");
+            if (!pending.TryRemove(idValue.GetString() ?? "", out var completion)) return;
+            if (root.TryGetProperty("error", out var error))
+            {
+                completion.TrySetException(new RuntimeException(
+                    error.TryGetProperty("code", out var code) ? code.GetString() ?? "operation_failed" : "operation_failed",
+                    error.TryGetProperty("message", out var message) ? message.GetString() ?? "The operation failed." : "The operation failed."));
+            }
+            else if (root.TryGetProperty("result", out var result)) completion.TrySetResult(result.Clone());
+            else throw new RuntimeException("invalid_response", "The desktop runtime returned a response without a result.");
+        }
+        catch (Exception error)
+        {
+            throw error is RuntimeException ? error : new RuntimeException("invalid_response", "The desktop runtime returned invalid JSON.", error);
+        }
     }
 
     private static async Task DrainErrorsAsync(StreamReader reader, CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested && await reader.ReadLineAsync(cancellationToken) is not null) { }
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && await reader.ReadLineAsync(cancellationToken) is not null) { }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
+        catch (IOException) { }
     }
 
-    public async ValueTask DisposeAsync()
+    private void ProcessExited(object? sender, EventArgs args)
     {
-        if (process is { HasExited: false })
+        var exited = sender as Process;
+        var status = exited is null ? null : SafeExitCode(exited);
+        var error = status == 0
+            ? new RuntimeException("runtime_exited", "The desktop runtime stopped.")
+            : new RuntimeException("runtime_exited", status is null
+                ? "The desktop runtime stopped unexpectedly."
+                : $"The desktop runtime exited with status {status}.");
+        Fail(error);
+    }
+
+    private static int? SafeExitCode(Process process)
+    {
+        try { return process.ExitCode; }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    private void Fail(Exception error)
+    {
+        if (Interlocked.Exchange(ref failed, 1) != 0) return;
+        failure = error;
+        foreach (var entry in pending.ToArray())
+            if (pending.TryRemove(entry.Key, out var completion)) completion.TrySetException(error);
+        lifetime.Cancel();
+        if (Volatile.Read(ref disposing) == 0) Exited?.Invoke(error);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (disposeLock) return new ValueTask(disposeTask ??= DisposeCoreAsync());
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        Interlocked.Exchange(ref disposing, 1);
+        if (IsRunning(process))
         {
-            try { await RequestAsync<JsonElement>("shutdown", new { }); }
-            catch { process.Kill(true); }
+            using var shutdown = new CancellationTokenSource(ShutdownTimeout);
+            try { await RequestAsync<JsonElement>("shutdown", new { }, shutdown.Token); }
+            catch (Exception) { }
+            try { await process.WaitForExitAsync(shutdown.Token); }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(true); }
+                catch (Exception) { }
+                using var killed = new CancellationTokenSource(DrainTimeout);
+                try { await process.WaitForExitAsync(killed.Token); }
+                catch (Exception) { }
+            }
+            catch (InvalidOperationException) { }
         }
+
+        lifetime.Cancel();
+        Fail(new RuntimeException("runtime_unavailable", "The desktop runtime is not running."));
+        var drains = new[] { readTask, errorTask }.Where(task => task is not null).Cast<Task>().ToArray();
+        if (drains.Length > 0) await Task.WhenAny(Task.WhenAll(drains), Task.Delay(DrainTimeout));
+        input?.Dispose();
+        if (process is not null) process.Exited -= ProcessExited;
         process?.Dispose();
-        writeLock.Dispose();
+    }
+
+    private static bool IsRunning(Process? process)
+    {
+        if (process is null) return false;
+        try { return !process.HasExited; }
+        catch (InvalidOperationException) { return false; }
     }
 }

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeClient.cs
@@ -270,18 +270,19 @@ public sealed class RuntimeClient : IAsyncDisposable
     private async Task DisposeCoreAsync()
     {
         Interlocked.Exchange(ref disposing, 1);
-        if (IsRunning(process))
+        var ownedProcess = process;
+        if (ownedProcess is not null && IsRunning(ownedProcess))
         {
             using var shutdown = new CancellationTokenSource(ShutdownTimeout);
             try { await RequestAsync<JsonElement>("shutdown", new { }, shutdown.Token); }
             catch (Exception) { }
-            try { await process.WaitForExitAsync(shutdown.Token); }
+            try { await ownedProcess.WaitForExitAsync(shutdown.Token); }
             catch (OperationCanceledException)
             {
-                try { process.Kill(true); }
+                try { ownedProcess.Kill(true); }
                 catch (Exception) { }
                 using var killed = new CancellationTokenSource(DrainTimeout);
-                try { await process.WaitForExitAsync(killed.Token); }
+                try { await ownedProcess.WaitForExitAsync(killed.Token); }
                 catch (Exception) { }
             }
             catch (InvalidOperationException) { }
@@ -292,8 +293,8 @@ public sealed class RuntimeClient : IAsyncDisposable
         var drains = new[] { readTask, errorTask }.Where(task => task is not null).Cast<Task>().ToArray();
         if (drains.Length > 0) await Task.WhenAny(Task.WhenAll(drains), Task.Delay(DrainTimeout));
         input?.Dispose();
-        if (process is not null) process.Exited -= ProcessExited;
-        process?.Dispose();
+        if (ownedProcess is not null) ownedProcess.Exited -= ProcessExited;
+        ownedProcess?.Dispose();
     }
 
     private static bool IsRunning(Process? process)

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimePresentation.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimePresentation.cs
@@ -1,0 +1,25 @@
+namespace PrivateAIGateway.Windows;
+
+internal static class RuntimePresentation
+{
+    internal static bool IsProtected(GatewayState state) =>
+        state.Status == "verified" && !state.ConfigurationVerification;
+
+    internal static bool ShowDevMode(GatewayState state) =>
+        IsProtected(state) && !state.Config.RequireProductionOs;
+
+    internal static string StatusLabel(GatewayState state) => state.Status switch
+    {
+        "verifying" when state.ConfigurationVerification => "Verifying configuration",
+        "verifying" => "Starting",
+        "verified" when state.ConfigurationVerification => "Configuration verified",
+        "verified" when !state.Config.RequireProductionOs => "Protected · Dev mode",
+        "verified" => "Protected",
+        "blocked" => "Blocked",
+        "error" => "Needs attention",
+        _ => "Not protected",
+    };
+
+    internal static string SummaryLabel(GatewayState state) =>
+        ShowDevMode(state) ? "Protected in dev mode" : StatusLabel(state);
+}

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeStore.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeStore.cs
@@ -58,8 +58,12 @@ public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
             next.Exited += error => App.MainWindow.DispatcherQueue.TryEnqueue(() => RuntimeExited(next, error));
             try
             {
+                App.Trace("runtime:start:starting");
                 await next.StartAsync();
+                App.Trace("runtime:start:completed");
+                App.Trace("runtime:handshake:starting");
                 await LoadInitialDataAsync(next);
+                App.Trace("runtime:handshake:completed");
                 EnsureOwned(next);
                 if (!next.IsAvailable)
                     throw new RuntimeException("runtime_exited", "The desktop runtime stopped during startup.");
@@ -68,6 +72,7 @@ public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
             }
             catch (Exception error)
             {
+                App.Trace($"runtime:restart-failed:{error.GetType().Name}");
                 if (ReferenceEquals(client, next)) client = null;
                 IsRuntimeAvailable = false;
                 ClearRuntimeData();

--- a/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeStore.cs
+++ b/apps/desktop/native/windows/PrivateAIGateway.Windows/RuntimeStore.cs
@@ -1,17 +1,20 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 
 namespace PrivateAIGateway.Windows;
 
 public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
 {
-    private readonly RuntimeClient client = new();
+    private readonly SemaphoreSlim lifecycleLock = new(1, 1);
+    private RuntimeClient? client;
+    private Task cleanupTask = Task.CompletedTask;
     private GatewayState state = GatewayState.Empty;
     private AgentStatus[] agents = [];
     private UsagePage usage = UsagePage.Empty;
     private string clientKey = "";
     private bool busy;
+    private bool runtimeAvailable;
+    private bool disposing;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<string>? Error;
@@ -20,112 +23,222 @@ public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
     public UsagePage Usage { get => usage; private set => Set(ref usage, value); }
     public string ClientKey { get => clientKey; private set => Set(ref clientKey, value); }
     public bool IsBusy { get => busy; private set => Set(ref busy, value); }
+    public bool IsRuntimeAvailable { get => runtimeAvailable; private set => Set(ref runtimeAvailable, value); }
     public string? UsageAgent { get; set; }
     public string? UsageModel { get; set; }
     public UsageRange UsageRange { get; set; } = UsageRange.ThirtyDays;
-    public bool IsRunning => State.Status is "verifying" or "verified" or "blocked";
-    public bool IsProtected => State.Status == "verified" && !State.ConfigurationVerification;
+    public bool IsRunning => IsRuntimeAvailable &&
+        (State.Status == "verifying" || State.Status == "verified" || State.Status == "blocked");
+    public bool IsProtected => IsRuntimeAvailable && RuntimePresentation.IsProtected(State);
     public bool IsDevMode => !State.Config.RequireProductionOs;
     public ConfidentialProfile? ActiveProfile => State.Profiles.FirstOrDefault(profile => profile.Id == State.ActiveProfileId);
 
-    public async Task InitializeAsync()
+    public Task<bool> InitializeAsync() => RestartAsync();
+
+    public async Task<bool> RestartAsync()
     {
-        client.StateChanged += next => App.MainWindow.DispatcherQueue.TryEnqueue(() => Accept(next));
-        client.Exited += error => App.MainWindow.DispatcherQueue.TryEnqueue(() => Error?.Invoke(error?.Message ?? "The desktop runtime stopped."));
-        await client.StartAsync();
-        await Task.WhenAll(ReloadStateAsync(), ReloadAgentsAsync(), ReloadUsageAsync(true), ReloadClientKeyAsync());
+        await lifecycleLock.WaitAsync();
+        try
+        {
+            if (disposing) return false;
+            IsBusy = true;
+            IsRuntimeAvailable = false;
+            ClearRuntimeData();
+            await cleanupTask;
+            cleanupTask = Task.CompletedTask;
+            if (client is { } previous)
+            {
+                client = null;
+                await previous.DisposeAsync();
+            }
+
+            var next = new RuntimeClient();
+            client = next;
+            next.StateChanged += state => App.MainWindow.DispatcherQueue.TryEnqueue(() => Accept(next, state));
+            next.Exited += error => App.MainWindow.DispatcherQueue.TryEnqueue(() => RuntimeExited(next, error));
+            try
+            {
+                await next.StartAsync();
+                await LoadInitialDataAsync(next);
+                EnsureOwned(next);
+                if (!next.IsAvailable)
+                    throw new RuntimeException("runtime_exited", "The desktop runtime stopped during startup.");
+                IsRuntimeAvailable = true;
+                return true;
+            }
+            catch (Exception error)
+            {
+                if (ReferenceEquals(client, next)) client = null;
+                IsRuntimeAvailable = false;
+                ClearRuntimeData();
+                await next.DisposeAsync();
+                ReportError(error);
+                return false;
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+            lifecycleLock.Release();
+        }
     }
 
-    public Task<GatewayState> SetProtectionAsync(bool enabled) => RunStateAsync(enabled
-        ? client.RequestAsync<GatewayState>("start", new StartParams(State.Config))
-        : client.RequestAsync<GatewayState>("stop", new { }));
+    public Task<GatewayState> SetProtectionAsync(bool enabled)
+    {
+        var runtime = CurrentClient();
+        return RunStateAsync(runtime, enabled
+            ? runtime.RequestAsync<GatewayState>("start", new StartParams(State.Config))
+            : runtime.RequestAsync<GatewayState>("stop", new { }));
+    }
 
-    public async Task<bool> VerifyAndSaveAsync(ConfidentialProfileInput profile, bool allowDevOs, string? key)
+    public async Task<(bool Success, string? Error)> VerifyAndSaveAsync(ConfidentialProfileInput profile, bool allowDevOs, string? key)
     {
         try
         {
+            var runtime = CurrentClient();
             IsBusy = true;
-            Accept(await client.RequestAsync<GatewayState>("verifyConfiguration", new VerifyParams(
-                profile, !allowDevOs, string.IsNullOrWhiteSpace(key) ? null : key)));
-            return true;
+            var next = await runtime.RequestAsync<GatewayState>("verifyConfiguration", new VerifyParams(
+                profile, !allowDevOs, string.IsNullOrWhiteSpace(key) ? null : key));
+            AcceptCurrent(runtime, next);
+            return (true, null);
         }
-        catch (Exception error) { Error?.Invoke(error.Message); return false; }
+        catch (Exception error) { return (false, error.Message); }
         finally { IsBusy = false; }
     }
 
-    public Task<GatewayState> ActivateProfileAsync(string id) => RunStateAsync(
-        client.RequestAsync<GatewayState>("activateProfile", new ProfileParams(id)));
-    public Task<GatewayState> DeleteProfileAsync(string id) => RunStateAsync(
-        client.RequestAsync<GatewayState>("deleteProfile", new ProfileParams(id)));
-    public Task<GatewayState> ClearCredentialAsync() => RunStateAsync(
-        client.RequestAsync<GatewayState>("clearApiKey", new { }));
-    public Task<GatewayState> SaveLocalApiAsync(LocalApiConfig config) => RunStateAsync(
-        client.RequestAsync<GatewayState>("saveLocalApiConfig", new LocalApiParams(config)));
+    public Task<GatewayState> ActivateProfileAsync(string id)
+    {
+        var runtime = CurrentClient();
+        return RunStateAsync(runtime, runtime.RequestAsync<GatewayState>("activateProfile", new ProfileParams(id)));
+    }
+
+    public Task<GatewayState> DeleteProfileAsync(string id)
+    {
+        var runtime = CurrentClient();
+        return RunStateAsync(runtime, runtime.RequestAsync<GatewayState>("deleteProfile", new ProfileParams(id)));
+    }
+
+    public Task<GatewayState> ClearCredentialAsync()
+    {
+        var runtime = CurrentClient();
+        return RunStateAsync(runtime, runtime.RequestAsync<GatewayState>("clearApiKey", new { }));
+    }
+
+    public Task<GatewayState> SaveLocalApiAsync(LocalApiConfig config)
+    {
+        var runtime = CurrentClient();
+        return RunStateAsync(runtime, runtime.RequestAsync<GatewayState>("saveLocalApiConfig", new LocalApiParams(config)));
+    }
 
     public async Task SetAgentAsync(AgentStatus agent, bool connected)
     {
         try
         {
+            var runtime = CurrentClient();
             var defaultModel = agent.Id == "codex" ? State.Catalog?.Models.FirstOrDefault()?.Id : null;
             var options = new ConnectOptions(defaultModel);
-            var preview = await client.RequestAsync<AgentPreview>("previewAgent", new AgentParams(agent.Id, connected, options));
-            await client.RequestAsync<AgentStatus>("applyAgent", new ApplyAgentParams(agent.Id, connected, preview.Revision, options));
-            await ReloadAgentsAsync();
+            var preview = await runtime.RequestAsync<AgentPreview>("previewAgent", new AgentParams(agent.Id, connected, options));
+            EnsureCurrent(runtime);
+            await runtime.RequestAsync<AgentStatus>("applyAgent", new ApplyAgentParams(agent.Id, connected, preview.Revision, options));
+            await ReloadAgentsAsync(runtime, true);
         }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        catch (Exception error) { ReportError(error); }
     }
 
     public async Task RestoreAllAgentsAsync()
     {
-        try { Agents = await client.RequestAsync<AgentStatus[]>("disconnectAllAgents", new { }); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
-    }
-
-    public async Task ReloadAgentsAsync()
-    {
-        try { Agents = await client.RequestAsync<AgentStatus[]>("listAgents", new { }); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
-    }
-
-    public async Task ReloadUsageAsync(bool reset)
-    {
         try
         {
-            var query = CurrentUsageQuery(reset ? null : Usage.NextCursor, 20);
-            var page = await client.RequestAsync<UsagePage>("queryUsage", new UsageParams(query));
-            Usage = reset ? page : page with { Items = [.. Usage.Items, .. page.Items] };
+            var runtime = CurrentClient();
+            var result = await runtime.RequestAsync<AgentStatus[]>("disconnectAllAgents", new { });
+            EnsureCurrent(runtime);
+            Agents = result;
         }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        catch (Exception error) { ReportError(error); }
     }
+
+    public Task ReloadAgentsAsync() => ReloadAgentsAsync(CurrentClient(), true);
+    public Task ReloadUsageAsync(bool reset) => ReloadUsageAsync(CurrentClient(), reset, true);
 
     public async Task ExportUsageAsync(string path)
     {
-        try { await client.RequestAsync<int>("exportUsageCsv", new ExportUsageParams(CurrentUsageQuery(null, null), path)); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        try
+        {
+            var runtime = CurrentClient();
+            await runtime.RequestAsync<int>("exportUsageCsv", new ExportUsageParams(CurrentUsageQuery(null, null), path));
+            EnsureCurrent(runtime);
+        }
+        catch (Exception error) { ReportError(error); }
     }
 
     public async Task ClearUsageAsync()
     {
-        try { await client.RequestAsync<ulong>("clearUsage", new { }); await ReloadUsageAsync(true); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        try
+        {
+            var runtime = CurrentClient();
+            await runtime.RequestAsync<ulong>("clearUsage", new { });
+            EnsureCurrent(runtime);
+            await ReloadUsageAsync(runtime, true, true);
+        }
+        catch (Exception error) { ReportError(error); }
     }
 
     public async Task RotateClientKeyAsync()
     {
-        try { ClientKey = await client.RequestAsync<string>("rotateClientKey", new { }); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        try
+        {
+            var runtime = CurrentClient();
+            var result = await runtime.RequestAsync<string>("rotateClientKey", new { });
+            EnsureCurrent(runtime);
+            ClientKey = result;
+        }
+        catch (Exception error) { ReportError(error); }
     }
 
-    private async Task ReloadStateAsync()
+    private async Task LoadInitialDataAsync(RuntimeClient runtime)
     {
-        try { Accept(await client.RequestAsync<GatewayState>("getState", new { })); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        var stateTask = runtime.RequestAsync<GatewayState>("getState", new { });
+        var agentsTask = runtime.RequestAsync<AgentStatus[]>("listAgents", new { });
+        var usageTask = runtime.RequestAsync<UsagePage>("queryUsage", new UsageParams(CurrentUsageQuery(null, 20)));
+        var keyTask = runtime.RequestAsync<string>("getClientKey", new { });
+        await Task.WhenAll(new Task[] { stateTask, agentsTask, usageTask, keyTask });
+        EnsureOwned(runtime);
+        State = await stateTask;
+        Agents = await agentsTask;
+        Usage = await usageTask;
+        ClientKey = await keyTask;
+        RaiseDerivedState();
     }
 
-    private async Task ReloadClientKeyAsync()
+    private async Task ReloadAgentsAsync(RuntimeClient runtime, bool reportError)
     {
-        try { ClientKey = await client.RequestAsync<string>("getClientKey", new { }); }
-        catch (Exception error) { Error?.Invoke(error.Message); }
+        try
+        {
+            var result = await runtime.RequestAsync<AgentStatus[]>("listAgents", new { });
+            EnsureCurrent(runtime);
+            Agents = result;
+        }
+        catch (Exception error)
+        {
+            if (reportError) ReportError(error);
+            else throw;
+        }
+    }
+
+    private async Task ReloadUsageAsync(RuntimeClient runtime, bool reset, bool reportError)
+    {
+        try
+        {
+            var query = CurrentUsageQuery(reset ? null : Usage.NextCursor, 20);
+            var page = await runtime.RequestAsync<UsagePage>("queryUsage", new UsageParams(query));
+            EnsureCurrent(runtime);
+            Usage = reset ? page : page with { Items = [.. Usage.Items, .. page.Items] };
+        }
+        catch (Exception error)
+        {
+            if (reportError) ReportError(error);
+            else throw;
+        }
     }
 
     private UsageQuery CurrentUsageQuery(string? cursor, int? limit)
@@ -140,22 +253,88 @@ public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
         return new(UsageAgent, UsageModel, null, since, null, cursor, limit);
     }
 
-    private async Task<GatewayState> RunStateAsync(Task<GatewayState> operation)
+    private async Task<GatewayState> RunStateAsync(RuntimeClient runtime, Task<GatewayState> operation)
     {
-        try { IsBusy = true; var next = await operation; Accept(next); return next; }
-        catch (Exception error) { Error?.Invoke(error.Message); throw; }
+        try
+        {
+            IsBusy = true;
+            var next = await operation;
+            AcceptCurrent(runtime, next);
+            return next;
+        }
+        catch (Exception error)
+        {
+            ReportError(error);
+            throw;
+        }
         finally { IsBusy = false; }
     }
 
-    private void Accept(GatewayState next)
+    private void Accept(RuntimeClient source, GatewayState next)
+    {
+        if (ReferenceEquals(client, source) && source.IsAvailable && IsRuntimeAvailable) AcceptState(next);
+    }
+
+    private void AcceptCurrent(RuntimeClient source, GatewayState next)
+    {
+        EnsureCurrent(source);
+        AcceptState(next);
+    }
+
+    private void AcceptState(GatewayState next)
     {
         var usageChanged = next.UsageRevision != State.UsageRevision;
         State = next;
+        RaiseDerivedState();
+        if (usageChanged && client is { } runtime && IsRuntimeAvailable) _ = ReloadUsageAsync(runtime, true, true);
+    }
+
+    private void RuntimeExited(RuntimeClient exited, Exception? error)
+    {
+        if (!ReferenceEquals(client, exited) || disposing) return;
+        IsRuntimeAvailable = false;
+        IsBusy = false;
+        ClearRuntimeData();
+        cleanupTask = exited.DisposeAsync().AsTask();
+        Error?.Invoke(error?.Message ?? "The desktop runtime stopped.");
+    }
+
+    private void ClearRuntimeData()
+    {
+        State = GatewayState.Empty;
+        Agents = [];
+        Usage = UsagePage.Empty;
+        ClientKey = "";
+        RaiseDerivedState();
+    }
+
+    private RuntimeClient CurrentClient() => client is { } runtime && IsRuntimeAvailable
+        ? runtime
+        : throw new RuntimeException("runtime_unavailable", "The desktop runtime is not running. Restart it to continue.");
+
+    private void EnsureCurrent(RuntimeClient source)
+    {
+        if (!ReferenceEquals(client, source) || !IsRuntimeAvailable)
+            throw new RuntimeException("runtime_restarted", "The desktop runtime restarted before the operation completed.");
+    }
+
+    private void EnsureOwned(RuntimeClient source)
+    {
+        if (!ReferenceEquals(client, source))
+            throw new RuntimeException("runtime_restarted", "The desktop runtime restarted before the operation completed.");
+    }
+
+    private void ReportError(Exception error)
+    {
+        if (!disposing) Error?.Invoke(error.Message);
+    }
+
+    private void RaiseDerivedState()
+    {
         OnPropertyChanged(nameof(IsRunning));
         OnPropertyChanged(nameof(IsProtected));
         OnPropertyChanged(nameof(IsDevMode));
         OnPropertyChanged(nameof(ActiveProfile));
-        if (usageChanged) _ = ReloadUsageAsync(true);
     }
 
     private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
@@ -166,7 +345,23 @@ public sealed class RuntimeStore : INotifyPropertyChanged, IAsyncDisposable
     }
 
     private void OnPropertyChanged(string? name) => PropertyChanged?.Invoke(this, new(name));
-    public ValueTask DisposeAsync() => client.DisposeAsync();
+
+    public async ValueTask DisposeAsync()
+    {
+        disposing = true;
+        await lifecycleLock.WaitAsync();
+        try
+        {
+            IsRuntimeAvailable = false;
+            await cleanupTask;
+            if (client is { } runtime)
+            {
+                client = null;
+                await runtime.DisposeAsync();
+            }
+        }
+        finally { lifecycleLock.Release(); }
+    }
 }
 
 public enum UsageRange { SevenDays, ThirtyDays, AllTime }

--- a/apps/desktop/scripts/native-runtime-smoke.mjs
+++ b/apps/desktop/scripts/native-runtime-smoke.mjs
@@ -100,7 +100,7 @@ function sendEnvelope(envelope) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       pending.delete(id);
-      reject(new Error(`Timed out waiting for ${method}`));
+      reject(new Error(`Timed out waiting for ${envelope.method}`));
     }, 15_000);
     pending.set(id, { resolve, reject, timer });
     child.stdin.write(`${message}\n`, (error) => {

--- a/apps/desktop/scripts/package-windows-native.mjs
+++ b/apps/desktop/scripts/package-windows-native.mjs
@@ -21,7 +21,7 @@ run(process.execPath, ["scripts/prepare-native-assets.mjs"]);
 run("node", ["scripts/bundle-native.mjs"]);
 await rm(stage, { recursive: true, force: true });
 await mkdir(stage, { recursive: true });
-run("dotnet", ["publish", project, "-c", "Release", "-r", "win-x64", "--self-contained", "true", "-p:Platform=x64", "-o", stage]);
+run("dotnet", ["publish", project, "-c", "Release", "-r", "win-x64", "--self-contained", "true", "-p:Platform=x64", "-m:2", "-o", stage]);
 
 const target = execFileSync(process.env.RUSTC ?? "rustc", ["-vV"], { encoding: "utf8" }).match(/^host: (.+)$/m)?.[1];
 if (!target) throw new Error("Cannot determine the Rust target triple");


### PR DESCRIPTION
## Summary
- Retain native controllers, supervise runtime processes, fail pending RPCs on disconnect, and provide explicit restart with generation isolation.
- Keep native pages and keyed interactive rows stable during state updates; correct protection and dev-mode presentation.
- Fix Windows profile actions and inline errors, defer page creation until the UI is loaded, and support Linux desktops without an SNI host.
- Replace GUI process-survival checks with real GUI-to-runtime handshakes and bounded shutdown checks. Add focused transport regressions.

## Verification
- Linux: four transport tests passed with warnings denied; isolated Xvfb GUI handshake, missing-runtime failure, and normal Quit passed.
- Windows: transport regression harness passed in CI. An initial GUI startup failure and subsequent factory type-inference error were addressed; final combined CI is pending.
- macOS native build, package, protocol smoke, and launch checks passed on the Windows checkpoint.
- No provider credentials, live inference, signing resources, or production configuration were used or changed.

This PR targets the desktop development branch in #174, not main. Final packaged-asset review and combined CI results will be added before marking ready.