### PR TITLE
Improve pag CLI discovery, profile workflows and reviewed automation

### DIFF
--- a/apps/desktop/BACKEND-CLI-REFACTOR.md
+++ b/apps/desktop/BACKEND-CLI-REFACTOR.md
@@ -17,6 +17,9 @@ native clients or their stdio runtime.
 
 ## Commands
 
+See the [CLI guide](CLI.md) for human and automated workflows, command discovery,
+confirmation rules, output contracts and desktop-only boundaries.
+
 ```sh
 pag status --json
 pag status --watch --json

--- a/apps/desktop/CLI.md
+++ b/apps/desktop/CLI.md
@@ -29,6 +29,13 @@ start protection. `start` waits for verified protection. `stop` stops protection
 and restores managed agent configuration but keeps management available.
 `service stop` shuts down the backend. Closing the desktop app does not stop it.
 
+Human `status` summarizes the backend PID/version, active profile and service,
+saved credential presence (not unlock status), Local API exposure, production OS
+policy, TEE identity/checks, catalog size and current-session usage. Retained
+catalogs are labeled cached when protection is inactive. Reported costs are
+session totals, not a billing reconciliation. Request contents and tokens are
+never included in this summary. `--json` retains the full existing state shape.
+
 Read-only commands do not start a missing backend. A successful `status` means
 the query succeeded, not that protection is active: inspect `gateway.status`
 and `gateway.configurationVerification` in JSON. Connection and configuration

--- a/apps/desktop/CLI.md
+++ b/apps/desktop/CLI.md
@@ -1,0 +1,112 @@
+# PAG CLI
+
+`pag` manages the same per-user backend as the desktop app. It does not require
+an open window. Installations must keep `pag`, `pag-service`, `aci`, and the
+credential helper together; see [distribution](CLI-DISTRIBUTION.md).
+
+## Discover Commands
+
+Start with `pag --help` and `<command> --help`. `pag schema` prints the command
+tree as JSON, derived from the same Clap definitions used for parsing. It is a
+discovery document, not an RPC or response JSON Schema.
+
+`pag completions bash` prints shell completion code without installing it or
+changing shell configuration. Other supported shells are listed in its help.
+
+## Lifecycle
+
+```sh
+pag service start
+pag profiles list
+pag start --profile work --timeout 90
+pag status
+pag stop
+pag service stop --yes
+```
+
+`service start` starts the management backend; saved `connectOnLaunch` may also
+start protection. `start` waits for verified protection. `stop` stops protection
+and restores managed agent configuration but keeps management available.
+`service stop` shuts down the backend. Closing the desktop app does not stop it.
+
+Read-only commands do not start a missing backend. A successful `status` means
+the query succeeded, not that protection is active: inspect `gateway.status`
+and `gateway.configurationVerification` in JSON. Connection and configuration
+states do not by themselves establish a verified inference session.
+
+## Profiles And Credentials
+
+```sh
+pag profiles show work
+pag profiles edit work --name "Work gateway"
+pag profiles edit work --require-production-os
+pag profiles verify work
+pag profiles export --output profiles.json
+pag profiles import profiles.json --yes
+```
+
+Adding, editing and verifying a profile use the backend's verification and
+credential-storage policy. Verification can change the active profile and
+restart protection; it is not a read-only probe. Credentials use a hidden prompt
+or explicit `--key-stdin`. Never pass a credential as an argument. Changing a
+service URL requires a credential for that destination, not implicit forwarding
+of the old one. Exported profiles do not contain credentials.
+
+`--key-stdin` is for a pipe or redirected file, not a terminal. The production
+OS requirement is a shared current policy, not a separate preference per profile;
+`edit --require-production-os` restores the strict policy.
+
+## Automation
+
+Use `--json --non-interactive` for data and `--yes` only for changes you intend
+to approve. These flags are independent: JSON and non-interactive mode never
+imply consent. Results go to stdout; failures go to stderr. Watch mode emits
+one JSON snapshot per line. Human-readable output is not a parsing contract.
+
+For reviewed agent changes, obtain a preview first:
+
+```sh
+pag --json agents connect codex --model MODEL --dry-run
+pag --json --yes agents connect codex --model MODEL --revision REVISION
+```
+
+Use the returned revision with the same agent, direction and options. A changed
+configuration is rejected rather than silently re-previewed and approved.
+Do not automatically retry mutations after a timeout or lost connection: they
+may have completed. Query state before deciding what to do next.
+
+Exit status is `0` for successful execution, `2` for invalid command arguments,
+and `1` for operation failures. With `--json`, failures have an `error` object
+with `code` and `message`. Argument errors use `invalid_arguments`; operation
+errors currently use `command_failed`. Do not classify failures by parsing
+human message text or assume all failures are retryable.
+
+`doctor` reports every independent check, even when some fail. In that case it
+prints the partial report on stdout and exits nonzero; the `errors` object
+identifies failed checks. `credentialPolicy` describes policy, not an actual
+credential-store unlock probe.
+
+## Coverage
+
+| Core capability | CLI |
+| --- | --- |
+| Backend and protection lifecycle | `service`, `start`, `stop`, `status --watch` |
+| Profile inspection, verification and selection | `profiles list/show/add/edit/verify/use/remove` |
+| Credential replacement and removal | `profiles verify --key-stdin`, `token clear-credential` |
+| Agent configuration review and restoration | `agents list/connect/disconnect/disconnect-all` |
+| Verified model catalog | `models list --refresh` |
+| Usage, filtering, pagination, CSV and deletion | `usage list/show/export/clear` |
+| Shared preferences and Local API settings | `settings show/set` |
+| Local inference token | `token show/rotate` |
+| Configuration backups and redacted diagnostics | `profiles import/export`, `diagnostics` |
+| CLI registration and app opening | `cli status/install/uninstall`, `app open` |
+| Installation and connection diagnostics | `doctor` |
+
+Usage time filters are Unix seconds. List pagination uses `--cursor` and
+`--limit`; CSV export covers all records matching its filters, not just the
+currently displayed page. Exports refuse existing destination files.
+
+OS login startup, notification permissions and installer-based app updates stay
+in the desktop UI or OS installer. Shared notification preferences are available
+through `settings`; they do not grant OS notification permission. CLI-only use
+still requires an accessible OS credential store. There is no plaintext fallback.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -330,6 +330,8 @@ Closing or quitting only the desktop UI leaves protection and the backend runnin
 use Stop All and Quit or `pag --yes service stop` to shut down both.
 
 Ordinary CLI output uses short status summaries, lists, and operation results.
+See the [CLI guide](CLI.md) for command discovery, profile editing, reviewed
+agent changes and a core-capability coverage matrix.
 For automation, use `pag --json --non-interactive <command>`. JSON mode never
 prompts; successful results go to stdout, structured errors to stderr.
 `status --watch --json` emits one JSON object per line. Argument errors exit

--- a/apps/desktop/gateway/src/agents.rs
+++ b/apps/desktop/gateway/src/agents.rs
@@ -1173,6 +1173,8 @@ impl Projector {
                 },
             ),
             revision: revision(
+                agent,
+                connect,
                 path.as_deref().ok(),
                 text.as_deref(),
                 store.get(agent.id()),
@@ -1197,6 +1199,8 @@ impl Projector {
             let path = self.action_path(agent, store.get(agent.id()), connect);
             let (text, read_error) = self.config_text_at(agent, &path);
             if revision(
+                agent,
+                connect,
                 path.as_deref().ok(),
                 text.as_deref(),
                 store.get(agent.id()),
@@ -2056,6 +2060,8 @@ fn merge_opencode_config(target: &mut serde_json::Value, source: serde_json::Val
 /// compared only, never logged or shown, since the text may contain
 /// credentials.
 fn revision(
+    agent: Agent,
+    connect: bool,
     path: Option<&Path>,
     text: Option<&str>,
     record: Option<&Connection>,
@@ -2067,6 +2073,8 @@ fn revision(
         hasher.update((bytes.len() as u64).to_be_bytes());
         hasher.update(bytes);
     };
+    part(agent.id().as_bytes());
+    part(&[u8::from(connect)]);
     part(path.map_or(&[][..], |path| path.as_os_str().as_encoded_bytes()));
     part(text.unwrap_or_default().as_bytes());
     part(
@@ -4210,6 +4218,18 @@ mod tests {
             .projector
             .preview(Agent::ClaudeCode, true, Some(&catalog), &claude_options())
             .unwrap();
+        let error = sandbox
+            .projector
+            .apply(
+                Agent::ClaudeCode,
+                false,
+                &preview.revision,
+                Some(&catalog),
+                &claude_options(),
+            )
+            .unwrap_err();
+        assert!(error.contains("changed since the preview"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"model": "opus"}"#);
         write(&path, r#"{"model": "sonnet"}"#);
         let error = sandbox
             .projector

--- a/apps/desktop/runtime/Cargo.lock
+++ b/apps/desktop/runtime/Cargo.lock
@@ -455,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1563,7 @@ name = "private-ai-gateway-desktop-runtime"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "futures-util",
  "libc",
  "netwatcher",

--- a/apps/desktop/runtime/Cargo.toml
+++ b/apps/desktop/runtime/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin/pag-service.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+tempfile = "3"
 rpassword = "7"
 desktop-gateway = { package = "private-ai-gateway-desktop-gateway", path = "../gateway" }
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -34,7 +36,6 @@ netwatcher = "0.8"
 libc = "0.2"
 socket2 = "0.6"
 rustix = { version = "1", features = ["process"] }
-tempfile = "3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 futures-util = "0.3"
@@ -44,5 +45,4 @@ zbus = { version = "5", default-features = false, features = ["tokio"] }
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Power", "Win32_System_Threading", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging", "Win32_System_Environment"] }
 
 [dev-dependencies]
-tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }

--- a/apps/desktop/runtime/src/bin/pag.rs
+++ b/apps/desktop/runtime/src/bin/pag.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser};
 use desktop_runtime::{
     client::Client,
     contracts::*,
@@ -13,241 +13,16 @@ use desktop_runtime::{
     usage::UsageQuery,
 };
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
+#[path = "pag/args.rs"]
+mod args;
 #[path = "pag/output.rs"]
 mod human;
+#[path = "pag/schema.rs"]
+mod schema;
 
-#[derive(Parser)]
-#[command(name = "pag", version = desktop_runtime::protocol::BUILD_VERSION, about = "Control the Private AI Gateway backend")]
-struct Cli {
-    #[arg(long, global = true)]
-    json: bool,
-    #[arg(
-        long,
-        visible_alias = "no-interactive",
-        global = true,
-        help = "Never prompt; use --yes to approve changes and --key-stdin for credentials"
-    )]
-    non_interactive: bool,
-    #[arg(
-        long,
-        global = true,
-        help = "Confirm configuration changes without prompting"
-    )]
-    yes: bool,
-    #[command(subcommand)]
-    command: Action,
-}
-
-#[derive(Subcommand)]
-enum Action {
-    Status {
-        #[arg(long)]
-        watch: bool,
-    },
-    Start {
-        #[arg(long)]
-        profile: Option<String>,
-        #[arg(long, default_value_t = 90, value_parser = clap::value_parser!(u64).range(1..=300))]
-        timeout: u64,
-    },
-    Stop,
-    Service {
-        #[command(subcommand)]
-        command: Service,
-    },
-    Profiles {
-        #[command(subcommand)]
-        command: Profiles,
-    },
-    Agents {
-        #[command(subcommand)]
-        command: Agents,
-    },
-    Models {
-        #[command(subcommand)]
-        command: Models,
-    },
-    Usage {
-        #[command(subcommand)]
-        command: Usage,
-    },
-    Settings {
-        #[command(subcommand)]
-        command: Settings,
-    },
-    Token {
-        #[command(subcommand)]
-        command: Token,
-    },
-    Cli {
-        #[command(subcommand)]
-        command: Registration,
-    },
-    App {
-        #[command(subcommand)]
-        command: App,
-    },
-    Doctor,
-    Diagnostics {
-        #[arg(long)]
-        output: PathBuf,
-    },
-}
-
-#[derive(Subcommand)]
-enum Service {
-    Start,
-    Stop,
-    Status,
-}
-#[derive(Subcommand)]
-enum App {
-    Open,
-}
-#[derive(Subcommand)]
-enum Registration {
-    Status,
-    Install {
-        #[arg(long)]
-        directory: Option<PathBuf>,
-    },
-    Uninstall {
-        #[arg(long)]
-        directory: Option<PathBuf>,
-    },
-}
-#[derive(Subcommand)]
-enum Token {
-    Rotate,
-    Show,
-    ClearCredential,
-}
-#[derive(Subcommand)]
-enum Models {
-    List {
-        #[arg(long)]
-        refresh: bool,
-    },
-}
-
-#[derive(Clone, Copy, ValueEnum)]
-enum Provider {
-    Phala,
-    Redpill,
-    Custom,
-}
-#[derive(Subcommand)]
-enum Profiles {
-    List,
-    Import {
-        file: PathBuf,
-    },
-    Export {
-        #[arg(long)]
-        output: PathBuf,
-    },
-    Add {
-        #[arg(long)]
-        id: String,
-        #[arg(long)]
-        name: String,
-        #[arg(long)]
-        url: String,
-        #[arg(long, value_enum, default_value_t = Provider::Custom)]
-        provider: Provider,
-        #[arg(long)]
-        key_stdin: bool,
-        #[arg(long)]
-        allow_development_os: bool,
-    },
-    Verify {
-        id: String,
-        #[arg(long)]
-        key_stdin: bool,
-    },
-    Use {
-        id: String,
-    },
-    Remove {
-        id: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum Agents {
-    List,
-    Connect {
-        id: String,
-        #[arg(long)]
-        model: Option<String>,
-        #[arg(long)]
-        dry_run: bool,
-    },
-    Disconnect {
-        id: String,
-        #[arg(long)]
-        dry_run: bool,
-    },
-    DisconnectAll,
-}
-
-#[derive(Args)]
-struct Filter {
-    #[arg(long)]
-    agent: Option<String>,
-    #[arg(long)]
-    model: Option<String>,
-    #[arg(long)]
-    session: Option<String>,
-    #[arg(long)]
-    since: Option<u64>,
-    #[arg(long)]
-    until: Option<u64>,
-    #[arg(long)]
-    cursor: Option<String>,
-    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u64).range(1..=100))]
-    limit: u64,
-}
-impl From<Filter> for UsageQuery {
-    fn from(filter: Filter) -> Self {
-        Self {
-            agent: filter.agent,
-            model: filter.model,
-            session_id: filter.session,
-            since: filter.since,
-            until: filter.until,
-            cursor: filter.cursor,
-            limit: Some(filter.limit as usize),
-        }
-    }
-}
-#[derive(Subcommand)]
-enum Usage {
-    List {
-        #[command(flatten)]
-        filter: Filter,
-    },
-    Show {
-        id: String,
-    },
-    Export {
-        #[command(flatten)]
-        filter: Filter,
-        #[arg(long)]
-        output: PathBuf,
-        #[arg(long, default_value = "csv", value_parser = ["csv"])]
-        format: String,
-    },
-    Clear,
-}
-
-#[derive(Subcommand)]
-enum Settings {
-    Show,
-    Set { key: String, value: String },
-}
+use args::*;
 
 fn main() {
     let args: Vec<_> = std::env::args_os().collect();
@@ -268,26 +43,66 @@ fn main() {
         Err(error) => error.exit(),
     };
     if let Err(error) = execute(&cli) {
-        if error == "Output pipe closed" {
-            return;
-        }
         if cli.json {
             eprintln!(
                 "{}",
                 json!({"error": {"code": "command_failed", "message": error}})
             );
         } else {
-            eprintln!("pag: {error}");
+            eprintln!("pag: {}", human::safe(&error));
         }
         std::process::exit(1);
     }
 }
 
 fn execute(cli: &Cli) -> Result<(), String> {
+    match &cli.command {
+        Action::Completions { shell } => {
+            let mut command = Cli::command();
+            let name = command.get_name().to_owned();
+            let mut completion = Vec::new();
+            clap_complete::generate(*shell, &mut command, name, &mut completion);
+            return finish_output(write_bytes(&completion));
+        }
+        Action::Schema => {
+            let mut command = Cli::command();
+            command.build();
+            return finish_output(write_text(
+                &serde_json::to_string(&schema::command(&command))
+                    .map_err(|_| "Cannot encode command schema")?,
+            ));
+        }
+        _ => {}
+    }
     let client = Client::new();
     let result = match &cli.command {
         Action::Status { watch: true } => {
-            return Client::watch_connection(|state| output(&state, cli).is_ok());
+            let mut previous = None;
+            let mut output_error = None;
+            let watched = Client::watch_connection(|state| {
+                let text = match render_output(&state, cli) {
+                    Ok(text) => text,
+                    Err(error) => {
+                        output_error = Some(OutputError::Message(error));
+                        return false;
+                    }
+                };
+                if !cli.json && previous.as_ref() == Some(&text) {
+                    return true;
+                }
+                previous = Some(text.clone());
+                match write_text(&text) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        output_error = Some(error);
+                        false
+                    }
+                }
+            });
+            return match output_error {
+                Some(error) => finish_output(Err(error)),
+                None => watched,
+            };
         }
         Action::Status { watch: false }
         | Action::Service {
@@ -367,6 +182,14 @@ fn execute(cli: &Cli) -> Result<(), String> {
         Action::Profiles { command } => {
             match command {
                 Profiles::List => value(client.state()?.profiles)?,
+                Profiles::Show { id } => value(
+                    client
+                        .state()?
+                        .profiles
+                        .into_iter()
+                        .find(|profile| profile.id == *id)
+                        .ok_or("Profile not found")?,
+                )?,
                 Profiles::Import { file } => {
                     let backup = desktop_runtime::maintenance::ProfileBackup::read(file)?;
                     confirm(
@@ -409,6 +232,10 @@ fn execute(cli: &Cli) -> Result<(), String> {
                     };
                     // Validate before reading a credential or making a request.
                     desktop_runtime::service_config::resolve_profile(profile.clone(), None)?;
+                    confirm(
+                        cli,
+                        "Verify and save this profile? This selects it as active and may restart protection.",
+                    )?;
                     Client::ensure_service()?;
                     if client.state()?.profiles.iter().any(|saved| saved.id == *id) {
                         return Err("Profile ID already exists. Use profiles verify to update its credential.".into());
@@ -427,6 +254,10 @@ fn execute(cli: &Cli) -> Result<(), String> {
                         .into_iter()
                         .find(|profile| profile.id == *id)
                         .ok_or("Profile not found")?;
+                    confirm(
+                        cli,
+                        "Verify and save this profile? This selects it as active and may restart protection.",
+                    )?;
                     let key = if *key_stdin
                         || !profile
                             .credential_saved
@@ -447,16 +278,81 @@ fn execute(cli: &Cli) -> Result<(), String> {
                         key,
                     })?
                 }
+                Profiles::Edit {
+                    id,
+                    name,
+                    url,
+                    provider,
+                    key_stdin,
+                    allow_development_os,
+                    require_production_os,
+                } => {
+                    let state = client.state()?;
+                    let saved = state
+                        .profiles
+                        .iter()
+                        .find(|profile| profile.id == *id)
+                        .ok_or("Profile not found")?;
+                    let profile = ConfidentialProfileInput {
+                        id: saved.id.clone(),
+                        name: name.clone().unwrap_or_else(|| saved.name.clone()),
+                        provider: provider
+                            .map(service_provider)
+                            .unwrap_or_else(|| saved.provider.clone()),
+                        remote_url: url.clone().unwrap_or_else(|| saved.remote_url.clone()),
+                    };
+                    let resolved =
+                        desktop_runtime::service_config::resolve_profile(profile.clone(), None)?;
+                    let target_changed = resolved.provider != saved.provider
+                        || resolved.remote_url != saved.remote_url;
+                    let credential_saved = saved
+                        .credential_saved
+                        .unwrap_or(saved.verified_at.is_some());
+                    confirm(
+                        cli,
+                        "Verify and save these profile changes? This selects the profile as active and may restart protection.",
+                    )?;
+                    let key = if *key_stdin || target_changed || !credential_saved {
+                        Some(read_key(cli, *key_stdin)?)
+                    } else {
+                        None
+                    };
+                    let production_os = if *allow_development_os {
+                        false
+                    } else if *require_production_os {
+                        true
+                    } else {
+                        state.config.require_production_os
+                    };
+                    client.request(Command::Verify {
+                        profile,
+                        require_production_os: production_os,
+                        key,
+                    })?
+                }
             }
         }
         Action::Agents { command } => match command {
             Agents::List => value(client.list_agents()?)?,
-            Agents::Connect { id, model, dry_run } => {
-                agent_change(&client, cli, id, true, model.clone(), *dry_run)?
-            }
-            Agents::Disconnect { id, dry_run } => {
-                agent_change(&client, cli, id, false, None, *dry_run)?
-            }
+            Agents::Connect {
+                id,
+                model,
+                dry_run,
+                revision,
+            } => agent_change(
+                &client,
+                cli,
+                id,
+                true,
+                model.clone(),
+                *dry_run,
+                revision.as_deref(),
+            )?,
+            Agents::Disconnect {
+                id,
+                dry_run,
+                revision,
+            } => agent_change(&client, cli, id, false, None, *dry_run, revision.as_deref())?,
             Agents::DisconnectAll => {
                 confirm(
                     cli,
@@ -480,14 +376,14 @@ fn execute(cli: &Cli) -> Result<(), String> {
             )?
         }
         Action::Usage { command } => match command {
-            Usage::List { filter } => value(client.query_usage(query(filter))?)?,
+            Usage::List { filter, page } => value(client.query_usage(query(filter, Some(page)))?)?,
             Usage::Show { id } => value(client.usage_record(id)?.ok_or("Usage record not found")?)?,
             Usage::Export { filter, output, .. } => {
                 let path = std::path::absolute(output).map_err(|_| "Cannot resolve export path")?;
                 if path.exists() {
                     return Err("Export target already exists; choose a new path.".into());
                 }
-                value(json!({"rows": client.export_usage_csv(query(filter), path)?}))?
+                value(json!({"rows": client.export_usage_csv(query(filter, None), path)?}))?
             }
             Usage::Clear => {
                 confirm(cli, "Permanently clear all usage history?")?;
@@ -501,17 +397,17 @@ fn execute(cli: &Cli) -> Result<(), String> {
                 }
                 Settings::Set { key, value: input } => {
                     confirm(cli, "Change gateway settings?")?;
-                    match key.as_str() {
-                    "autoCliRegistration" => value(
+                    match key {
+                    SettingsKey::AutoCliRegistration => value(
                         client.set_preference(Preference::AutoCliRegistration(parse_bool(input)?))?,
                     )?,
-                    "notifications" => value(client.set_preference(Preference::Notifications(
+                    SettingsKey::Notifications => value(client.set_preference(Preference::Notifications(
                         serde_json::from_str(input).map_err(|_| "Expected notification settings as a JSON object with boolean values")?
                     ))?)?,
-                    "connectOnLaunch" => value(
+                    SettingsKey::ConnectOnLaunch => value(
                         client.set_preference(Preference::ConnectOnLaunch(parse_bool(input)?))?,
                     )?,
-                    "appearance" => value(client.set_preference(Preference::Appearance(
+                    SettingsKey::Appearance => value(client.set_preference(Preference::Appearance(
                         match input.as_str() {
                             "system" => Appearance::System,
                             "light" => Appearance::Light,
@@ -519,28 +415,31 @@ fn execute(cli: &Cli) -> Result<(), String> {
                             _ => return Err("Expected system, light, or dark".into()),
                         },
                     ))?)?,
-                    "updateChannel" => value(client.set_preference(Preference::UpdateChannel(
+                    SettingsKey::UpdateChannel => value(client.set_preference(Preference::UpdateChannel(
                         match input.as_str() {
                             "beta" => UpdateChannel::Beta,
                             "stable" => UpdateChannel::Stable,
                             _ => return Err("Expected beta or stable".into()),
                         },
                     ))?)?,
-                    _ => {
+                    SettingsKey::ListenAddress
+                    | SettingsKey::AllowNetworkAccess
+                    | SettingsKey::Port
+                    | SettingsKey::ClientHost => {
                         let mut config = client.state()?.local_api;
-                        match key.as_str() {
-                            "listenAddress" => config.listen_address = input.clone(),
-                            "allowNetworkAccess" => {
+                        match key {
+                            SettingsKey::ListenAddress => config.listen_address = input.clone(),
+                            SettingsKey::AllowNetworkAccess => {
                                 config.allow_network_access = parse_bool(input)?
                             }
-                            "port" => {
+                            SettingsKey::Port => {
                                 config.port =
                                     input.parse().map_err(|_| "Expected a valid port number")?
                             }
-                            "clientHost" => {
+                            SettingsKey::ClientHost => {
                                 config.client_host = (!input.is_empty()).then(|| input.clone())
                             }
-                            _ => return Err("Unknown setting".into()),
+                            _ => unreachable!(),
                         }
                         desktop_runtime::local_api::resolve(config.clone())?;
                         client.request(Command::SaveLocalApi(config))?
@@ -578,7 +477,15 @@ fn execute(cli: &Cli) -> Result<(), String> {
             }
         },
         Action::Doctor => {
-            json!({"version": desktop_runtime::protocol::BUILD_VERSION, "backendRunning": client.is_running()?, "cli": desktop_runtime::cli_install::status()?, "backendExecutable": desktop_runtime::launch::service_executable()?, "endpoint": desktop_runtime::transport::endpoint_path().map_err(|_| "Cannot resolve management endpoint")?, "credentialPolicy": "OS credential store; no plaintext fallback"})
+            let report = doctor(&client);
+            if report["errors"]
+                .as_object()
+                .is_some_and(|errors| !errors.is_empty())
+            {
+                finish_output(output(&report, cli))?;
+                return Err("One or more diagnostic checks failed.".into());
+            }
+            report
         }
         Action::Diagnostics { output } => {
             let path = new_export_path(output)?;
@@ -614,8 +521,9 @@ fn execute(cli: &Cli) -> Result<(), String> {
             });
             json!({"opened": true})
         }
+        Action::Completions { .. } | Action::Schema => unreachable!(),
     };
-    output(&result, cli)
+    finish_output(output(&result, cli))
 }
 
 fn new_export_path(path: &std::path::Path) -> Result<PathBuf, String> {
@@ -626,17 +534,26 @@ fn new_export_path(path: &std::path::Path) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-fn query(filter: &Filter) -> UsageQuery {
+fn query(filter: &UsageFilter, page: Option<&Pagination>) -> UsageQuery {
     UsageQuery {
         agent: filter.agent.clone(),
         model: filter.model.clone(),
         session_id: filter.session.clone(),
         since: filter.since,
         until: filter.until,
-        cursor: filter.cursor.clone(),
-        limit: Some(filter.limit as usize),
+        cursor: page.and_then(|page| page.cursor.clone()),
+        limit: page.map(|page| page.limit as usize),
     }
 }
+
+fn service_provider(provider: Provider) -> ServiceProvider {
+    match provider {
+        Provider::Phala => ServiceProvider::Phala,
+        Provider::Redpill => ServiceProvider::Redpill,
+        Provider::Custom => ServiceProvider::Custom,
+    }
+}
+
 fn agent_change(
     client: &Client,
     cli: &Cli,
@@ -644,10 +561,18 @@ fn agent_change(
     connect: bool,
     model: Option<String>,
     dry_run: bool,
+    revision: Option<&str>,
 ) -> Result<Value, String> {
     let options = ConnectOptions {
         default_model: model,
     };
+    if let Some(revision) = revision {
+        confirm(
+            cli,
+            "Apply this previously previewed agent configuration revision?",
+        )?;
+        return value(client.apply_agent(id.into(), connect, revision.into(), options)?);
+    }
     let preview = client.preview_agent(id.into(), connect, options.clone())?;
     if dry_run {
         return value(preview);
@@ -658,6 +583,50 @@ fn agent_change(
     confirm(cli, "Apply these agent configuration changes?")?;
     value(client.apply_agent(id.into(), connect, preview.revision, options)?)
 }
+
+fn doctor(client: &Client) -> Value {
+    let mut errors = Map::new();
+    let backend_running = doctor_check(&mut errors, "backendRunning", client.is_running());
+    let cli = doctor_check(&mut errors, "cli", desktop_runtime::cli_install::status());
+    let backend_executable = doctor_check(
+        &mut errors,
+        "backendExecutable",
+        desktop_runtime::launch::service_executable(),
+    );
+    let endpoint = doctor_check(
+        &mut errors,
+        "endpoint",
+        desktop_runtime::transport::endpoint_path()
+            .map_err(|_| "Cannot resolve management endpoint".to_string()),
+    );
+    json!({
+        "version": desktop_runtime::protocol::BUILD_VERSION,
+        "backendRunning": backend_running,
+        "cli": cli,
+        "backendExecutable": backend_executable,
+        "endpoint": endpoint,
+        "credentialPolicy": "OS credential store; no plaintext fallback",
+        "errors": errors,
+    })
+}
+
+fn doctor_check<T: Serialize>(
+    errors: &mut Map<String, Value>,
+    name: &str,
+    result: Result<T, String>,
+) -> Value {
+    match result {
+        Ok(value) => serde_json::to_value(value).unwrap_or_else(|_| {
+            errors.insert(name.into(), json!("Cannot encode diagnostic result"));
+            Value::Null
+        }),
+        Err(error) => {
+            errors.insert(name.into(), json!(error));
+            Value::Null
+        }
+    }
+}
+
 fn confirm(cli: &Cli, prompt: &str) -> Result<(), String> {
     if cli.yes {
         return Ok(());
@@ -681,6 +650,12 @@ fn confirm(cli: &Cli, prompt: &str) -> Result<(), String> {
 }
 fn read_key(cli: &Cli, stdin: bool) -> Result<String, String> {
     let key = if stdin {
+        if io::stdin().is_terminal() {
+            return Err(
+                "Refusing to read a credential from a terminal with --key-stdin; omit the flag for a hidden prompt."
+                    .into(),
+            );
+        }
         let mut bytes = Vec::new();
         io::stdin()
             .take(514)
@@ -704,16 +679,46 @@ fn parse_bool(value: &str) -> Result<bool, String> {
 fn value(input: impl Serialize) -> Result<Value, String> {
     serde_json::to_value(input).map_err(|_| "Cannot encode output".into())
 }
-fn output(input: &impl Serialize, cli: &Cli) -> Result<(), String> {
+
+enum OutputError {
+    BrokenPipe,
+    Message(String),
+}
+
+fn render_output(input: &impl Serialize, cli: &Cli) -> Result<String, String> {
     let text = if cli.json {
         serde_json::to_string(input).map_err(|_| "Cannot encode output")?
     } else {
         human::render(&cli.command, &value(input)?)
     };
-    match writeln!(io::stdout().lock(), "{text}") {
+    Ok(text)
+}
+
+fn output(input: &impl Serialize, cli: &Cli) -> Result<(), OutputError> {
+    write_text(&render_output(input, cli).map_err(OutputError::Message)?)
+}
+
+fn write_text(text: &str) -> Result<(), OutputError> {
+    let mut output = io::stdout().lock();
+    match writeln!(output, "{text}") {
         Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Err("Output pipe closed".into()),
-        Err(_) => Err("Cannot write output".into()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Err(OutputError::BrokenPipe),
+        Err(_) => Err(OutputError::Message("Cannot write output".into())),
+    }
+}
+
+fn write_bytes(bytes: &[u8]) -> Result<(), OutputError> {
+    match io::stdout().lock().write_all(bytes) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Err(OutputError::BrokenPipe),
+        Err(_) => Err(OutputError::Message("Cannot write output".into())),
+    }
+}
+
+fn finish_output(result: Result<(), OutputError>) -> Result<(), String> {
+    match result {
+        Ok(()) | Err(OutputError::BrokenPipe) => Ok(()),
+        Err(OutputError::Message(error)) => Err(error),
     }
 }
 

--- a/apps/desktop/runtime/src/bin/pag/args.rs
+++ b/apps/desktop/runtime/src/bin/pag/args.rs
@@ -1,0 +1,392 @@
+use std::{fmt, path::PathBuf};
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
+
+#[derive(Parser)]
+#[command(
+    name = "pag",
+    version = desktop_runtime::protocol::BUILD_VERSION,
+    about = "Control the Private AI Gateway",
+    long_about = "Control the Private AI Gateway backend, protected connection, profiles, and coding-agent integrations. `pag start` explicitly starts protection and waits for verification. `pag service start` starts the backend; saved connect-on-launch behavior may then start protection automatically."
+)]
+pub(super) struct Cli {
+    /// Emit compact JSON instead of human-readable output.
+    #[arg(long, global = true)]
+    pub(super) json: bool,
+    /// Never prompt. Mutations still require --yes and credentials require --key-stdin.
+    #[arg(long, visible_alias = "no-interactive", global = true)]
+    pub(super) non_interactive: bool,
+    /// Approve a command's documented mutation without prompting.
+    #[arg(long, global = true)]
+    pub(super) yes: bool,
+    #[command(subcommand)]
+    pub(super) command: Action,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Action {
+    /// Show backend and gateway state. This does not start the backend.
+    Status {
+        /// Stream state changes. Human output suppresses unchanged heartbeats; JSON remains NDJSON.
+        #[arg(long)]
+        watch: bool,
+    },
+    /// Start protection and wait for a verified connection.
+    #[command(
+        long_about = "Start the local backend if needed, optionally select a profile, then start protection and wait for verification. This may change the active profile and starts network activity toward the configured service."
+    )]
+    Start {
+        /// Select this saved profile before starting protection.
+        #[arg(long)]
+        profile: Option<String>,
+        /// Maximum verification wait in seconds. The backend may continue verifying after timeout.
+        #[arg(long, default_value_t = 90, value_parser = clap::value_parser!(u64).range(1..=300))]
+        timeout: u64,
+    },
+    /// Stop protection and restore managed agent configurations; keep the backend running.
+    Stop,
+    /// Manage the local backend process. Starting it may honor saved connect-on-launch behavior.
+    Service {
+        #[command(subcommand)]
+        command: Service,
+    },
+    /// List, inspect, verify, import, export, select, or delete service profiles.
+    Profiles {
+        #[command(subcommand)]
+        command: Profiles,
+    },
+    /// Inspect or change supported coding-agent configurations.
+    Agents {
+        #[command(subcommand)]
+        command: Agents,
+    },
+    /// Inspect models from the last verified catalog.
+    Models {
+        #[command(subcommand)]
+        command: Models,
+    },
+    /// Query or export local usage records.
+    Usage {
+        #[command(subcommand)]
+        command: Usage,
+    },
+    /// Inspect or change desktop and Local API settings.
+    Settings {
+        #[command(subcommand)]
+        command: Settings,
+    },
+    /// Manage the Local API token and active profile credential.
+    Token {
+        #[command(subcommand)]
+        command: Token,
+    },
+    /// Manage installation of the pag command.
+    Cli {
+        #[command(subcommand)]
+        command: Registration,
+    },
+    /// Open the installed desktop app. App startup may honor saved connect-on-launch behavior.
+    App {
+        #[command(subcommand)]
+        command: App,
+    },
+    /// Report independent local installation and backend diagnostics without starting services.
+    Doctor,
+    /// Export a redacted diagnostics report to a new file.
+    Diagnostics {
+        /// New destination path. Existing files are never overwritten.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Generate shell completions from the current command definition.
+    Completions {
+        /// Shell whose completion script should be written to stdout.
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+    /// Emit basic machine-readable Clap command and argument metadata as JSON.
+    Schema,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Service {
+    /// Start the local backend. Saved connect-on-launch behavior may start protection afterward.
+    Start,
+    /// Stop the backend and restore managed agent configurations.
+    Stop,
+    /// Show backend and gateway state without starting the backend.
+    Status,
+}
+
+#[derive(Subcommand)]
+pub(super) enum App {
+    /// Open the installed desktop UI; startup may honor saved connect-on-launch behavior.
+    Open,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Registration {
+    /// Show whether pag is registered on PATH.
+    Status,
+    /// Register pag in a user-writable directory.
+    Install {
+        /// Installation directory; omit to use the platform default.
+        #[arg(long)]
+        directory: Option<PathBuf>,
+    },
+    /// Remove a pag registration previously installed by this app.
+    Uninstall {
+        /// Registration directory; omit to use the platform default.
+        #[arg(long)]
+        directory: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+pub(super) enum Token {
+    /// Rotate the Local API token, immediately revoking the previous token.
+    Rotate,
+    /// Print the Local API token to stdout. Treat output as a secret.
+    Show,
+    /// Remove the active profile's stored service credential.
+    ClearCredential,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Models {
+    /// List models from the verified catalog.
+    List {
+        /// Re-fetch the catalog from the verified service before listing it.
+        #[arg(long)]
+        refresh: bool,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub(super) enum Provider {
+    Phala,
+    Redpill,
+    Custom,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Profiles {
+    /// List saved profile metadata. Credentials are never returned.
+    List,
+    /// Show one saved profile. Credentials are never returned.
+    Show {
+        /// Saved profile ID.
+        id: String,
+    },
+    /// Import unverified profile metadata without credentials.
+    Import {
+        /// Versioned profile backup JSON file.
+        file: PathBuf,
+    },
+    /// Export profile metadata without credentials or verification evidence.
+    Export {
+        /// New destination path. Existing files are never overwritten.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Verify and save a new profile and credential.
+    Add {
+        #[arg(long, help = "Unique profile ID")]
+        id: String,
+        #[arg(long, help = "Display name")]
+        name: String,
+        #[arg(long, help = "ACI service endpoint URL")]
+        url: String,
+        #[arg(long, value_enum, default_value_t = Provider::Custom)]
+        provider: Provider,
+        /// Read the credential from stdin instead of a hidden terminal prompt.
+        #[arg(long)]
+        key_stdin: bool,
+        /// Permit a verified development OS image for this profile.
+        #[arg(long)]
+        allow_development_os: bool,
+    },
+    /// Re-verify a saved profile, optionally replacing its credential.
+    Verify {
+        /// Saved profile ID.
+        id: String,
+        /// Read a replacement credential from stdin.
+        #[arg(long)]
+        key_stdin: bool,
+    },
+    /// Edit, verify, and save an existing profile.
+    #[command(
+        long_about = "Edit an existing profile and verify the resulting configuration before saving it. Changing provider or endpoint requires a new credential via --key-stdin or a hidden terminal prompt; the old credential is never sent to a new target."
+    )]
+    Edit {
+        /// Saved profile ID.
+        id: String,
+        /// New display name.
+        #[arg(long)]
+        name: Option<String>,
+        /// New ACI service endpoint URL.
+        #[arg(long)]
+        url: Option<String>,
+        /// New service provider type.
+        #[arg(long, value_enum)]
+        provider: Option<Provider>,
+        /// Read a replacement credential from stdin.
+        #[arg(long)]
+        key_stdin: bool,
+        /// Permit a verified development OS image; otherwise retain the current global policy.
+        #[arg(long, conflicts_with = "require_production_os")]
+        allow_development_os: bool,
+        /// Require a production OS image; otherwise retain the current global policy.
+        #[arg(long, conflicts_with = "allow_development_os")]
+        require_production_os: bool,
+    },
+    /// Make a saved profile active.
+    Use { id: String },
+    /// Delete a profile and its stored credential.
+    Remove { id: String },
+}
+
+#[derive(Subcommand)]
+pub(super) enum Agents {
+    /// List supported agents and their actual configuration state.
+    List,
+    /// Connect an agent to the Local API.
+    Connect {
+        /// Agent ID reported by `pag agents list`.
+        id: String,
+        /// Optional default model from the verified catalog.
+        #[arg(long)]
+        model: Option<String>,
+        /// Preview changes and return a revision without applying them.
+        #[arg(long, conflicts_with = "revision")]
+        dry_run: bool,
+        /// Apply exactly this previously previewed revision without previewing again.
+        #[arg(long)]
+        revision: Option<String>,
+    },
+    /// Disconnect an agent and restore its managed configuration.
+    Disconnect {
+        /// Agent ID reported by `pag agents list`.
+        id: String,
+        /// Preview changes and return a revision without applying them.
+        #[arg(long, conflicts_with = "revision")]
+        dry_run: bool,
+        /// Apply exactly this previously previewed revision without previewing again.
+        #[arg(long)]
+        revision: Option<String>,
+    },
+    /// Disconnect all managed agents and restore their configurations.
+    DisconnectAll,
+}
+
+#[derive(Args)]
+pub(super) struct UsageFilter {
+    /// Match an agent ID.
+    #[arg(long)]
+    pub(super) agent: Option<String>,
+    /// Match a model ID.
+    #[arg(long)]
+    pub(super) model: Option<String>,
+    /// Match a session ID.
+    #[arg(long)]
+    pub(super) session: Option<String>,
+    /// Include records at or after this Unix timestamp in seconds.
+    #[arg(long)]
+    pub(super) since: Option<u64>,
+    /// Include records at or before this Unix timestamp in seconds.
+    #[arg(long)]
+    pub(super) until: Option<u64>,
+}
+
+#[derive(Args)]
+pub(super) struct Pagination {
+    /// Continue after a nextCursor returned by an earlier list response.
+    #[arg(long)]
+    pub(super) cursor: Option<String>,
+    /// Maximum records to return.
+    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u64).range(1..=100))]
+    pub(super) limit: u64,
+}
+
+#[derive(Subcommand)]
+pub(super) enum Usage {
+    /// List a page of usage records.
+    List {
+        #[command(flatten)]
+        filter: UsageFilter,
+        #[command(flatten)]
+        page: Pagination,
+    },
+    /// Show one usage record by ID.
+    Show { id: String },
+    /// Export every matching record to a new CSV file; pagination does not apply.
+    Export {
+        #[command(flatten)]
+        filter: UsageFilter,
+        /// New destination path. Existing files are never overwritten.
+        #[arg(long)]
+        output: PathBuf,
+        #[arg(long, default_value = "csv", value_parser = ["csv"])]
+        format: String,
+    },
+    /// Permanently delete all local usage history.
+    Clear,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(super) enum SettingsKey {
+    #[value(name = "autoCliRegistration")]
+    AutoCliRegistration,
+    #[value(name = "notifications")]
+    Notifications,
+    #[value(name = "connectOnLaunch")]
+    ConnectOnLaunch,
+    #[value(name = "appearance")]
+    Appearance,
+    #[value(name = "updateChannel")]
+    UpdateChannel,
+    #[value(name = "listenAddress")]
+    ListenAddress,
+    #[value(name = "allowNetworkAccess")]
+    AllowNetworkAccess,
+    #[value(name = "port")]
+    Port,
+    #[value(name = "clientHost")]
+    ClientHost,
+}
+
+impl SettingsKey {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::AutoCliRegistration => "autoCliRegistration",
+            Self::Notifications => "notifications",
+            Self::ConnectOnLaunch => "connectOnLaunch",
+            Self::Appearance => "appearance",
+            Self::UpdateChannel => "updateChannel",
+            Self::ListenAddress => "listenAddress",
+            Self::AllowNetworkAccess => "allowNetworkAccess",
+            Self::Port => "port",
+            Self::ClientHost => "clientHost",
+        }
+    }
+}
+
+impl fmt::Display for SettingsKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Subcommand)]
+pub(super) enum Settings {
+    /// Show desktop preferences and Local API settings.
+    Show,
+    /// Change one setting. This may restart the Local API or protection.
+    Set {
+        #[arg(value_enum)]
+        key: SettingsKey,
+        /// Boolean keys use true/false; appearance uses system/light/dark; updateChannel uses beta/stable; notifications is a JSON object with boolean fields.
+        value: String,
+    },
+}

--- a/apps/desktop/runtime/src/bin/pag/output.rs
+++ b/apps/desktop/runtime/src/bin/pag/output.rs
@@ -113,20 +113,159 @@ pub(super) fn render(action: &Action, value: &Value) -> String {
 
 fn status(value: &Value) -> String {
     if value["status"] == "not_running" {
-        return "Backend not running.".into();
+        return "Backend not running.\nStart backend: pag service start\nStart protection: pag start".into();
     }
     let state = value.get("gateway").unwrap_or(value);
     let status = match state["status"].as_str() {
-        Some("verified") if state["configurationVerification"] != true => "Protected",
+        _ if state["backendConnected"] == false => "Backend disconnected (protection unknown)",
+        _ if state["configurationVerification"] == true => {
+            "Verifying profile (not protecting traffic)"
+        }
+        Some("verified") => "Protected",
         Some("verifying") => "Verifying",
         Some("blocked") => "Not protected (blocked)",
         Some("error") => "Not protected (error)",
         _ => "Not protected",
     };
     let mut lines = vec![status.to_string()];
+    if let Some(backend) = value.get("backend").filter(|backend| backend.is_object()) {
+        lines.push(format!(
+            "Backend: running (PID {}, version {})",
+            text(&backend["processId"]),
+            text(&backend["version"])
+        ));
+    }
+    let profile = state["profiles"].as_array().and_then(|profiles| {
+        profiles
+            .iter()
+            .find(|profile| profile["id"] == state["activeProfileId"])
+    });
+    if let Some(profile) = profile {
+        lines.push(format!(
+            "Profile: {} ({})",
+            text(&profile["name"]),
+            text(&profile["id"])
+        ));
+        lines.push(format!(
+            "Service: {} | {}",
+            text(&profile["provider"]),
+            text(&profile["remoteUrl"])
+        ));
+    } else if let Some(id) = state["activeProfileId"]
+        .as_str()
+        .filter(|id| !id.is_empty())
+    {
+        lines.push(format!("Profile: {}", safe(id)));
+    } else if state["profiles"].is_array() {
+        lines.push("Profile: None selected".into());
+    }
+    if let Some(saved) = state["apiKeySaved"].as_bool() {
+        lines.push(format!(
+            "Service credential: {}",
+            if saved {
+                "Saved (OS credential store)"
+            } else {
+                "Not saved"
+            }
+        ));
+    }
+    if state.get("localApi").is_some() {
+        lines.push(format!(
+            "Local API: {}",
+            state["proxyUrl"]
+                .as_str()
+                .map(safe)
+                .unwrap_or_else(|| "Not listening".into())
+        ));
+        if let Some(network) = state["localApi"]["allowNetworkAccess"].as_bool() {
+            lines.push(format!(
+                "Network access: {}",
+                if network { "Allowed" } else { "Loopback only" }
+            ));
+        }
+    } else if let Some(endpoint) = state["proxyUrl"].as_str() {
+        lines.push(format!("Local API: {}", safe(endpoint)));
+    }
+    if let Some(required) = state["config"]["requireProductionOs"].as_bool() {
+        lines.push(format!(
+            "Production OS: {}",
+            if required {
+                "Required"
+            } else {
+                "Development images allowed"
+            }
+        ));
+    }
+    if let Some(identity) = state
+        .get("identity")
+        .filter(|identity| identity.is_object())
+    {
+        lines.push(format!(
+            "Identity: {} | {}",
+            text(&identity["teeType"]),
+            text(&identity["trustLevel"])
+        ));
+    }
+    if let Some(checks) = state["checks"]
+        .as_array()
+        .filter(|checks| !checks.is_empty())
+    {
+        let count = |status: &str| {
+            checks
+                .iter()
+                .filter(|check| check["status"] == status)
+                .count()
+        };
+        lines.push(format!(
+            "Checks: {} passed, {} failed, {} skipped",
+            count("pass"),
+            count("fail"),
+            count("skip")
+        ));
+        for check in checks
+            .iter()
+            .filter(|check| check["status"] == "fail")
+            .take(3)
+        {
+            lines.push(format!("  Failed: {}", text(&check["title"])));
+        }
+    }
+    if let Some(models) = state["catalog"]["models"].as_array() {
+        let label = if state["status"] == "verified"
+            && state["configurationVerification"] != true
+            && state["backendConnected"] != false
+        {
+            "Models"
+        } else {
+            "Cached models"
+        };
+        lines.push(format!("{label}: {}", models.len()));
+    } else if state.get("config").is_some() {
+        lines.push("Models: No verified catalog".into());
+    }
+    if let Some(session) = state["sessionId"].as_str() {
+        lines.push(format!("Session: {}", safe(session)));
+        if let Some(usage) = state.get("sessionUsage").filter(|usage| usage.is_object()) {
+            lines.push(format!(
+                "Requests: {} total | {} protected | {} blocked locally | {} failed proof",
+                text(&usage["requests"]),
+                text(&usage["protected"]),
+                text(&usage["blockedLocally"]),
+                text(&usage["failedProof"])
+            ));
+            lines.push(format!(
+                "Tokens: {} input | {} output | {} cache read | {} cache write",
+                text(&usage["inputTokens"]),
+                text(&usage["outputTokens"]),
+                text(&usage["cacheReadTokens"]),
+                text(&usage["cacheWriteTokens"])
+            ));
+            if let Some(cost) = usage["costUsd"].as_f64() {
+                lines.push(format!("Reported cost: ${cost:.6} USD"));
+            }
+        }
+    }
     for (key, label) in [
-        ("activeProfileId", "Profile"),
-        ("proxyUrl", "Local API"),
         ("progress", "Progress"),
         ("error", "Error"),
         ("endpointError", "Warning"),
@@ -260,6 +399,51 @@ fn label(key: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn status_includes_operational_context_without_credentials_or_activity() {
+        assert!(status(&json!({"status":"not_running"})).contains("pag service start"));
+        let value = json!({
+            "backend": {"processId":42,"version":"0.1.0"},
+            "gateway": {
+                "status":"verified", "activeProfileId":"work", "apiKeySaved":true,
+                "profiles":[{"id":"work","name":"Work","provider":"redpill","remoteUrl":"https://tee.redpill.ai"}],
+                "proxyUrl":"http://127.0.0.1:4180", "localApi":{"allowNetworkAccess":false},
+                "config":{"requireProductionOs":true},
+                "identity":{"teeType":"tdx","trustLevel":"production"},
+                "checks":[{"title":"Identity","status":"pass"}],
+                "catalog":{"models":[{"id":"model"}]}, "sessionId":"session-1",
+                "sessionUsage":{"requests":12,"protected":10,"blockedLocally":1,"failedProof":1,"inputTokens":100,"outputTokens":20,"cacheReadTokens":5,"cacheWriteTokens":0,"costUsd":0.0012},
+                "activity":[{"detail":"private request detail"}], "token":"never-print-token"
+            }
+        });
+        let output = status(&value);
+        for expected in [
+            "Backend: running (PID 42, version 0.1.0)",
+            "Profile: Work (work)",
+            "Service: redpill | https://tee.redpill.ai",
+            "Production OS: Required",
+            "Identity: tdx | production",
+            "Checks: 1 passed, 0 failed, 0 skipped",
+            "Models: 1",
+            "Requests: 12 total | 10 protected | 1 blocked locally | 1 failed proof",
+            "Tokens: 100 input | 20 output | 5 cache read | 0 cache write",
+            "Reported cost: $0.001200 USD",
+        ] {
+            assert!(output.contains(expected), "missing {expected}: {output}");
+        }
+        assert!(!output.contains("private request detail"));
+        assert!(!output.contains("never-print-token"));
+        let mut state = value["gateway"].clone();
+        state["status"] = json!("stopped");
+        assert!(status(&state).contains("Cached models: 1"));
+        state["status"] = json!("verified");
+        state["backendConnected"] = json!(false);
+        assert!(status(&state).starts_with("Backend disconnected (protection unknown)"));
+        state["backendConnected"] = json!(true);
+        state["configurationVerification"] = json!(true);
+        assert!(status(&state).starts_with("Verifying profile (not protecting traffic)"));
+    }
 
     #[test]
     fn status_and_nested_details_do_not_emit_terminal_controls() {

--- a/apps/desktop/runtime/src/bin/pag/output.rs
+++ b/apps/desktop/runtime/src/bin/pag/output.rs
@@ -29,19 +29,24 @@ pub(super) fn render(action: &Action, value: &Value) -> String {
         | Action::Diagnostics { .. } => format!("Exported to {}", text(&value["exported"])),
         Action::Profiles {
             command: Profiles::Use { id },
-        } => format!("Selected profile: {id}"),
+        } => format!("Selected profile: {}\n{}", safe(id), status(value)),
         Action::Profiles {
             command: Profiles::Remove { id },
-        } => format!("Deleted profile: {id}"),
+        } => format!("Deleted profile: {}", safe(id)),
         Action::Profiles {
-            command: Profiles::Add { .. } | Profiles::Verify { .. },
-        } => status(value),
+            command: Profiles::Add { .. } | Profiles::Verify { .. } | Profiles::Edit { .. },
+        } => format!("Profile verified and saved.\n{}", status(value)),
         Action::Agents {
-            command: Agents::List | Agents::DisconnectAll,
+            command:
+                Agents::List
+                | Agents::DisconnectAll
+                | Agents::Connect { dry_run: false, .. }
+                | Agents::Disconnect { dry_run: false, .. },
         } => {
-            let Some(agents) = value.as_array() else {
-                return details(value);
-            };
+            let agents = value
+                .as_array()
+                .map(Vec::as_slice)
+                .unwrap_or_else(|| std::slice::from_ref(value));
             if agents.is_empty() {
                 return "No agents.".into();
             }
@@ -50,42 +55,37 @@ pub(super) fn render(action: &Action, value: &Value) -> String {
                 .map(|agent| {
                     let state = if agent["installed"] == false {
                         "Not installed"
+                    } else if agent["authorized"] == true {
+                        "Connected (authorized)"
                     } else if agent["connected"] == true {
-                        "Connected"
+                        "Configured (not authorized)"
+                    } else if agent["recorded"] == true {
+                        "Saved connection (inactive)"
                     } else {
                         "Not connected"
                     };
                     let mut line =
                         format!("{}  {}  {state}", text(&agent["id"]), text(&agent["name"]));
                     if let Some(attention) = agent["attention"].as_str().filter(|s| !s.is_empty()) {
-                        line.push_str(&format!("\n  {attention}"));
+                        line.push_str(&format!("\n  {}", safe(attention)));
+                    }
+                    if let Some(error) = agent["error"].as_str().filter(|s| !s.is_empty()) {
+                        line.push_str(&format!("\n  Error: {}", safe(error)));
                     }
                     line
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
         }
-        Action::Agents {
-            command: Agents::Connect {
-                id, dry_run: false, ..
-            },
-        } => format!("Connected {id}. Configuration is applied while protected."),
-        Action::Agents {
-            command: Agents::Disconnect { id, dry_run: false },
-        } => format!("Disconnected {id}."),
         Action::Models {
             command: Models::List { .. },
         } => list(&value["models"], &["id", "name"], "No models."),
         Action::Usage {
             command: Usage::List { .. },
         } => {
-            let mut lines = list(
-                &value["items"],
-                &["id", "model", "status", "inputTokens", "outputTokens"],
-                "No usage records.",
-            );
+            let mut lines = usage_list(&value["items"]);
             if let Some(cursor) = value["nextCursor"].as_str() {
-                lines.push_str(&format!("\nNext cursor: {cursor}"));
+                lines.push_str(&format!("\nNext cursor: {}", safe(cursor)));
             }
             lines
         }
@@ -97,7 +97,7 @@ pub(super) fn render(action: &Action, value: &Value) -> String {
         } => format!("Deleted {} usage records.", text(&value["deleted"])),
         Action::Settings {
             command: Settings::Set { key, .. },
-        } => format!("Updated {key}."),
+        } => format!("Updated {}.", safe(&key.to_string())),
         Action::Token {
             command: Token::Show,
         } => text(&value["token"]),
@@ -119,6 +119,7 @@ fn status(value: &Value) -> String {
     let status = match state["status"].as_str() {
         Some("verified") if state["configurationVerification"] != true => "Protected",
         Some("verifying") => "Verifying",
+        Some("blocked") => "Not protected (blocked)",
         Some("error") => "Not protected (error)",
         _ => "Not protected",
     };
@@ -126,12 +127,46 @@ fn status(value: &Value) -> String {
     for (key, label) in [
         ("activeProfileId", "Profile"),
         ("proxyUrl", "Local API"),
+        ("progress", "Progress"),
+        ("error", "Error"),
         ("endpointError", "Warning"),
     ] {
         if let Some(value) = state[key].as_str().filter(|s| !s.is_empty()) {
-            lines.push(format!("{label}: {value}"));
+            lines.push(format!("{label}: {}", safe(value)));
         }
     }
+    if state["wakeMonitorAvailable"] == false {
+        lines
+            .push("Warning: Wake monitoring unavailable; reconnect protection after sleep.".into());
+    }
+    lines.join("\n")
+}
+
+fn usage_list(value: &Value) -> String {
+    let Some(rows) = value.as_array().filter(|rows| !rows.is_empty()) else {
+        return "No usage records.".into();
+    };
+    let mut lines =
+        vec!["Id  |  Model  |  HTTP  |  Verification  |  Input tokens  |  Output tokens".into()];
+    lines.extend(rows.iter().map(|row| {
+        let verdict = if row["leftDevice"] == false {
+            "Blocked locally"
+        } else if row["verified"] == true {
+            "Verified"
+        } else if row["verified"] == false {
+            "Failed"
+        } else {
+            "Unverified"
+        };
+        format!(
+            "{}  |  {}  |  {}  |  {verdict}  |  {}  |  {}",
+            text(&row["id"]),
+            text(&row["model"]),
+            text(&row["status"]),
+            text(&row["inputTokens"]),
+            text(&row["outputTokens"])
+        )
+    }));
     lines.join("\n")
 }
 
@@ -188,17 +223,27 @@ fn text(value: &Value) -> String {
         Value::Null => "-".into(),
         Value::Bool(true) => "Yes".into(),
         Value::Bool(false) => "No".into(),
-        Value::String(value) => value
-            .chars()
-            .map(|c| if c.is_control() { ' ' } else { c })
-            .collect(),
+        Value::String(value) => safe(value),
         _ => value.to_string(),
     }
 }
 
+pub(super) fn safe(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}') {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 fn label(key: &str) -> String {
     let mut label = String::new();
-    for (index, c) in key.chars().enumerate() {
+    for (index, c) in safe(key).chars().enumerate() {
         if index == 0 {
             label.extend(c.to_uppercase());
         } else if c.is_uppercase() {
@@ -209,4 +254,53 @@ fn label(key: &str) -> String {
         }
     }
     label
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn status_and_nested_details_do_not_emit_terminal_controls() {
+        let output = status(
+            &json!({"status":"error", "error":"bad\u{001b}[31m\nline", "progress":"Checking", "wakeMonitorAvailable":false}),
+        );
+        assert!(output.contains("Error: bad [31m line"));
+        assert!(output.contains("Progress: Checking"));
+        assert!(output.contains("Wake monitoring unavailable"));
+        assert!(
+            !details(&json!({"\u{001b}key":"\u{202e}value"})).contains(['\u{001b}', '\u{202e}'])
+        );
+    }
+
+    #[test]
+    fn usage_separates_http_status_from_receipt_verification() {
+        let output = usage_list(&json!([
+            {"id":"a", "status":200, "leftDevice":true, "verified":false},
+            {"id":"b", "status":0, "leftDevice":false, "verified":null},
+            {"id":"c", "status":200, "leftDevice":true, "verified":true}
+        ]));
+        assert!(output.contains("200  |  Failed"));
+        assert!(output.contains("0  |  Blocked locally"));
+        assert!(output.contains("200  |  Verified"));
+    }
+
+    #[test]
+    fn agent_list_distinguishes_authorization_from_retained_configuration() {
+        let output = render(
+            &Action::Agents {
+                command: Agents::List,
+            },
+            &json!([
+                {"id":"active", "installed":true, "connected":true, "authorized":true},
+                {"id":"stale", "installed":true, "connected":true, "authorized":false, "error":"changed\u{001b}"},
+                {"id":"saved", "installed":true, "connected":false, "recorded":true}
+            ]),
+        );
+        assert!(output.contains("Connected (authorized)"));
+        assert!(output.contains("Configured (not authorized)"));
+        assert!(output.contains("Saved connection (inactive)"));
+        assert!(output.contains("Error: changed "));
+    }
 }

--- a/apps/desktop/runtime/src/bin/pag/schema.rs
+++ b/apps/desktop/runtime/src/bin/pag/schema.rs
@@ -1,0 +1,51 @@
+use clap::Command;
+use serde_json::{json, Value};
+
+pub(super) fn command(command: &Command) -> Value {
+    json!({
+        "name": command.get_name(),
+        "version": command.get_version(),
+        "about": command.get_about().map(ToString::to_string),
+        "longAbout": command.get_long_about().map(ToString::to_string),
+        "arguments": command.get_arguments().map(argument).collect::<Vec<_>>(),
+        "commands": command.get_subcommands().map(self::command).collect::<Vec<_>>(),
+    })
+}
+
+fn argument(argument: &clap::Arg) -> Value {
+    let takes_value = argument.get_action().takes_values();
+    let possible_values = if takes_value {
+        argument
+            .get_possible_values()
+            .into_iter()
+            .filter(|value| !value.is_hide_set())
+            .map(|value| value.get_name().to_owned())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    json!({
+        "id": argument.get_id().as_str(),
+        "long": argument.get_long(),
+        "short": argument.get_short().map(|short| short.to_string()),
+        "index": argument.get_index(),
+        "visibleAliases": argument.get_visible_aliases(),
+        "visibleShortAliases": argument.get_visible_short_aliases(),
+        "help": argument.get_help().map(ToString::to_string),
+        "longHelp": argument.get_long_help().map(ToString::to_string),
+        "required": argument.is_required_set(),
+        "global": argument.is_global_set(),
+        "takesValue": takes_value,
+        "numArgs": argument.get_num_args().map(|range| json!({
+            "min": range.min_values(),
+            "max": range.max_values(),
+        })),
+        "valueNames": argument.get_value_names().map(|names| {
+            names.iter().map(ToString::to_string).collect::<Vec<_>>()
+        }),
+        "defaultValues": argument.get_default_values().iter().map(|value| {
+            value.to_string_lossy().into_owned()
+        }).collect::<Vec<_>>(),
+        "possibleValues": possible_values,
+    })
+}

--- a/apps/desktop/runtime/src/maintenance.rs
+++ b/apps/desktop/runtime/src/maintenance.rs
@@ -117,9 +117,29 @@ fn resolve(profile: &ProfileConfiguration) -> Result<ConfidentialProfile, String
 }
 
 pub fn write_json(path: &Path, data: &impl Serialize) -> Result<(), String> {
+    use std::io::Write;
     let text = serde_json::to_string_pretty(data).map_err(|_| "Could not encode the export")?;
-    desktop_gateway::agents::write_atomic(path, &text, None)
-        .map_err(|_| "Could not save the export file".to_string())
+    let write = || -> std::io::Result<()> {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        let mut file = tempfile::NamedTempFile::new_in(parent)?;
+        file.write_all(text.as_bytes())?;
+        file.as_file().sync_all()?;
+        // Publish only the completed file, and atomically refuse any existing destination.
+        file.persist_noclobber(path).map_err(|error| error.error)?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    };
+    write().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::AlreadyExists {
+            "Export target already exists; choose a new path.".to_string()
+        } else {
+            "Could not save the export file".to_string()
+        }
+    })
 }
 
 /// An allowlist of typed fields; never serialize state, raw errors or stderr.
@@ -143,6 +163,22 @@ pub fn diagnostics(state: &GatewayState, version: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn export_never_replaces_an_existing_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("profiles.json");
+        write_json(&destination, &serde_json::json!({"original":true})).unwrap();
+        let original = std::fs::read(&destination).unwrap();
+        assert!(write_json(&destination, &serde_json::json!({"replacement":true})).is_err());
+        assert_eq!(std::fs::read(&destination).unwrap(), original);
+        #[cfg(unix)]
+        {
+            let link = directory.path().join("link.json");
+            std::os::unix::fs::symlink(&destination, &link).unwrap();
+            assert!(write_json(&link, &serde_json::json!({})).is_err());
+            assert_eq!(std::fs::read(&destination).unwrap(), original);
+        }
+    }
     fn backup() -> ProfileBackup {
         ProfileBackup {
             version: 1,

--- a/apps/desktop/runtime/tests/cli.rs
+++ b/apps/desktop/runtime/tests/cli.rs
@@ -31,6 +31,107 @@ fn argument_errors_are_machine_readable_in_json_mode() {
     }
 }
 
+#[test]
+fn command_discovery_is_detailed_and_machine_readable() {
+    let settings = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .args(["settings", "set", "--help"])
+        .output()
+        .unwrap();
+    assert_success(&settings);
+    let settings = String::from_utf8(settings.stdout).unwrap();
+    for key in [
+        "autoCliRegistration",
+        "connectOnLaunch",
+        "allowNetworkAccess",
+        "clientHost",
+    ] {
+        assert!(settings.contains(key), "missing settings key {key}");
+    }
+
+    let usage = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .args(["usage", "export", "--help"])
+        .output()
+        .unwrap();
+    assert_success(&usage);
+    let usage = String::from_utf8(usage.stdout).unwrap();
+    assert!(usage.contains("Unix timestamp in seconds"));
+    assert!(!usage.contains("--cursor"));
+    assert!(!usage.contains("--limit"));
+
+    let schema = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .arg("schema")
+        .output()
+        .unwrap();
+    assert_success(&schema);
+    let schema: Value = serde_json::from_slice(&schema.stdout).unwrap();
+    assert_eq!(schema["name"], "pag");
+    let json_flag = schema["arguments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|arg| arg["long"] == "json")
+        .unwrap();
+    assert_eq!(json_flag["takesValue"], false);
+    assert_eq!(json_flag["numArgs"]["max"], 0);
+    assert_eq!(json_flag["possibleValues"], serde_json::json!([]));
+    assert!(schema["commands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|command| command["name"] == "profiles"));
+
+    let completion = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .args(["completions", "bash"])
+        .output()
+        .unwrap();
+    assert_success(&completion);
+    assert!(String::from_utf8(completion.stdout)
+        .unwrap()
+        .contains("pag"));
+
+    let conflict = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .args([
+            "agents",
+            "connect",
+            "codex",
+            "--dry-run",
+            "--revision",
+            "preview-revision",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(conflict.status.code(), Some(2));
+}
+
+#[test]
+fn adding_a_profile_requires_consent_before_startup_or_credential_input() {
+    let home = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_pag"))
+        .args([
+            "--json",
+            "profiles",
+            "add",
+            "--id",
+            "test",
+            "--name",
+            "Test",
+            "--url",
+            "https://example.com",
+            "--key-stdin",
+        ])
+        .env(desktop_gateway::agents::HOME_OVERRIDE_ENV, home.path())
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("--yes"));
+    assert!(fs::read_dir(home.path()).unwrap().next().is_none());
+}
+
 impl Backend {
     fn start() -> Self {
         let directory = tempfile::tempdir().unwrap();
@@ -133,6 +234,24 @@ fn two_cli_clients_share_state_and_disconnect_does_not_stop_service() {
         .join("home/.private-ai-gateway/helpers/private-ai-gateway-helper")
         .is_file());
     let first = backend.run(&["status"]);
+    let rejected = backend
+        .command(&[
+            "--json",
+            "--yes",
+            "agents",
+            "disconnect",
+            "codex",
+            "--revision",
+            "stale-revision",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(rejected.status.code(), Some(1));
+    let rejected: Value = serde_json::from_slice(&rejected.stderr).unwrap();
+    assert!(rejected["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("revision_conflict"));
     assert_eq!(first["gateway"]["status"], "stopped");
     let second = backend.run(&["service", "start"]);
     assert_eq!(first["backend"]["instanceId"], second["instanceId"]);
@@ -166,6 +285,12 @@ fn two_cli_clients_share_state_and_disconnect_does_not_stop_service() {
     assert_eq!(
         backend.run(&["profiles", "import", backup.to_str().unwrap(), "--yes"])["imported"],
         1
+    );
+    let profiles = backend.run(&["profiles", "list"]);
+    let profile_id = profiles[0]["id"].as_str().unwrap();
+    assert_eq!(
+        backend.run(&["profiles", "show", profile_id])["name"],
+        "Work"
     );
     let exported = backend.directory.path().join("exported.json");
     backend.run(&["profiles", "export", "--output", exported.to_str().unwrap()]);
@@ -222,6 +347,20 @@ fn shutdown_is_explicit_and_read_only_commands_do_not_restart_backend() {
 fn malformed_client_and_watch_disconnect_do_not_stop_backend() {
     use std::io::{BufReader, Write};
     let backend = Backend::start();
+    let home = backend.directory.path().join("diagnostic-home");
+    let command_dir = home.join(".local/bin");
+    fs::create_dir_all(&command_dir).unwrap();
+    fs::write(command_dir.join("pag"), "unrelated command").unwrap();
+    let diagnostic = backend
+        .command(&["doctor", "--json"])
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert_eq!(diagnostic.status.code(), Some(1));
+    let diagnostic: Value = serde_json::from_slice(&diagnostic.stdout).unwrap();
+    assert_eq!(diagnostic["backendRunning"], true);
+    assert!(diagnostic["errors"]["cli"].is_string());
+    assert!(diagnostic["endpoint"].is_string());
     let endpoint = backend.run(&["doctor"])["endpoint"]
         .as_str()
         .unwrap()

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -759,6 +759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,6 +3709,7 @@ name = "private-ai-gateway-desktop-runtime"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "futures-util",
  "libc",
  "netwatcher",

--- a/apps/desktop/src/renderer/components/maintenance.tsx
+++ b/apps/desktop/src/renderer/components/maintenance.tsx
@@ -25,12 +25,12 @@ export function ProfileTransfer({ api, disabled, onBusy, onMessage }: {
         const result = await api.importProfiles(backup);
         onMessage(`${result.imported} imported, ${result.skipped} duplicates skipped.`, false);
       } else {
-        const path = mock ? "profiles.json" : await save({ title: "Export Profile Configurations (No Keys)", defaultPath: "private-ai-gateway-profiles.json", filters });
+        const path = mock ? "profiles.json" : await save({ title: "Export Profiles to a New File (No Keys)", defaultPath: "private-ai-gateway-profiles.json", filters });
         if (!path) return;
         await api.exportProfiles(path);
         onMessage("Profile configurations exported without credentials.", false);
       }
-    } catch { onMessage(importing ? "Could not import profile configurations. Check the file format and profile limit." : "Could not export profile configurations.", true); }
+    } catch { onMessage(importing ? "Could not import profile configurations. Check the file format and profile limit." : "Could not export profile configurations. Choose a new file name and check write permissions.", true); }
     finally { setBusy(false); onBusy(false); }
   };
   return <div className="flex items-center gap-2">
@@ -45,11 +45,11 @@ export function ExportDiagnostics({ api, onMessage }: { api: DesktopApi; onMessa
     if (busy) return;
     setBusy(true);
     try {
-      const path = mock ? "diagnostics.json" : await save({ title: "Export Redacted Diagnostics", defaultPath: "private-ai-gateway-diagnostics.json", filters });
+      const path = mock ? "diagnostics.json" : await save({ title: "Export Redacted Diagnostics to a New File", defaultPath: "private-ai-gateway-diagnostics.json", filters });
       if (!path) return;
       await api.exportDiagnostics(path);
       onMessage("Diagnostics exported without keys, URLs, local paths or request content.");
-    } catch { onMessage("Could not export diagnostics."); }
+    } catch { onMessage("Could not export diagnostics. Choose a new file name and check write permissions."); }
     finally { setBusy(false); }
   };
   return <SettingsLink title={busy ? "Exporting diagnostics" : "Export diagnostics"} aria-label="Export diagnostics" disabled={busy} onClick={() => void run()} />;


### PR DESCRIPTION
## Summary
- Audit core CLI coverage against the latest #177 backend. Add profiles show/edit, explicit production-policy controls, discoverable setting names, shell completions and Clap-derived JSON command metadata.
- Bind reviewed agent changes to the original revision, including agent identity and connect/disconnect direction. Preserve existing successful JSON response shapes.
- Confirm profile mutations before credentials or backend startup; changing endpoint/provider requires a new credential. Refuse terminal echo through --key-stdin.
- Improve human status, agent authorization and receipt-verification output; sanitize terminal controls and suppress unchanged human watch heartbeats. Preserve JSON NDJSON and propagate output failures.
- Doctor retains independent diagnostics and exits nonzero on check failure. JSON profile/diagnostic exports now publish atomically without overwriting existing files or symlinks; GUI export prompts explicitly require a new file.
- Document workflows, coverage and OS-only boundaries in apps/desktop/CLI.md. No backend IPC redesign, new daemon, global shell edits or arbitrary RPC escape hatch.

## Merge Readiness
- Final review found no remaining merge-blocking issues. Head ee3e226 is clean and includes current #177 base 6664670.
- Ready to merge into #177 only; no merge or release has been performed as part of this preparation.
- Rich status reads existing snapshots only: backend/profile/API/policy/verification/catalog/session totals, with explicit cached and disconnected states. JSON remains unchanged.

## Verification
- Rust 1.89 runtime all-target tests: 44 library, 6 CLI unit, 6 CLI process tests passed; 2 environment/subprocess fixtures intentionally ignored.
- Gateway library: 72 tests passed, 1 real credential-store test intentionally ignored.
- Runtime all-target Clippy -D warnings, Rust formatting and git diff --check passed.
- npm run check and 2 focused Playwright export workflows passed.
- Current head ee3e2268d7bb08a918f8ac803fce6f7ecd10c78a passed all CI: https://github.com/Dstack-TEE/private-ai-gateway/actions/runs/34123383890 . macOS ARM64 app/DMG, Windows x64 NSIS and Linux x64 DEB/RPM jobs all succeeded, including their native tests and package checks. No real credentials or paid inference used.

## Boundaries
- Stacked on #177 at 66646705746d4f36f1a4e998f7b7d7f835ac26df; this PR is not a main merge or release.
- OS login startup, native notification permission and installer updates remain UI/OS functions.
- The shared Client still exposes String errors. JSON operation failures retain command_failed; this PR does not manufacture typed retry semantics by parsing messages. That remains a distinct follow-up API change.
- Automation compatibility changes are deliberate: profile mutations require --yes; usage export rejects previously ignored pagination flags; both GUI and CLI JSON exports refuse overwrite.