### PR TITLE
Remove legacy user-only middleware identity compatibility

### DIFF
--- a/src/middleware/types.rs
+++ b/src/middleware/types.rs
@@ -161,7 +161,7 @@ pub struct OrganizationScope {
     pub workspace_id: i64,
 }
 
-/// Authenticated actor and optional resource scope fixed by pre-consult.
+/// Anonymous requests omit identity; authenticated actors carry their resource scope.
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TenantIdentity {
@@ -248,8 +248,8 @@ impl TryFrom<PreConsultWire> for PreConsult {
                 return Err("organizationId and workspaceId must be positive and provided together")
             }
         };
-        if organization.is_some() && user_id.is_none() {
-            return Err("organizationId and workspaceId require a positive userId");
+        if organization.is_some() != user_id.is_some() {
+            return Err("userId, organizationId and workspaceId must be provided together");
         }
 
         Ok(Self {
@@ -334,15 +334,7 @@ mod tests {
     use super::PreConsult;
 
     #[test]
-    fn tenant_identity_accepts_legacy_and_expanded_scopes() {
-        let legacy: PreConsult = serde_json::from_value(serde_json::json!({
-            "allow": true,
-            "userId": 7
-        }))
-        .unwrap();
-        assert_eq!(legacy.tenant.user_id, Some(7));
-        assert!(legacy.tenant.organization.is_none());
-
+    fn tenant_identity_accepts_scoped_and_anonymous_requests() {
         let user_with_resources: PreConsult = serde_json::from_value(serde_json::json!({
             "allow": true,
             "userId": 7,
@@ -371,6 +363,7 @@ mod tests {
     #[test]
     fn tenant_identity_rejects_invalid_wire_shapes() {
         for invalid in [
+            serde_json::json!({ "allow": true, "userId": 7 }),
             serde_json::json!({ "allow": true, "userId": 0 }),
             serde_json::json!({
                 "allow": true,

--- a/tests/middleware_completion.rs
+++ b/tests/middleware_completion.rs
@@ -641,6 +641,8 @@ async fn empty_candidates_is_reported_as_a_control_failure() {
             "allow": true,
             "candidates": [],
             "userId": 7,
+            "organizationId": 11,
+            "workspaceId": 13,
             "virtualKeyId": 3
         }),
     )
@@ -907,6 +909,8 @@ async fn buffered_success_transforms_injects_cost_and_meters() {
             "candidates": [{ "routeId": "anthropic:claude", "format": "anthropic" }],
             "pricing": { "inputCostPerToken": "0.000001", "outputCostPerToken": "0.000002" },
             "userId": 7,
+            "organizationId": 11,
+            "workspaceId": 13,
             "virtualKeyId": 3
         }),
     )
@@ -943,8 +947,8 @@ async fn buffered_success_transforms_injects_cost_and_meters() {
         "report usage must be pre-cost-injection"
     );
     assert_eq!(report["userId"], json!(7));
-    assert!(report.get("organizationId").is_none());
-    assert!(report.get("workspaceId").is_none());
+    assert_eq!(report["organizationId"], json!(11));
+    assert_eq!(report["workspaceId"], json!(13));
     assert_eq!(report["isStreaming"], json!(false));
 }
 


### PR DESCRIPTION
Reject user-only pre-consult identities: authenticated responses require positive userId, organizationId and workspaceId. Preserve anonymous requests and ACI identity/receipt behavior.

Validation: Rust 1.94 identity unit tests, 54 catalog/completion integration tests and rustfmt passed. No new test files or dependencies.

Rollout: Edge #34 → Control #64 → this PR, after legacy queue/cache convergence. Control #64 must include complete identity on RPM/TPM 429 responses; otherwise strict parsing turns rate-limit denials into 503. Production queue verification remains outstanding. No production changes.
