### PR TITLE
fix(desktop): package the shared Tauri WebUI on Windows and Linux

### DIFF
--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -2,6 +2,11 @@ name: Desktop macOS
 
 on:
   workflow_dispatch:
+    inputs:
+      run_ui_tests:
+        description: Run optional renderer and installed app UI checks
+        type: boolean
+        default: false
   pull_request:
     paths:
       - '.github/workflows/desktop-macos.yml'
@@ -85,6 +90,7 @@ jobs:
           cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
 
       - name: Renderer smoke (Playwright, stateful mock)
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
         working-directory: apps/desktop
         run: |
           npx playwright install chromium
@@ -138,6 +144,7 @@ jobs:
             "test-results/live-service.json"
 
       - name: Launch tray app and capture menu bar
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
         continue-on-error: true
         working-directory: apps/desktop
         shell: bash

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -2,6 +2,11 @@ name: Desktop native clients
 
 on:
   workflow_dispatch:
+    inputs:
+      run_ui_tests:
+        description: Run optional experimental native client launch checks
+        type: boolean
+        default: false
   pull_request:
     paths:
       - '.github/workflows/desktop-native.yml'
@@ -85,6 +90,7 @@ jobs:
         working-directory: apps/desktop
         run: dbus-run-session -- node scripts/native-runtime-smoke.mjs release/native-linux/Private-AI-Gateway/private-ai-gateway-desktop-service
       - name: Launch native Linux client
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
         working-directory: apps/desktop
         shell: bash
         run: |
@@ -140,6 +146,7 @@ jobs:
         working-directory: apps/desktop
         run: node scripts/native-runtime-smoke.mjs release/native-windows/Private-AI-Gateway/private-ai-gateway-desktop-service.exe
       - name: Launch native Windows client
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
         working-directory: apps/desktop
         shell: pwsh
         run: |
@@ -194,6 +201,7 @@ jobs:
         working-directory: apps/desktop
         run: node scripts/native-runtime-smoke.mjs 'release/native-macos/Private AI Gateway.app/Contents/MacOS/private-ai-gateway-desktop-service'
       - name: Launch native macOS client
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
         working-directory: apps/desktop
         shell: bash
         run: |

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -176,6 +176,9 @@ jobs:
           if ($installers.Count -ne 1) { throw 'Expected one NSIS installer' }
           $installDir = Join-Path $env:RUNNER_TEMP 'Tauri Installed Smoke'
           $toolsDir = Join-Path $env:RUNNER_TEMP 'tauri-tools'
+          $evidenceDir = Join-Path $PWD 'test-results/installed'
+          New-Item -ItemType Directory -Force $evidenceDir | Out-Null
+          'Preparing installed Windows smoke; no WebDriver session yet.' | Set-Content "$evidenceDir/workflow-stage.txt"
           if (Test-Path $installDir) { throw 'Smoke install directory already exists' }
           function Run-Installer($executable, $arguments) {
             $process = Start-Process -FilePath $executable -ArgumentList $arguments -PassThru
@@ -214,6 +217,7 @@ jobs:
             $driverVersion = [version]$driverVersions[0].Value
             if ($driverVersion.ToString(3) -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
             Write-Host "Selected WebView2: $version; driver: $driverVersion"
+            "WebView2=$version; EdgeDriver=$driverVersion; starting native driver launch diagnostics" | Set-Content "$evidenceDir/workflow-stage.txt"
             $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
             node scripts/installed-webview-smoke.mjs @smokeArgs
             if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -2,6 +2,12 @@ name: Desktop Tauri Windows and Linux
 
 on:
   workflow_dispatch:
+    inputs:
+      run_ui_tests:
+        description: Run optional Playwright and installed WebView UI checks
+        type: boolean
+        required: false
+        default: false
   pull_request:
     paths:
       - '.github/workflows/desktop-tauri.yml'
@@ -23,6 +29,7 @@ jobs:
     timeout-minutes: 60
     env:
       CARGO_BUILD_JOBS: 2
+      RUN_UI_TESTS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ui_tests }}
     defaults:
       run:
         working-directory: apps/desktop
@@ -50,7 +57,18 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev patchelf webkit2gtk-driver xvfb gnome-keyring dbus-x11
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev patchelf gnome-keyring dbus-x11
+
+      - name: Install optional Linux UI test dependencies
+        if: runner.os == 'Linux' && env.RUN_UI_TESTS == 'true'
+        run: sudo apt-get install -y webkit2gtk-driver xvfb
+
+      - name: Report UI checks not run
+        if: env.RUN_UI_TESTS != 'true'
+        shell: bash
+        run: |
+          echo 'UI checks: not run (explicit workflow_dispatch opt-in required).'
+          echo 'UI checks: not run (explicit workflow_dispatch opt-in required).' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install desktop dependencies
         run: npm ci
@@ -59,6 +77,7 @@ jobs:
         run: npm run check
 
       - name: Renderer smoke (Playwright, stateful mock)
+        if: env.RUN_UI_TESTS == 'true'
         run: |
           npx playwright install chromium
           npm run test:renderer -- --workers=2
@@ -72,17 +91,13 @@ jobs:
         run: npm run tauri build -- --config src-tauri/tauri.brand.conf.json
 
       - name: Test Tauri backend
-        run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
+        run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml --lib
 
-      - name: Hermes path and projection regression
-        run: cargo test --release --locked --manifest-path gateway/Cargo.toml --lib hermes
+      - name: Test shared gateway library
+        run: cargo test --release --locked --manifest-path gateway/Cargo.toml --lib
 
-      # Cargo integration tests also compile the root server binary, whose
-      # dstack transport is Unix-only. Windows still exercises installed aci.exe
-      # below; it must not be reported as passing this integration suite.
-      - name: ACI signed-artifact regression (local fixture service)
-        if: runner.os == 'Linux'
-        run: cargo test --release --locked --manifest-path ../../Cargo.toml --test aci_cli
+      - name: Test shared runtime library
+        run: cargo test --release --locked --manifest-path runtime/Cargo.toml --lib
 
       - name: Inspect Linux package sidecars
         if: runner.os == 'Linux'
@@ -124,6 +139,7 @@ jobs:
             apps/desktop/src-tauri/target/release/bundle/deb/*.deb
 
       - name: Install task-local Tauri WebDriver
+        if: env.RUN_UI_TESTS == 'true'
         run: cargo install tauri-driver --version 2.0.6 --locked --root "${{ runner.temp }}/tauri-tools"
 
       - name: Installed Linux package smoke
@@ -152,6 +168,7 @@ jobs:
           trap cleanup EXIT
           sudo apt-get install -y "${packages[0]}"
           node scripts/packaged-sidecars-smoke.mjs /usr/bin
+          mkdir -p test-results/installed
           export TAURI_SMOKE_KEYRING_HOME="$scratch"
           export XDG_RUNTIME_DIR="$scratch/runtime"
           mkdir -m 700 "$XDG_RUNTIME_DIR"
@@ -160,11 +177,15 @@ jobs:
             keyring_pid=$!
             trap "kill $keyring_pid 2>/dev/null || true; wait $keyring_pid || true" EXIT
             gdbus wait --session --timeout 10 org.freedesktop.secrets
-            cargo test --release --locked --manifest-path gateway/Cargo.toml -- --ignored keyring_round_trip
-            xvfb-run -a node scripts/installed-webview-smoke.mjs \
-              /usr/bin/private-ai-gateway-desktop \
-              "$RUNNER_TEMP/tauri-tools/bin/tauri-driver" \
-              /usr/bin/WebKitWebDriver "$PWD/test-results/installed"
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored keyring_round_trip
+            if [[ "$RUN_UI_TESTS" == "true" ]]; then
+              xvfb-run -a node scripts/installed-webview-smoke.mjs \
+                /usr/bin/private-ai-gateway-desktop \
+                "$RUNNER_TEMP/tauri-tools/bin/tauri-driver" \
+                /usr/bin/WebKitWebDriver "$PWD/test-results/installed"
+            else
+              echo "Installed WebView UI checks: not run (opt-in disabled)." | tee "$PWD/test-results/installed/workflow-stage.txt"
+            fi
           '
 
       - name: Installed Windows package smoke
@@ -178,7 +199,7 @@ jobs:
           $toolsDir = Join-Path $env:RUNNER_TEMP 'tauri-tools'
           $evidenceDir = Join-Path $PWD 'test-results/installed'
           New-Item -ItemType Directory -Force $evidenceDir | Out-Null
-          'Preparing installed Windows smoke; no WebDriver session yet.' | Set-Content "$evidenceDir/workflow-stage.txt"
+          'Preparing installed Windows package checks.' | Set-Content "$evidenceDir/workflow-stage.txt"
           if (Test-Path $installDir) { throw 'Smoke install directory already exists' }
           function Run-Installer($executable, $arguments) {
             $process = Start-Process -FilePath $executable -ArgumentList $arguments -PassThru
@@ -196,31 +217,35 @@ jobs:
             $env:PAG_TEST_HELPER_PATH = "$installDir/private-ai-gateway-helper.exe"
             cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored hermes_windows_installed_command_round_trip
             if ($LASTEXITCODE -ne 0) { throw 'Hermes Windows credential command failed' }
-            cargo test --release --locked --manifest-path gateway/Cargo.toml -- --ignored keyring_round_trip
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored keyring_round_trip
             if ($LASTEXITCODE -ne 0) { throw 'Credential Manager round trip failed' }
-            $webviews = @(Get-ChildItem @("${env:ProgramFiles(x86)}/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe", "$env:LOCALAPPDATA/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe") -ErrorAction SilentlyContinue)
-            if ($webviews.Count -eq 0) { throw 'WebView2 runtime not found' }
-            $version = ($webviews | Sort-Object { [version]$_.VersionInfo.ProductVersion } -Descending | Select-Object -First 1).VersionInfo.ProductVersion
-            Invoke-WebRequest "https://msedgedriver.microsoft.com/$version/edgedriver_win64.zip" -OutFile "$toolsDir/edgedriver.zip"
-            Expand-Archive "$toolsDir/edgedriver.zip" -DestinationPath "$toolsDir/edge"
-            # Microsoft's WebDriver contract requires matching major.minor.build.
-            # https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
-            # https://learn.microsoft.com/microsoft-edge/webdriver/#download-microsoft-edge-webdriver
-            $env:TAURI_SMOKE_EDGE_BUILD = ([version]$version).ToString(3)
-            $driverBanner = (& "$toolsDir/edge/msedgedriver.exe" --version 2>&1 | Out-String).Trim()
-            $driverExitCode = $LASTEXITCODE
-            Write-Host "EdgeDriver --version exit code: $driverExitCode; banner: $driverBanner"
-            $driverVersions = [regex]::Matches($driverBanner, '(?<![\d.])\d+\.\d+\.\d+\.\d+(?![\d.])')
-            if ($driverExitCode -ne 0 -or $driverVersions.Count -ne 1) {
-              throw 'Cannot determine EdgeDriver version'
+            if ($env:RUN_UI_TESTS -eq 'true') {
+              $webviews = @(Get-ChildItem @("${env:ProgramFiles(x86)}/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe", "$env:LOCALAPPDATA/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe") -ErrorAction SilentlyContinue)
+              if ($webviews.Count -eq 0) { throw 'WebView2 runtime not found' }
+              $version = ($webviews | Sort-Object { [version]$_.VersionInfo.ProductVersion } -Descending | Select-Object -First 1).VersionInfo.ProductVersion
+              Invoke-WebRequest "https://msedgedriver.microsoft.com/$version/edgedriver_win64.zip" -OutFile "$toolsDir/edgedriver.zip"
+              Expand-Archive "$toolsDir/edgedriver.zip" -DestinationPath "$toolsDir/edge"
+              # Microsoft's WebDriver contract requires matching major.minor.build.
+              # https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
+              # https://learn.microsoft.com/microsoft-edge/webdriver/#download-microsoft-edge-webdriver
+              $env:TAURI_SMOKE_EDGE_BUILD = ([version]$version).ToString(3)
+              $driverBanner = (& "$toolsDir/edge/msedgedriver.exe" --version 2>&1 | Out-String).Trim()
+              $driverExitCode = $LASTEXITCODE
+              Write-Host "EdgeDriver --version exit code: $driverExitCode; banner: $driverBanner"
+              $driverVersions = [regex]::Matches($driverBanner, '(?<![\d.])\d+\.\d+\.\d+\.\d+(?![\d.])')
+              if ($driverExitCode -ne 0 -or $driverVersions.Count -ne 1) {
+                throw 'Cannot determine EdgeDriver version'
+              }
+              $driverVersion = [version]$driverVersions[0].Value
+              if ($driverVersion.ToString(3) -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
+              Write-Host "Selected WebView2: $version; driver: $driverVersion"
+              "WebView2=$version; EdgeDriver=$driverVersion; starting installed app with scoped CDP, then attaching WebDriver" | Set-Content "$evidenceDir/workflow-stage.txt"
+              $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
+              node scripts/installed-webview-smoke.mjs @smokeArgs
+              if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }
+            } else {
+              'Installed WebView UI checks: not run (opt-in disabled).' | Tee-Object -FilePath "$evidenceDir/workflow-stage.txt"
             }
-            $driverVersion = [version]$driverVersions[0].Value
-            if ($driverVersion.ToString(3) -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
-            Write-Host "Selected WebView2: $version; driver: $driverVersion"
-            "WebView2=$version; EdgeDriver=$driverVersion; starting installed app with scoped CDP, then attaching WebDriver" | Set-Content "$evidenceDir/workflow-stage.txt"
-            $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
-            node scripts/installed-webview-smoke.mjs @smokeArgs
-            if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }
           } finally {
             if (Test-Path "$installDir/uninstall.exe") {
               Run-Installer "$installDir/uninstall.exe" "/S _?=$installDir"
@@ -232,7 +257,7 @@ jobs:
           }
 
       - name: Upload installed-app evidence
-        if: always()
+        if: always() && env.RUN_UI_TESTS == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: desktop-tauri-installed-${{ runner.os }}
@@ -240,13 +265,22 @@ jobs:
           retention-days: 14
           path: apps/desktop/test-results/installed/
 
+      - name: Upload non-UI package check status
+        if: always() && env.RUN_UI_TESTS != 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-tauri-package-checks-${{ runner.os }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: apps/desktop/test-results/installed/workflow-stage.txt
+
       - name: Remove task-local drivers
-        if: always()
+        if: always() && env.RUN_UI_TESTS == 'true'
         shell: bash
         run: rm -rf "$RUNNER_TEMP/tauri-tools"
 
       - name: Upload renderer failure evidence
-        if: failure()
+        if: failure() && env.RUN_UI_TESTS == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: desktop-tauri-renderer-${{ runner.os }}

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Test Tauri backend
         run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
 
+      - name: Hermes path and projection regression
+        run: cargo test --release --locked --manifest-path gateway/Cargo.toml --lib hermes
+
       # Cargo integration tests also compile the root server binary, whose
       # dstack transport is Unix-only. Windows still exercises installed aci.exe
       # below; it must not be reported as passing this integration suite.
@@ -187,6 +190,9 @@ jobs:
             Run-Installer $installers[0].FullName "/S /D=$installDir"
             node scripts/packaged-sidecars-smoke.mjs $installDir
             if ($LASTEXITCODE -ne 0) { throw 'Installed sidecar smoke failed' }
+            $env:PAG_TEST_HELPER_PATH = "$installDir/private-ai-gateway-helper.exe"
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored hermes_windows_installed_command_round_trip
+            if ($LASTEXITCODE -ne 0) { throw 'Hermes Windows credential command failed' }
             cargo test --release --locked --manifest-path gateway/Cargo.toml -- --ignored keyring_round_trip
             if ($LASTEXITCODE -ne 0) { throw 'Credential Manager round trip failed' }
             $webviews = @(Get-ChildItem @("${env:ProgramFiles(x86)}/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe", "$env:LOCALAPPDATA/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe") -ErrorAction SilentlyContinue)

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -194,6 +194,16 @@ jobs:
             $version = ($webviews | Sort-Object { [version]$_.VersionInfo.ProductVersion } -Descending | Select-Object -First 1).VersionInfo.ProductVersion
             Invoke-WebRequest "https://msedgedriver.microsoft.com/$version/edgedriver_win64.zip" -OutFile "$toolsDir/edgedriver.zip"
             Expand-Archive "$toolsDir/edgedriver.zip" -DestinationPath "$toolsDir/edge"
+            # Microsoft's WebDriver contract requires matching major.minor.build.
+            # https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
+            # https://learn.microsoft.com/microsoft-edge/webdriver/#download-microsoft-edge-webdriver
+            $env:TAURI_SMOKE_EDGE_BUILD = ([version]$version).ToString(3)
+            $driverVersion = & "$toolsDir/edge/msedgedriver.exe" --version
+            if ($LASTEXITCODE -ne 0 -or $driverVersion -notmatch '^MSEdgeDriver (\d+\.\d+\.\d+)\.') {
+              throw 'Cannot determine EdgeDriver version'
+            }
+            if ($Matches[1] -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
+            Write-Host "Selected WebView2: $version; driver: $driverVersion"
             $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
             node scripts/installed-webview-smoke.mjs @smokeArgs
             if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Test shared runtime library
         run: cargo test --release --locked --manifest-path runtime/Cargo.toml --lib
 
+      # This integration target also compiles the Unix-only root server.
+      # Windows exercises the installed ACI executable below instead.
+      - name: ACI signed-artifact regression (local fixture service)
+        if: runner.os == 'Linux'
+        run: cargo test --release --locked --manifest-path ../../Cargo.toml --test aci_cli
+
       - name: Inspect Linux package sidecars
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -21,6 +21,8 @@ jobs:
         os: [windows-latest, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    env:
+      CARGO_BUILD_JOBS: 2
     defaults:
       run:
         working-directory: apps/desktop
@@ -37,6 +39,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: true
           workspaces: |
             . -> target
             apps/desktop/gateway -> target
@@ -63,16 +66,13 @@ jobs:
       - name: Build bundled Rust sidecars
         run: npm run build:native
 
-      - name: Test ACI sidecar
-        run: cargo test --locked --manifest-path ../../Cargo.toml --bin aci
-
-      - name: Test Tauri backend
-        run: cargo test --locked --manifest-path src-tauri/Cargo.toml
-
       # Tauri merges the host platform config, then the brand overlay. Its
       # beforeBuildCommand builds the same production Vite renderer as macOS.
       - name: Package Tauri app
         run: npm run tauri build -- --config src-tauri/tauri.brand.conf.json
+
+      - name: Test Tauri backend
+        run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
 
       - name: Inspect Linux package sidecars
         if: runner.os == 'Linux'

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -217,7 +217,7 @@ jobs:
             $driverVersion = [version]$driverVersions[0].Value
             if ($driverVersion.ToString(3) -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
             Write-Host "Selected WebView2: $version; driver: $driverVersion"
-            "WebView2=$version; EdgeDriver=$driverVersion; starting native driver launch diagnostics" | Set-Content "$evidenceDir/workflow-stage.txt"
+            "WebView2=$version; EdgeDriver=$driverVersion; starting installed app with scoped CDP, then attaching WebDriver" | Set-Content "$evidenceDir/workflow-stage.txt"
             $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
             node scripts/installed-webview-smoke.mjs @smokeArgs
             if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -50,7 +50,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev patchelf webkit2gtk-driver xvfb gnome-keyring dbus-x11
 
       - name: Install desktop dependencies
         run: npm ci
@@ -73,6 +73,13 @@ jobs:
 
       - name: Test Tauri backend
         run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
+
+      # Cargo integration tests also compile the root server binary, whose
+      # dstack transport is Unix-only. Windows still exercises installed aci.exe
+      # below; it must not be reported as passing this integration suite.
+      - name: ACI signed-artifact regression (local fixture service)
+        if: runner.os == 'Linux'
+        run: cargo test --release --locked --manifest-path ../../Cargo.toml --test aci_cli
 
       - name: Inspect Linux package sidecars
         if: runner.os == 'Linux'
@@ -112,6 +119,107 @@ jobs:
           path: |
             apps/desktop/src-tauri/target/release/bundle/nsis/*-setup.exe
             apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+
+      - name: Install task-local Tauri WebDriver
+        run: cargo install tauri-driver --version 2.0.6 --locked --root "${{ runner.temp }}/tauri-tools"
+
+      - name: Installed Linux package smoke
+        if: runner.os == 'Linux'
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          packages=("$PWD"/src-tauri/target/release/bundle/deb/*.deb)
+          test "${#packages[@]}" -eq 1
+          package="$(dpkg-deb --field "${packages[0]}" Package)"
+          if dpkg-query --show "$package" >/dev/null 2>&1; then
+            echo "Refusing to replace an existing installation: $package"
+            exit 1
+          fi
+          scratch="$(mktemp -d)"
+          cleanup() {
+            local status=0
+            sudo dpkg --remove "$package" || status=$?
+            for binary in private-ai-gateway-desktop aci private-ai-gateway-helper; do
+              test ! -e "/usr/bin/$binary" || status=1
+            done
+            rm -rf "$scratch"
+            return "$status"
+          }
+          trap cleanup EXIT
+          sudo apt-get install -y "${packages[0]}"
+          node scripts/packaged-sidecars-smoke.mjs /usr/bin
+          export TAURI_SMOKE_KEYRING_HOME="$scratch"
+          export XDG_RUNTIME_DIR="$scratch/runtime"
+          mkdir -m 700 "$XDG_RUNTIME_DIR"
+          dbus-run-session -- bash -euo pipefail -c '
+            HOME="$TAURI_SMOKE_KEYRING_HOME" gnome-keyring-daemon --foreground --unlock --components=secrets <<< ci-smoke-only &
+            keyring_pid=$!
+            trap "kill $keyring_pid 2>/dev/null || true; wait $keyring_pid || true" EXIT
+            gdbus wait --session --timeout 10 org.freedesktop.secrets
+            cargo test --release --locked --manifest-path gateway/Cargo.toml -- --ignored keyring_round_trip
+            xvfb-run -a node scripts/installed-webview-smoke.mjs \
+              /usr/bin/private-ai-gateway-desktop \
+              "$RUNNER_TEMP/tauri-tools/bin/tauri-driver" \
+              /usr/bin/WebKitWebDriver "$PWD/test-results/installed"
+          '
+
+      - name: Installed Windows package smoke
+        if: runner.os == 'Windows'
+        shell: pwsh
+        timeout-minutes: 10
+        run: |
+          $installers = @(Get-ChildItem src-tauri/target/release/bundle/nsis/*-setup.exe)
+          if ($installers.Count -ne 1) { throw 'Expected one NSIS installer' }
+          $installDir = Join-Path $env:RUNNER_TEMP 'Tauri Installed Smoke'
+          $toolsDir = Join-Path $env:RUNNER_TEMP 'tauri-tools'
+          if (Test-Path $installDir) { throw 'Smoke install directory already exists' }
+          function Run-Installer($executable, $arguments) {
+            $process = Start-Process -FilePath $executable -ArgumentList $arguments -PassThru
+            if (!$process.WaitForExit(120000)) {
+              Stop-Process -Id $process.Id -Force
+              throw 'Installer timed out'
+            }
+            if ($process.ExitCode -ne 0) { throw "Installer failed: $($process.ExitCode)" }
+          }
+          try {
+            # NSIS /D must be last and unquoted, including when it contains spaces.
+            Run-Installer $installers[0].FullName "/S /D=$installDir"
+            node scripts/packaged-sidecars-smoke.mjs $installDir
+            if ($LASTEXITCODE -ne 0) { throw 'Installed sidecar smoke failed' }
+            cargo test --release --locked --manifest-path gateway/Cargo.toml -- --ignored keyring_round_trip
+            if ($LASTEXITCODE -ne 0) { throw 'Credential Manager round trip failed' }
+            $webviews = @(Get-ChildItem @("${env:ProgramFiles(x86)}/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe", "$env:LOCALAPPDATA/Microsoft/EdgeWebView/Application/*/msedgewebview2.exe") -ErrorAction SilentlyContinue)
+            if ($webviews.Count -eq 0) { throw 'WebView2 runtime not found' }
+            $version = ($webviews | Sort-Object { [version]$_.VersionInfo.ProductVersion } -Descending | Select-Object -First 1).VersionInfo.ProductVersion
+            Invoke-WebRequest "https://msedgedriver.microsoft.com/$version/edgedriver_win64.zip" -OutFile "$toolsDir/edgedriver.zip"
+            Expand-Archive "$toolsDir/edgedriver.zip" -DestinationPath "$toolsDir/edge"
+            $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
+            node scripts/installed-webview-smoke.mjs @smokeArgs
+            if ($LASTEXITCODE -ne 0) { throw 'Installed WebView smoke failed' }
+          } finally {
+            if (Test-Path "$installDir/uninstall.exe") {
+              Run-Installer "$installDir/uninstall.exe" "/S _?=$installDir"
+            }
+            foreach ($binary in @('private-ai-gateway-desktop', 'aci', 'private-ai-gateway-helper')) {
+              if (Test-Path "$installDir/$binary.exe") { throw "Uninstall left $binary behind" }
+            }
+            if (Test-Path $installDir) { Remove-Item $installDir -Recurse -Force }
+          }
+
+      - name: Upload installed-app evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-tauri-installed-${{ runner.os }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: apps/desktop/test-results/installed/
+
+      - name: Remove task-local drivers
+        if: always()
+        shell: bash
+        run: rm -rf "$RUNNER_TEMP/tauri-tools"
 
       - name: Upload renderer failure evidence
         if: failure()

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -204,11 +204,15 @@ jobs:
             # https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
             # https://learn.microsoft.com/microsoft-edge/webdriver/#download-microsoft-edge-webdriver
             $env:TAURI_SMOKE_EDGE_BUILD = ([version]$version).ToString(3)
-            $driverVersion = & "$toolsDir/edge/msedgedriver.exe" --version
-            if ($LASTEXITCODE -ne 0 -or $driverVersion -notmatch '^MSEdgeDriver (\d+\.\d+\.\d+)\.') {
+            $driverBanner = (& "$toolsDir/edge/msedgedriver.exe" --version 2>&1 | Out-String).Trim()
+            $driverExitCode = $LASTEXITCODE
+            Write-Host "EdgeDriver --version exit code: $driverExitCode; banner: $driverBanner"
+            $driverVersions = [regex]::Matches($driverBanner, '(?<![\d.])\d+\.\d+\.\d+\.\d+(?![\d.])')
+            if ($driverExitCode -ne 0 -or $driverVersions.Count -ne 1) {
               throw 'Cannot determine EdgeDriver version'
             }
-            if ($Matches[1] -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
+            $driverVersion = [version]$driverVersions[0].Value
+            if ($driverVersion.ToString(3) -ne $env:TAURI_SMOKE_EDGE_BUILD) { throw 'EdgeDriver does not match WebView2' }
             Write-Host "Selected WebView2: $version; driver: $driverVersion"
             $smokeArgs = @("$installDir/private-ai-gateway-desktop.exe", "$toolsDir/bin/tauri-driver.exe", "$toolsDir/edge/msedgedriver.exe", "$PWD/test-results/installed")
             node scripts/installed-webview-smoke.mjs @smokeArgs

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -1,0 +1,123 @@
+name: Desktop Tauri Windows and Linux
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/desktop-tauri.yml'
+      - 'apps/desktop/**'
+      - 'src/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: apps/desktop
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            apps/desktop/gateway -> target
+            apps/desktop/runtime -> target
+            apps/desktop/src-tauri -> target
+
+      - name: Install Linux desktop dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev patchelf
+
+      - name: Install desktop dependencies
+        run: npm ci
+
+      - name: Check shared React renderer
+        run: npm run check
+
+      - name: Renderer smoke (Playwright, stateful mock)
+        run: |
+          npx playwright install chromium
+          npm run test:renderer -- --workers=2
+
+      - name: Build bundled Rust sidecars
+        run: npm run build:native
+
+      - name: Test ACI sidecar
+        run: cargo test --locked --manifest-path ../../Cargo.toml --bin aci
+
+      - name: Test Tauri backend
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml
+
+      # Tauri merges the host platform config, then the brand overlay. Its
+      # beforeBuildCommand builds the same production Vite renderer as macOS.
+      - name: Package Tauri app
+        run: npm run tauri build -- --config src-tauri/tauri.brand.conf.json
+
+      - name: Inspect Linux package sidecars
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_dir="$(mktemp -d)"
+          trap 'rm -rf "$package_dir"' EXIT
+          packages=(src-tauri/target/release/bundle/deb/*.deb)
+          test "${#packages[@]}" -eq 1
+          dpkg-deb --extract "${packages[0]}" "$package_dir"
+          for binary in private-ai-gateway-desktop aci private-ai-gateway-helper; do
+            test -x "$package_dir/usr/bin/$binary"
+          done
+          "$package_dir/usr/bin/aci" --help
+
+      - name: Inspect Windows sidecars and installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          foreach ($binary in @('private-ai-gateway-desktop', 'aci', 'private-ai-gateway-helper')) {
+            if (!(Test-Path "src-tauri/target/release/$binary.exe")) {
+              throw "Missing executable: $binary"
+            }
+          }
+          $installers = @(Get-ChildItem src-tauri/target/release/bundle/nsis/*-setup.exe)
+          if ($installers.Count -ne 1) { throw 'Expected one NSIS installer' }
+          & src-tauri/target/release/aci.exe --help
+          if ($LASTEXITCODE -ne 0) { throw 'ACI sidecar failed to launch' }
+
+      - name: Upload Tauri package
+        uses: actions/upload-artifact@v6
+        with:
+          name: private-ai-gateway-tauri-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            apps/desktop/src-tauri/target/release/bundle/nsis/*-setup.exe
+            apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+
+      - name: Upload renderer failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-tauri-renderer-${{ runner.os }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: apps/desktop/playwright-artifacts/

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -39,7 +39,16 @@ protocol is the service's own response, shown as such.
   single-instance plugin only focuses the window; the lock decides).
 - **Local endpoint** defaults to loopback-only `http://127.0.0.1:4180`. The
   app claims the configured address and port before agent connections are
-  available.
+  available. Windows, macOS, and Linux share the same listener, token checks,
+  and verified-session gate. Internal requests to the ACI sidecar bypass
+  environment/system HTTP proxies. Enabling network access does not change OS
+  firewall rules; reaching the gateway from another device depends on those
+  rules as well as the configured listen address.
+- **Agent connection state** describes the managed configuration and token,
+  not a live connection to an agent process or successful inference. A connected
+  agent can remain configured while protection is stopped; its requests stay
+  blocked until the gateway is verified. Refreshing unchanged agent tokens
+  does not revoke pending requests.
 - **Sessions.** The proxy forwards only while a *verified session* is
   published: the sidecar's verified identity and the catalog read through it,
   together, under one generation (per sidecar start) and epoch (per identity
@@ -54,12 +63,13 @@ protocol is the service's own response, shown as such.
   delivered. A failure before `send()` is recorded as `Blocked locally`; once
   upstream delivery begins, a timeout or connection failure is recorded as an
   upstream failure with delivery explicitly unconfirmed, never as "did not
-  leave this Mac." Deletes revoke the key in memory before touching the
+  leave this device." Deletes revoke the key in memory before touching the
   credential store. The sidecar re-checks verification for every method and
   refuses to forward when a re-verification changed the service identity
   mid-request.
-- **Agent tokens** are random per-agent secrets in owner-only files under the
-  app data directory. A token is a capability for that agent's endpoints
+- **Agent tokens** are random per-agent secrets in files under the user app
+  data directory (owner-only on Unix, inherited user-directory ACLs on Windows).
+  A token is a capability for that agent's endpoints
   (Claude Code: Messages and `count_tokens`; Codex and Pi: Responses and
   `responses/compact`; OpenCode and Hermes: Chat Completions; `/v1/models`
   for all) plus
@@ -78,10 +88,11 @@ protocol is the service's own response, shown as such.
   credential is loaded into the proxy's memory and swapped for the agent token
   on the way to the sidecar; it never reaches the window. Previews show `Existing secret` /
   `Managed local credential` in place of values; the connection record stores
-  an opaque `secret_ref`. Record, tokens, and temp files are owner-only
-  (0600/0700; on Windows they inherit the per-user profile ACL) and tightened
-  when read; config writes hold a cross-process file lock from the revision
-  check to the final rename.
+  an opaque `secret_ref`. Record, tokens, and temp files use 0600/0700 on Unix;
+  Windows inherits the per-user directory ACL rather than rewriting it.
+  Explicit Unix maintenance tightens permissions; ordinary reads do not.
+  Config writes hold a cross-process file lock from the revision check to the
+  final rename.
 - **Confidential AI profiles** are verified before they are saved. A profile
   combines a user-visible name, provider, endpoint, and authentication method.
   Settings offers local, self-hosted branding for the Phala and RedPill
@@ -148,8 +159,11 @@ Python's actual shell contract, including a special-character path and missing
 token/executable cases. A passing command test is not proof of successful
 verified inference or a complete Hermes connection workflow.
 Pi's Windows credential commands use its own Bash discovery with a system-shell
-fallback; not every Windows shell configuration has been validated. Neither
-contract should be inferred from Claude Code's Git `sh` behavior.
+fallback. Its projection uses the same encoded PowerShell command so neither
+Bash nor `cmd.exe` has to parse the helper path. Native Windows execution of the
+Pi projection still needs verification. Neither contract should be inferred
+from Claude Code's Git `sh` behavior. Windows home discovery prefers
+`USERPROFILE` over Git's `HOME`; explicit agent-specific overrides still apply.
 
 The verified catalog is the only model source. Codex requires a selected
 verified default because it does not discover this custom provider's model
@@ -160,12 +174,12 @@ as a concise catalog summary instead of serialized JSON. `Apply` refuses if any
 moved. Token, parked secrets, config, and record are applied as one transaction
 and rolled back together.
 `Disconnect` and `Restore all` work without endpoint or gateway.
-`Disconnect` tombstones the record (disabled, cleanup pending), deletes the
-token file before any record or config is touched, and syncs the removal to
-the parent directory (on Windows, a directory-handle flush) before anything
-else runs: revoking the capability itself is durable, so no later failure can
-leave an agent authorized, while the record stays visible for an idempotent
-retry. A failed sync fails the disconnect closed. `Disconnect` removes token,
+`Disconnect` tombstones the record (disabled, cleanup pending) and revokes the
+token before restoring config. Unix syncs the removal to the parent directory.
+Windows first clears and flushes the regular token file, then removes it; a
+recovered directory entry can therefore contain only an empty tombstone, not
+the old capability. A persistence failure fails the disconnect closed and the
+record remains visible for retry. `Disconnect` removes token,
 record, and consumed parked secrets and leaves an unreadable config untouched.
 Install detection requires a real executable on `PATH` or in common per-user
 and macOS package-manager binary directories; a config directory alone does

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -281,7 +281,10 @@ runners. `tauri-driver` uses the installed release app with the real React
 bundle and WebView bridge, without test hooks or weakened verification. The
 smoke covers startup, agent discovery, unverified-connect rejection, empty
 restore/export, local client-token rotation, endpoint settings and restart
-persistence. All app and agent files use a temporary `PRIVATE_AI_GATEWAY_HOME`.
+persistence. Gateway and agent configuration files use a temporary
+`PRIVATE_AI_GATEWAY_HOME`. Linux XDG data/config/cache/state directories are
+created privately for the smoke; Windows native profile environment variables
+remain intact on the disposable runner so WebView2 uses a valid OS profile.
 The existing credential-store round trip runs against Windows Credential
 Manager or a temporary Linux Secret Service session. The installed helper is
 checked with synthetic local token files, not provider credentials.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,10 +1,10 @@
 # Private AI Gateway Desktop
 
-Desktop clients that turn the bundled `aci serve` verifier into a local gateway
-for Codex, Claude Code, OpenCode, Pi, and Hermes. One Rust runtime owns policy,
-persistence, credentials, usage, agent projection, and process lifecycle;
-SwiftUI/AppKit, WinUI 3, GTK4/libadwaita, and the migration Tauri client are
-presentation adapters over the same versioned protocol.
+The React/Tauri desktop app turns the bundled `aci serve` verifier into a local
+gateway for Codex, Claude Code, OpenCode, Pi, and Hermes on macOS, Windows, and
+Linux. One React renderer and Rust runtime own the UI, policy, persistence,
+credentials, usage, agent projection, and process lifecycle. Preexisting
+experimental platform clients under `native/` are separate from this package.
 
 > Every request goes to a hardware-verified private AI service, and every
 > response is checked against its signed receipt.
@@ -193,15 +193,14 @@ add the official assets they reference before selecting them.
 
 ## Development
 
-The native clients launch `private-ai-gateway-desktop-service` and communicate
-over versioned NDJSON on stdin/stdout. No management HTTP listener is opened.
+The experimental native clients launch `private-ai-gateway-desktop-service`
+and communicate over versioned NDJSON on stdin/stdout. No management HTTP listener is opened.
 See [`native/ARCHITECTURE.md`](native/ARCHITECTURE.md) for the platform boundary
 and parity contract.
 
-Build the Rust CLI once, then run the Tauri migration client:
+Run the shared React/Tauri app (requires the host's Tauri v2 prerequisites):
 
 ```bash
-cargo build --bin aci
 cd apps/desktop
 npm ci
 npm run dev
@@ -211,7 +210,18 @@ Tauri launches the target-triple-specific `aci` binary as an external sidecar.
 The development command builds a debug sidecar; packaged builds always compile
 and bundle a release sidecar from this repository.
 
-Build platform-native packages on their target operating system:
+Build the React/Tauri package on its target operating system:
+
+```bash
+npm run dist
+```
+
+This produces a macOS app/DMG, Windows NSIS installer, or Linux DEB. The same
+Vite renderer and Tauri commands ship on all three platforms. Linux desktop
+environments need an AppIndicator-compatible tray and a Secret Service
+credential store. Windows uses WebView2 (installed by NSIS when missing).
+
+The preexisting experimental platform clients have separate build commands:
 
 ```bash
 npm run dist:native:macos
@@ -237,24 +247,41 @@ usage, persistent-history filters and cursor pagination, CSV/clear flows,
 proof and local-block semantics, profile management, native dialog focus,
 dark/high-contrast/reduced-motion
 media, 200% zoom, and
-940/720/540/320 widths. CI runs it on the macOS package job.
+940/720/540/320 widths. CI runs it on all three Tauri package jobs.
 
 ## Packaging
 
-`npm run dist` remains the Tauri migration package. It builds the release `aci`
-sidecar and runs `tauri build`. Xcode 26 or newer is required to package the
-adaptive macOS app icon. A macOS runner produces `Private AI Gateway.app`, a
-DMG, and a ZIP artifact.
+`npm run dist` builds the React/Tauri package. It builds the release Rust
+sidecars and runs `tauri build`. Tauri automatically merges
+`tauri.windows.conf.json` or `tauri.linux.conf.json` into `tauri.conf.json`,
+then applies the generated `tauri.brand.conf.json` overlay. The macOS app/DMG
+targets and brand icon overlay are unchanged. Xcode 26 or newer is required
+to package the adaptive macOS app icon. A macOS runner produces
+`Private AI Gateway.app`, a DMG, and a ZIP artifact.
 
-`scripts/bundle-native.mjs` builds two sidecars with `--locked`: the `aci`
+The Tauri bundle includes two sidecars built with `--locked`: the `aci`
 verifier and `private-ai-gateway-helper`, a console binary from the gateway
 crate that prints an agent's local token (kept separate from the GUI app so
-stdout works on Windows). The desktop gateway and Tauri crates declare
+stdout works on Windows). `scripts/bundle-native.mjs` also builds the runtime
+service used by the experimental clients; Tauri does not bundle that service.
+Sidecars are installed beside the Tauri executable, including `.exe` on
+Windows and `/usr/bin` in the DEB. AppImage is not currently a supported
+package: its temporary mount path would be persisted in agents' helper
+commands and become invalid after the app restarts.
+
+The `Desktop Tauri Windows and Linux` workflow builds the actual NSIS and DEB
+packages, runs the shared production renderer tests and Rust backend tests,
+and checks the sidecars without contacting a live provider. Renderer tests use
+the existing stateful mock; they do not prove native WebView or tray behavior.
+Hosted package builds and installed-app smoke checks are still required before
+claiming a platform release is ready.
+
+The desktop gateway and Tauri crates declare
 `rust-version = 1.89`, the highest MSRV in their locked dependency graphs
 (`aes` 0.9.3: 1.89; `keyring` 4.2: 1.88), and commit their `Cargo.lock` files.
-The root `aci` follows the root workspace toolchain and currently targets Unix
-because the dstack SDK transport uses a Unix-domain socket. CI tests the
-gateway crate and helper on Rust 1.89 on Ubuntu and Windows, checks the Tauri
+The root `aci` follows the root workspace toolchain; its dstack SDK dependency
+is gated by `cfg(unix)`, while Windows packages use the same verifier CLI source.
+CI tests the gateway crate and helper on Rust 1.89 on Ubuntu and Windows, checks the Tauri
 backend on Ubuntu, builds the complete app on macOS, and smoke-tests the
 credential store on macOS, Windows, and (under `dbus-run-session` with
 gnome-keyring) Linux.
@@ -262,7 +289,7 @@ gnome-keyring) Linux.
 The `Desktop native clients` workflow independently builds and launches the
 SwiftUI/AppKit, WinUI 3, and GTK4/libadwaita packages, runs one shared protocol
 fixture plus the packaged runtime smoke, and uploads each platform artifact.
-The existing `Desktop macOS` workflow continues to build the Tauri migration
+The existing `Desktop macOS` workflow continues to build the React/Tauri
 package on `macos-26`, launches the packaged tray app, runs the bundled sidecar
 against `https://tee.redpill.ai`, checks the verified local `/v1/models` path,
 and uploads a screenshot plus codesign, Gatekeeper, and size inspection output.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -129,7 +129,27 @@ protocol is the service's own response, shown as such.
 | Claude Code | `~/.claude/settings.json`: `env.ANTHROPIC_BASE_URL`, gateway model discovery, `apiKeyHelper`; optional `env.ANTHROPIC_MODEL`; higher-priority exported credentials must be unset | helper command |
 | OpenCode | `opencode.json`: an app-owned `@ai-sdk/openai-compatible` provider whose model map is generated from the verified catalog; optional default | token file |
 | Pi | `~/.pi/agent/models.json`: an app-owned Responses provider whose models, limits, modalities, reasoning flag, and prices come from the verified catalog | helper command |
-| Hermes | `~/.hermes/config.yaml`: a comment-preserving custom Chat Completions provider with `discover_models`, optional default, and command-backed auth | helper command |
+| Hermes | Platform Hermes home, `config.yaml`: a comment-preserving custom Chat Completions provider with `discover_models`, optional default, and command-backed auth | helper command |
+
+Hermes honors `HERMES_HOME` first. Otherwise Windows uses
+`%LOCALAPPDATA%\hermes` (falling back to `%USERPROFILE%\AppData\Local\hermes`),
+while macOS/Linux use `~/.hermes`. Windows install detection also checks
+`<Hermes home>/bin`, as used by the official native Windows installer.
+`PRIVATE_AI_GATEWAY_HOME` disables external agent path overrides so smoke tests
+stay inside their temporary home. These paths follow
+[Hermes 9a84bee](https://github.com/NousResearch/hermes-agent/blob/9a84bee265daad14340a80d7585928cd8ea1f9eb/hermes_constants.py#L45).
+
+Windows Hermes [`key_cmd`](https://github.com/NousResearch/hermes-agent/blob/9a84bee265daad14340a80d7585928cd8ea1f9eb/agent/command_token_source.py#L36)
+uses Python `shell=True` (normally `cmd.exe`). Its
+projection uses Windows PowerShell `-EncodedCommand` so paths containing spaces
+or shell metacharacters reach the helper unchanged; helper failures remain
+failures. The installed-package test runs this generated command through
+Python's actual shell contract, including a special-character path and missing
+token/executable cases. A passing command test is not proof of successful
+verified inference or a complete Hermes connection workflow.
+Pi's Windows credential commands use its own Bash discovery with a system-shell
+fallback; not every Windows shell configuration has been validated. Neither
+contract should be inferred from Claude Code's Git `sh` behavior.
 
 The verified catalog is the only model source. Codex requires a selected
 verified default because it does not discover this custom provider's model

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -276,6 +276,26 @@ the existing stateful mock; they do not prove native WebView or tray behavior.
 Hosted package builds and installed-app smoke checks are still required before
 claiming a platform release is ready.
 
+The package workflow now installs and uninstalls the NSIS/DEB on disposable
+runners. `tauri-driver` uses the installed release app with the real React
+bundle and WebView bridge, without test hooks or weakened verification. The
+smoke covers startup, agent discovery, unverified-connect rejection, empty
+restore/export, local client-token rotation, endpoint settings and restart
+persistence. All app and agent files use a temporary `PRIVATE_AI_GATEWAY_HOME`.
+The existing credential-store round trip runs against Windows Credential
+Manager or a temporary Linux Secret Service session. The installed helper is
+checked with synthetic local token files, not provider credentials.
+
+Installed ACI checks cover offline audit and fail-closed loopback failures for
+`verify`, `sessions`, `send`, and `serve`. The existing `tests/aci_cli.rs`
+signed-artifact regression runs in release mode on Linux; its Cargo integration
+target also builds the Unix-only root server, currently blocking Windows use.
+DEB installs `/usr/bin/aci`; NSIS supports the executable's full installed path
+and does not promise a bare `aci` command on PATH. Neither fixture tests nor
+WebDriver prove successful attested inference, verified agent connect/restore,
+native tray clicks, graceful Quit, or login-item registration. These remain
+separate release checks; process-tree cleanup in the smoke is not a Quit test.
+
 The desktop gateway and Tauri crates declare
 `rust-version = 1.89`, the highest MSRV in their locked dependency graphs
 (`aes` 0.9.3: 1.89; `keyring` 4.2: 1.88), and commit their `Cargo.lock` files.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -2,8 +2,8 @@
 
 The React/Tauri desktop app turns the bundled `aci serve` verifier into a local
 gateway for Codex, Claude Code, OpenCode, Pi, and Hermes on macOS, Windows, and
-Linux. One React renderer and Rust runtime own the UI, policy, persistence,
-credentials, usage, agent projection, and process lifecycle. Preexisting
+Linux. One shared React renderer handles the UI; the Rust runtime owns policy,
+persistence, credentials, usage, agent projection, and process lifecycle. Preexisting
 experimental platform clients under `native/` are separate from this package.
 
 > Every request goes to a hardware-verified private AI service, and every

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -304,16 +304,18 @@ package: its temporary mount path would be persisted in agents' helper
 commands and become invalid after the app restarts.
 
 The `Desktop Tauri Windows and Linux` workflow builds the actual NSIS and DEB
-packages, runs the shared production renderer tests and Rust backend tests,
-and checks the sidecars without contacting a live provider. Renderer tests use
-the existing stateful mock; they do not prove native WebView or tray behavior.
-Hosted package builds and installed-app smoke checks are still required before
-claiming a platform release is ready.
+packages, checks TypeScript and the Tauri/shared Rust libraries, and checks the
+installed sidecars without contacting a live provider. UI checks are disabled
+by default and require the explicit `run_ui_tests` manual input. This includes
+the stateful mock renderer tests, which do not prove native WebView behavior.
+The macOS and experimental native workflows also require an explicit opt-in
+before launching UI. Passing code checks alone is not a full release acceptance.
 
 The package workflow now installs and uninstalls the NSIS/DEB on disposable
-runners. `tauri-driver` uses the installed release app with the real React
-bundle and WebView bridge, without test hooks or weakened verification. The
-smoke covers startup, agent discovery, unverified-connect rejection, empty
+runners. The optional WebDriver checks use the installed release app with the
+real React bundle and WebView bridge; Windows uses EdgeDriver attach with
+process-local debugging arguments, while Linux uses `tauri-driver`. The
+checks target startup, agent discovery, unverified-connect rejection, empty
 restore/export, local client-token rotation, endpoint settings and restart
 persistence. Gateway and agent configuration files use a temporary
 `PRIVATE_AI_GATEWAY_HOME`. Linux XDG data/config/cache/state directories are

--- a/apps/desktop/gateway/Cargo.lock
+++ b/apps/desktop/gateway/Cargo.lock
@@ -1201,6 +1201,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/gateway/Cargo.toml
+++ b/apps/desktop/gateway/Cargo.toml
@@ -33,6 +33,9 @@ tokio-util = "0.7"
 toml_edit = "0.25"
 yaml-edit = { version = "0.3.1", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+base64 = "0.22"
+
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
 tempfile = "3"

--- a/apps/desktop/gateway/src/agents.rs
+++ b/apps/desktop/gateway/src/agents.rs
@@ -189,7 +189,15 @@ impl Agent {
                 .unwrap_or_else(|| home.join(".pi").join("agent"))
                 .join("models.json"),
             Agent::Hermes => override_dir("HERMES_HOME")
-                .unwrap_or_else(|| home.join(".hermes"))
+                .unwrap_or_else(|| {
+                    if cfg!(windows) {
+                        override_dir("LOCALAPPDATA")
+                            .unwrap_or_else(|| home.join("AppData").join("Local"))
+                            .join("hermes")
+                    } else {
+                        home.join(".hermes")
+                    }
+                })
                 .join("config.yaml"),
         }
     }
@@ -353,7 +361,7 @@ fn fields(agent: Agent, inputs: &Inputs<'_>) -> Result<Vec<Field>, String> {
                 boolean(&["providers", provider, "discover_models"], true),
                 set(
                     &["providers", provider, "key_cmd"],
-                    helper_command(inputs.helper_exe, "hermes")?,
+                    hermes_helper_command(inputs.helper_exe)?,
                 ),
                 set(&["model", "provider"], format!("custom:{provider}")),
             ];
@@ -678,6 +686,39 @@ fn helper_command(exe: &Path, agent: &str) -> Result<String, String> {
     Ok(format!("{quoted} --agent-token {agent}"))
 }
 
+#[cfg(not(windows))]
+fn hermes_helper_command(exe: &Path) -> Result<String, String> {
+    helper_command(exe, "hermes")
+}
+
+#[cfg(windows)]
+fn hermes_helper_command(exe: &Path) -> Result<String, String> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    let path = exe
+        .to_str()
+        .ok_or_else(|| "The app path is not valid Unicode".to_string())?;
+    if path.contains('\0') {
+        return Err("The app path contains a null character".to_string());
+    }
+    // Hermes uses Python shell=True (cmd.exe). Encoding the PowerShell command
+    // and its path data keeps shell metacharacters and Unicode quote characters
+    // out of both parsers. No execution-policy override is needed.
+    let encoded_path = STANDARD.encode(
+        path.encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>(),
+    );
+    let command = format!(
+        "$ErrorActionPreference = 'Stop'; & ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{encoded_path}'))) --agent-token hermes; exit $LASTEXITCODE"
+    );
+    let bytes: Vec<u8> = command.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    Ok(format!(
+        "powershell.exe -NoProfile -NonInteractive -EncodedCommand {}",
+        STANDARD.encode(bytes)
+    ))
+}
+
 /// Credential-bearing keys: their values never reach previews, manifests,
 /// or logs.
 fn is_sensitive(path: &[String]) -> bool {
@@ -762,13 +803,15 @@ impl Projector {
         endpoint: &str,
         secrets: Arc<dyn SecretStore>,
     ) -> Result<Self, String> {
-        let home = env_path(HOME_OVERRIDE_ENV).map_or_else(home_dir, Ok)?;
+        let home_override = env_path(HOME_OVERRIDE_ENV);
+        let tool_env = home_override.is_none();
+        let home = home_override.map_or_else(home_dir, Ok)?;
         Ok(Self::at(
             home,
             app_data_dir()?,
             helper_exe,
             endpoint,
-            true,
+            tool_env,
             secrets,
         ))
     }
@@ -1601,7 +1644,12 @@ fn cli_paths(home: &Path, tool_env: bool) -> Vec<PathBuf> {
 }
 
 fn find_cli(agent: Agent, home: &Path, tool_env: bool) -> Option<PathBuf> {
-    let paths = cli_paths(home, tool_env);
+    let mut paths = cli_paths(home, tool_env);
+    if cfg!(windows) && agent == Agent::Hermes {
+        if let Some(directory) = agent.config_path(home, tool_env).parent() {
+            paths.push(directory.join("bin"));
+        }
+    }
     find_cli_in_paths(agent, &paths)
 }
 
@@ -1855,6 +1903,93 @@ mod tests {
         }
     }
 
+    #[test]
+    fn hermes_paths_follow_platform_overrides_and_isolate_test_home() {
+        const CASE_ENV: &str = "PAG_TEST_HERMES_PATH_CASE";
+        const ROOT_ENV: &str = "PAG_TEST_HERMES_PATH_ROOT";
+        if let Ok(case) = env::var(CASE_ENV) {
+            let root = PathBuf::from(env::var_os(ROOT_ENV).unwrap());
+            let home = root.join(if case == "isolated" {
+                "isolated"
+            } else {
+                "user"
+            });
+            let default = if cfg!(windows) {
+                home.join("AppData").join("Local").join("hermes")
+            } else {
+                home.join(".hermes")
+            };
+            let expected = match case.as_str() {
+                "override" => root.join("custom-profile"),
+                "local-appdata" if cfg!(windows) => root.join("local-data").join("hermes"),
+                _ => default,
+            };
+            let projector = Projector::new(
+                root.join(helper_binary_name()),
+                ENDPOINT,
+                Arc::new(MemoryStore::default()),
+            )
+            .unwrap();
+            assert_eq!(projector.home, home);
+            assert_eq!(
+                Agent::Hermes.config_path(&projector.home, projector.tool_env),
+                expected.join("config.yaml")
+            );
+            if case == "isolated" {
+                assert!(!projector.tool_env);
+                assert_eq!(projector.data_dir, home.join(".private-ai-gateway"));
+                for agent in Agent::ALL {
+                    assert!(agent
+                        .config_path(&projector.home, projector.tool_env)
+                        .starts_with(&home));
+                }
+            }
+            if cfg!(windows) {
+                let executable = expected.join("bin").join("hermes.exe");
+                write(&executable, "launcher fixture");
+                assert_eq!(
+                    find_cli(Agent::Hermes, &projector.home, projector.tool_env),
+                    Some(executable)
+                );
+            }
+            return;
+        }
+
+        // Process-local environment avoids races with the other agent tests.
+        let root = tempfile::tempdir().unwrap();
+        for case in ["default", "local-appdata", "override", "isolated"] {
+            let mut command = Command::new(env::current_exe().unwrap());
+            command
+                .args([
+                    "--exact",
+                    "agents::tests::hermes_paths_follow_platform_overrides_and_isolate_test_home",
+                ])
+                .env(CASE_ENV, case)
+                .env(ROOT_ENV, root.path())
+                .env("HOME", root.path().join("user"))
+                .env("USERPROFILE", root.path().join("user"))
+                .env("APPDATA", root.path().join("roaming"))
+                .env("XDG_DATA_HOME", root.path().join("data"))
+                .env("PATH", "")
+                .env_remove(HOME_OVERRIDE_ENV)
+                .env_remove("HERMES_HOME")
+                .env_remove("LOCALAPPDATA");
+            if case != "default" {
+                command.env("LOCALAPPDATA", root.path().join("local-data"));
+            }
+            if matches!(case, "override" | "isolated") {
+                command.env("HERMES_HOME", root.path().join("custom-profile"));
+            }
+            if case == "isolated" {
+                command
+                    .env(HOME_OVERRIDE_ENV, root.path().join("isolated"))
+                    .env("CODEX_HOME", root.path().join("outside-codex"));
+            }
+            let output = command.output().unwrap();
+            assert!(output.status.success(), "{case}: {output:?}");
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn command_output_resolves_the_discovered_shebang_runtime() {
@@ -2064,7 +2199,7 @@ mod tests {
             .contains("--agent-token pi"));
         disconnect(&sandbox, Agent::Pi);
 
-        let path = sandbox.home.join(".hermes").join("config.yaml");
+        let path = Agent::Hermes.config_path(&sandbox.home, sandbox.projector.tool_env);
         write(&path, "# keep this comment\ntheme: dark\n");
         let preview = sandbox
             .projector
@@ -2122,9 +2257,77 @@ mod tests {
                 .as_deref(),
             Some("chat_completions")
         );
-        assert!(hermes
-            .get_str(&["providers", "private-ai-gateway", "key_cmd"])
-            .is_some_and(|command| command.contains("--agent-token hermes")));
+        assert_eq!(
+            hermes.get_str(&["providers", "private-ai-gateway", "key_cmd"]),
+            Some(hermes_helper_command(&fresh.projector.helper_exe).unwrap())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires the installed helper and Python on a disposable Windows runner"]
+    fn hermes_windows_installed_command_round_trip() {
+        let installed = PathBuf::from(env::var_os("PAG_TEST_HELPER_PATH").unwrap());
+        assert!(installed.is_absolute() && installed.is_file());
+        assert!(installed.to_str().unwrap().contains(' '));
+        let home = tempfile::tempdir().unwrap();
+        let data = home.path().join(".private-ai-gateway");
+        let tokens = TokenFiles::new(&data);
+        let hostile = home
+            .path()
+            .join("quote'\u{2019}; Write-Output injected; # %PAG_CMD_PROBE% ! ^ & (meta)")
+            .join(helper_binary_name());
+        fs::create_dir_all(hostile.parent().unwrap()).unwrap();
+        fs::copy(&installed, &hostile).unwrap();
+        for executable in [&installed, &hostile] {
+            let token = tokens.ensure("hermes").unwrap();
+            let fields = fields(
+                Agent::Hermes,
+                &Inputs {
+                    endpoint: ENDPOINT,
+                    helper_exe: executable,
+                    token_path: &tokens.path("hermes"),
+                    codex_catalog_path: &data.join(CODEX_CATALOG_FILE),
+                    catalog: Some(&catalog()),
+                    options: &ConnectOptions::default(),
+                },
+            )
+            .unwrap();
+            let command = fields
+                .into_iter()
+                .find(|field| field.path == owned(&["providers", "private-ai-gateway", "key_cmd"]))
+                .and_then(|field| match field.value {
+                    Some(ConfigValue::Str(command)) => Some(command),
+                    _ => None,
+                })
+                .unwrap();
+            let run = || {
+                Command::new("python")
+                    .args([
+                        "-c",
+                        "import subprocess,sys; p=subprocess.run(sys.argv[1],shell=True,capture_output=True,text=True,timeout=15); sys.stdout.write(p.stdout); sys.stderr.write(p.stderr); sys.exit(p.returncode)",
+                        &command,
+                    ])
+                    .env(HOME_OVERRIDE_ENV, home.path())
+                    .env("PAG_CMD_PROBE", "expanded-by-shell")
+                    .output()
+                    .unwrap()
+            };
+            let output = run();
+            assert!(output.status.success(), "{output:?}");
+            assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), token);
+            fs::remove_file(tokens.path("hermes")).unwrap();
+            let output = run();
+            assert!(!output.status.success());
+            assert!(output.stdout.is_empty());
+            if executable == &hostile {
+                fs::remove_file(executable).unwrap();
+                let output = run();
+                assert!(!output.status.success());
+                assert!(output.stdout.is_empty());
+            }
+        }
+        assert!(hermes_helper_command(Path::new("bad\0path")).is_err());
     }
 
     #[test]

--- a/apps/desktop/gateway/src/agents.rs
+++ b/apps/desktop/gateway/src/agents.rs
@@ -1304,6 +1304,26 @@ impl Projector {
                 }
             }
         }
+        #[cfg(windows)]
+        if agent == Agent::Pi && status.connected && !record.disabled && !record.cleanup_pending {
+            if let Ok(command) = helper_command(&self.helper_exe, "pi") {
+                let legacy = format!("!{command}");
+                let legacy_record = record.fields.iter().any(|field| {
+                    field.path == owned(&["providers", "private-ai-gateway"])
+                        && matches!(&field.value, Some(ConfigValue::Json(provider))
+                            if provider.get("apiKey").and_then(serde_json::Value::as_str) == Some(legacy.as_str()))
+                });
+                if legacy_record {
+                    status.connected = false;
+                    status.authorized = false;
+                    status.attention = Some(
+                        "This Pi connection uses the old Windows credential command. Disconnect, \
+                         then Connect again to update it."
+                            .to_string(),
+                    );
+                }
+            }
+        }
         status
     }
 
@@ -2222,6 +2242,79 @@ mod tests {
         assert!(pi_status.connected && pi_status.authorized);
         let pi_token = sandbox.projector.tokens.read("pi").unwrap().unwrap();
         assert_eq!(tokens.agent_for(&pi_token), Some("pi"));
+        #[cfg(windows)]
+        {
+            let config_path = Agent::Pi.config_path(&sandbox.home, sandbox.projector.tool_env);
+            let mut legacy = provider.clone();
+            legacy["apiKey"] = json!(format!(
+                "!{}",
+                helper_command(&sandbox.projector.helper_exe, "pi").unwrap()
+            ));
+            let value = ConfigValue::Json(legacy);
+            let mut config = doc(&sandbox, Agent::Pi);
+            config
+                .set_value(&["providers", "private-ai-gateway"], &value)
+                .unwrap();
+            write(&config_path, &config.render().unwrap());
+            let mut store = sandbox.projector.load_store().unwrap();
+            store
+                .get_mut("pi")
+                .unwrap()
+                .fields
+                .iter_mut()
+                .find(|field| field.path == owned(&["providers", "private-ai-gateway"]))
+                .unwrap()
+                .value = Some(value);
+            sandbox.projector.save_store(&store).unwrap();
+            let config_before = fs::read(&config_path).unwrap();
+            let record_before = fs::read(sandbox.projector.store_path()).unwrap();
+            let token_before = fs::read(sandbox.projector.tokens.path("pi")).unwrap();
+            let (statuses, tokens) = sandbox.projector.scan(None).unwrap();
+            let pi = statuses.iter().find(|status| status.id == "pi").unwrap();
+            assert!(pi.recorded && !pi.connected && !pi.authorized);
+            assert!(pi
+                .attention
+                .as_deref()
+                .unwrap()
+                .contains("Disconnect, then Connect"));
+            assert_eq!(tokens.agent_for(&pi_token), None);
+            assert_eq!(fs::read(&config_path).unwrap(), config_before);
+            assert_eq!(
+                fs::read(sandbox.projector.store_path()).unwrap(),
+                record_before
+            );
+            assert_eq!(
+                fs::read(sandbox.projector.tokens.path("pi")).unwrap(),
+                token_before
+            );
+
+            config
+                .set_str(
+                    &["providers", "private-ai-gateway", "apiKey"],
+                    "!user-command",
+                )
+                .unwrap();
+            write(&config_path, &config.render().unwrap());
+            let edited = fs::read(&config_path).unwrap();
+            let (statuses, tokens) = sandbox.projector.scan(None).unwrap();
+            let pi = statuses.iter().find(|status| status.id == "pi").unwrap();
+            assert!(pi.recorded && !pi.connected && !pi.authorized);
+            assert!(pi
+                .attention
+                .as_deref()
+                .unwrap()
+                .contains("no longer matches"));
+            assert_eq!(tokens.agent_for(&pi_token), None);
+            assert_eq!(fs::read(&config_path).unwrap(), edited);
+            assert_eq!(
+                fs::read(sandbox.projector.store_path()).unwrap(),
+                record_before
+            );
+            assert_eq!(
+                fs::read(sandbox.projector.tokens.path("pi")).unwrap(),
+                token_before
+            );
+        }
         disconnect(&sandbox, Agent::Pi);
 
         let path = Agent::Hermes.config_path(&sandbox.home, sandbox.projector.tool_env);

--- a/apps/desktop/gateway/src/agents.rs
+++ b/apps/desktop/gateway/src/agents.rs
@@ -59,6 +59,7 @@ pub struct AgentStatus {
     pub config_path: String,
     pub installed: bool,
     /// The config currently carries this app's projection and a token exists.
+    /// This does not imply a verified gateway session or successful inference.
     pub connected: bool,
     /// A connection record exists (whatever the config now says).
     pub recorded: bool,
@@ -361,7 +362,7 @@ fn fields(agent: Agent, inputs: &Inputs<'_>) -> Result<Vec<Field>, String> {
                 boolean(&["providers", provider, "discover_models"], true),
                 set(
                     &["providers", provider, "key_cmd"],
-                    hermes_helper_command(inputs.helper_exe)?,
+                    credential_helper_command(inputs.helper_exe, Agent::Hermes)?,
                 ),
                 set(&["model", "provider"], format!("custom:{provider}")),
             ];
@@ -469,7 +470,7 @@ fn pi_provider(
     Ok(serde_json::json!({
         "baseUrl": format!("{base}/v1"),
         "api": "openai-responses",
-        "apiKey": format!("!{}", helper_command(helper_exe, "pi")?),
+        "apiKey": format!("!{}", credential_helper_command(helper_exe, Agent::Pi)?),
         "models": models,
     }))
 }
@@ -687,12 +688,12 @@ fn helper_command(exe: &Path, agent: &str) -> Result<String, String> {
 }
 
 #[cfg(not(windows))]
-fn hermes_helper_command(exe: &Path) -> Result<String, String> {
-    helper_command(exe, "hermes")
+fn credential_helper_command(exe: &Path, agent: Agent) -> Result<String, String> {
+    helper_command(exe, agent.id())
 }
 
 #[cfg(windows)]
-fn hermes_helper_command(exe: &Path) -> Result<String, String> {
+fn credential_helper_command(exe: &Path, agent: Agent) -> Result<String, String> {
     use base64::{engine::general_purpose::STANDARD, Engine};
 
     let path = exe
@@ -701,16 +702,17 @@ fn hermes_helper_command(exe: &Path) -> Result<String, String> {
     if path.contains('\0') {
         return Err("The app path contains a null character".to_string());
     }
-    // Hermes uses Python shell=True (cmd.exe). Encoding the PowerShell command
-    // and its path data keeps shell metacharacters and Unicode quote characters
-    // out of both parsers. No execution-policy override is needed.
+    // Hermes uses cmd.exe; Pi tries Bash then falls back to cmd.exe. Only the
+    // PowerShell executable, fixed switches and base64 reach either shell.
+    // The path stays data, including metacharacters and Unicode quotes.
     let encoded_path = STANDARD.encode(
         path.encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>(),
     );
     let command = format!(
-        "$ErrorActionPreference = 'Stop'; & ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{encoded_path}'))) --agent-token hermes; exit $LASTEXITCODE"
+        "$ErrorActionPreference = 'Stop'; & ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{encoded_path}'))) --agent-token {}; exit $LASTEXITCODE",
+        agent.id()
     );
     let bytes: Vec<u8> = command.encode_utf16().flat_map(u16::to_le_bytes).collect();
     Ok(format!(
@@ -1743,6 +1745,10 @@ fn env_path(name: &str) -> Option<PathBuf> {
 }
 
 fn home_dir() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    if let Some(home) = env_path("USERPROFILE") {
+        return Ok(home);
+    }
     env_path("HOME")
         .or_else(|| env_path("USERPROFILE"))
         .ok_or_else(|| "Cannot determine the home directory".to_string())
@@ -1957,7 +1963,13 @@ mod tests {
 
         // Process-local environment avoids races with the other agent tests.
         let root = tempfile::tempdir().unwrap();
-        for case in ["default", "local-appdata", "override", "isolated"] {
+        for case in [
+            "default",
+            "local-appdata",
+            "override",
+            "isolated",
+            "native-home",
+        ] {
             let mut command = Command::new(env::current_exe().unwrap());
             command
                 .args([
@@ -1974,7 +1986,7 @@ mod tests {
                 .env_remove(HOME_OVERRIDE_ENV)
                 .env_remove("HERMES_HOME")
                 .env_remove("LOCALAPPDATA");
-            if case != "default" {
+            if matches!(case, "local-appdata" | "override" | "isolated") {
                 command.env("LOCALAPPDATA", root.path().join("local-data"));
             }
             if matches!(case, "override" | "isolated") {
@@ -1984,6 +1996,9 @@ mod tests {
                 command
                     .env(HOME_OVERRIDE_ENV, root.path().join("isolated"))
                     .env("CODEX_HOME", root.path().join("outside-codex"));
+            }
+            if cfg!(windows) && case == "native-home" {
+                command.env("HOME", root.path().join("git-home"));
             }
             let output = command.output().unwrap();
             assert!(output.status.success(), "{case}: {output:?}");
@@ -2193,10 +2208,20 @@ mod tests {
         };
         assert_eq!(provider["models"].as_array().unwrap().len(), 2);
         assert_eq!(provider["models"][0]["id"], "openai/gpt-oss-20b");
-        assert!(provider["apiKey"]
-            .as_str()
-            .unwrap()
-            .contains("--agent-token pi"));
+        assert_eq!(
+            provider["apiKey"],
+            format!(
+                "!{}",
+                credential_helper_command(&sandbox.projector.helper_exe, Agent::Pi).unwrap()
+            )
+        );
+        // A scan without a catalog retains the configuration connection.
+        // This flag is not runtime verification or evidence of forwarding.
+        let (statuses, tokens) = sandbox.projector.scan(None).unwrap();
+        let pi_status = statuses.iter().find(|status| status.id == "pi").unwrap();
+        assert!(pi_status.connected && pi_status.authorized);
+        let pi_token = sandbox.projector.tokens.read("pi").unwrap().unwrap();
+        assert_eq!(tokens.agent_for(&pi_token), Some("pi"));
         disconnect(&sandbox, Agent::Pi);
 
         let path = Agent::Hermes.config_path(&sandbox.home, sandbox.projector.tool_env);
@@ -2259,7 +2284,7 @@ mod tests {
         );
         assert_eq!(
             hermes.get_str(&["providers", "private-ai-gateway", "key_cmd"]),
-            Some(hermes_helper_command(&fresh.projector.helper_exe).unwrap())
+            Some(credential_helper_command(&fresh.projector.helper_exe, Agent::Hermes).unwrap())
         );
     }
 
@@ -2327,7 +2352,7 @@ mod tests {
                 assert!(output.stdout.is_empty());
             }
         }
-        assert!(hermes_helper_command(Path::new("bad\0path")).is_err());
+        assert!(credential_helper_command(Path::new("bad\0path"), Agent::Hermes).is_err());
     }
 
     #[test]
@@ -2819,6 +2844,50 @@ mod tests {
                 Err(error) => panic!("cannot run sh: {error}"),
             }
         }
+        #[cfg(windows)]
+        {
+            use base64::{engine::general_purpose::STANDARD, Engine};
+
+            // Pi's Bash and cmd.exe fallback see only fixed switches and a
+            // base64 word. Neither shell interprets the Windows helper path.
+            let hostile = Path::new(r"C:\Users\O'Brien %USERPROFILE% ! &\helper.exe");
+            let provider = pi_provider(&catalog(), ENDPOINT, hostile).unwrap();
+            let command = provider["apiKey"]
+                .as_str()
+                .unwrap()
+                .strip_prefix('!')
+                .unwrap();
+            let words: Vec<_> = command.split_ascii_whitespace().collect();
+            assert_eq!(words.len(), 5);
+            assert_eq!(
+                &words[..4],
+                &[
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-EncodedCommand"
+                ]
+            );
+            assert_eq!(shlex::split(command).unwrap(), words);
+            let bytes = STANDARD.decode(words[4]).unwrap();
+            let script = String::from_utf16(
+                &bytes
+                    .chunks_exact(2)
+                    .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+            let encoded_path = STANDARD.encode(
+                hostile
+                    .to_str()
+                    .unwrap()
+                    .encode_utf16()
+                    .flat_map(u16::to_le_bytes)
+                    .collect::<Vec<_>>(),
+            );
+            assert!(script.contains(&format!("FromBase64String('{encoded_path}')")));
+            assert!(script.ends_with("--agent-token pi; exit $LASTEXITCODE"));
+        }
     }
 
     /// Deleting the token file is the revocation itself: even when the very
@@ -3009,7 +3078,7 @@ mod tests {
         tokio::spawn(async move { axum::serve(sidecar_listener, sidecar).await.unwrap() });
 
         let (sender, _events) = tokio::sync::mpsc::channel(8);
-        let state = ProxyState::new(sender);
+        let state = ProxyState::new(sender).unwrap();
         state.set_api_key(Some("sk-live".into()));
         state.publish(Session {
             generation: 1,

--- a/apps/desktop/gateway/src/proxy.rs
+++ b/apps/desktop/gateway/src/proxy.rs
@@ -134,13 +134,16 @@ pub struct ProxyState {
 impl ProxyState {
     /// `events` is bounded; when it is full, low-value rejection events are
     /// dropped rather than blocking a request.
-    pub fn new(events: mpsc::Sender<ProxyEvent>) -> Arc<Self> {
+    pub fn new(events: mpsc::Sender<ProxyEvent>) -> Result<Arc<Self>, String> {
         let client = reqwest::Client::builder()
+            // This client talks only to the owned loopback sidecar, never a
+            // system or environment proxy that could receive request secrets.
+            .no_proxy()
             .connect_timeout(UPSTREAM_CONNECT_TIMEOUT)
             .read_timeout(UPSTREAM_READ_TIMEOUT)
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
-        Arc::new(Self {
+            .map_err(|_| "Cannot initialize the local gateway HTTP client".to_string())?;
+        Ok(Arc::new(Self {
             session: RwLock::new(Session::default()),
             credentials: RwLock::new(Credentials::default()),
             credential_epoch: AtomicU64::new(1),
@@ -150,7 +153,7 @@ impl ProxyState {
             in_flight: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
             #[cfg(test)]
             pause: std::sync::Mutex::new(None),
-        })
+        }))
     }
 
     /// Cancel every delivery admitted so far; called after any state change
@@ -182,8 +185,13 @@ impl ProxyState {
     }
 
     pub fn set_tokens(&self, tokens: TokenSet) {
-        write(&self.credentials).tokens = tokens;
+        let mut credentials = write(&self.credentials);
+        if credentials.tokens == tokens {
+            return;
+        }
+        credentials.tokens = tokens;
         self.credential_epoch.fetch_add(1, Ordering::SeqCst);
+        drop(credentials);
         self.revoke_deliveries();
     }
 
@@ -1246,7 +1254,7 @@ mod tests {
 
     fn state() -> (Arc<ProxyState>, mpsc::Receiver<ProxyEvent>) {
         let (sender, receiver) = mpsc::channel(4);
-        (ProxyState::new(sender), receiver)
+        (ProxyState::new(sender).unwrap(), receiver)
     }
 
     fn tokens() -> TokenSet {
@@ -1255,6 +1263,68 @@ mod tests {
         set.insert("claude-token".to_string(), "claude-code".to_string());
         set.insert("opencode-token".to_string(), "opencode".to_string());
         set
+    }
+
+    #[test]
+    fn sidecar_requests_ignore_proxy_environment() {
+        const CHILD: &str = "PAG_TEST_PROXY_ENV_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            // Isolate proxy variables from the other concurrently running tests.
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "proxy::tests::sidecar_requests_ignore_proxy_environment",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .env("HTTP_PROXY", "http://127.0.0.1:1")
+                .env("http_proxy", "http://127.0.0.1:1")
+                .env("ALL_PROXY", "http://127.0.0.1:1")
+                .env("all_proxy", "http://127.0.0.1:1")
+                .env("NO_PROXY", "")
+                .env("no_proxy", "")
+                .status()
+                .unwrap();
+            assert!(status.success());
+            return;
+        }
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let (state, _events) = state();
+            let sidecar = mock_sidecar().await;
+            assert!(reqwest::Client::builder()
+                .timeout(Duration::from_secs(1))
+                .build()
+                .unwrap()
+                .get(format!("{sidecar}/v1/models"))
+                .send()
+                .await
+                .is_err());
+            verified(&state, &sidecar, 1, 1).await;
+            let response = state
+                .client
+                .post(format!("{sidecar}/v1/responses"))
+                .json(&json!({ "model": "openai/gpt-oss-20b", "input": "fixture" }))
+                .send()
+                .await
+                .unwrap();
+            assert!(response.status().is_success());
+        });
+    }
+
+    #[tokio::test]
+    async fn unchanged_agent_tokens_preserve_pending_requests() {
+        let (state, _events) = state();
+        state.set_tokens(tokens());
+        let epoch = state.credential_epoch.load(Ordering::SeqCst);
+        let gate = read(&state.gate).clone();
+
+        state.set_tokens(tokens());
+        assert_eq!(state.credential_epoch.load(Ordering::SeqCst), epoch);
+        assert!(!gate.is_cancelled());
+
+        state.set_tokens(tokens().without("codex"));
+        assert_ne!(state.credential_epoch.load(Ordering::SeqCst), epoch);
+        assert!(gate.is_cancelled());
     }
 
     async fn verified(state: &ProxyState, sidecar: &str, generation: u64, epoch: u64) {

--- a/apps/desktop/gateway/src/tokens.rs
+++ b/apps/desktop/gateway/src/tokens.rs
@@ -41,9 +41,9 @@ pub fn agent_allows(agent: &str, path: &str) -> bool {
 
 pub struct TokenFiles {
     dir: PathBuf,
-    /// Persists a directory-entry removal (see `sync_dir`); swappable in
-    /// tests to prove revocation order and fail-closed behaviour without
-    /// tracing syscalls.
+    /// Completes the platform revocation barrier after removal (see
+    /// `sync_dir`); swappable in tests to prove revocation order and
+    /// fail-closed behaviour without tracing syscalls.
     sync_parent: fn(&Path) -> io::Result<()>,
 }
 
@@ -69,6 +69,10 @@ impl TokenFiles {
         if let Some(existing) = self.read(agent)? {
             return Ok(existing);
         }
+        // An interrupted Windows revocation can intentionally leave an empty,
+        // durably-cleared tombstone. Remove it before create_new issues the
+        // replacement; a missing path remains a no-op.
+        self.revoke(agent)?;
         self.issue(agent)
     }
 
@@ -111,15 +115,22 @@ impl TokenFiles {
         Ok(())
     }
 
-    /// Durable revocation: the token file is removed and the removal is
-    /// persisted (parent-directory sync) before this returns, so a crash or
-    /// power loss right after cannot resurrect the token. A missing file
-    /// changed no directory entry and needs no sync.
+    /// Durable revocation: Unix persists the removal through a parent-directory
+    /// sync; Windows first persists an empty file before removing it, so a
+    /// rolled-back deletion cannot resurrect the old capability. A missing file
+    /// needs no persistence barrier.
     pub fn revoke(&self, agent: &str) -> Result<(), String> {
-        match fs::remove_file(self.path(agent)) {
+        let path = self.path(agent);
+        #[cfg(windows)]
+        match neutralize_private(&path) {
+            Ok(true) => {}
+            Ok(false) => return Ok(()),
+            Err(error) => return Err(format!("Cannot revoke the {agent} token: {error}")),
+        }
+        match fs::remove_file(path) {
             Ok(()) => (self.sync_parent)(&self.dir).map_err(|error| {
                 format!(
-                    "The {agent} token file was deleted but the removal could not be \
+                    "The {agent} token file was deleted but durable revocation could not be \
                      persisted: {error}"
                 )
             }),
@@ -141,7 +152,7 @@ impl TokenFiles {
 }
 
 /// Issued tokens mapped to the agent they authenticate.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TokenSet(HashMap<String, String>);
 
 impl TokenSet {
@@ -277,30 +288,59 @@ pub fn tighten_private(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Durably persist a change to a directory's entries (a file removal). On
-/// Unix this is the mature pattern: open the directory itself
-/// (`O_DIRECTORY`, `O_NOFOLLOW`; std adds `O_CLOEXEC`) and `fsync` the
-/// handle. On Windows a `FlushFileBuffers` is issued on a
-/// `FILE_FLAG_BACKUP_SEMANTICS` directory handle via `File::sync_all`;
-/// beyond that there is no POSIX-style directory fsync — NTFS journals
-/// metadata operations, so the flush plus the journal is the strongest
-/// guarantee available without raw volume access.
+/// On Windows, make the old capability durably unusable before unlinking it.
+/// `FlushFileBuffers` is supported for regular writable file handles, not by
+/// the documented directory-handle contract. If an unflushed deletion is
+/// rolled back after a crash, the recovered entry therefore names an empty
+/// file rather than the old token.
+#[cfg(windows)]
+fn neutralize_private(path: &Path) -> io::Result<bool> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    let file = match fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(symlink_refused());
+    }
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the token path is not a regular file",
+        ));
+    }
+    file.set_len(0)?;
+    file.sync_all()?;
+    Ok(true)
+}
+
+/// Durably persist a change to a directory's entries on Unix: open the
+/// directory itself (`O_DIRECTORY`, `O_NOFOLLOW`; std adds `O_CLOEXEC`) and
+/// `fsync` the handle.
+#[cfg(unix)]
 pub(crate) fn sync_dir(dir: &Path) -> io::Result<()> {
     let mut options = fs::OpenOptions::new();
     options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc_directory() | libc_nofollow());
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::OpenOptionsExt;
-        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-        // FlushFileBuffers needs write access on the handle.
-        options.write(true).custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-    }
+    use std::os::unix::fs::OpenOptionsExt;
+    options.custom_flags(libc_directory() | libc_nofollow());
     options.open(dir)?.sync_all()
+}
+
+/// Windows revocation durability comes from `neutralize_private`; there is no
+/// documented POSIX-style parent-directory flush to add after the unlink.
+#[cfg(windows)]
+pub(crate) fn sync_dir(_dir: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -398,5 +438,39 @@ mod tests {
         assert!(agent_allows(LOCAL_TOOLS_AGENT, "/v1/chat/completions"));
         assert!(agent_allows("opencode", "/v1/models"));
         assert!(!agent_allows("opencode", "/v1/responses"));
+    }
+
+    #[test]
+    fn ensure_replaces_an_empty_revocation_tombstone() {
+        let dir = std::env::temp_dir().join(format!("pag-token-tombstone-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let files = TokenFiles::new(&dir);
+        let old = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        fs::write(files.path(LOCAL_TOOLS_AGENT), "").unwrap();
+
+        let replacement = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        assert_ne!(replacement, old);
+        assert_eq!(
+            files.read(LOCAL_TOOLS_AGENT).unwrap().as_deref(),
+            Some(replacement.as_str())
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rotate_sync_failure_leaves_no_readable_old_token() {
+        let dir = std::env::temp_dir().join(format!("pag-token-rotate-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let mut files = TokenFiles::new(&dir);
+        let old = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        files.set_sync_parent(|_| Err(io::Error::other("injected sync failure")));
+
+        assert!(files.rotate(LOCAL_TOOLS_AGENT).is_err());
+        assert!(files.read(LOCAL_TOOLS_AGENT).unwrap().is_none());
+
+        files.set_sync_parent(sync_dir);
+        let replacement = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        assert_ne!(replacement, old);
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/apps/desktop/native/linux/Cargo.lock
+++ b/apps/desktop/native/linux/Cargo.lock
@@ -1652,6 +1652,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/runtime/Cargo.lock
+++ b/apps/desktop/runtime/Cargo.lock
@@ -1270,6 +1270,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/runtime/src/controller.rs
+++ b/apps/desktop/runtime/src/controller.rs
@@ -36,31 +36,58 @@ pub struct DesktopRuntime {
     secrets: Arc<dyn SecretStore>,
     credentials: ClientCredentials,
     endpoint: EndpointRuntime,
+    local_api_update: tokio::sync::Mutex<()>,
     codex_sync: CodexCatalogSync,
     helper_path: PathBuf,
-    #[allow(dead_code)]
     instance: Option<lock::InstanceLock>,
 }
 
-struct ClientCredentials(Mutex<TokenFiles>);
+struct ClientCredentials(Mutex<ClientCredentialState>);
+
+struct ClientCredentialState {
+    files: TokenFiles,
+    rotation_failed: bool,
+}
 
 impl ClientCredentials {
     fn new() -> Result<Self, String> {
-        Ok(Self(Mutex::new(TokenFiles::new(&app_data_dir()?))))
+        Ok(Self::from_files(TokenFiles::new(&app_data_dir()?)))
+    }
+
+    fn from_files(files: TokenFiles) -> Self {
+        Self(Mutex::new(ClientCredentialState {
+            files,
+            rotation_failed: false,
+        }))
     }
 
     fn token(&self) -> Result<String, String> {
-        self.0
+        self.active_token()?.ok_or_else(|| {
+            "Client key rotation failed; generate a new client key before using the Local API"
+                .to_string()
+        })
+    }
+
+    fn active_token(&self) -> Result<Option<String>, String> {
+        let state = self
+            .0
             .lock()
-            .map_err(|_| "Client credential store unavailable".to_string())?
-            .ensure(LOCAL_TOOLS_AGENT)
+            .map_err(|_| "Client credential store unavailable".to_string())?;
+        if state.rotation_failed {
+            return Ok(None);
+        }
+        state.files.ensure(LOCAL_TOOLS_AGENT).map(Some)
     }
 
     fn rotate(&self) -> Result<String, String> {
-        self.0
+        let mut state = self
+            .0
             .lock()
-            .map_err(|_| "Client credential store unavailable".to_string())?
-            .rotate(LOCAL_TOOLS_AGENT)
+            .map_err(|_| "Client credential store unavailable".to_string())?;
+        state.rotation_failed = true;
+        let token = state.files.rotate(LOCAL_TOOLS_AGENT)?;
+        state.rotation_failed = false;
+        Ok(token)
     }
 }
 
@@ -221,7 +248,7 @@ impl DesktopRuntime {
             ),
         };
         let (proxy_events_tx, mut proxy_events) = tokio::sync::mpsc::channel::<ProxyEvent>(256);
-        let proxy = ProxyState::new(proxy_events_tx);
+        let proxy = ProxyState::new(proxy_events_tx)?;
         let (usage, usage_error) = match UsageStore::open(data_dir.join("usage.sqlite3")) {
             Ok(store) => (Arc::new(store), None),
             Err(error) => match UsageStore::memory() {
@@ -254,6 +281,7 @@ impl DesktopRuntime {
             secrets,
             credentials: ClientCredentials::new()?,
             endpoint: EndpointRuntime::default(),
+            local_api_update: tokio::sync::Mutex::new(()),
             codex_sync: CodexCatalogSync::default(),
             helper_path: options.helper_path,
             instance,
@@ -303,6 +331,7 @@ impl DesktopRuntime {
     }
 
     pub fn start(self: &Arc<Self>, config: StartGatewayConfig) -> Result<GatewayState, String> {
+        let _endpoint = self.endpoint_guard()?;
         let config = service_config::resolve_runtime_config(config)?;
         let state = self.manager.snapshot()?;
         if config.remote_url != state.config.remote_url {
@@ -340,6 +369,7 @@ impl DesktopRuntime {
     }
 
     pub async fn shutdown(&self) -> Result<(), String> {
+        let _endpoint = self.local_api_update.lock().await;
         let gateway = self.manager.stop().map(|_| ());
         let endpoint = self.endpoint.stop().await;
         gateway.and(endpoint)
@@ -351,6 +381,12 @@ impl DesktopRuntime {
 
     fn current_projector(&self) -> Result<Projector, String> {
         self.projector(&self.manager.local_api()?.endpoint)
+    }
+
+    fn endpoint_guard(&self) -> Result<tokio::sync::MutexGuard<'_, ()>, String> {
+        self.local_api_update
+            .try_lock()
+            .map_err(|_| "Another gateway operation is in progress; try again shortly".to_string())
     }
 
     fn reload_agent_tokens(&self) -> Result<(), String> {
@@ -368,6 +404,7 @@ impl DesktopRuntime {
         require_production_os: bool,
         key: Option<String>,
     ) -> Result<GatewayState, String> {
+        let endpoint = self.endpoint_guard()?;
         if self.manager.is_running()? {
             return Err("Stop protection before verifying a different service".to_string());
         }
@@ -427,6 +464,7 @@ impl DesktopRuntime {
             self.manager.restore_snapshot(previous);
             return Err("Configuration verification did not start".to_string());
         };
+        drop(endpoint);
         let verified = self.manager.wait_for_verification(&session_id).await;
         let stop_result = self.manager.stop();
         if let Err(error) = verified {
@@ -605,6 +643,7 @@ impl DesktopRuntime {
     }
 
     pub fn rotate_client_key(&self) -> Result<String, String> {
+        let _endpoint = self.endpoint_guard()?;
         self.proxy
             .set_tokens(self.proxy.tokens().without(LOCAL_TOOLS_AGENT));
         let token = self.credentials.rotate()?;
@@ -618,6 +657,10 @@ impl DesktopRuntime {
         self: &Arc<Self>,
         config: LocalApiConfig,
     ) -> Result<GatewayState, String> {
+        let _endpoint = self.local_api_update.lock().await;
+        if self.instance.is_none() {
+            return Err("Change Local API settings in the primary app instance".to_string());
+        }
         if self.manager.is_running()? {
             return Err("Stop protection before changing Local API settings".to_string());
         }
@@ -696,6 +739,7 @@ impl DesktopRuntime {
     }
 
     pub fn list_agents(&self) -> Result<Vec<AgentStatus>, String> {
+        let _endpoint = self.endpoint_guard()?;
         let session = self.proxy.session();
         let catalog = session.verified.then_some(session.catalog).flatten();
         let projector = self.current_projector()?;
@@ -740,6 +784,7 @@ impl DesktopRuntime {
         revision: String,
         options: ConnectOptions,
     ) -> Result<AgentStatus, String> {
+        let _endpoint = self.endpoint_guard()?;
         let agent = Agent::from_id(&agent_id)?;
         let catalog = self.connection_catalog(agent, connect)?;
         let projector = self.current_projector()?;
@@ -761,6 +806,7 @@ impl DesktopRuntime {
     }
 
     pub fn disconnect_all_agents(&self) -> Result<Vec<AgentStatus>, String> {
+        let _endpoint = self.endpoint_guard()?;
         self.proxy
             .set_tokens(with_client_token(TokenSet::default(), &self.credentials)?);
         let projector = self.current_projector()?;
@@ -860,7 +906,9 @@ fn with_client_token(
     mut tokens: TokenSet,
     credentials: &ClientCredentials,
 ) -> Result<TokenSet, String> {
-    tokens.insert(credentials.token()?, LOCAL_TOOLS_AGENT.to_string());
+    if let Some(token) = credentials.active_token()? {
+        tokens.insert(token, LOCAL_TOOLS_AGENT.to_string());
+    }
     Ok(tokens)
 }
 
@@ -872,5 +920,233 @@ fn restore_secret_entry(
     match value {
         Some(value) => secrets.set(entry, value),
         None => secrets.delete(entry),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        sync::mpsc::Receiver,
+    };
+
+    use super::*;
+    use crate::gateway::{SidecarChild, SidecarEvent};
+    use desktop_gateway::agents::HOME_OVERRIDE_ENV;
+
+    struct RefusingLauncher;
+
+    impl SidecarLauncher for RefusingLauncher {
+        fn spawn(
+            &self,
+            _: Vec<String>,
+        ) -> Result<(Receiver<SidecarEvent>, Box<dyn SidecarChild>), String> {
+            Err("The sidecar must not start while Local API settings are tested".to_string())
+        }
+    }
+
+    /// A runtime over the overridden data directory that never touches the
+    /// OS keyring or spawns a sidecar. `instance` mirrors what `launch`
+    /// decided about the primary-instance lock.
+    fn runtime(
+        instance: Option<lock::InstanceLock>,
+    ) -> (Arc<DesktopRuntime>, Receiver<ProxyEvent>) {
+        let data_dir = app_data_dir().unwrap();
+        let (events, receiver) = tokio::sync::mpsc::channel(8);
+        let proxy = ProxyState::new(events).unwrap();
+        let usage = Arc::new(UsageStore::memory().unwrap());
+        let settings = service_config::ServiceSettings::default();
+        let manager = Arc::new(GatewayManager::new(
+            proxy.clone(),
+            usage.clone(),
+            Arc::new(RefusingLauncher),
+            LocalApiConfig::default(),
+            settings.runtime_config().unwrap(),
+            settings.profiles,
+            settings.active_profile_id,
+        ));
+        let runtime = Arc::new(DesktopRuntime {
+            manager,
+            proxy,
+            usage,
+            secrets: Arc::new(KeyringStore),
+            credentials: ClientCredentials::from_files(TokenFiles::new(&data_dir)),
+            endpoint: EndpointRuntime::default(),
+            local_api_update: tokio::sync::Mutex::new(()),
+            codex_sync: CodexCatalogSync::default(),
+            helper_path: data_dir.join("private-ai-gateway-helper"),
+            instance,
+        });
+        (runtime, receiver)
+    }
+
+    fn free_port() -> u16 {
+        TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn is_free(port: u16) -> bool {
+        TcpListener::bind((Ipv4Addr::LOCALHOST, port)).is_ok()
+    }
+
+    fn loopback(port: u16) -> LocalApiConfig {
+        LocalApiConfig {
+            port,
+            ..LocalApiConfig::default()
+        }
+    }
+
+    #[test]
+    fn failed_client_rotation_does_not_reload_the_old_key() {
+        let data = tempfile::tempdir().unwrap();
+        let files = TokenFiles::new(data.path());
+        let old = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        let token_path = files.path(LOCAL_TOOLS_AGENT);
+        let protected_path = if cfg!(unix) {
+            token_path.parent().unwrap()
+        } else {
+            token_path.as_path()
+        };
+        let original = std::fs::metadata(protected_path).unwrap().permissions();
+        let mut readonly = original.clone();
+        readonly.set_readonly(true);
+        std::fs::set_permissions(protected_path, readonly).unwrap();
+        let credentials = ClientCredentials::from_files(files);
+        let failed = credentials.rotate();
+        // Restore permissions before assertions so the fixture is always removable.
+        std::fs::set_permissions(protected_path, original).unwrap();
+        assert!(failed.is_err());
+        assert_eq!(std::fs::read_to_string(&token_path).unwrap(), old);
+        assert!(credentials.token().is_err());
+        let mut agents = TokenSet::default();
+        agents.insert("agent-fixture".to_string(), "pi".to_string());
+        let active = with_client_token(agents, &credentials).unwrap();
+        assert_eq!(active.agent_for(&old), None);
+        assert_eq!(active.agent_for("agent-fixture"), Some("pi"));
+
+        let replacement = credentials.rotate().unwrap();
+        assert_ne!(replacement, old);
+        assert_eq!(credentials.token().unwrap(), replacement);
+    }
+
+    async fn health(bind: SocketAddr) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut stream = tokio::net::TcpStream::connect(bind).await.unwrap();
+            stream
+                .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .await
+                .unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).await.unwrap();
+            response
+        })
+        .await
+        .expect("Local API health request timed out")
+    }
+
+    /// Runs in a child process: the data-directory override is process
+    /// environment, which must not race the other tests in this binary.
+    #[test]
+    fn local_api_settings_stay_consistent_and_primary_only() {
+        const CHILD: &str = "PAG_TEST_LOCAL_API_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let home = tempfile::tempdir().unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "controller::tests::local_api_settings_stay_consistent_and_primary_only",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .env(HOME_OVERRIDE_ENV, home.path())
+                .status()
+                .unwrap();
+            assert!(status.success());
+            return;
+        }
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let data_dir = app_data_dir().unwrap();
+                let config_file = data_dir.join("local-api.json");
+                let primary_lock = lock::instance(&data_dir)
+                    .unwrap()
+                    .expect("the first process is the primary instance");
+                let (primary, _events) = runtime(Some(primary_lock));
+                let initial = local_api::resolve(loopback(free_port())).unwrap();
+                let listener = proxy::bind_std(initial.bind).unwrap();
+                primary
+                    .manager
+                    .set_endpoint(initial.config.clone(), Ok(initial.endpoint.clone()));
+                primary
+                    .endpoint
+                    .start(
+                        primary.manager.clone(),
+                        primary.proxy.clone(),
+                        listener,
+                        initial.config.clone(),
+                    )
+                    .unwrap();
+
+                // Two overlapping saves: the second waits for the first
+                // instead of racing it through the listener hand-over.
+                let (first, second) = (free_port(), free_port());
+                let (a, b) = tokio::join!(
+                    primary.save_local_api_config(loopback(first)),
+                    primary.save_local_api_config(loopback(second))
+                );
+                let (a, b) = (a.unwrap(), b.unwrap());
+                let mut saved = [a.local_api.port, b.local_api.port];
+                let mut requested = [first, second];
+                saved.sort_unstable();
+                requested.sort_unstable();
+                assert_eq!(saved, requested, "each save completed with its own port");
+                let live = primary.manager.local_api().unwrap();
+                assert!(requested.contains(&live.bind.port()));
+                assert_eq!(
+                    local_api::load().unwrap().bind,
+                    live.bind,
+                    "persisted settings match the bound listener"
+                );
+                let response = health(live.bind).await;
+                assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+                for port in [initial.bind.port(), first, second] {
+                    if port != live.bind.port() {
+                        assert!(is_free(port), "port {port} was released");
+                    }
+                }
+
+                // A process that lost the instance lock must neither save,
+                // bind, nor touch the shared settings file.
+                assert!(lock::instance(&data_dir).unwrap().is_none());
+                let (secondary, _secondary_events) = runtime(None);
+                secondary.manager.set_endpoint(
+                    LocalApiConfig::default(),
+                    Err("Another Private AI Gateway instance is already running".to_string()),
+                );
+                let persisted = std::fs::read(&config_file).unwrap();
+                let hijack = free_port();
+                let error = secondary
+                    .save_local_api_config(loopback(hijack))
+                    .await
+                    .unwrap_err();
+                assert!(error.contains("primary"), "{error}");
+                assert_eq!(std::fs::read(&config_file).unwrap(), persisted);
+                assert!(is_free(hijack));
+                assert!(secondary.endpoint.0.lock().unwrap().is_none());
+                let state = secondary.manager.snapshot().unwrap();
+                assert!(state.proxy_url.is_none() && state.endpoint_error.is_some());
+                assert!(health(live.bind).await.starts_with("HTTP/1.1 200"));
+
+                primary.shutdown().await.unwrap();
+                assert!(is_free(live.bind.port()));
+            });
     }
 }

--- a/apps/desktop/runtime/src/local_api.rs
+++ b/apps/desktop/runtime/src/local_api.rs
@@ -55,7 +55,9 @@ pub fn resolve(mut config: LocalApiConfig) -> Result<ResolvedLocalApi, String> {
         return Err("Port must be between 1024 and 65535".to_string());
     }
     if !config.allow_network_access && !address.is_loopback() {
-        return Err("Turn on Allow network access before listening outside this Mac".to_string());
+        return Err(
+            "Turn on Allow network access before listening outside this device".to_string(),
+        );
     }
     config.client_host = normalize_client_host(config.client_host.as_deref())?;
     if address.is_unspecified() && config.client_host.is_none() {

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
+
+const [application, driverPath, nativeDriver, evidenceDirectory] = process.argv.slice(2);
+assert.ok([application, driverPath, nativeDriver, evidenceDirectory].every((value) => value && path.isAbsolute(value)),
+  "Supply absolute installed app, tauri-driver, native driver, and evidence paths");
+const home = await mkdtemp(path.join(os.tmpdir(), "tauri-installed-"));
+const data = path.join(home, ".private-ai-gateway");
+const env = { ...process.env, PRIVATE_AI_GATEWAY_HOME: home, HOME: home, USERPROFILE: home,
+  XDG_DATA_HOME: path.join(home, "data"), XDG_CONFIG_HOME: path.join(home, "config"),
+  XDG_CACHE_HOME: path.join(home, "cache"), APPDATA: path.join(home, "roaming"), LOCALAPPDATA: path.join(home, "local") };
+let driver;
+let driverExit;
+let session;
+let base;
+
+async function freePort() {
+  const socket = createServer();
+  socket.listen(0, "127.0.0.1");
+  await once(socket, "listening");
+  const address = socket.address();
+  assert.ok(address && typeof address !== "string");
+  await new Promise((resolve, reject) => socket.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+async function request(method, route, body) {
+  const response = await fetch(`${base}${route}`, { method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30_000) });
+  const result = await response.json();
+  assert.ok(response.ok, `WebDriver ${route}: ${JSON.stringify(result.value)}`);
+  return result.value;
+}
+
+async function until(check) {
+  const deadline = Date.now() + 30_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try { if (await check()) return; } catch (error) { lastError = error; }
+    await delay(250);
+  }
+  throw new Error("Installed app did not become ready", { cause: lastError });
+}
+
+const execute = (script, args = []) => request("POST", `/session/${session}/execute/sync`, { script, args });
+async function invoke(command, args = {}) {
+  const result = await request("POST", `/session/${session}/execute/async`, {
+    script: `const done = arguments[arguments.length - 1];
+      window.__TAURI_INTERNALS__.invoke(arguments[0], arguments[1]).then(
+        value => done({ value }), error => done({ error: String(error) }));`, args: [command, args],
+  });
+  if (result.error) throw new Error(result.error);
+  return result.value;
+}
+
+async function launch() {
+  const port = await freePort();
+  const nativePort = await freePort();
+  assert.notEqual(port, nativePort, "WebDriver ports must be distinct");
+  base = `http://127.0.0.1:${port}`;
+  driver = spawn(driverPath, ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver],
+    { env, detached: process.platform !== "win32", stdio: ["ignore", "inherit", "inherit"] });
+  driverExit = new Promise((resolve) => {
+    driver.once("error", resolve);
+    driver.once("exit", resolve);
+  });
+  await until(async () => {
+    assert.equal(driver.exitCode, null, "tauri-driver exited");
+    return (await request("GET", "/status")).ready;
+  });
+  const created = await request("POST", "/session", { capabilities: { alwaysMatch: {
+    "tauri:options": { application },
+  } } });
+  session = created.sessionId;
+  assert.ok(session);
+  await until(() => execute("return !!window.__TAURI_INTERNALS__ && !!document.querySelector('#nav-overview')"));
+}
+
+async function shutdown() {
+  try {
+    if (session) await request("DELETE", `/session/${session}`);
+  } finally {
+    session = undefined;
+    if (driver?.pid) {
+      // CloseRequested deliberately hides this tray app. End the owned driver
+      // process tree too; session deletion alone is not an application quit.
+      if (process.platform === "win32") {
+        if (driver.exitCode === null) await promisify(execFile)("taskkill", ["/PID", String(driver.pid), "/T", "/F"]);
+      } else {
+        try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
+      }
+      await driverExit;
+    }
+    driver = undefined;
+  }
+}
+
+try {
+  await mkdir(data, { recursive: true, mode: 0o700 });
+  await mkdir(evidenceDirectory, { recursive: true });
+  const config = { listenAddress: "127.0.0.1", allowNetworkAccess: false, port: await freePort() };
+  await writeFile(path.join(data, "local-api.json"), JSON.stringify(config), { mode: 0o600 });
+  await launch();
+  const state = await invoke("get_gateway_state");
+  assert.equal(state.status, "stopped");
+  assert.equal(state.apiKeySaved, false);
+  assert.ok(!state.error && !state.endpointError, JSON.stringify(state));
+  assert.equal(state.proxyUrl, `http://127.0.0.1:${config.port}`);
+  const agents = await invoke("list_agents");
+  assert.deepEqual(agents.map((agent) => agent.id).sort(), ["claude-code", "codex", "hermes", "opencode", "pi"]);
+  await assert.rejects(invoke("preview_agent_connection", { agentId: "codex", connect: true, options: {} }), /wait until it is verified/);
+  assert.equal((await invoke("disconnect_all_agents")).length, 5);
+
+  assert.deepEqual((await invoke("query_usage", { query: {} })).items, []);
+  const csv = path.join(home, "usage.csv");
+  assert.equal(await invoke("export_usage_csv", { query: {}, path: csv }), 0);
+  assert.ok((await readFile(csv, "utf8")).includes("agent"));
+  const oldToken = await invoke("get_client_key");
+  const token = await invoke("rotate_client_key");
+  assert.notEqual(token, oldToken);
+  for (const [credential, expected] of [[oldToken, 401], [token, 503]]) {
+    const response = await fetch(`${state.proxyUrl}/v1/models`, {
+      headers: { Authorization: `Bearer ${credential}` }, signal: AbortSignal.timeout(5000),
+    });
+    assert.equal(response.status, expected);
+    await response.arrayBuffer();
+  }
+  await execute("document.querySelector('#nav-settings').click()");
+  await until(() => execute("return document.querySelector('#nav-settings').getAttribute('aria-current') === 'page'"));
+  const screenshot = await request("GET", `/session/${session}/screenshot`);
+  await writeFile(path.join(evidenceDirectory, "installed-settings.png"), Buffer.from(screenshot, "base64"));
+  config.port = await freePort();
+  assert.equal((await invoke("save_local_api_config", { config })).localApi.port, config.port);
+  await shutdown();
+  await launch();
+  assert.equal((await invoke("get_gateway_state")).localApi.port, config.port);
+  assert.equal(await invoke("get_client_key"), token);
+  console.log("Installed WebView: real React/IPC, five-agent discovery, unverified-connect rejection, empty restore/export, local token rotation/revocation, settings persistence and restart passed");
+  console.log("Not covered: verified connect/inference, native tray interaction, login registration or graceful Quit");
+} catch (error) {
+  if (session) {
+    try {
+      const screenshot = await request("GET", `/session/${session}/screenshot`);
+      await writeFile(path.join(evidenceDirectory, "installed-failure.png"), Buffer.from(screenshot, "base64"));
+    } catch (captureError) {
+      console.error("Could not capture the failed WebView:", captureError.message);
+    }
+  }
+  throw error;
+} finally {
+  try { await shutdown(); } finally { await rm(home, { recursive: true, force: true }); }
+}

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -23,99 +23,59 @@ let driver;
 let driverExit;
 let driverError;
 let driverExited;
+let app;
+let appExit;
+let appError;
+let appExited;
 let session;
 let base;
 let launchNumber = 0;
 let captureDriverLog = false;
 let driverLog = "";
 const diagnosticEvents = [];
-let previousProcesses = new Map();
 let webviewDataDirectory;
-const observedPortFiles = new Set();
 
 function record(event, details = {}) {
   diagnosticEvents.push({ at: new Date().toISOString(), event, ...details });
 }
 
-async function sampleWindowsProcesses() {
-  // Persist only allowlisted discovery switches from owned processes, never
-  // full command lines, environment, window titles, or unrelated process data.
-  const script = `
-    $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe' OR Name = 'msedgedriver.exe'")
-    $selected = @($all | Where-Object { $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION -or $_.ProcessId -eq [int]$env:TAURI_SMOKE_DRIVER_PID })
-    for ($depth = 0; $depth -lt 8; $depth++) {
-      $ids = @($selected | ForEach-Object ProcessId)
-      $next = @($all | Where-Object { $_.ParentProcessId -in $ids -and $_.ProcessId -notin $ids })
-      if (!$next.Count) { break }
-      $selected += $next
-    }
-    ConvertTo-Json -Depth 4 -Compress -InputObject @($selected | Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CreationDate, @{
-      Name = 'DiscoverySwitches'; Expression = { @([regex]::Matches($_.CommandLine, '--(?:remote-debugging-port|remote-debugging-address|user-data-dir)=(?:"[^"]*"|[^\\s"]+)') | ForEach-Object Value) }
-    })
-  `;
-  const { stdout } = await promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
-    Buffer.from(script, "utf16le").toString("base64")], {
-    env: { ...process.env, TAURI_SMOKE_APPLICATION: application, TAURI_SMOKE_DRIVER_PID: String(driver?.pid ?? 0) },
-    timeout: 5000, maxBuffer: 262144,
+async function windowsCommand(script, variables) {
+  return promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
+    Buffer.from(`$ErrorActionPreference = 'Stop'; ${script}`, "utf16le").toString("base64")], {
+    env: { ...process.env, ...variables }, timeout: 8000, maxBuffer: 65536,
   });
-  const processes = JSON.parse(stdout);
-  const current = new Map(processes.map((process) => [`${process.ProcessId}:${process.CreationDate}`, process]));
-  for (const [key, process] of current) {
-    if (!previousProcesses.has(key)) record("process-first-observed", { process });
-  }
-  for (const [key, process] of previousProcesses) {
-    if (!current.has(key)) record("process-no-longer-observed", { process });
-  }
-  previousProcesses = current;
-  record("windows-process-snapshot", { launch: launchNumber, processes });
 }
 
-async function monitorWindowsLaunch(signal) {
-  while (!signal.aborted) {
-    try { await sampleWindowsProcesses(); } catch (error) {
-      record("process-snapshot-error", { code: error.code, killed: error.killed });
-    }
-    try { await inspectDevToolsDiscovery(); } catch (error) {
-      record("devtools-discovery-error", { name: error.name, code: error.code });
-    }
-    try { await delay(1000, undefined, { signal }); } catch { break; }
-  }
-}
-
-async function inspectDevToolsDiscovery() {
-  // Only inspect our explicit WebView2 UDF, never enumerate a user profile.
-  // WebView2 may place Chromium state below EBWebView inside the UDF.
-  for (const relative of ["DevToolsActivePort", "EBWebView/DevToolsActivePort"]) {
-    const file = path.join(webviewDataDirectory, relative);
-    if (observedPortFiles.has(file)) continue;
-    try {
-      const resolved = await realpath(file);
-      assert.ok(resolved.startsWith(`${await realpath(home)}${path.sep}`));
-      assert.ok((await stat(resolved)).size <= 4096, "Unexpected DevTools port file size");
-      const lines = (await readFile(resolved, "utf8")).trim().split(/\r?\n/);
-      assert.match(lines[0], /^\d{1,5}$/);
-      const port = Number(lines[0]);
-      assert.ok(port > 0 && port <= 65535);
-      observedPortFiles.add(file);
-      record("devtools-port-file", { launch: launchNumber, relative, port,
-        browserSocketPathPresent: lines[1]?.startsWith("/devtools/browser/") === true });
-      for (const endpoint of ["/json/version", "/json/list"]) {
-        try {
-          const response = await fetch(`http://127.0.0.1:${port}${endpoint}`, { signal: AbortSignal.timeout(1000) });
-          const value = await response.json();
-          const details = endpoint === "/json/version"
-            ? { browser: value.Browser, protocolVersion: value["Protocol-Version"], browserSocketPresent: typeof value.webSocketDebuggerUrl === "string" }
-            : { targetCount: Array.isArray(value) ? value.length : null,
-                targetTypes: Array.isArray(value) ? [...new Set(value.map((target) => target.type))] : [] };
-          record("devtools-http-probe", { launch: launchNumber, endpoint, status: response.status, ...details });
-        } catch (error) {
-          record("devtools-http-probe-error", { launch: launchNumber, endpoint, name: error.name });
-        }
+async function waitForCdp(port) {
+  const deadline = Date.now() + 30_000;
+  let targets;
+  await until(async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(1000) });
+    // Even a non-CDP HTTP listener must reach the ownership check, rather
+    // than turning a port conflict into a generic readiness timeout.
+    await response.body?.cancel();
+    return true;
+  });
+  // A released ephemeral port can be taken by another process. Verify the
+  // listener belongs to this app's tree before allowing WebDriver to attach.
+  await windowsCommand(`
+    $listeners = @(Get-NetTCPConnection -State Listen -LocalPort $env:TAURI_SMOKE_CDP_PORT)
+    if (!$listeners.Count) { throw 'CDP listener disappeared' }
+    foreach ($listener in $listeners) {
+      if ($listener.LocalAddress -notin @('127.0.0.1', '::1')) { throw 'CDP is not loopback-only' }
+      $owner = $listener.OwningProcess
+      for ($depth = 0; $depth -lt 8 -and $owner -ne [int]$env:TAURI_SMOKE_APP_PID; $depth++) {
+        $owner = (Get-CimInstance Win32_Process -Filter "ProcessId = $owner").ParentProcessId
       }
-    } catch (error) {
-      if (error.code !== "ENOENT") throw error;
+      if ($owner -ne [int]$env:TAURI_SMOKE_APP_PID) { throw 'CDP port conflict: listener is outside the owned app tree' }
     }
-  }
+  `, { TAURI_SMOKE_CDP_PORT: String(port), TAURI_SMOKE_APP_PID: String(app.pid) });
+  await until(async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(1000) });
+    targets = await response.json();
+    return response.ok && Array.isArray(targets) && targets.some((target) => target.type === "page");
+  }, Math.max(0, deadline - Date.now()));
+  record("cdp-ready", { launch: launchNumber, targetCount: targets.length });
 }
 
 async function freePort() {
@@ -145,10 +105,12 @@ async function request(method, route, body) {
   }
 }
 
-async function until(check) {
-  const deadline = Date.now() + 30_000;
+async function until(check, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
   let lastError;
   while (Date.now() < deadline) {
+    if (appError) throw appError;
+    if (appExited) throw new Error(`Installed app exited with status ${app.exitCode}`);
     if (driverError) throw driverError;
     if (driverExited) throw new Error(`tauri-driver exited with status ${driver.exitCode}`);
     try { if (await check()) return; } catch (error) { lastError = error; }
@@ -170,36 +132,56 @@ async function invoke(command, args = {}) {
 
 async function launch() {
   launchNumber++;
+  driverError = undefined;
+  driverExited = false;
   const port = await freePort();
   const nativePort = await freePort();
   assert.notEqual(port, nativePort, "WebDriver ports must be distinct");
   base = `http://127.0.0.1:${port}`;
-  // Match tauri-driver 2.0.6's Windows capabilities directly so the native
-  // driver can receive --verbose (the intermediary cannot forward that flag).
+  // Use Microsoft's attach contract on the same installed release executable.
   // https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
   // https://learn.microsoft.com/microsoft-edge/webdriver/capabilities-edge-options
   const windows = process.platform === "win32";
+  let cdpPort;
   if (windows) {
     webviewDataDirectory = path.join(home, `webview-${launchNumber}`);
     await mkdir(webviewDataDirectory, { mode: 0o700 });
+    cdpPort = await freePort();
+    assert.ok(cdpPort !== port && cdpPort !== nativePort, "CDP and driver ports must be distinct");
+    appError = undefined;
+    appExited = false;
+    app = spawn(application, [], { env: {
+      ...env,
+      WEBVIEW2_USER_DATA_FOLDER: webviewDataDirectory,
+      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-address=127.0.0.1 --remote-debugging-port=${cdpPort}`,
+    }, stdio: "ignore" });
+    record("app-start", { launch: launchNumber, pid: app.pid });
+    appExit = new Promise((resolve) => {
+      app.on("error", (error) => {
+        appError = error;
+        if (!app.pid) { appExited = true; resolve(); }
+      });
+      app.once("exit", (code, signal) => {
+        record("app-exit", { launch: launchNumber, code, signal });
+        appExited = true;
+        resolve();
+      });
+    });
+    await waitForCdp(cdpPort);
   }
   const executable = windows ? nativeDriver : driverPath;
-  const args = windows ? [`--port=${port}`, "--host=127.0.0.1", "--verbose"]
+  const args = windows ? [`--port=${port}`, "--host=127.0.0.1"]
     : ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver];
-  const driverEnv = windows
-    ? { ...env, TAURI_AUTOMATION: "true", TAURI_WEBVIEW_AUTOMATION: "true" }
-    : env;
-  captureDriverLog = true;
+  // Windows verbose driver logs contain CDP websocket URLs and IPC payloads.
+  captureDriverLog = !windows;
   driver = spawn(executable, args,
-    { env: driverEnv, detached: !windows, stdio: ["ignore", "pipe", "pipe"] });
+    { env, detached: !windows, stdio: ["ignore", "pipe", "pipe"] });
   const collectLog = (chunk) => {
     if (captureDriverLog) driverLog = (driverLog + chunk.toString()).slice(-1_048_576);
   };
   driver.stdout.on("data", collectLog);
   driver.stderr.on("data", collectLog);
   record("driver-start", { launch: launchNumber, executable, pid: driver.pid });
-  driverError = undefined;
-  driverExited = false;
   driverExit = new Promise((resolve) => {
     driver.on("error", (error) => {
       driverError = error;
@@ -216,22 +198,16 @@ async function launch() {
     assert.equal(driver.exitCode, null, "tauri-driver exited");
     return (await request("GET", "/status")).ready;
   });
-  const monitorAbort = new AbortController();
-  const monitor = windows ? monitorWindowsLaunch(monitorAbort.signal) : Promise.resolve();
   let created;
   try {
     const capabilities = windows ? {
       browserName: "webview2", "ms:edgeChromium": true,
-      "ms:edgeOptions": { binary: application, args: [], webviewOptions: { userDataFolder: webviewDataDirectory } },
+      "ms:edgeOptions": { debuggerAddress: `127.0.0.1:${cdpPort}` },
     } : { "tauri:options": { application } };
-    record("session-launch", { launch: launchNumber, capabilities });
+    record("session-launch", { launch: launchNumber, mode: windows ? "attach" : "launch" });
     created = await request("POST", "/session", { capabilities: { alwaysMatch: capabilities } });
   } finally {
     captureDriverLog = false;
-    monitorAbort.abort();
-    await monitor;
-    if (windows) record("devtools-discovery-summary", { launch: launchNumber,
-      portFilesObserved: [...observedPortFiles].filter((file) => file.startsWith(`${webviewDataDirectory}${path.sep}`)).length });
     await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
   }
   session = created.sessionId;
@@ -244,6 +220,15 @@ async function launch() {
     console.log(`Installed WebView2 runtime: ${version}`);
   }
   await until(() => execute("return !!window.__TAURI_INTERNALS__ && !!document.querySelector('#nav-overview')"));
+}
+
+async function reap(exit, label) {
+  let timer;
+  try {
+    await Promise.race([exit, new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`Timed out reaping the owned ${label}`)), 5000);
+    })]);
+  } finally { clearTimeout(timer); }
 }
 
 async function shutdown() {
@@ -264,36 +249,44 @@ async function shutdown() {
               // Native EdgeDriver has no tauri-driver Job wrapper. Surface tree
               // cleanup failures; killing only its parent is not sufficient.
               driver.kill("SIGKILL");
+              await reap(driverExit, "driver");
               throw error;
             }
           }
         } else {
           try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
         }
-        let timer;
-        try {
-          await Promise.race([driverExit, new Promise((_, reject) => {
-            timer = setTimeout(() => reject(new Error("Timed out reaping the owned driver tree")), 5000);
-          })]);
-        } finally {
-          clearTimeout(timer);
-        }
+        await reap(driverExit, "driver");
       }
     } finally {
-      if (process.platform === "win32") {
-        // Also reap an app whose native driver exited before taskkill could
-        // follow its tree. Restrict selection to this smoke's installed path.
-        await promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
-          Buffer.from(`
-            $apps = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe'" | Where-Object { $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION })
-            foreach ($app in $apps) {
-              & "$env:SystemRoot/System32/taskkill.exe" /PID $app.ProcessId /T /F
-              if ($LASTEXITCODE -ne 0) { throw "Cannot clean up installed smoke app" }
+      if (app?.pid) {
+        // Attach session deletion does not own the app. Kill it independently,
+        // including orphaned WebView2 processes identified by our private UDF.
+        await windowsCommand(`
+          $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'")
+          $isOwned = {
+            ($_.ProcessId -eq [int]$env:TAURI_SMOKE_APP_PID -and $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION) -or
+            ($_.Name -eq 'msedgewebview2.exe' -and $_.CommandLine -and $_.CommandLine.Contains($env:TAURI_SMOKE_UDF))
+          }
+          $owned = @($all | Where-Object $isOwned)
+          foreach ($process in $owned) {
+            if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
+              & "$env:SystemRoot/System32/taskkill.exe" /PID $process.ProcessId /T /F | Out-Null
+              if ($LASTEXITCODE -ne 0 -and (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue)) {
+                throw 'Cannot clean up the owned app or WebView2 process'
+              }
             }
-          `, "utf16le").toString("base64")], {
-          env: { ...process.env, TAURI_SMOKE_APPLICATION: application }, timeout: 8000, maxBuffer: 65536,
-        });
+          }
+          $remaining = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'" | Where-Object $isOwned)
+          if ($remaining.Count) { throw 'Owned app tree remains; retaining private UDF' }
+        `, { TAURI_SMOKE_APP_PID: String(app.pid), TAURI_SMOKE_APPLICATION: path.normalize(application),
+          TAURI_SMOKE_UDF: path.normalize(webviewDataDirectory) });
+        await reap(appExit, "app");
+        record("app-tree-cleaned", { launch: launchNumber });
       }
+      app = undefined;
+      appExited = false;
+      appError = undefined;
       driver = undefined;
     }
   }
@@ -346,7 +339,7 @@ try {
   console.log("Installed WebView: real React/IPC, five-agent discovery, unverified-connect rejection, empty restore/export, local token rotation/revocation, settings persistence and restart passed");
   console.log("Not covered: verified connect/inference, native tray interaction, login registration or graceful Quit");
 } catch (error) {
-  record("smoke-failure", { name: error.name, message: error.message });
+  record("smoke-failure", { name: error.name });
   if (session) {
     try {
       const screenshot = await request("GET", `/session/${session}/screenshot`);
@@ -357,15 +350,11 @@ try {
   }
   throw error;
 } finally {
-  try { await shutdown(); } finally {
+  let cleaned = false;
+  try { await shutdown(); cleaned = true; } finally {
     try {
-      if (process.platform === "win32") {
-        try { await sampleWindowsProcesses(); } catch (error) {
-          record("cleanup-snapshot-error", { message: error.message });
-        }
-      }
       await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
       await writeFile(path.join(evidenceDirectory, "launch-diagnostics.json"), JSON.stringify(diagnosticEvents, null, 2), { mode: 0o600 });
-    } finally { await rm(home, { recursive: true, force: true }); }
+    } finally { if (cleaned) await rm(home, { recursive: true, force: true }); }
   }
 }

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -136,11 +136,14 @@ async function launch() {
   // https://learn.microsoft.com/microsoft-edge/webdriver/capabilities-edge-options
   const windows = process.platform === "win32";
   const executable = windows ? nativeDriver : driverPath;
-  const args = windows ? [`--port=${port}`, "--verbose"]
+  const args = windows ? [`--port=${port}`, "--host=127.0.0.1", "--verbose"]
     : ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver];
+  const driverEnv = windows
+    ? { ...env, TAURI_AUTOMATION: "true", TAURI_WEBVIEW_AUTOMATION: "true" }
+    : env;
   captureDriverLog = true;
   driver = spawn(executable, args,
-    { env, detached: !windows, stdio: ["ignore", "pipe", "pipe"] });
+    { env: driverEnv, detached: !windows, stdio: ["ignore", "pipe", "pipe"] });
   const collectLog = (chunk) => {
     if (captureDriverLog) driverLog = (driverLog + chunk.toString()).slice(-1_048_576);
   };

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -34,6 +34,26 @@ let captureDriverLog = false;
 let driverLog = "";
 const diagnosticEvents = [];
 let webviewDataDirectory;
+let stage = "prepare";
+let stageStarted = Date.now();
+
+function enterStage(value) {
+  stage = value;
+  stageStarted = Date.now();
+}
+
+function failureDetails(error) {
+  // Error messages, subprocess output and WebDriver payloads may contain
+  // credentials. Preserve only types/codes and a bounded cause chain.
+  const causes = [];
+  for (let current = error; current && causes.length < 4; current = current.cause) {
+    const code = current.code;
+    causes.push({ name: current.name,
+      code: typeof code === "number" || (typeof code === "string" && /^[A-Z0-9_]+$/.test(code)) ? code : undefined,
+      killed: current.killed === true });
+  }
+  return { stage, elapsedMs: Date.now() - stageStarted, causes };
+}
 
 function record(event, details = {}) {
   diagnosticEvents.push({ at: new Date().toISOString(), event, ...details });
@@ -47,6 +67,7 @@ async function windowsCommand(script, variables) {
 }
 
 async function waitForCdp(port) {
+  enterStage("cdp-http-ready");
   const deadline = Date.now() + 30_000;
   let targets;
   await until(async () => {
@@ -58,6 +79,7 @@ async function waitForCdp(port) {
   });
   // A released ephemeral port can be taken by another process. Verify the
   // listener belongs to this app's tree before allowing WebDriver to attach.
+  enterStage("cdp-listener-ownership");
   await windowsCommand(`
     $listeners = @(Get-NetTCPConnection -State Listen -LocalPort $env:TAURI_SMOKE_CDP_PORT)
     if (!$listeners.Count) { throw 'CDP listener disappeared' }
@@ -70,6 +92,7 @@ async function waitForCdp(port) {
       if ($owner -ne [int]$env:TAURI_SMOKE_APP_PID) { throw 'CDP port conflict: listener is outside the owned app tree' }
     }
   `, { TAURI_SMOKE_CDP_PORT: String(port), TAURI_SMOKE_APP_PID: String(app.pid) });
+  enterStage("cdp-page-ready");
   await until(async () => {
     const response = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(1000) });
     targets = await response.json();
@@ -116,7 +139,7 @@ async function until(check, timeoutMs = 30_000) {
     try { if (await check()) return; } catch (error) { lastError = error; }
     await delay(250);
   }
-  throw new Error("Installed app did not become ready", { cause: lastError });
+  throw Object.assign(new Error("Installed app did not become ready", { cause: lastError }), { code: "READINESS_TIMEOUT" });
 }
 
 const execute = (script, args = []) => request("POST", `/session/${session}/execute/sync`, { script, args });
@@ -170,6 +193,7 @@ async function launch() {
     await waitForCdp(cdpPort);
   }
   const executable = windows ? nativeDriver : driverPath;
+  enterStage("driver-ready");
   const args = windows ? [`--port=${port}`, "--host=127.0.0.1"]
     : ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver];
   // Windows verbose driver logs contain CDP websocket URLs and IPC payloads.
@@ -205,6 +229,7 @@ async function launch() {
       "ms:edgeOptions": { debuggerAddress: `127.0.0.1:${cdpPort}` },
     } : { "tauri:options": { application } };
     record("session-launch", { launch: launchNumber, mode: windows ? "attach" : "launch" });
+    enterStage("webdriver-session");
     created = await request("POST", "/session", { capabilities: { alwaysMatch: capabilities } });
   } finally {
     captureDriverLog = false;
@@ -219,6 +244,7 @@ async function launch() {
       "The actual WebView2 runtime does not match the selected EdgeDriver build");
     console.log(`Installed WebView2 runtime: ${version}`);
   }
+  enterStage("renderer-ready");
   await until(() => execute("return !!window.__TAURI_INTERNALS__ && !!document.querySelector('#nav-overview')"));
 }
 
@@ -232,66 +258,89 @@ async function reap(exit, label) {
 }
 
 async function shutdown() {
+  const failures = [];
   try {
+    enterStage("cleanup-session");
     if (session) await request("DELETE", `/session/${session}`);
-  } finally {
-    session = undefined;
-    try {
-      if (driver?.pid) {
-        // CloseRequested deliberately hides this tray app. End the owned driver
-        // process tree too; session deletion alone is not an application quit.
-        if (process.platform === "win32") {
-          if (!driverExited) {
-            try {
-              await promisify(execFile)(path.join(process.env.SystemRoot, "System32", "taskkill.exe"),
-                ["/PID", String(driver.pid), "/T", "/F"], { timeout: 5000 });
-            } catch (error) {
-              // Native EdgeDriver has no tauri-driver Job wrapper. Surface tree
-              // cleanup failures; killing only its parent is not sufficient.
-              driver.kill("SIGKILL");
-              await reap(driverExit, "driver");
-              throw error;
-            }
+  } catch (error) {
+    failures.push(failureDetails(error));
+  }
+  session = undefined;
+  try {
+    enterStage("cleanup-driver");
+    if (driver?.pid) {
+      // CloseRequested deliberately hides this tray app. End the owned driver
+      // process tree too; session deletion alone is not an application quit.
+      if (process.platform === "win32") {
+        if (!driverExited) {
+          try {
+            await promisify(execFile)(path.join(process.env.SystemRoot, "System32", "taskkill.exe"),
+              ["/PID", String(driver.pid), "/T", "/F"], { timeout: 5000 });
+          } catch (error) {
+            // A concurrent driver exit can make taskkill fail. Reaping is
+            // mandatory; the independently owned app is checked below too.
+            if (!driverExited) driver.kill("SIGKILL");
+            await reap(driverExit, "driver");
+            record("driver-kill-race", failureDetails(error));
           }
-        } else {
-          try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
         }
-        await reap(driverExit, "driver");
+      } else {
+        try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
       }
-    } finally {
-      if (app?.pid) {
-        // Attach session deletion does not own the app. Kill it independently,
-        // including orphaned WebView2 processes identified by our private UDF.
-        await windowsCommand(`
-          $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'")
-          $isOwned = {
-            ($_.ProcessId -eq [int]$env:TAURI_SMOKE_APP_PID -and $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION) -or
-            ($_.Name -eq 'msedgewebview2.exe' -and $_.CommandLine -and $_.CommandLine.Contains($env:TAURI_SMOKE_UDF))
-          }
-          $owned = @($all | Where-Object $isOwned)
-          foreach ($process in $owned) {
-            if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
-              & "$env:SystemRoot/System32/taskkill.exe" /PID $process.ProcessId /T /F | Out-Null
-              if ($LASTEXITCODE -ne 0 -and (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue)) {
-                throw 'Cannot clean up the owned app or WebView2 process'
-              }
-            }
-          }
-          $remaining = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'" | Where-Object $isOwned)
-          if ($remaining.Count) { throw 'Owned app tree remains; retaining private UDF' }
-        `, { TAURI_SMOKE_APP_PID: String(app.pid), TAURI_SMOKE_APPLICATION: path.normalize(application),
-          TAURI_SMOKE_UDF: path.normalize(webviewDataDirectory) });
-        await reap(appExit, "app");
-        record("app-tree-cleaned", { launch: launchNumber });
-      }
-      app = undefined;
-      appExited = false;
-      appError = undefined;
-      driver = undefined;
+      await reap(driverExit, "driver");
     }
+    driver = undefined;
+  } catch (error) {
+    failures.push(failureDetails(error));
+  }
+  try {
+    enterStage("cleanup-app");
+    if (app?.pid) {
+      // Attach session deletion does not own the app. Kill it independently,
+      // including orphaned WebView2 processes identified by our private UDF.
+      await windowsCommand(`
+        $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'")
+        $isOwned = {
+          ($_.ProcessId -eq [int]$env:TAURI_SMOKE_APP_PID -and $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION) -or
+          ($_.Name -eq 'msedgewebview2.exe' -and $_.CommandLine -and $_.CommandLine.Contains($env:TAURI_SMOKE_UDF))
+        }
+        $owned = @($all | Where-Object $isOwned)
+        foreach ($process in $owned) {
+          if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
+            # Descendants can exit while taskkill walks the tree. Its exit
+            # code alone cannot decide whether owned processes remain.
+            $ErrorActionPreference = 'Continue'
+            try { & "$env:SystemRoot/System32/taskkill.exe" /PID $process.ProcessId /T /F 2>$null | Out-Null }
+            finally { $ErrorActionPreference = 'Stop' }
+          }
+        }
+        $deadline = [DateTime]::UtcNow.AddSeconds(5)
+        do {
+          $remaining = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe'" | Where-Object $isOwned)
+          if (!$remaining.Count) { break }
+          Start-Sleep -Milliseconds 100
+        } while ([DateTime]::UtcNow -lt $deadline)
+        if ($remaining.Count) { exit 3 }
+        exit 0
+      `, { TAURI_SMOKE_APP_PID: String(app.pid), TAURI_SMOKE_APPLICATION: path.normalize(application),
+        TAURI_SMOKE_UDF: path.normalize(webviewDataDirectory) });
+      await reap(appExit, "app");
+      record("app-tree-cleaned", { launch: launchNumber });
+    }
+    app = undefined;
+    appExited = false;
+    appError = undefined;
+  } catch (error) {
+    failures.push(failureDetails(error));
+  }
+  if (failures.length) {
+    for (const failure of failures) record("cleanup-failure", failure);
+    throw Object.assign(new Error("Owned process cleanup was not confirmed"), { code: "CLEANUP_UNCONFIRMED", failures });
   }
 }
 
+let primaryFailure;
+const additionalFailures = [];
 try {
   for (const directory of Object.values(xdgDirectories)) {
     await mkdir(directory, { recursive: true, mode: 0o700 });
@@ -302,6 +351,7 @@ try {
   const config = { listenAddress: "127.0.0.1", allowNetworkAccess: false, port: await freePort() };
   await writeFile(path.join(data, "local-api.json"), JSON.stringify(config), { mode: 0o600 });
   await launch();
+  enterStage("react-ipc-checks");
   const state = await invoke("get_gateway_state");
   assert.equal(state.status, "stopped");
   assert.equal(state.apiKeySaved, false);
@@ -334,27 +384,39 @@ try {
   assert.equal((await invoke("save_local_api_config", { config })).localApi.port, config.port);
   await shutdown();
   await launch();
+  enterStage("restart-persistence");
   assert.equal((await invoke("get_gateway_state")).localApi.port, config.port);
   assert.equal(await invoke("get_client_key"), token);
   console.log("Installed WebView: real React/IPC, five-agent discovery, unverified-connect rejection, empty restore/export, local token rotation/revocation, settings persistence and restart passed");
   console.log("Not covered: verified connect/inference, native tray interaction, login registration or graceful Quit");
 } catch (error) {
-  record("smoke-failure", { name: error.name });
+  primaryFailure = failureDetails(error);
+  record("smoke-failure", primaryFailure);
   if (session) {
     try {
       const screenshot = await request("GET", `/session/${session}/screenshot`);
       await writeFile(path.join(evidenceDirectory, "installed-failure.png"), Buffer.from(screenshot, "base64"));
     } catch (captureError) {
-      console.error("Could not capture the failed WebView:", captureError.message);
+      record("failure-screenshot-error", failureDetails(captureError));
     }
   }
-  throw error;
 } finally {
   let cleaned = false;
-  try { await shutdown(); cleaned = true; } finally {
-    try {
-      await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
-      await writeFile(path.join(evidenceDirectory, "launch-diagnostics.json"), JSON.stringify(diagnosticEvents, null, 2), { mode: 0o600 });
-    } finally { if (cleaned) await rm(home, { recursive: true, force: true }); }
+  try { await shutdown(); cleaned = true; } catch (error) {
+    additionalFailures.push(...(error.failures ?? [failureDetails(error)]));
   }
+  try {
+    enterStage("write-evidence");
+    await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
+    await writeFile(path.join(evidenceDirectory, "launch-diagnostics.json"), JSON.stringify(diagnosticEvents, null, 2), { mode: 0o600 });
+  } catch (error) { additionalFailures.push(failureDetails(error)); }
+  if (cleaned) {
+    enterStage("remove-private-home");
+    try { await rm(home, { recursive: true, force: true }); } catch (error) {
+      additionalFailures.push(failureDetails(error));
+    }
+  }
+}
+if (primaryFailure || additionalFailures.length) {
+  throw new Error(JSON.stringify({ primaryFailure, additionalFailures }));
 }

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -13,11 +13,16 @@ assert.ok([application, driverPath, nativeDriver, evidenceDirectory].every((valu
   "Supply absolute installed app, tauri-driver, native driver, and evidence paths");
 const home = await mkdtemp(path.join(os.tmpdir(), "tauri-installed-"));
 const data = path.join(home, ".private-ai-gateway");
-const env = { ...process.env, PRIVATE_AI_GATEWAY_HOME: home, HOME: home, USERPROFILE: home,
+const env = { ...process.env, PRIVATE_AI_GATEWAY_HOME: home };
+const xdgDirectories = process.platform === "linux" ? {
   XDG_DATA_HOME: path.join(home, "data"), XDG_CONFIG_HOME: path.join(home, "config"),
-  XDG_CACHE_HOME: path.join(home, "cache"), APPDATA: path.join(home, "roaming"), LOCALAPPDATA: path.join(home, "local") };
+  XDG_CACHE_HOME: path.join(home, "cache"), XDG_STATE_HOME: path.join(home, "state"),
+} : {};
+Object.assign(env, xdgDirectories);
 let driver;
 let driverExit;
+let driverError;
+let driverExited;
 let session;
 let base;
 
@@ -44,6 +49,8 @@ async function until(check) {
   const deadline = Date.now() + 30_000;
   let lastError;
   while (Date.now() < deadline) {
+    if (driverError) throw driverError;
+    if (driverExited) throw new Error(`tauri-driver exited with status ${driver.exitCode}`);
     try { if (await check()) return; } catch (error) { lastError = error; }
     await delay(250);
   }
@@ -68,9 +75,15 @@ async function launch() {
   base = `http://127.0.0.1:${port}`;
   driver = spawn(driverPath, ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver],
     { env, detached: process.platform !== "win32", stdio: ["ignore", "inherit", "inherit"] });
+  driverError = undefined;
+  driverExited = false;
   driverExit = new Promise((resolve) => {
-    driver.once("error", resolve);
-    driver.once("exit", resolve);
+    driver.on("error", (error) => {
+      driverError = error;
+      // A failed spawn has no process to reap. Other errors do not mean exit.
+      if (!driver.pid) { driverExited = true; resolve(); }
+    });
+    driver.once("exit", () => { driverExited = true; resolve(); });
   });
   await until(async () => {
     assert.equal(driver.exitCode, null, "tauri-driver exited");
@@ -81,6 +94,13 @@ async function launch() {
   } } });
   session = created.sessionId;
   assert.ok(session);
+  if (process.platform === "win32") {
+    const version = created.capabilities.browserVersion;
+    assert.equal(typeof version, "string", "WebDriver did not report the WebView2 version");
+    assert.equal(version.split(".").slice(0, 3).join("."), process.env.TAURI_SMOKE_EDGE_BUILD,
+      "The actual WebView2 runtime does not match the selected EdgeDriver build");
+    console.log(`Installed WebView2 runtime: ${version}`);
+  }
   await until(() => execute("return !!window.__TAURI_INTERNALS__ && !!document.querySelector('#nav-overview')"));
 }
 
@@ -93,17 +113,36 @@ async function shutdown() {
       // CloseRequested deliberately hides this tray app. End the owned driver
       // process tree too; session deletion alone is not an application quit.
       if (process.platform === "win32") {
-        if (driver.exitCode === null) await promisify(execFile)("taskkill", ["/PID", String(driver.pid), "/T", "/F"]);
+        if (!driverExited) {
+          try {
+            await promisify(execFile)(path.join(process.env.SystemRoot, "System32", "taskkill.exe"),
+              ["/PID", String(driver.pid), "/T", "/F"], { timeout: 5000 });
+          } catch (error) {
+            // tauri-driver owns a kill-on-close Windows Job, including children.
+            // Kill the driver even when taskkill itself fails or times out.
+            if (!driverExited && !driver.kill("SIGKILL")) throw error;
+          }
+        }
       } else {
         try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
       }
-      await driverExit;
+      let timer;
+      try {
+        await Promise.race([driverExit, new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error("Timed out reaping the owned driver tree")), 5000);
+        })]);
+      } finally {
+        clearTimeout(timer);
+      }
     }
     driver = undefined;
   }
 }
 
 try {
+  for (const directory of Object.values(xdgDirectories)) {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+  }
   await mkdir(data, { recursive: true, mode: 0o700 });
   await mkdir(evidenceDirectory, { recursive: true });
   const config = { listenAddress: "127.0.0.1", allowNetworkAccess: false, port: await freePort() };

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -30,13 +30,16 @@ let captureDriverLog = false;
 let driverLog = "";
 const diagnosticEvents = [];
 let previousProcesses = new Map();
+let webviewDataDirectory;
+const observedPortFiles = new Set();
 
 function record(event, details = {}) {
   diagnosticEvents.push({ at: new Date().toISOString(), event, ...details });
 }
 
 async function sampleWindowsProcesses() {
-  // No command lines, environment, window titles, or unrelated process data.
+  // Persist only allowlisted discovery switches from owned processes, never
+  // full command lines, environment, window titles, or unrelated process data.
   const script = `
     $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe' OR Name = 'msedgedriver.exe'")
     $selected = @($all | Where-Object { $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION -or $_.ProcessId -eq [int]$env:TAURI_SMOKE_DRIVER_PID })
@@ -46,7 +49,9 @@ async function sampleWindowsProcesses() {
       if (!$next.Count) { break }
       $selected += $next
     }
-    ConvertTo-Json -Compress -InputObject @($selected | Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CreationDate)
+    ConvertTo-Json -Depth 4 -Compress -InputObject @($selected | Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CreationDate, @{
+      Name = 'DiscoverySwitches'; Expression = { @([regex]::Matches($_.CommandLine, '--(?:remote-debugging-port|remote-debugging-address|user-data-dir)=(?:"[^"]*"|[^\\s"]+)') | ForEach-Object Value) }
+    })
   `;
   const { stdout } = await promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
     Buffer.from(script, "utf16le").toString("base64")], {
@@ -68,9 +73,48 @@ async function sampleWindowsProcesses() {
 async function monitorWindowsLaunch(signal) {
   while (!signal.aborted) {
     try { await sampleWindowsProcesses(); } catch (error) {
-      record("process-snapshot-error", { message: error.message });
+      record("process-snapshot-error", { code: error.code, killed: error.killed });
+    }
+    try { await inspectDevToolsDiscovery(); } catch (error) {
+      record("devtools-discovery-error", { name: error.name, code: error.code });
     }
     try { await delay(1000, undefined, { signal }); } catch { break; }
+  }
+}
+
+async function inspectDevToolsDiscovery() {
+  // Only inspect our explicit WebView2 UDF, never enumerate a user profile.
+  // WebView2 may place Chromium state below EBWebView inside the UDF.
+  for (const relative of ["DevToolsActivePort", "EBWebView/DevToolsActivePort"]) {
+    const file = path.join(webviewDataDirectory, relative);
+    if (observedPortFiles.has(file)) continue;
+    try {
+      const resolved = await realpath(file);
+      assert.ok(resolved.startsWith(`${await realpath(home)}${path.sep}`));
+      assert.ok((await stat(resolved)).size <= 4096, "Unexpected DevTools port file size");
+      const lines = (await readFile(resolved, "utf8")).trim().split(/\r?\n/);
+      assert.match(lines[0], /^\d{1,5}$/);
+      const port = Number(lines[0]);
+      assert.ok(port > 0 && port <= 65535);
+      observedPortFiles.add(file);
+      record("devtools-port-file", { launch: launchNumber, relative, port,
+        browserSocketPathPresent: lines[1]?.startsWith("/devtools/browser/") === true });
+      for (const endpoint of ["/json/version", "/json/list"]) {
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}${endpoint}`, { signal: AbortSignal.timeout(1000) });
+          const value = await response.json();
+          const details = endpoint === "/json/version"
+            ? { browser: value.Browser, protocolVersion: value["Protocol-Version"], browserSocketPresent: typeof value.webSocketDebuggerUrl === "string" }
+            : { targetCount: Array.isArray(value) ? value.length : null,
+                targetTypes: Array.isArray(value) ? [...new Set(value.map((target) => target.type))] : [] };
+          record("devtools-http-probe", { launch: launchNumber, endpoint, status: response.status, ...details });
+        } catch (error) {
+          record("devtools-http-probe-error", { launch: launchNumber, endpoint, name: error.name });
+        }
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
   }
 }
 
@@ -135,6 +179,10 @@ async function launch() {
   // https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
   // https://learn.microsoft.com/microsoft-edge/webdriver/capabilities-edge-options
   const windows = process.platform === "win32";
+  if (windows) {
+    webviewDataDirectory = path.join(home, `webview-${launchNumber}`);
+    await mkdir(webviewDataDirectory, { mode: 0o700 });
+  }
   const executable = windows ? nativeDriver : driverPath;
   const args = windows ? [`--port=${port}`, "--host=127.0.0.1", "--verbose"]
     : ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver];
@@ -174,7 +222,7 @@ async function launch() {
   try {
     const capabilities = windows ? {
       browserName: "webview2", "ms:edgeChromium": true,
-      "ms:edgeOptions": { binary: application, args: [] },
+      "ms:edgeOptions": { binary: application, args: [], webviewOptions: { userDataFolder: webviewDataDirectory } },
     } : { "tauri:options": { application } };
     record("session-launch", { launch: launchNumber, capabilities });
     created = await request("POST", "/session", { capabilities: { alwaysMatch: capabilities } });
@@ -182,6 +230,8 @@ async function launch() {
     captureDriverLog = false;
     monitorAbort.abort();
     await monitor;
+    if (windows) record("devtools-discovery-summary", { launch: launchNumber,
+      portFilesObserved: [...observedPortFiles].filter((file) => file.startsWith(`${webviewDataDirectory}${path.sep}`)).length });
     await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
   }
   session = created.sessionId;

--- a/apps/desktop/scripts/installed-webview-smoke.mjs
+++ b/apps/desktop/scripts/installed-webview-smoke.mjs
@@ -25,6 +25,54 @@ let driverError;
 let driverExited;
 let session;
 let base;
+let launchNumber = 0;
+let captureDriverLog = false;
+let driverLog = "";
+const diagnosticEvents = [];
+let previousProcesses = new Map();
+
+function record(event, details = {}) {
+  diagnosticEvents.push({ at: new Date().toISOString(), event, ...details });
+}
+
+async function sampleWindowsProcesses() {
+  // No command lines, environment, window titles, or unrelated process data.
+  const script = `
+    $all = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe' OR Name = 'msedgewebview2.exe' OR Name = 'msedgedriver.exe'")
+    $selected = @($all | Where-Object { $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION -or $_.ProcessId -eq [int]$env:TAURI_SMOKE_DRIVER_PID })
+    for ($depth = 0; $depth -lt 8; $depth++) {
+      $ids = @($selected | ForEach-Object ProcessId)
+      $next = @($all | Where-Object { $_.ParentProcessId -in $ids -and $_.ProcessId -notin $ids })
+      if (!$next.Count) { break }
+      $selected += $next
+    }
+    ConvertTo-Json -Compress -InputObject @($selected | Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CreationDate)
+  `;
+  const { stdout } = await promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
+    Buffer.from(script, "utf16le").toString("base64")], {
+    env: { ...process.env, TAURI_SMOKE_APPLICATION: application, TAURI_SMOKE_DRIVER_PID: String(driver?.pid ?? 0) },
+    timeout: 5000, maxBuffer: 262144,
+  });
+  const processes = JSON.parse(stdout);
+  const current = new Map(processes.map((process) => [`${process.ProcessId}:${process.CreationDate}`, process]));
+  for (const [key, process] of current) {
+    if (!previousProcesses.has(key)) record("process-first-observed", { process });
+  }
+  for (const [key, process] of previousProcesses) {
+    if (!current.has(key)) record("process-no-longer-observed", { process });
+  }
+  previousProcesses = current;
+  record("windows-process-snapshot", { launch: launchNumber, processes });
+}
+
+async function monitorWindowsLaunch(signal) {
+  while (!signal.aborted) {
+    try { await sampleWindowsProcesses(); } catch (error) {
+      record("process-snapshot-error", { message: error.message });
+    }
+    try { await delay(1000, undefined, { signal }); } catch { break; }
+  }
+}
 
 async function freePort() {
   const socket = createServer();
@@ -37,12 +85,20 @@ async function freePort() {
 }
 
 async function request(method, route, body) {
-  const response = await fetch(`${base}${route}`, { method,
-    headers: { "Content-Type": "application/json" },
-    body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30_000) });
-  const result = await response.json();
-  assert.ok(response.ok, `WebDriver ${route}: ${JSON.stringify(result.value)}`);
-  return result.value;
+  const started = Date.now();
+  record("webdriver-request", { method, route });
+  try {
+    const response = await fetch(`${base}${route}`, { method,
+      headers: { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30_000) });
+    const result = await response.json();
+    record("webdriver-response", { method, route, status: response.status, elapsedMs: Date.now() - started });
+    assert.ok(response.ok, `WebDriver ${route}: ${JSON.stringify(result.value)}`);
+    return result.value;
+  } catch (error) {
+    record("webdriver-request-error", { method, route, elapsedMs: Date.now() - started, name: error.name });
+    throw new Error(`WebDriver ${method} ${route} failed after ${Date.now() - started}ms`, { cause: error });
+  }
 }
 
 async function until(check) {
@@ -69,12 +125,28 @@ async function invoke(command, args = {}) {
 }
 
 async function launch() {
+  launchNumber++;
   const port = await freePort();
   const nativePort = await freePort();
   assert.notEqual(port, nativePort, "WebDriver ports must be distinct");
   base = `http://127.0.0.1:${port}`;
-  driver = spawn(driverPath, ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver],
-    { env, detached: process.platform !== "win32", stdio: ["ignore", "inherit", "inherit"] });
+  // Match tauri-driver 2.0.6's Windows capabilities directly so the native
+  // driver can receive --verbose (the intermediary cannot forward that flag).
+  // https://learn.microsoft.com/microsoft-edge/webview2/how-to/webdriver
+  // https://learn.microsoft.com/microsoft-edge/webdriver/capabilities-edge-options
+  const windows = process.platform === "win32";
+  const executable = windows ? nativeDriver : driverPath;
+  const args = windows ? [`--port=${port}`, "--verbose"]
+    : ["--port", String(port), "--native-port", String(nativePort), "--native-driver", nativeDriver];
+  captureDriverLog = true;
+  driver = spawn(executable, args,
+    { env, detached: !windows, stdio: ["ignore", "pipe", "pipe"] });
+  const collectLog = (chunk) => {
+    if (captureDriverLog) driverLog = (driverLog + chunk.toString()).slice(-1_048_576);
+  };
+  driver.stdout.on("data", collectLog);
+  driver.stderr.on("data", collectLog);
+  record("driver-start", { launch: launchNumber, executable, pid: driver.pid });
   driverError = undefined;
   driverExited = false;
   driverExit = new Promise((resolve) => {
@@ -83,15 +155,32 @@ async function launch() {
       // A failed spawn has no process to reap. Other errors do not mean exit.
       if (!driver.pid) { driverExited = true; resolve(); }
     });
-    driver.once("exit", () => { driverExited = true; resolve(); });
+    driver.once("exit", (code, signal) => {
+      record("driver-exit", { launch: launchNumber, code, signal });
+      driverExited = true;
+      resolve();
+    });
   });
   await until(async () => {
     assert.equal(driver.exitCode, null, "tauri-driver exited");
     return (await request("GET", "/status")).ready;
   });
-  const created = await request("POST", "/session", { capabilities: { alwaysMatch: {
-    "tauri:options": { application },
-  } } });
+  const monitorAbort = new AbortController();
+  const monitor = windows ? monitorWindowsLaunch(monitorAbort.signal) : Promise.resolve();
+  let created;
+  try {
+    const capabilities = windows ? {
+      browserName: "webview2", "ms:edgeChromium": true,
+      "ms:edgeOptions": { binary: application, args: [] },
+    } : { "tauri:options": { application } };
+    record("session-launch", { launch: launchNumber, capabilities });
+    created = await request("POST", "/session", { capabilities: { alwaysMatch: capabilities } });
+  } finally {
+    captureDriverLog = false;
+    monitorAbort.abort();
+    await monitor;
+    await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
+  }
   session = created.sessionId;
   assert.ok(session);
   if (process.platform === "win32") {
@@ -109,33 +198,51 @@ async function shutdown() {
     if (session) await request("DELETE", `/session/${session}`);
   } finally {
     session = undefined;
-    if (driver?.pid) {
-      // CloseRequested deliberately hides this tray app. End the owned driver
-      // process tree too; session deletion alone is not an application quit.
-      if (process.platform === "win32") {
-        if (!driverExited) {
-          try {
-            await promisify(execFile)(path.join(process.env.SystemRoot, "System32", "taskkill.exe"),
-              ["/PID", String(driver.pid), "/T", "/F"], { timeout: 5000 });
-          } catch (error) {
-            // tauri-driver owns a kill-on-close Windows Job, including children.
-            // Kill the driver even when taskkill itself fails or times out.
-            if (!driverExited && !driver.kill("SIGKILL")) throw error;
+    try {
+      if (driver?.pid) {
+        // CloseRequested deliberately hides this tray app. End the owned driver
+        // process tree too; session deletion alone is not an application quit.
+        if (process.platform === "win32") {
+          if (!driverExited) {
+            try {
+              await promisify(execFile)(path.join(process.env.SystemRoot, "System32", "taskkill.exe"),
+                ["/PID", String(driver.pid), "/T", "/F"], { timeout: 5000 });
+            } catch (error) {
+              // Native EdgeDriver has no tauri-driver Job wrapper. Surface tree
+              // cleanup failures; killing only its parent is not sufficient.
+              driver.kill("SIGKILL");
+              throw error;
+            }
           }
+        } else {
+          try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
         }
-      } else {
-        try { process.kill(-driver.pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; }
+        let timer;
+        try {
+          await Promise.race([driverExit, new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error("Timed out reaping the owned driver tree")), 5000);
+          })]);
+        } finally {
+          clearTimeout(timer);
+        }
       }
-      let timer;
-      try {
-        await Promise.race([driverExit, new Promise((_, reject) => {
-          timer = setTimeout(() => reject(new Error("Timed out reaping the owned driver tree")), 5000);
-        })]);
-      } finally {
-        clearTimeout(timer);
+    } finally {
+      if (process.platform === "win32") {
+        // Also reap an app whose native driver exited before taskkill could
+        // follow its tree. Restrict selection to this smoke's installed path.
+        await promisify(execFile)("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand",
+          Buffer.from(`
+            $apps = @(Get-CimInstance Win32_Process -Filter "Name = 'private-ai-gateway-desktop.exe'" | Where-Object { $_.ExecutablePath -eq $env:TAURI_SMOKE_APPLICATION })
+            foreach ($app in $apps) {
+              & "$env:SystemRoot/System32/taskkill.exe" /PID $app.ProcessId /T /F
+              if ($LASTEXITCODE -ne 0) { throw "Cannot clean up installed smoke app" }
+            }
+          `, "utf16le").toString("base64")], {
+          env: { ...process.env, TAURI_SMOKE_APPLICATION: application }, timeout: 8000, maxBuffer: 65536,
+        });
       }
+      driver = undefined;
     }
-    driver = undefined;
   }
 }
 
@@ -145,6 +252,7 @@ try {
   }
   await mkdir(data, { recursive: true, mode: 0o700 });
   await mkdir(evidenceDirectory, { recursive: true });
+  record("smoke-start", { platform: process.platform, application, driverPath, nativeDriver });
   const config = { listenAddress: "127.0.0.1", allowNetworkAccess: false, port: await freePort() };
   await writeFile(path.join(data, "local-api.json"), JSON.stringify(config), { mode: 0o600 });
   await launch();
@@ -185,6 +293,7 @@ try {
   console.log("Installed WebView: real React/IPC, five-agent discovery, unverified-connect rejection, empty restore/export, local token rotation/revocation, settings persistence and restart passed");
   console.log("Not covered: verified connect/inference, native tray interaction, login registration or graceful Quit");
 } catch (error) {
+  record("smoke-failure", { name: error.name, message: error.message });
   if (session) {
     try {
       const screenshot = await request("GET", `/session/${session}/screenshot`);
@@ -195,5 +304,15 @@ try {
   }
   throw error;
 } finally {
-  try { await shutdown(); } finally { await rm(home, { recursive: true, force: true }); }
+  try { await shutdown(); } finally {
+    try {
+      if (process.platform === "win32") {
+        try { await sampleWindowsProcesses(); } catch (error) {
+          record("cleanup-snapshot-error", { message: error.message });
+        }
+      }
+      await writeFile(path.join(evidenceDirectory, "driver-launch.log"), driverLog, { mode: 0o600 });
+      await writeFile(path.join(evidenceDirectory, "launch-diagnostics.json"), JSON.stringify(diagnosticEvents, null, 2), { mode: 0o600 });
+    } finally { await rm(home, { recursive: true, force: true }); }
+  }
 }

--- a/apps/desktop/scripts/packaged-sidecars-smoke.mjs
+++ b/apps/desktop/scripts/packaged-sidecars-smoke.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [directory] = process.argv.slice(2);
+assert.ok(directory && path.isAbsolute(directory), "Supply the installed binary directory");
+const binary = (name) => path.join(directory, `${name}${process.platform === "win32" ? ".exe" : ""}`);
+const home = await mkdtemp(path.join(os.tmpdir(), "tauri-sidecars-"));
+const env = { ...process.env, PRIVATE_AI_GATEWAY_HOME: home, ACI_API_KEY: "", NO_PROXY: "127.0.0.1,localhost", no_proxy: "127.0.0.1,localhost" };
+const requests = [];
+// A deliberately unavailable loopback service: no quote verification can fetch
+// collateral, and none of the commands may progress to inference or sessions.
+const server = createServer((request, response) => {
+  requests.push(new URL(request.url, "http://localhost").pathname);
+  response.writeHead(503, { "Content-Type": "application/json" });
+  response.end(JSON.stringify({ error: "local fixture unavailable" }));
+});
+
+function run(name, args, expected) {
+  return new Promise((resolve, reject) => {
+    execFile(binary(name), args, { env, timeout: 20_000, maxBuffer: 1_048_576 }, (error, stdout, stderr) => {
+      try {
+        assert.equal(error?.code ?? 0, expected, `${name}: unexpected exit (${stderr})`);
+        resolve(stdout);
+      } catch (failure) {
+        reject(failure);
+      }
+    });
+  });
+}
+
+try {
+  const fixture = fileURLToPath(new URL("../../../tests/fixtures/aci_report_fixture.json", import.meta.url));
+  const nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
+  const audit = JSON.parse(await run("aci", ["audit", "--report", fixture, "--nonce", nonce, "--json"], 1));
+  assert.equal(audit.verdict.verified, false);
+  assert.ok(audit.checks.some((check) => check.id === "id-1" && check.status !== "pass"));
+  assert.ok(audit.checks.some((check) => check.id === "id-2" && check.status === "pass"));
+  const malformed = path.join(home, "malformed.json");
+  await writeFile(malformed, "{", { mode: 0o600 });
+  await run("aci", ["audit", "--report", malformed, "--json"], 1);
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const url = `http://127.0.0.1:${address.port}`;
+  for (const command of ["verify", "sessions", "send"]) {
+    await run("aci", [command, url, "--json"], 1);
+  }
+  const events = (await run("aci", ["serve", url, "--json-events", "--listen", "127.0.0.1:0", "--control", "127.0.0.1:0"], 1))
+    .trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  assert.ok(events.some((event) => event.type === "fatal"));
+  assert.ok(events.every((event) => event.type !== "ready"));
+  assert.deepEqual(requests, Array(4).fill("/v1/aci/attestation"));
+  console.log("Installed ACI: offline audit, malformed input, verify/sessions/send/serve fail-closed checks passed");
+
+  const tokens = path.join(home, ".private-ai-gateway", "agent-tokens");
+  await mkdir(tokens, { recursive: true, mode: 0o700 });
+  for (const agent of ["codex", "claude-code", "opencode", "pi", "hermes"]) {
+    await run("private-ai-gateway-helper", ["--agent-token", agent], 1);
+    // Synthetic local token fixture, not a provider credential or a claim that
+    // a verified agent connection has been established.
+    const token = `smoke-local-token-${agent}`;
+    const tokenPath = path.join(tokens, agent);
+    await writeFile(tokenPath, token, { mode: 0o600, flag: "wx" });
+    assert.equal(await run("private-ai-gateway-helper", ["--agent-token", agent], 0), token);
+    assert.equal(await readFile(tokenPath, "utf8"), token);
+    await rm(tokenPath);
+    await run("private-ai-gateway-helper", ["--agent-token", agent], 1);
+  }
+  await run("private-ai-gateway-helper", ["--agent-token", "unknown-agent"], 1);
+  console.log("Installed helper: five isolated token reads and missing/deleted/unknown-agent failures passed");
+} finally {
+  server.closeAllConnections();
+  await new Promise((resolve, reject) => server.close((error) => {
+    if (error && error.code !== "ERR_SERVER_NOT_RUNNING") reject(error);
+    else resolve();
+  }));
+  await rm(home, { recursive: true, force: true });
+}

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -284,6 +284,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-launch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17918dba7ecf78b9a14507ec9f984e7977d13fad87dc86d61038980a45d128cf"
+dependencies = [
+ "dirs 6.0.0",
+ "os_info",
+ "smappservice-rs",
+ "thiserror 2.0.20",
+ "windows-registry",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +630,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -2608,6 +2628,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2922,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3021,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3226,6 +3297,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 name = "private-ai-gateway-desktop"
 version = "0.1.0"
 dependencies = [
+ "auto-launch 0.6.0",
  "objc2",
  "objc2-app-kit",
  "private-ai-gateway-desktop-gateway",
@@ -4085,6 +4157,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-service-management",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,7 +4531,7 @@ version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
 dependencies = [
- "auto-launch",
+ "auto-launch 0.5.0",
  "serde",
  "serde_json",
  "tauri",
@@ -5696,6 +5780,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3250,6 +3250,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,16 +23,19 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 tauri = { version = "2.11.5", features = ["image-png", "tray-icon"] }
 tauri-plugin-clipboard-manager = "2.3.3"
-tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2.7.3"
 tauri-plugin-opener = "2.5.5"
 tauri-plugin-shell = "2.3.6"
 tauri-plugin-single-instance = "2.4"
 tokio = { version = "1", features = ["sync", "time"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+auto-launch = "0.6"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication"] }
+tauri-plugin-autostart = "2.5.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/desktop/src-tauri/src/autostart.rs
+++ b/apps/desktop/src-tauri/src/autostart.rs
@@ -1,0 +1,184 @@
+#[cfg(target_os = "macos")]
+use tauri::AppHandle;
+
+#[cfg(target_os = "macos")]
+use tauri_plugin_autostart::ManagerExt;
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+mod platform {
+    use std::path::Path;
+
+    use auto_launch::{AutoLaunch, AutoLaunchBuilder};
+    use tauri::{AppHandle, Manager};
+
+    pub struct ManagerState(AutoLaunch);
+
+    pub fn setup(app: &AppHandle) -> Result<(), auto_launch::Error> {
+        let executable = std::env::current_exe()?;
+        app.manage(ManagerState(build(
+            app.package_info().name.as_str(),
+            &executable,
+        )?));
+        Ok(())
+    }
+
+    pub fn is_enabled(app: &AppHandle) -> Result<bool, String> {
+        #[cfg(target_os = "linux")]
+        validate_linux_home(app)?;
+        app.state::<ManagerState>()
+            .0
+            .is_enabled()
+            .map_err(|error| error.to_string())
+    }
+
+    pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+        #[cfg(target_os = "linux")]
+        validate_linux_home(app)?;
+        let manager = app.state::<ManagerState>();
+        if enabled {
+            manager.0.enable()
+        } else {
+            manager.0.disable()
+        }
+        .map_err(|error| error.to_string())
+    }
+
+    fn build(app_name: &str, executable: &Path) -> Result<AutoLaunch, auto_launch::Error> {
+        let mut builder = AutoLaunchBuilder::new();
+        builder
+            .set_app_name(app_name)
+            .set_app_path(&launch_path(executable)?)
+            .set_args(&[crate::AUTOSTART_ARG]);
+        #[cfg(target_os = "linux")]
+        builder.set_linux_launch_mode(auto_launch::LinuxLaunchMode::XdgAutostart);
+        #[cfg(target_os = "windows")]
+        builder.set_windows_enable_mode(auto_launch::WindowsEnableMode::CurrentUser);
+        builder.build()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn launch_path(path: &Path) -> Result<String, auto_launch::Error> {
+        Ok(windows_launch_path(path))
+    }
+
+    #[cfg(any(target_os = "windows", test))]
+    fn windows_launch_path(path: &Path) -> String {
+        format!("\"{}\"", path.display())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn launch_path(path: &Path) -> Result<String, auto_launch::Error> {
+        let path = path.to_str().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Application path is not valid UTF-8",
+            )
+        })?;
+        if path.contains('=') {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Application path cannot contain '=' in a desktop entry",
+            )
+            .into());
+        }
+        let mut escaped = String::with_capacity(path.len() + 2);
+        escaped.push('"');
+        for character in path.chars() {
+            match character {
+                '\\' => escaped.push_str("\\\\\\\\"),
+                '"' => escaped.push_str("\\\\\\\""),
+                '`' => escaped.push_str("\\\\`"),
+                '$' => escaped.push_str("\\\\$"),
+                '%' => escaped.push_str("%%"),
+                _ => escaped.push(character),
+            }
+        }
+        escaped.push('"');
+        Ok(escaped)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn validate_linux_home(app: &AppHandle) -> Result<(), String> {
+        let home = app
+            .path()
+            .home_dir()
+            .map_err(|error| format!("Cannot locate the user home directory: {error}"))?;
+        validate_home_path(&home)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn validate_home_path(path: &Path) -> Result<(), String> {
+        if path.is_absolute() {
+            Ok(())
+        } else {
+            Err("Cannot use a relative home directory for Open at Login".to_string())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn escapes_linux_desktop_exec_path() {
+            let cases = [
+                (
+                    "/usr/bin/private-ai-gateway-desktop",
+                    r#""/usr/bin/private-ai-gateway-desktop""#,
+                ),
+                (
+                    "/opt/Private AI Gateway/app",
+                    r#""/opt/Private AI Gateway/app""#,
+                ),
+                (
+                    r#"/opt/$cash/`tick`/back\slash/quo"te/%app"#,
+                    r#""/opt/\\$cash/\\`tick\\`/back\\\\slash/quo\\\"te/%%app""#,
+                ),
+            ];
+
+            for (path, expected) in cases {
+                assert_eq!(launch_path(Path::new(path)).unwrap(), expected);
+            }
+            assert!(launch_path(Path::new("/opt/app=name")).is_err());
+        }
+
+        #[test]
+        fn quotes_windows_startup_path() {
+            assert_eq!(
+                windows_launch_path(Path::new(
+                    r"C:\Program Files\Private AI Gateway\private-ai-gateway-desktop.exe"
+                )),
+                r#""C:\Program Files\Private AI Gateway\private-ai-gateway-desktop.exe""#
+            );
+        }
+
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn requires_absolute_linux_home() {
+            assert!(validate_home_path(Path::new("/home/user")).is_ok());
+            assert!(validate_home_path(Path::new("relative/home")).is_err());
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub use platform::{is_enabled, set_enabled, setup};
+
+#[cfg(target_os = "macos")]
+pub fn is_enabled(app: &AppHandle) -> Result<bool, String> {
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    let manager = app.autolaunch();
+    if enabled {
+        manager.enable()
+    } else {
+        manager.disable()
+    }
+    .map_err(|error| error.to_string())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -170,6 +170,9 @@ fn copy_text(app: AppHandle, text: String) -> Result<(), String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Synchronous setup and tray callbacks also spawn shared runtime tasks.
+    let runtime_handle = tauri::async_runtime::handle();
+    let _runtime_guard = runtime_handle.inner().enter();
     let show_on_launch =
         !std::env::args_os().any(|argument| argument == std::ffi::OsStr::new(AUTOSTART_ARG));
     let launcher = Arc::new(TauriSidecarLauncher::default());

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod autostart;
 mod menu;
 mod runtime_adapter;
 mod tray;
@@ -178,14 +179,16 @@ pub fn run() {
     let launcher = Arc::new(TauriSidecarLauncher::default());
     let launcher_for_setup = launcher.clone();
 
-    let app = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+    let app =
+        tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tray::show_window(app);
-        }))
-        .plugin(tauri_plugin_autostart::init(
-            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            Some(vec![AUTOSTART_ARG]),
-        ))
+        }));
+    #[cfg(target_os = "macos")]
+    let app = app.plugin(tauri_plugin_autostart::init(
+        tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+        Some(vec![AUTOSTART_ARG]),
+    ));
+    let app = app
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
@@ -213,6 +216,8 @@ pub fn run() {
             disconnect_all_agents
         ])
         .setup(move |app| {
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            autostart::setup(app.handle())?;
             launcher_for_setup.initialize(app.handle().clone())?;
             let helper_path = std::env::current_exe()
                 .map_err(|error| format!("Cannot locate the app executable: {error}"))?

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -3,7 +3,6 @@ use tauri::{
     tray::TrayIconBuilder,
     AppHandle, Emitter, Manager, Wry,
 };
-use tauri_plugin_autostart::ManagerExt;
 
 use desktop_gateway::brand::PRODUCT_NAME as APP_NAME;
 use desktop_runtime::{contracts::GatewayState, controller::DesktopRuntime};
@@ -24,7 +23,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .enabled(false)
         .build(app)?;
     let autostart = CheckMenuItemBuilder::with_id("autostart", "Open at Login")
-        .checked(app.autolaunch().is_enabled().unwrap_or(false))
+        .checked(crate::autostart::is_enabled(app).unwrap_or(false))
         .build(app)?;
     let menu = MenuBuilder::new(app)
         .item(&toggle)
@@ -86,11 +85,7 @@ fn toggle_or_open_settings(app: &AppHandle) {
 fn sync_autostart(app: &AppHandle) {
     let menu = app.state::<TrayMenu>();
     let checked = menu.autostart.is_checked().unwrap_or(false);
-    let result = if checked {
-        app.autolaunch().enable()
-    } else {
-        app.autolaunch().disable()
-    };
+    let result = crate::autostart::set_enabled(app, checked);
     if let Err(error) = result {
         let _ = menu.autostart.set_checked(!checked);
         app.state::<std::sync::Arc<DesktopRuntime>>()

--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "targets": ["deb"]
+  }
+}

--- a/apps/desktop/src-tauri/tauri.windows.conf.json
+++ b/apps/desktop/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "targets": ["nsis"]
+  }
+}

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1003,7 +1003,7 @@ function StatusSurface({
       <div className="status-edge status-edge-right" aria-hidden="true" />
 
       <div className="status-segment status-local">
-        <div className="status-heading"><Laptop size={18} aria-hidden="true" /><span>This Mac</span></div>
+        <div className="status-heading"><Laptop size={18} aria-hidden="true" /><span>This device</span></div>
         <span className="status-meta">{enabled} enabled · {connected} active</span>
         <div className="status-agent-icons" role="group" aria-label="Enabled agents">
           {agents.filter((agent) => agent.recorded).slice(0, 5).map((agent) => (
@@ -1012,7 +1012,7 @@ function StatusSurface({
             </span>
           ))}
         </div>
-        <p>Enabled agents send their requests to the gateway on this Mac.</p>
+        <p>Enabled agents send their requests to the gateway on this device.</p>
       </div>
 
       <div className="status-segment status-gateway">
@@ -1517,7 +1517,7 @@ function UsageView({
       <section className="group usage-history" aria-labelledby="usage-history-title">
         <h2 className="group-title" id="usage-history-title" tabIndex={-1}>
           Usage history
-          <span aria-live="polite">{loading ? "Loading" : `${page?.summary.requests ?? 0} records · kept on this Mac`}</span>
+          <span aria-live="polite">{loading ? "Loading" : `${page?.summary.requests ?? 0} records · kept on this device`}</span>
           <span className="group-actions">
             <IconButton label="Export usage as CSV" onClick={() => void exportCsv()}><Download size={16} /></IconButton>
             <IconButton label="Clear usage history" onClick={() => setConfirmClear(true)}><Trash2 size={16} /></IconButton>
@@ -1658,7 +1658,7 @@ function Evidence({ activity }: { activity: RequestActivity }): React.JSX.Elemen
       <dt>Network</dt>
       <dd>
         {!activity.leftDevice
-          ? "Blocked locally; request content did not leave this Mac."
+          ? "Blocked locally; request content did not leave this device."
           : deliveryUnconfirmed
             ? "The request entered upstream delivery; whether the service received it could not be confirmed."
             : "Forwarded to the attested service."}
@@ -2145,7 +2145,7 @@ function LocalApiSheet({
               <IconButton label="Copy client key" onClick={() => void onCopy("Client key", clientKey)}>{copied === "Client key" ? <Check size={16} /> : <Copy size={16} />}</IconButton>
               <button type="button" className="button" disabled={frozen || saving} onClick={() => void onRotate()}><RefreshCw size={15} />Generate</button>
             </div>
-            <span className={`field-note ${copied === "Client key" ? "is-saved" : ""}`} id="client-key-note">{copied === "Client key" ? "Copied" : "Stored in an owner-only file; agent keys are separate."}</span>
+            <span className={`field-note ${copied === "Client key" ? "is-saved" : ""}`} id="client-key-note">{copied === "Client key" ? "Copied" : "Stored locally for this user; agent keys are separate."}</span>
           </div>
         </div>
         <div className="sheet-card endpoints-card">
@@ -2187,7 +2187,7 @@ function PrivacyVerification({ state, verified }: { state: GatewayState; verifie
       ok: verified && passed("id-6"),
       title: "Attested encrypted channel",
       detail: verified
-        ? "Requests leave this Mac only over an SPKI-pinned TLS channel whose key is bound to the verified service identity."
+        ? "Requests leave this device only over an SPKI-pinned TLS channel whose key is bound to the verified service identity."
         : "Not established while protection is off.",
     },
     {


### PR DESCRIPTION
## Scope
Use the existing React renderer and Tauri backend on every platform. Only four files change: platform bundle configurations, the new Tauri package workflow, and documentation. No renderer, runtime, macOS release/branding, or experimental native-client source was changed.

## Changes
- Standard Tauri overlays select Windows NSIS and Linux DEB.
- Hosted CI builds the production Vite bundle and real Tauri packages, runs existing tests, and checks the bundled ACI/helper binaries.
- AppImage remains unsupported because its temporary mount path would be persisted in agent helper commands.

## Verification
- Hosted Tauri workflow passed on Windows and Ubuntu: https://github.com/Dstack-TEE/private-ai-gateway/actions/runs/34019966216
- Renderer checks and existing 9-test suite passed on both platforms.
- Tauri backend tests and actual sidecar launch checks passed on both platforms.
- NSIS and DEB artifacts are uploaded to that run.
- Existing macOS Tauri package and cross-platform check-matrix jobs passed.
- The unchanged experimental WinUI workflow fails at native startup; this is not the Tauri package job and was not modified to hide the failure.

## Remaining Validation
Installed-app WebView, tray, and startup interaction checks have not been performed. Mock renderer tests are not a substitute for those checks. No real provider credentials, signing resources, or production configuration were used.

This corrects the direction of closed PR #178 and targets desktop development PR #174. Kept draft for installed-app review; not merged.