### PR TITLE
Fix attestation nonce example from 16 to 32 bytes

### DIFF
--- a/docs/attested-confidential-inference.md
+++ b/docs/attested-confidential-inference.md
@@ -71,7 +71,7 @@ Save these response values:
 Generate a fresh nonce before fetching the attestation report.
 
 ```bash
-NONCE="$(openssl rand -hex 16)"
+NONCE="$(openssl rand -hex 32)"
 
 curl "$API_BASE_URL/v1/aci/attestation?nonce=$NONCE" \
   -o attestation-report.json


### PR DESCRIPTION
## Summary

- The ACI spec requires a 32-byte nonce (64 hex characters) for attestation requests
- The doc example in `docs/attested-confidential-inference.md` used `openssl rand -hex 16` (16 bytes = 32 hex), which would be rejected by the gateway's `e2ee_invalid_nonce` validation
- Corrected to `openssl rand -hex 32`