### PR TITLE
fix(desktop): complete platform safeguards on current Tauri client

### DIFF
--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -130,6 +130,7 @@ jobs:
           cargo +1.89 test --locked --manifest-path apps/desktop/runtime/Cargo.toml
           cargo +1.89 test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml
           cargo test --locked --bin aci
+          cargo test --locked --test aci_cli
 
   package:
     needs: verify

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -3,6 +3,10 @@ name: Desktop Tauri
 on:
   workflow_dispatch:
     inputs:
+      run_ui_tests:
+        description: Run optional renderer and installed app UI checks
+        default: false
+        type: boolean
       production_macos:
         description: Sign and notarize the macOS package for distribution
         required: true
@@ -48,6 +52,9 @@ on:
 
 permissions:
   contents: read
+
+env:
+  CARGO_BUILD_JOBS: 2
 
 concurrency:
   group: desktop-${{ github.event_name }}-${{ github.ref }}-${{ inputs.release_version || 'ci' }}
@@ -101,9 +108,13 @@ jobs:
         working-directory: apps/desktop
         run: |
           npm run check
+          npm run test:release
+      - name: Optional renderer UI checks
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ui_tests
+        working-directory: apps/desktop
+        run: |
           npx playwright install chromium
           npm run test:renderer
-          npm run test:release
       - name: Stage Tauri sidecars
         working-directory: apps/desktop
         run: npm run build:sidecars:debug
@@ -181,7 +192,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev gnome-keyring dbus-x11
       - name: Install desktop dependencies
         working-directory: apps/desktop
         run: npm ci
@@ -256,12 +267,95 @@ jobs:
             --issuer "$APPLE_API_ISSUER" \
             --wait
           xcrun stapler staple "$dmg"
+
+      - name: Test Windows desktop libraries
+        if: runner.os == 'Windows'
+        working-directory: apps/desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test --release --locked --manifest-path gateway/Cargo.toml --lib
+          cargo test --release --locked --manifest-path runtime/Cargo.toml --lib
+          cargo test --release --locked --manifest-path src-tauri/Cargo.toml --lib
+
+      - name: Check installed Windows sidecars without UI
+        if: runner.os == 'Windows'
+        working-directory: apps/desktop
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem src-tauri/target/release/bundle/nsis/*.exe)
+          if ($installers.Count -ne 1) { throw 'Expected one NSIS installer' }
+          $installDir = Join-Path $env:RUNNER_TEMP 'Tauri Installed Check'
+          if (Test-Path $installDir) { throw 'Install check directory already exists' }
+          function Run-Installer($executable, $arguments) {
+            $process = Start-Process -FilePath $executable -ArgumentList $arguments -PassThru
+            if (!$process.WaitForExit(60000)) {
+              & taskkill.exe /PID $process.Id /T /F
+              throw 'Installer timed out'
+            }
+            if ($process.ExitCode -ne 0) { throw "Installer failed: $($process.ExitCode)" }
+          }
+          try {
+            Run-Installer $installers[0].FullName "/S /D=$installDir"
+            node scripts/packaged-sidecars-smoke.mjs $installDir
+            if ($LASTEXITCODE -ne 0) { throw 'Installed sidecar checks failed' }
+            $env:PAG_TEST_HELPER_PATH = "$installDir/private-ai-gateway-helper.exe"
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored hermes_windows_installed_command_round_trip
+            if ($LASTEXITCODE -ne 0) { throw 'Hermes credential command failed' }
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored keyring_round_trip
+            if ($LASTEXITCODE -ne 0) { throw 'Credential Manager check failed' }
+          } finally {
+            if (Test-Path "$installDir/uninstall.exe") {
+              Run-Installer "$installDir/uninstall.exe" "/S _?=$installDir"
+            }
+            foreach ($binary in @('private-ai-gateway-desktop.exe', 'aci.exe', 'private-ai-gateway-helper.exe')) {
+              if (Test-Path "$installDir/$binary") { throw "Uninstall left $binary" }
+            }
+          }
+
+      - name: Check installed Linux sidecars without UI
+        if: runner.os == 'Linux'
+        working-directory: apps/desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=(src-tauri/target/release/bundle/deb/*.deb)
+          test "${#packages[@]}" -eq 1
+          package=$(dpkg-deb -f "${packages[0]}" Package)
+          if dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q 'install ok installed'; then
+            echo 'Refusing to replace an existing installation'
+            exit 1
+          fi
+          scratch=$(mktemp -d "$RUNNER_TEMP/tauri-installed.XXXXXX")
+          cleanup() {
+            local status=$?
+            sudo apt-get remove -y "$package" || status=1
+            for binary in private-ai-gateway-desktop aci private-ai-gateway-helper; do
+              if [[ -e "/usr/bin/$binary" ]]; then status=1; fi
+            done
+            rm -rf "$scratch"
+            return "$status"
+          }
+          trap cleanup EXIT
+          sudo apt-get install -y "${packages[0]}"
+          node scripts/packaged-sidecars-smoke.mjs /usr/bin
+          export TAURI_CHECK_KEYRING_HOME="$scratch"
+          export XDG_RUNTIME_DIR="$scratch/runtime"
+          mkdir -m 700 "$XDG_RUNTIME_DIR"
+          dbus-run-session -- bash -euc '
+            HOME="$TAURI_CHECK_KEYRING_HOME" gnome-keyring-daemon --foreground --unlock --components=secrets <<< ci-check-only &
+            keyring_pid=$!
+            trap "kill $keyring_pid 2>/dev/null || true; wait $keyring_pid || true" EXIT
+            gdbus wait --session --timeout 10 org.freedesktop.secrets
+            cargo test --release --locked --manifest-path gateway/Cargo.toml --lib -- --ignored keyring_round_trip
+          '
       - name: Stage and inspect macOS package
         if: runner.os == 'macOS'
         working-directory: apps/desktop
         shell: bash
         env:
           PRODUCTION_MACOS: ${{ inputs.production_macos }}
+          RUN_UI_TESTS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ui_tests }}
         run: |
           set -euo pipefail
           mkdir -p release
@@ -288,21 +382,25 @@ jobs:
           else
             grep -q '^Signature=adhoc$' <<<"$codesign_details"
           fi
-          launch_log="$RUNNER_TEMP/private-ai-gateway-launch.log"
-          "$app_bundle/Contents/MacOS/private-ai-gateway-desktop" >"$launch_log" 2>&1 &
-          app_pid=$!
-          cleanup() {
-            kill "$app_pid" 2>/dev/null || true
-            wait "$app_pid" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-          sleep 5
-          if ! kill -0 "$app_pid" 2>/dev/null; then
-            cat "$launch_log"
-            exit 1
+          if [[ "$RUN_UI_TESTS" == true ]]; then
+            launch_log="$RUNNER_TEMP/private-ai-gateway-launch.log"
+            "$app_bundle/Contents/MacOS/private-ai-gateway-desktop" >"$launch_log" 2>&1 &
+            app_pid=$!
+            cleanup() {
+              kill "$app_pid" 2>/dev/null || true
+              wait "$app_pid" 2>/dev/null || true
+            }
+            trap cleanup EXIT
+            sleep 5
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              cat "$launch_log"
+              exit 1
+            fi
+            cleanup
+            trap - EXIT
+          else
+            echo 'Installed UI checks: not run (manual opt-in required).'
           fi
-          cleanup
-          trap - EXIT
           hdiutil verify "$dmg"
           cp "$dmg" release/
           ditto -c -k --sequesterRsrc --keepParent "$app_bundle" "release/Private-AI-Gateway-macos-arm64.zip"

--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -338,7 +338,7 @@ jobs:
             return "$status"
           }
           trap cleanup EXIT
-          sudo apt-get install -y "${packages[0]}"
+          sudo apt-get install -y "./${packages[0]}"
           node scripts/packaged-sidecars-smoke.mjs /usr/bin
           export TAURI_CHECK_KEYRING_HOME="$scratch"
           export XDG_RUNTIME_DIR="$scratch/runtime"

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -488,7 +488,12 @@ usage, persistent-history filters and cursor pagination, CSV/clear flows,
 proof and local-block semantics, profile management, system confirmation boundaries,
 dark/high-contrast/reduced-motion
 media, 200% zoom, and
-940/720/540/320 widths. CI runs it before all three platform packages.
+940/720/540/320 widths. UI checks require the explicit `run_ui_tests` manual
+workflow input and are disabled on ordinary PR builds. TypeScript, release
+manifest tests, and Rust checks still run. Windows package jobs also execute
+the shared libraries' tests. NSIS/DEB installation checks exercise the bundled
+ACI and helper without opening the app, then uninstall the package; temporary
+credential-store fixtures are separate from real provider credentials.
 
 ## Packaging
 

--- a/apps/desktop/gateway/Cargo.lock
+++ b/apps/desktop/gateway/Cargo.lock
@@ -1201,6 +1201,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/gateway/Cargo.toml
+++ b/apps/desktop/gateway/Cargo.toml
@@ -33,6 +33,9 @@ tokio-util = "0.7"
 toml_edit = "0.25"
 yaml-edit = { version = "0.3.1", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+base64 = "0.22"
+
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
 tempfile = "3"

--- a/apps/desktop/gateway/src/agents.rs
+++ b/apps/desktop/gateway/src/agents.rs
@@ -189,7 +189,15 @@ impl Agent {
                 .unwrap_or_else(|| home.join(".pi").join("agent"))
                 .join("models.json"),
             Agent::Hermes => override_dir("HERMES_HOME")
-                .unwrap_or_else(|| home.join(".hermes"))
+                .unwrap_or_else(|| {
+                    if cfg!(windows) {
+                        override_dir("LOCALAPPDATA")
+                            .unwrap_or_else(|| home.join("AppData").join("Local"))
+                            .join("hermes")
+                    } else {
+                        home.join(".hermes")
+                    }
+                })
                 .join("config.yaml"),
         }
     }
@@ -353,7 +361,7 @@ fn fields(agent: Agent, inputs: &Inputs<'_>) -> Result<Vec<Field>, String> {
                 boolean(&["providers", provider, "discover_models"], true),
                 set(
                     &["providers", provider, "key_cmd"],
-                    helper_command(inputs.helper_exe, "hermes")?,
+                    credential_helper_command(inputs.helper_exe, Agent::Hermes)?,
                 ),
                 set(&["model", "provider"], format!("custom:{provider}")),
             ];
@@ -461,7 +469,7 @@ fn pi_provider(
     Ok(serde_json::json!({
         "baseUrl": format!("{base}/v1"),
         "api": "openai-responses",
-        "apiKey": format!("!{}", helper_command(helper_exe, "pi")?),
+        "apiKey": format!("!{}", credential_helper_command(helper_exe, Agent::Pi)?),
         "models": models,
     }))
 }
@@ -678,6 +686,39 @@ fn helper_command(exe: &Path, agent: &str) -> Result<String, String> {
     Ok(format!("{quoted} --agent-token {agent}"))
 }
 
+#[cfg(not(windows))]
+fn credential_helper_command(exe: &Path, agent: Agent) -> Result<String, String> {
+    helper_command(exe, agent.id())
+}
+
+#[cfg(windows)]
+fn credential_helper_command(exe: &Path, agent: Agent) -> Result<String, String> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    let path = exe
+        .to_str()
+        .ok_or_else(|| "The app path is not valid Unicode".to_string())?;
+    if path.contains('\0') {
+        return Err("The app path contains a null character".to_string());
+    }
+    // Hermes uses cmd.exe; Pi tries Bash then falls back to cmd.exe. Only the
+    // fixed switches and base64 reach either shell; the helper path stays data.
+    let encoded_path = STANDARD.encode(
+        path.encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>(),
+    );
+    let command = format!(
+        "$ErrorActionPreference = 'Stop'; & ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{encoded_path}'))) --agent-token {}; exit $LASTEXITCODE",
+        agent.id()
+    );
+    let bytes: Vec<u8> = command.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    Ok(format!(
+        "powershell.exe -NoProfile -NonInteractive -EncodedCommand {}",
+        STANDARD.encode(bytes)
+    ))
+}
+
 /// Credential-bearing keys: their values never reach previews, manifests,
 /// or logs.
 fn is_sensitive(path: &[String]) -> bool {
@@ -769,13 +810,15 @@ impl Projector {
         endpoint: &str,
         secrets: Arc<dyn SecretStore>,
     ) -> Result<Self, String> {
-        let home = env_path(HOME_OVERRIDE_ENV).map_or_else(home_dir, Ok)?;
+        let home_override = env_path(HOME_OVERRIDE_ENV);
+        let tool_env = home_override.is_none();
+        let home = home_override.map_or_else(home_dir, Ok)?;
         Ok(Self::at(
             home,
             app_data_dir()?,
             helper_exe,
             endpoint,
-            true,
+            tool_env,
             secrets,
         ))
     }
@@ -1402,6 +1445,26 @@ impl Projector {
                 }
             }
         }
+        #[cfg(windows)]
+        if agent == Agent::Pi && status.connected && !record.disabled && !record.cleanup_pending {
+            if let Ok(command) = helper_command(&self.helper_exe, "pi") {
+                let legacy = format!("!{command}");
+                let legacy_record = record.fields.iter().any(|field| {
+                    field.path == owned(&["providers", "private-ai-gateway"])
+                        && matches!(&field.value, Some(ConfigValue::Json(provider))
+                            if provider.get("apiKey").and_then(serde_json::Value::as_str) == Some(legacy.as_str()))
+                });
+                if legacy_record {
+                    status.connected = false;
+                    status.authorized = false;
+                    status.attention = Some(
+                        "This Pi connection uses the old Windows credential command. Disconnect, \
+                         then Connect again to update it."
+                            .to_string(),
+                    );
+                }
+            }
+        }
         status
     }
 
@@ -1744,7 +1807,12 @@ fn cli_paths(home: &Path, tool_env: bool) -> Vec<PathBuf> {
 }
 
 fn find_cli(agent: Agent, home: &Path, tool_env: bool) -> Option<PathBuf> {
-    let paths = cli_paths(home, tool_env);
+    let mut paths = cli_paths(home, tool_env);
+    if cfg!(windows) && agent == Agent::Hermes {
+        if let Some(directory) = agent.config_path(home, tool_env).parent() {
+            paths.push(directory.join("bin"));
+        }
+    }
     find_cli_in_paths(agent, &paths)
 }
 
@@ -1838,6 +1906,10 @@ fn env_path(name: &str) -> Option<PathBuf> {
 }
 
 fn home_dir() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    if let Some(home) = env_path("USERPROFILE") {
+        return Ok(home);
+    }
     env_path("HOME")
         .or_else(|| env_path("USERPROFILE"))
         .ok_or_else(|| "Cannot determine the home directory".to_string())
@@ -2017,6 +2089,169 @@ mod tests {
         let _ = fs::remove_dir_all(root);
         assert!(output.status.success());
         assert_eq!(output.stdout, b"bundled-catalog");
+    }
+
+    #[test]
+    fn hermes_paths_follow_platform_overrides_and_isolate_test_home() {
+        const CASE_ENV: &str = "PAG_TEST_HERMES_PATH_CASE";
+        const ROOT_ENV: &str = "PAG_TEST_HERMES_PATH_ROOT";
+        if let Ok(case) = env::var(CASE_ENV) {
+            let root = PathBuf::from(env::var_os(ROOT_ENV).unwrap());
+            let home = root.join(if case == "isolated" {
+                "isolated"
+            } else {
+                "user"
+            });
+            let default = if cfg!(windows) {
+                home.join("AppData").join("Local").join("hermes")
+            } else {
+                home.join(".hermes")
+            };
+            let expected = match case.as_str() {
+                "override" => root.join("custom-profile"),
+                "local-appdata" if cfg!(windows) => root.join("local-data").join("hermes"),
+                _ => default,
+            };
+            let projector = Projector::new(
+                root.join(helper_binary_name()),
+                ENDPOINT,
+                Arc::new(MemoryStore::default()),
+            )
+            .unwrap();
+            assert_eq!(projector.home, home);
+            assert_eq!(
+                Agent::Hermes.config_path(&projector.home, projector.tool_env),
+                expected.join("config.yaml")
+            );
+            if case == "isolated" {
+                assert!(!projector.tool_env);
+                assert_eq!(projector.data_dir, home.join(".private-ai-gateway"));
+                for agent in Agent::ALL {
+                    assert!(agent
+                        .config_path(&projector.home, projector.tool_env)
+                        .starts_with(&home));
+                }
+            }
+            if cfg!(windows) {
+                let executable = expected.join("bin").join("hermes.exe");
+                write(&executable, "launcher fixture");
+                assert_eq!(
+                    find_cli(Agent::Hermes, &projector.home, projector.tool_env),
+                    Some(executable)
+                );
+            }
+            return;
+        }
+
+        // Process-local environment avoids races with the other agent tests.
+        let root = tempfile::tempdir().unwrap();
+        for case in [
+            "default",
+            "local-appdata",
+            "override",
+            "isolated",
+            "native-home",
+        ] {
+            let mut command = Command::new(env::current_exe().unwrap());
+            command
+                .args([
+                    "--exact",
+                    "agents::tests::hermes_paths_follow_platform_overrides_and_isolate_test_home",
+                ])
+                .env(CASE_ENV, case)
+                .env(ROOT_ENV, root.path())
+                .env("HOME", root.path().join("user"))
+                .env("USERPROFILE", root.path().join("user"))
+                .env("APPDATA", root.path().join("roaming"))
+                .env("XDG_DATA_HOME", root.path().join("data"))
+                .env("PATH", "")
+                .env_remove(HOME_OVERRIDE_ENV)
+                .env_remove("HERMES_HOME")
+                .env_remove("LOCALAPPDATA");
+            if matches!(case, "local-appdata" | "override" | "isolated") {
+                command.env("LOCALAPPDATA", root.path().join("local-data"));
+            }
+            if matches!(case, "override" | "isolated") {
+                command.env("HERMES_HOME", root.path().join("custom-profile"));
+            }
+            if case == "isolated" {
+                command
+                    .env(HOME_OVERRIDE_ENV, root.path().join("isolated"))
+                    .env("CODEX_HOME", root.path().join("outside-codex"));
+            }
+            if cfg!(windows) && case == "native-home" {
+                command.env("HOME", root.path().join("git-home"));
+            }
+            let output = command.output().unwrap();
+            assert!(output.status.success(), "{case}: {output:?}");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires the installed helper and Python on a disposable Windows runner"]
+    fn hermes_windows_installed_command_round_trip() {
+        let installed = PathBuf::from(env::var_os("PAG_TEST_HELPER_PATH").unwrap());
+        assert!(installed.is_absolute() && installed.is_file());
+        assert!(installed.to_str().unwrap().contains(' '));
+        let home = tempfile::tempdir().unwrap();
+        let data = home.path().join(".private-ai-gateway");
+        let tokens = TokenFiles::new(&data);
+        let hostile = home
+            .path()
+            .join("quote'\u{2019}; Write-Output injected; # %PAG_CMD_PROBE% ! ^ & (meta)")
+            .join(helper_binary_name());
+        fs::create_dir_all(hostile.parent().unwrap()).unwrap();
+        fs::copy(&installed, &hostile).unwrap();
+        for executable in [&installed, &hostile] {
+            let token = tokens.ensure("hermes").unwrap();
+            let fields = fields(
+                Agent::Hermes,
+                &Inputs {
+                    endpoint: ENDPOINT,
+                    helper_exe: executable,
+                    token_path: &tokens.path("hermes"),
+                    codex_catalog_path: &data.join(CODEX_CATALOG_FILE),
+                    catalog: Some(&catalog()),
+                    options: &ConnectOptions::default(),
+                },
+            )
+            .unwrap();
+            let command = fields
+                .into_iter()
+                .find(|field| field.path == owned(&["providers", "private-ai-gateway", "key_cmd"]))
+                .and_then(|field| match field.value {
+                    Some(ConfigValue::Str(command)) => Some(command),
+                    _ => None,
+                })
+                .unwrap();
+            let run = || {
+                Command::new("python")
+                    .args([
+                        "-c",
+                        "import subprocess,sys; p=subprocess.run(sys.argv[1],shell=True,capture_output=True,text=True,timeout=15); sys.stdout.write(p.stdout); sys.stderr.write(p.stderr); sys.exit(p.returncode)",
+                        &command,
+                    ])
+                    .env(HOME_OVERRIDE_ENV, home.path())
+                    .env("PAG_CMD_PROBE", "expanded-by-shell")
+                    .output()
+                    .unwrap()
+            };
+            let output = run();
+            assert!(output.status.success(), "{output:?}");
+            assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), token);
+            fs::remove_file(tokens.path("hermes")).unwrap();
+            let output = run();
+            assert!(!output.status.success());
+            assert!(output.stdout.is_empty());
+            if executable == &hostile {
+                fs::remove_file(executable).unwrap();
+                let output = run();
+                assert!(!output.status.success());
+                assert!(output.stdout.is_empty());
+            }
+        }
+        assert!(credential_helper_command(Path::new("bad\0path"), Agent::Hermes).is_err());
     }
 
     fn connect(sandbox: &Sandbox) -> AgentStatus {
@@ -2338,13 +2573,90 @@ mod tests {
         };
         assert_eq!(provider["models"].as_array().unwrap().len(), 2);
         assert_eq!(provider["models"][0]["id"], "openai/gpt-oss-20b");
-        assert!(provider["apiKey"]
-            .as_str()
-            .unwrap()
-            .contains("--agent-token pi"));
+        assert_eq!(
+            provider["apiKey"],
+            format!(
+                "!{}",
+                credential_helper_command(&sandbox.projector.helper_exe, Agent::Pi).unwrap()
+            )
+        );
+        #[cfg(windows)]
+        {
+            let pi_token = sandbox.projector.tokens.read("pi").unwrap().unwrap();
+            let config_path = Agent::Pi.config_path(&sandbox.home, sandbox.projector.tool_env);
+            let mut legacy = provider.clone();
+            legacy["apiKey"] = json!(format!(
+                "!{}",
+                helper_command(&sandbox.projector.helper_exe, "pi").unwrap()
+            ));
+            let value = ConfigValue::Json(legacy);
+            let mut config = doc(&sandbox, Agent::Pi);
+            config
+                .set_value(&["providers", "private-ai-gateway"], &value)
+                .unwrap();
+            write(&config_path, &config.render().unwrap());
+            let mut store = sandbox.projector.load_store().unwrap();
+            store
+                .get_mut("pi")
+                .unwrap()
+                .fields
+                .iter_mut()
+                .find(|field| field.path == owned(&["providers", "private-ai-gateway"]))
+                .unwrap()
+                .value = Some(value);
+            sandbox.projector.save_store(&store).unwrap();
+            let config_before = fs::read(&config_path).unwrap();
+            let record_before = fs::read(sandbox.projector.store_path()).unwrap();
+            let token_before = fs::read(sandbox.projector.tokens.path("pi")).unwrap();
+            let (statuses, tokens) = sandbox.projector.scan(None).unwrap();
+            let pi = statuses.iter().find(|status| status.id == "pi").unwrap();
+            assert!(pi.recorded && !pi.connected && !pi.authorized);
+            assert!(pi
+                .attention
+                .as_deref()
+                .unwrap()
+                .contains("Disconnect, then Connect"));
+            assert_eq!(tokens.agent_for(&pi_token), None);
+            assert_eq!(fs::read(&config_path).unwrap(), config_before);
+            assert_eq!(
+                fs::read(sandbox.projector.store_path()).unwrap(),
+                record_before
+            );
+            assert_eq!(
+                fs::read(sandbox.projector.tokens.path("pi")).unwrap(),
+                token_before
+            );
+
+            config
+                .set_str(
+                    &["providers", "private-ai-gateway", "apiKey"],
+                    "!user-command",
+                )
+                .unwrap();
+            write(&config_path, &config.render().unwrap());
+            let edited = fs::read(&config_path).unwrap();
+            let (statuses, tokens) = sandbox.projector.scan(None).unwrap();
+            let pi = statuses.iter().find(|status| status.id == "pi").unwrap();
+            assert!(pi.recorded && !pi.connected && !pi.authorized);
+            assert!(pi
+                .attention
+                .as_deref()
+                .unwrap()
+                .contains("no longer matches"));
+            assert_eq!(tokens.agent_for(&pi_token), None);
+            assert_eq!(fs::read(&config_path).unwrap(), edited);
+            assert_eq!(
+                fs::read(sandbox.projector.store_path()).unwrap(),
+                record_before
+            );
+            assert_eq!(
+                fs::read(sandbox.projector.tokens.path("pi")).unwrap(),
+                token_before
+            );
+        }
         disconnect(&sandbox, Agent::Pi);
 
-        let path = sandbox.home.join(".hermes").join("config.yaml");
+        let path = Agent::Hermes.config_path(&sandbox.home, sandbox.projector.tool_env);
         write(&path, "# keep this comment\ntheme: dark\n");
         let preview = sandbox
             .projector
@@ -2402,9 +2714,10 @@ mod tests {
                 .as_deref(),
             Some("chat_completions")
         );
-        assert!(hermes
-            .get_str(&["providers", "private-ai-gateway", "key_cmd"])
-            .is_some_and(|command| command.contains("--agent-token hermes")));
+        assert_eq!(
+            hermes.get_str(&["providers", "private-ai-gateway", "key_cmd"]),
+            Some(credential_helper_command(&fresh.projector.helper_exe, Agent::Hermes).unwrap())
+        );
     }
 
     #[test]
@@ -2907,6 +3220,50 @@ mod tests {
                 Err(error) => panic!("cannot run sh: {error}"),
             }
         }
+        #[cfg(windows)]
+        {
+            use base64::{engine::general_purpose::STANDARD, Engine};
+
+            // Pi's Bash and cmd.exe fallback see only fixed switches and a
+            // base64 word. Neither shell interprets the Windows helper path.
+            let hostile = Path::new(r"C:\Users\O'Brien %USERPROFILE% ! &\helper.exe");
+            let provider = pi_provider(&catalog(), ENDPOINT, hostile).unwrap();
+            let command = provider["apiKey"]
+                .as_str()
+                .unwrap()
+                .strip_prefix('!')
+                .unwrap();
+            let words: Vec<_> = command.split_ascii_whitespace().collect();
+            assert_eq!(words.len(), 5);
+            assert_eq!(
+                &words[..4],
+                &[
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-EncodedCommand"
+                ]
+            );
+            assert_eq!(shlex::split(command).unwrap(), words);
+            let bytes = STANDARD.decode(words[4]).unwrap();
+            let script = String::from_utf16(
+                &bytes
+                    .chunks_exact(2)
+                    .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+            let encoded_path = STANDARD.encode(
+                hostile
+                    .to_str()
+                    .unwrap()
+                    .encode_utf16()
+                    .flat_map(u16::to_le_bytes)
+                    .collect::<Vec<_>>(),
+            );
+            assert!(script.contains(&format!("FromBase64String('{encoded_path}')")));
+            assert!(script.ends_with("--agent-token pi; exit $LASTEXITCODE"));
+        }
     }
 
     /// Deleting the token file is the revocation itself: even when the very
@@ -3097,7 +3454,7 @@ mod tests {
         tokio::spawn(async move { axum::serve(sidecar_listener, sidecar).await.unwrap() });
 
         let (sender, _events) = tokio::sync::mpsc::channel(8);
-        let state = ProxyState::new(sender);
+        let state = ProxyState::new(sender).unwrap();
         state.set_api_key(Some("sk-live".into()));
         state.publish(Session {
             generation: 1,

--- a/apps/desktop/gateway/src/proxy.rs
+++ b/apps/desktop/gateway/src/proxy.rs
@@ -134,13 +134,15 @@ pub struct ProxyState {
 impl ProxyState {
     /// `events` is bounded; when it is full, low-value rejection events are
     /// dropped rather than blocking a request.
-    pub fn new(events: mpsc::Sender<ProxyEvent>) -> Arc<Self> {
+    pub fn new(events: mpsc::Sender<ProxyEvent>) -> Result<Arc<Self>, String> {
         let client = reqwest::Client::builder()
+            // Only the owned loopback sidecar may receive these requests.
+            .no_proxy()
             .connect_timeout(UPSTREAM_CONNECT_TIMEOUT)
             .read_timeout(UPSTREAM_READ_TIMEOUT)
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
-        Arc::new(Self {
+            .map_err(|_| "Cannot initialize the local gateway HTTP client".to_string())?;
+        Ok(Arc::new(Self {
             session: RwLock::new(Session::default()),
             credentials: RwLock::new(Credentials::default()),
             credential_epoch: AtomicU64::new(1),
@@ -150,7 +152,7 @@ impl ProxyState {
             in_flight: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
             #[cfg(test)]
             pause: std::sync::Mutex::new(None),
-        })
+        }))
     }
 
     /// Cancel every delivery admitted so far; called after any state change
@@ -1254,7 +1256,7 @@ mod tests {
 
     fn state() -> (Arc<ProxyState>, mpsc::Receiver<ProxyEvent>) {
         let (sender, receiver) = mpsc::channel(4);
-        (ProxyState::new(sender), receiver)
+        (ProxyState::new(sender).unwrap(), receiver)
     }
 
     fn tokens() -> TokenSet {
@@ -1263,6 +1265,56 @@ mod tests {
         set.insert("claude-token".to_string(), "claude-code".to_string());
         set.insert("opencode-token".to_string(), "opencode".to_string());
         set
+    }
+
+    #[test]
+    fn sidecar_requests_ignore_proxy_environment() {
+        const CHILD: &str = "PAG_TEST_PROXY_ENV_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            // Isolate proxy variables from the other concurrently running tests.
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "proxy::tests::sidecar_requests_ignore_proxy_environment",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .env("HTTP_PROXY", "http://127.0.0.1:1")
+                .env("http_proxy", "http://127.0.0.1:1")
+                .env("ALL_PROXY", "http://127.0.0.1:1")
+                .env("all_proxy", "http://127.0.0.1:1")
+                .env("NO_PROXY", "")
+                .env("no_proxy", "")
+                .status()
+                .unwrap();
+            assert!(status.success());
+            return;
+        }
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let (state, _events) = state();
+                let sidecar = mock_sidecar().await;
+                assert!(reqwest::Client::builder()
+                    .timeout(Duration::from_secs(1))
+                    .build()
+                    .unwrap()
+                    .get(format!("{sidecar}/v1/models"))
+                    .send()
+                    .await
+                    .is_err());
+                verified(&state, &sidecar, 1, 1).await;
+                let response = state
+                    .client
+                    .post(format!("{sidecar}/v1/responses"))
+                    .json(&json!({ "model": "openai/gpt-oss-20b", "input": "fixture" }))
+                    .send()
+                    .await
+                    .unwrap();
+                assert!(response.status().is_success());
+            });
     }
 
     async fn verified(state: &ProxyState, sidecar: &str, generation: u64, epoch: u64) {

--- a/apps/desktop/gateway/src/tokens.rs
+++ b/apps/desktop/gateway/src/tokens.rs
@@ -41,9 +41,8 @@ pub fn agent_allows(agent: &str, path: &str) -> bool {
 
 pub struct TokenFiles {
     dir: PathBuf,
-    /// Persists a directory-entry removal (see `sync_dir`); swappable in
-    /// tests to prove revocation order and fail-closed behaviour without
-    /// tracing syscalls.
+    /// Completes the platform revocation barrier after removal (see
+    /// `sync_dir`); swappable in tests to prove fail-closed behaviour.
     sync_parent: fn(&Path) -> io::Result<()>,
 }
 
@@ -69,6 +68,8 @@ impl TokenFiles {
         if let Some(existing) = self.read(agent)? {
             return Ok(existing);
         }
+        // An interrupted Windows revocation can leave a durably empty tombstone.
+        self.revoke(agent)?;
         self.issue(agent)
     }
 
@@ -111,15 +112,21 @@ impl TokenFiles {
         Ok(())
     }
 
-    /// Durable revocation: the token file is removed and the removal is
-    /// persisted (parent-directory sync) before this returns, so a crash or
-    /// power loss right after cannot resurrect the token. A missing file
-    /// changed no directory entry and needs no sync.
+    /// Unix persists removal through a parent-directory sync; Windows first
+    /// persists an empty file so a rolled-back deletion cannot restore the key.
+    /// A missing file needs no persistence barrier.
     pub fn revoke(&self, agent: &str) -> Result<(), String> {
-        match fs::remove_file(self.path(agent)) {
+        let path = self.path(agent);
+        #[cfg(windows)]
+        match neutralize_private(&path) {
+            Ok(true) => {}
+            Ok(false) => return Ok(()),
+            Err(error) => return Err(format!("Cannot revoke the {agent} token: {error}")),
+        }
+        match fs::remove_file(path) {
             Ok(()) => (self.sync_parent)(&self.dir).map_err(|error| {
                 format!(
-                    "The {agent} token file was deleted but the removal could not be \
+                    "The {agent} token file was deleted but durable revocation could not be \
                      persisted: {error}"
                 )
             }),
@@ -277,30 +284,53 @@ pub fn tighten_private(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Durably persist a change to a directory's entries (a file removal). On
-/// Unix this is the mature pattern: open the directory itself
-/// (`O_DIRECTORY`, `O_NOFOLLOW`; std adds `O_CLOEXEC`) and `fsync` the
-/// handle. On Windows a `FlushFileBuffers` is issued on a
-/// `FILE_FLAG_BACKUP_SEMANTICS` directory handle via `File::sync_all`;
-/// beyond that there is no POSIX-style directory fsync — NTFS journals
-/// metadata operations, so the flush plus the journal is the strongest
-/// guarantee available without raw volume access.
+/// FlushFileBuffers supports regular writable files, not directory handles.
+/// Clear and flush before unlinking so a recovered entry cannot revive a key.
+#[cfg(windows)]
+fn neutralize_private(path: &Path) -> io::Result<bool> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    let file = match fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(symlink_refused());
+    }
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the token path is not a regular file",
+        ));
+    }
+    file.set_len(0)?;
+    file.sync_all()?;
+    Ok(true)
+}
+
+/// Persist Unix directory entries through an O_DIRECTORY, O_NOFOLLOW handle.
+#[cfg(unix)]
 pub(crate) fn sync_dir(dir: &Path) -> io::Result<()> {
     let mut options = fs::OpenOptions::new();
     options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc_directory() | libc_nofollow());
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::OpenOptionsExt;
-        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-        // FlushFileBuffers needs write access on the handle.
-        options.write(true).custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-    }
+    use std::os::unix::fs::OpenOptionsExt;
+    options.custom_flags(libc_directory() | libc_nofollow());
     options.open(dir)?.sync_all()
+}
+
+/// Windows revocation is already durable after neutralize_private.
+#[cfg(windows)]
+pub(crate) fn sync_dir(_dir: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -336,6 +366,33 @@ fn libc_nofollow() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ensure_replaces_an_empty_revocation_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = TokenFiles::new(dir.path());
+        let old = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        #[cfg(windows)]
+        assert!(neutralize_private(&files.path(LOCAL_TOOLS_AGENT)).unwrap());
+        #[cfg(not(windows))]
+        fs::write(files.path(LOCAL_TOOLS_AGENT), "").unwrap();
+        assert!(files.read(LOCAL_TOOLS_AGENT).unwrap().is_none());
+        let replacement = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        assert_ne!(replacement, old);
+        assert_eq!(files.read(LOCAL_TOOLS_AGENT).unwrap(), Some(replacement));
+    }
+
+    #[test]
+    fn rotate_sync_failure_leaves_no_readable_old_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut files = TokenFiles::new(dir.path());
+        let old = files.ensure(LOCAL_TOOLS_AGENT).unwrap();
+        files.set_sync_parent(|_| Err(io::Error::other("injected sync failure")));
+        assert!(files.rotate(LOCAL_TOOLS_AGENT).is_err());
+        assert!(files.read(LOCAL_TOOLS_AGENT).unwrap().is_none());
+        files.set_sync_parent(sync_dir);
+        assert_ne!(files.ensure(LOCAL_TOOLS_AGENT).unwrap(), old);
+    }
 
     #[test]
     fn tokens_are_private_per_agent_and_revocable() {

--- a/apps/desktop/runtime/Cargo.lock
+++ b/apps/desktop/runtime/Cargo.lock
@@ -1270,6 +1270,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "bytes",
  "fd-lock",
  "futures-util",

--- a/apps/desktop/runtime/src/controller.rs
+++ b/apps/desktop/runtime/src/controller.rs
@@ -46,29 +46,55 @@ pub struct DesktopRuntime {
     lifecycle: tokio::sync::Mutex<()>,
     exiting: AtomicBool,
     helper_path: PathBuf,
-    #[allow(dead_code)]
     instance: Option<lock::InstanceLock>,
 }
 
-struct ClientCredentials(Mutex<TokenFiles>);
+struct ClientCredentials(Mutex<ClientCredentialState>);
+
+struct ClientCredentialState {
+    files: TokenFiles,
+    rotation_failed: bool,
+}
 
 impl ClientCredentials {
     fn new() -> Result<Self, String> {
-        Ok(Self(Mutex::new(TokenFiles::new(&app_data_dir()?))))
+        Ok(Self::from_files(TokenFiles::new(&app_data_dir()?)))
+    }
+
+    fn from_files(files: TokenFiles) -> Self {
+        Self(Mutex::new(ClientCredentialState {
+            files,
+            rotation_failed: false,
+        }))
     }
 
     fn token(&self) -> Result<String, String> {
-        self.0
+        self.active_token()?.ok_or_else(|| {
+            "Client key rotation failed; generate a new client key before using the Local API"
+                .to_string()
+        })
+    }
+
+    fn active_token(&self) -> Result<Option<String>, String> {
+        let state = self
+            .0
             .lock()
-            .map_err(|_| "Client credential store unavailable".to_string())?
-            .ensure(LOCAL_TOOLS_AGENT)
+            .map_err(|_| "Client credential store unavailable".to_string())?;
+        if state.rotation_failed {
+            return Ok(None);
+        }
+        state.files.ensure(LOCAL_TOOLS_AGENT).map(Some)
     }
 
     fn rotate(&self) -> Result<String, String> {
-        self.0
+        let mut state = self
+            .0
             .lock()
-            .map_err(|_| "Client credential store unavailable".to_string())?
-            .rotate(LOCAL_TOOLS_AGENT)
+            .map_err(|_| "Client credential store unavailable".to_string())?;
+        state.rotation_failed = true;
+        let token = state.files.rotate(LOCAL_TOOLS_AGENT)?;
+        state.rotation_failed = false;
+        Ok(token)
     }
 }
 
@@ -226,7 +252,7 @@ impl DesktopRuntime {
             ),
         };
         let (proxy_events_tx, mut proxy_events) = tokio::sync::mpsc::channel::<ProxyEvent>(256);
-        let proxy = ProxyState::new(proxy_events_tx);
+        let proxy = ProxyState::new(proxy_events_tx)?;
         let (usage, usage_error) = match UsageStore::open(data_dir.join("usage.sqlite3")) {
             Ok(store) => (Arc::new(store), None),
             Err(error) => match UsageStore::memory() {
@@ -901,6 +927,9 @@ impl DesktopRuntime {
         config: LocalApiConfig,
     ) -> Result<GatewayState, String> {
         let _operation = self.configuration_change()?;
+        if self.instance.is_none() {
+            return Err("Change Local API settings in the primary app instance".to_string());
+        }
         let previous = self.manager.snapshot()?;
         if previous.status == "verifying" {
             return Err("Wait for the current verification to finish".to_string());
@@ -1196,7 +1225,9 @@ fn with_client_token(
     mut tokens: TokenSet,
     credentials: &ClientCredentials,
 ) -> Result<TokenSet, String> {
-    tokens.insert(credentials.token()?, LOCAL_TOOLS_AGENT.to_string());
+    if let Some(token) = credentials.active_token()? {
+        tokens.insert(token, LOCAL_TOOLS_AGENT.to_string());
+    }
     Ok(tokens)
 }
 
@@ -1237,7 +1268,7 @@ mod tests {
         directory: &std::path::Path,
     ) -> Arc<DesktopRuntime> {
         let (events, _) = tokio::sync::mpsc::channel(8);
-        let proxy = ProxyState::new(events);
+        let proxy = ProxyState::new(events).unwrap();
         let usage = Arc::new(UsageStore::memory().unwrap());
         let manager = Arc::new(GatewayManager::new(
             proxy.clone(),
@@ -1251,7 +1282,7 @@ mod tests {
             proxy,
             usage,
             secrets: Arc::new(KeyringStore),
-            credentials: ClientCredentials(Mutex::new(TokenFiles::new(directory))),
+            credentials: ClientCredentials::from_files(TokenFiles::new(directory)),
             legacy_credential_pending: Mutex::new(false),
             endpoint: EndpointRuntime::new(executor.handle().clone()),
             codex_sync: CodexCatalogSync::default(),
@@ -1325,6 +1356,16 @@ mod tests {
             runtime.proxy.tokens().agent_for("agent-token"),
             Some("codex")
         );
+        // A readable leftover must not be admitted by a later scan or key read.
+        std::fs::remove_dir(&token_path).unwrap();
+        std::fs::write(&token_path, &rotated).unwrap();
+        assert!(runtime.client_key().is_err());
+        let active = with_client_token(runtime.proxy.tokens(), &runtime.credentials).unwrap();
+        assert_eq!(active.agent_for(&rotated), None);
+        assert_eq!(active.agent_for("agent-token"), Some("codex"));
+        let replacement = runtime.rotate_client_key().unwrap();
+        assert_ne!(replacement, rotated);
+        assert_eq!(runtime.client_key().unwrap(), replacement);
     }
 
     #[test]
@@ -1364,7 +1405,22 @@ mod tests {
                 port: occupied.local_addr().unwrap().port(),
                 ..config.clone()
             };
-            assert!(runtime.save_local_api_config(candidate).await.is_err());
+            // A secondary instance cannot touch the listener or persisted config.
+            assert!(runtime
+                .save_local_api_config(candidate.clone())
+                .await
+                .unwrap_err()
+                .contains("primary"));
+            assert!(std::net::TcpStream::connect(original.bind).is_ok());
+            // Exercise rollback directly without a primary instance or user data.
+            assert!(runtime
+                .rebind_local_api(
+                    candidate.clone(),
+                    original.clone(),
+                    local_api::resolve(candidate).unwrap()
+                )
+                .await
+                .is_err());
             let state = runtime.state().unwrap();
             assert_eq!(state.local_api, config);
             assert_eq!(state.proxy_url.as_deref(), Some(original.endpoint.as_str()));

--- a/apps/desktop/scripts/packaged-sidecars-smoke.mjs
+++ b/apps/desktop/scripts/packaged-sidecars-smoke.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [directory] = process.argv.slice(2);
+assert.ok(directory && path.isAbsolute(directory), "Supply the installed binary directory");
+const binary = (name) => path.join(directory, `${name}${process.platform === "win32" ? ".exe" : ""}`);
+const home = await mkdtemp(path.join(os.tmpdir(), "tauri-sidecars-"));
+const env = { ...process.env, PRIVATE_AI_GATEWAY_HOME: home, ACI_API_KEY: "", NO_PROXY: "127.0.0.1,localhost", no_proxy: "127.0.0.1,localhost" };
+const requests = [];
+// A deliberately unavailable loopback service: no quote verification can fetch
+// collateral, and none of the commands may progress to inference or sessions.
+const server = createServer((request, response) => {
+  requests.push(new URL(request.url, "http://localhost").pathname);
+  response.writeHead(503, { "Content-Type": "application/json" });
+  response.end(JSON.stringify({ error: "local fixture unavailable" }));
+});
+
+function run(name, args, expected) {
+  return new Promise((resolve, reject) => {
+    execFile(binary(name), args, { env, timeout: 20_000, maxBuffer: 1_048_576 }, (error, stdout, stderr) => {
+      try {
+        assert.equal(error?.code ?? 0, expected, `${name}: unexpected exit (${stderr})`);
+        resolve(stdout);
+      } catch (failure) {
+        reject(failure);
+      }
+    });
+  });
+}
+
+try {
+  const fixture = fileURLToPath(new URL("../../../tests/fixtures/aci_report_fixture.json", import.meta.url));
+  const nonce = "cd20088d763605cf78564e5b35524ad52715419624b76e029582a3652758708d";
+  const audit = JSON.parse(await run("aci", ["audit", "--report", fixture, "--nonce", nonce, "--json"], 1));
+  assert.equal(audit.verdict.verified, false);
+  assert.ok(audit.checks.some((check) => check.id === "id-1" && check.status !== "pass"));
+  assert.ok(audit.checks.some((check) => check.id === "id-2" && check.status === "pass"));
+  const malformed = path.join(home, "malformed.json");
+  await writeFile(malformed, "{", { mode: 0o600 });
+  await run("aci", ["audit", "--report", malformed, "--json"], 1);
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const url = `http://127.0.0.1:${address.port}`;
+  for (const command of ["verify", "sessions", "send"]) {
+    await run("aci", [command, url, "--json"], 1);
+  }
+  const events = (await run("aci", ["serve", url, "--json-events", "--listen", "127.0.0.1:0", "--control", "127.0.0.1:0"], 1))
+    .trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  assert.ok(events.some((event) => event.type === "fatal"));
+  assert.ok(events.every((event) => event.type !== "ready"));
+  assert.deepEqual(requests, Array(4).fill("/v1/aci/attestation"));
+  console.log("Installed ACI: offline audit, malformed input, verify/sessions/send/serve fail-closed checks passed");
+
+  const tokens = path.join(home, ".private-ai-gateway", "agent-tokens");
+  await mkdir(tokens, { recursive: true, mode: 0o700 });
+  for (const agent of ["codex", "claude-code", "opencode", "pi", "hermes"]) {
+    await run("private-ai-gateway-helper", ["--agent-token", agent], 1);
+    // Synthetic local token fixture, not a provider credential or a claim that
+    // a verified agent connection has been established.
+    const token = `smoke-local-token-${agent}`;
+    const tokenPath = path.join(tokens, agent);
+    await writeFile(tokenPath, token, { mode: 0o600, flag: "wx" });
+    assert.equal(await run("private-ai-gateway-helper", ["--agent-token", agent], 0), token);
+    assert.equal(await readFile(tokenPath, "utf8"), token);
+    await rm(tokenPath);
+    await run("private-ai-gateway-helper", ["--agent-token", agent], 1);
+  }
+  await run("private-ai-gateway-helper", ["--agent-token", "unknown-agent"], 1);
+  console.log("Installed helper: five isolated token reads and missing/deleted/unknown-agent failures passed");
+} finally {
+  server.closeAllConnections();
+  await new Promise((resolve, reject) => server.close((error) => {
+    if (error && error.code !== "ERR_SERVER_NOT_RUNNING") reject(error);
+    else resolve();
+  }));
+  await rm(home, { recursive: true, force: true });
+}

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3422,6 +3422,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 name = "private-ai-gateway-desktop"
 version = "0.1.0"
 dependencies = [
+ "auto-launch 0.5.0",
  "auto-launch 0.6.0",
  "objc2",
  "objc2-app-kit",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -293,6 +293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-launch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17918dba7ecf78b9a14507ec9f984e7977d13fad87dc86d61038980a45d128cf"
+dependencies = [
+ "dirs 6.0.0",
+ "os_info",
+ "smappservice-rs",
+ "thiserror 2.0.20",
+ "windows-registry",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +639,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -2701,6 +2721,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3027,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3132,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3351,6 +3422,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 name = "private-ai-gateway-desktop"
 version = "0.1.0"
 dependencies = [
+ "auto-launch 0.6.0",
  "objc2",
  "objc2-app-kit",
  "private-ai-gateway-desktop-gateway",
@@ -3379,6 +3451,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "fd-lock",
  "futures-util",
@@ -4330,6 +4403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-service-management",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,7 +4815,7 @@ version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
 dependencies = [
- "auto-launch",
+ "auto-launch 0.5.0",
  "serde",
  "serde_json",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,7 +25,6 @@ semver = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 tauri = { version = "2.11.5", features = ["image-png", "tray-icon"] }
 tauri-plugin-clipboard-manager = "2.3.3"
-tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2.7.3"
 tauri-plugin-opener = "2.5.5"
 tauri-plugin-shell = "2.3.6"
@@ -34,9 +33,13 @@ tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 tokio = { version = "1", features = ["sync", "time"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+auto-launch = "0.6"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication"] }
+tauri-plugin-autostart = "2.5.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,8 +33,11 @@ tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 tokio = { version = "1", features = ["sync", "time"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 auto-launch = "0.6"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+auto-launch-windows = { package = "auto-launch", version = "0.5.0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/apps/desktop/src-tauri/src/autostart.rs
+++ b/apps/desktop/src-tauri/src/autostart.rs
@@ -9,6 +9,8 @@ mod platform {
     use std::path::Path;
 
     use auto_launch::{AutoLaunch, AutoLaunchBuilder};
+    #[cfg(target_os = "windows")]
+    use auto_launch_windows as auto_launch;
     use tauri::{AppHandle, Manager};
 
     pub struct ManagerState(AutoLaunch);
@@ -53,8 +55,6 @@ mod platform {
             .set_args(&[crate::AUTOSTART_ARG]);
         #[cfg(target_os = "linux")]
         builder.set_linux_launch_mode(auto_launch::LinuxLaunchMode::XdgAutostart);
-        #[cfg(target_os = "windows")]
-        builder.set_windows_enable_mode(auto_launch::WindowsEnableMode::CurrentUser);
         builder.build()
     }
 

--- a/apps/desktop/src-tauri/src/autostart.rs
+++ b/apps/desktop/src-tauri/src/autostart.rs
@@ -18,7 +18,11 @@ mod platform {
     pub fn setup(app: &AppHandle) -> Result<(), auto_launch::Error> {
         let executable = std::env::current_exe()?;
         #[cfg(target_os = "linux")]
-        let executable = app.env().appimage.unwrap_or(executable);
+        let executable = app
+            .env()
+            .appimage
+            .map(std::path::PathBuf::from)
+            .unwrap_or(executable);
         app.manage(ManagerState(build(
             app.package_info().name.as_str(),
             &executable,

--- a/apps/desktop/src-tauri/src/autostart.rs
+++ b/apps/desktop/src-tauri/src/autostart.rs
@@ -1,0 +1,195 @@
+#[cfg(target_os = "macos")]
+use tauri::AppHandle;
+
+#[cfg(target_os = "macos")]
+use tauri_plugin_autostart::ManagerExt;
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+mod platform {
+    use std::path::Path;
+
+    use auto_launch::{AutoLaunch, AutoLaunchBuilder};
+    use tauri::{AppHandle, Manager};
+
+    pub struct ManagerState(AutoLaunch);
+
+    pub fn setup(app: &AppHandle) -> Result<(), auto_launch::Error> {
+        let executable = std::env::current_exe()?;
+        #[cfg(target_os = "linux")]
+        let executable = app.env().appimage.unwrap_or(executable);
+        app.manage(ManagerState(build(
+            app.package_info().name.as_str(),
+            &executable,
+        )?));
+        Ok(())
+    }
+
+    pub fn is_enabled(app: &AppHandle) -> Result<bool, String> {
+        #[cfg(target_os = "linux")]
+        validate_linux_home(app)?;
+        app.state::<ManagerState>()
+            .0
+            .is_enabled()
+            .map_err(|error| error.to_string())
+    }
+
+    pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+        #[cfg(target_os = "linux")]
+        validate_linux_home(app)?;
+        let manager = app.state::<ManagerState>();
+        if enabled {
+            manager.0.enable()
+        } else {
+            manager.0.disable()
+        }
+        .map_err(|error| error.to_string())
+    }
+
+    fn build(app_name: &str, executable: &Path) -> Result<AutoLaunch, auto_launch::Error> {
+        let mut builder = AutoLaunchBuilder::new();
+        builder
+            .set_app_name(app_name)
+            .set_app_path(&launch_path(executable)?)
+            .set_args(&[crate::AUTOSTART_ARG]);
+        #[cfg(target_os = "linux")]
+        builder.set_linux_launch_mode(auto_launch::LinuxLaunchMode::XdgAutostart);
+        #[cfg(target_os = "windows")]
+        builder.set_windows_enable_mode(auto_launch::WindowsEnableMode::CurrentUser);
+        builder.build()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn launch_path(path: &Path) -> Result<String, auto_launch::Error> {
+        Ok(windows_launch_path(path))
+    }
+
+    #[cfg(any(target_os = "windows", test))]
+    fn windows_launch_path(path: &Path) -> String {
+        format!("\"{}\"", path.display())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn launch_path(path: &Path) -> Result<String, auto_launch::Error> {
+        let path = path.to_str().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Application path is not valid UTF-8",
+            )
+        })?;
+        if path.contains('=') || path.contains('\0') {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Application path cannot contain '=' or NUL in a desktop entry",
+            )
+            .into());
+        }
+        let mut escaped = String::with_capacity(path.len() + 2);
+        escaped.push('"');
+        // Desktop entry string escaping is applied before Exec argument unquoting.
+        for character in path.chars() {
+            match character {
+                '\n' => escaped.push_str("\\n"),
+                '\r' => escaped.push_str("\\r"),
+                '\t' => escaped.push_str("\\t"),
+                '\\' => escaped.push_str("\\\\\\\\"),
+                '"' => escaped.push_str("\\\\\\\""),
+                '`' => escaped.push_str("\\\\`"),
+                '$' => escaped.push_str("\\\\$"),
+                '%' => escaped.push_str("%%"),
+                _ => escaped.push(character),
+            }
+        }
+        escaped.push('"');
+        Ok(escaped)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn validate_linux_home(app: &AppHandle) -> Result<(), String> {
+        let home = app
+            .path()
+            .home_dir()
+            .map_err(|error| format!("Cannot locate the user home directory: {error}"))?;
+        validate_home_path(&home)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn validate_home_path(path: &Path) -> Result<(), String> {
+        if path.is_absolute() {
+            Ok(())
+        } else {
+            Err("Cannot use a relative home directory for Open at Login".to_string())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn escapes_linux_desktop_exec_path() {
+            let cases = [
+                (
+                    "/usr/bin/private-ai-gateway-desktop",
+                    r#""/usr/bin/private-ai-gateway-desktop""#,
+                ),
+                (
+                    "/opt/Private AI Gateway/app",
+                    r#""/opt/Private AI Gateway/app""#,
+                ),
+                (
+                    r#"/opt/$cash/`tick`/back\slash/quo"te/%app"#,
+                    r#""/opt/\\$cash/\\`tick\\`/back\\\\slash/quo\\\"te/%%app""#,
+                ),
+            ];
+
+            for (path, expected) in cases {
+                assert_eq!(launch_path(Path::new(path)).unwrap(), expected);
+            }
+            assert!(launch_path(Path::new("/opt/app=name")).is_err());
+            assert!(launch_path(Path::new("/opt/app\0name")).is_err());
+            assert_eq!(
+                launch_path(Path::new("/opt/line\nreturn\rtab\tapp")).unwrap(),
+                r#""/opt/line\nreturn\rtab\tapp""#
+            );
+        }
+
+        #[test]
+        fn quotes_windows_startup_path() {
+            assert_eq!(
+                windows_launch_path(Path::new(
+                    r"C:\Program Files\Private AI Gateway\private-ai-gateway-desktop.exe"
+                )),
+                r#""C:\Program Files\Private AI Gateway\private-ai-gateway-desktop.exe""#
+            );
+        }
+
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn requires_absolute_linux_home() {
+            assert!(validate_home_path(Path::new("/home/user")).is_ok());
+            assert!(validate_home_path(Path::new("relative/home")).is_err());
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub use platform::{is_enabled, set_enabled, setup};
+
+#[cfg(target_os = "macos")]
+pub fn is_enabled(app: &AppHandle) -> Result<bool, String> {
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    let manager = app.autolaunch();
+    if enabled {
+        manager.enable()
+    } else {
+        manager.disable()
+    }
+    .map_err(|error| error.to_string())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod autostart;
 mod menu;
 mod native_dialog;
 mod runtime_adapter;
@@ -23,7 +24,6 @@ use desktop_runtime::{
 };
 use runtime_adapter::TauriSidecarLauncher;
 use tauri::{AppHandle, Emitter, Manager, State, WindowEvent};
-use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_clipboard_manager::ClipboardExt;
 
 pub(crate) async fn run_blocking<T: Send + 'static>(
@@ -54,10 +54,7 @@ async fn get_launch_preferences(app: AppHandle) -> Result<LaunchPreferences, Str
 
 fn load_launch_preferences(app: &AppHandle) -> Result<LaunchPreferences, String> {
     Ok(LaunchPreferences {
-        open_at_login: app
-            .autolaunch()
-            .is_enabled()
-            .map_err(|error| error.to_string())?,
+        open_at_login: autostart::is_enabled(app)?,
         connect_on_launch: desktop_runtime::preferences::load()?.connect_on_launch,
     })
 }
@@ -403,14 +400,16 @@ pub fn run() {
     let launcher = Arc::new(TauriSidecarLauncher::default());
     let launcher_for_setup = launcher.clone();
 
-    let app = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+    let app =
+        tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tray::show_window(app);
-        }))
-        .plugin(tauri_plugin_autostart::init(
-            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            Some(vec![AUTOSTART_ARG]),
-        ))
+        }));
+    #[cfg(target_os = "macos")]
+    let app = app.plugin(tauri_plugin_autostart::init(
+        tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+        Some(vec![AUTOSTART_ARG]),
+    ));
+    let app = app
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
@@ -466,6 +465,8 @@ pub fn run() {
             disconnect_all_agents
         ])
         .setup(move |app| {
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            autostart::setup(app.handle())?;
             if let Ok(preferences) = desktop_runtime::preferences::load() {
                 apply_appearance(app.handle(), preferences.appearance);
             }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -7,7 +7,6 @@ use tauri::{
     tray::TrayIconBuilder,
     AppHandle, Emitter, Manager, Wry,
 };
-use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_clipboard_manager::ClipboardExt;
 
 use desktop_gateway::agents::{Agent, AgentStatus, ConnectOptions};
@@ -40,7 +39,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .enabled(false)
         .build(app)?;
     let autostart = CheckMenuItemBuilder::with_id("autostart", "Open at Login")
-        .checked(app.autolaunch().is_enabled().unwrap_or(false))
+        .checked(crate::autostart::is_enabled(app).unwrap_or(false))
         .build(app)?;
     let endpoint = MenuItemBuilder::with_id("copy-endpoint", "Copy Local API Endpoint")
         .enabled(false)
@@ -340,12 +339,8 @@ fn sync_autostart(app: &AppHandle) {
 }
 
 pub fn set_open_at_login(app: &AppHandle, enabled: bool) -> Result<(), String> {
-    if enabled {
-        app.autolaunch().enable()
-    } else {
-        app.autolaunch().disable()
-    }
-    .map_err(|error| format!("Open at Login could not be changed: {error}"))?;
+    crate::autostart::set_enabled(app, enabled)
+        .map_err(|error| format!("Open at Login could not be changed: {error}"))?;
     if let Some(menu) = app.try_state::<TrayMenu>() {
         let _ = menu.autostart.set_checked(enabled);
     }


### PR DESCRIPTION
## Base And Scope

Stacked on #177 (`feat/private-ai-gateway-native-clients`), based on `d0e2477fcf78f5f4cf7706d90d04405481f44a6e`. Replaces #179, which was based on superseded #174.

This is a semantic port, not a merge of the old desktop implementation. The current Luma UI, native interactions, updater, signed release channels, window state, protection-scoped connections, and live Local API reconfiguration are preserved.

## Missing Fixes Ported

- Windows home/Hermes path resolution and Pi/Hermes credential commands; exact legacy Windows Pi detection requires explicit reconnect without rewriting user files.
- Windows token revocation clears and flushes the regular file before removal; empty tombstones cannot restore the old capability.
- Internal ACI HTTP requests bypass system/environment proxies and fail explicitly if client initialization fails.
- Local API changes require the primary instance. Failed client-key rotation cannot reload a readable stale key.
- Autostart executable quoting and Linux desktop-entry escaping. Windows retains the current-user-only library backend; macOS retains its existing LaunchAgent plugin.

## Existing Fixes Retained

#177 already preserves requests when tokens are unchanged, invalidates the renderer client-key cache after failed rotation, serializes lifecycle/configuration operations, and supports live listener replacement. Those implementations are retained rather than replaced with #179's older behavior.

Provider credentials remain in the system credential store. Local client/agent tokens remain restricted user files for helper/OpenCode compatibility.

## Verification

- Gateway library: 49 passed, one OS-keyring test intentionally ignored locally.
- Runtime library: 19 passed.
- Windows gateway test code: cross-compilation check passed; not an installed Windows execution result.
- Rust formatting, whitespace, Node script syntax, and workflow actionlint checks passed.
- Current workflow extended with Windows library and installed NSIS/DEB sidecar/keyring checks. Release/update publishing logic is unchanged.
- UI execution is manual opt-in only. No UI test or production release was run during this port.

Fresh CI on this base is required; the old #179 green runs do not validate #177.

## Remaining Boundary

The existing AppImage helper path still follows the temporary mount. Stable helper persistence for AppImage remains a separate issue; this port does not remove or rewrite #177's AppImage/update release mechanism. Installed-package checks here cover NSIS and DEB, not AppImage behavior or real-provider inference.

No merge requested.
