### PR TITLE
Fix desktop release Clippy failure in login state

### DIFF
--- a/apps/desktop/runtime/src/account_login.rs
+++ b/apps/desktop/runtime/src/account_login.rs
@@ -142,7 +142,7 @@ impl Authorization {
 
 enum LoginState {
     Authorizing(JoinHandle<Result<Authorization, String>>),
-    Authorized(Authorization),
+    Authorized(Box<Authorization>),
     Failed(String),
 }
 
@@ -199,7 +199,7 @@ impl PendingLogin {
                 return Ok(None);
             }
             self.state = match task.await {
-                Ok(Ok(authorization)) => LoginState::Authorized(authorization),
+                Ok(Ok(authorization)) => LoginState::Authorized(Box::new(authorization)),
                 Ok(Err(error)) => LoginState::Failed(error),
                 Err(_) => LoginState::Failed("Account login stopped".into()),
             };


### PR DESCRIPTION
Desktop prerelease beta.30 stops at Clippy because `LoginState::Authorized` stores a 232-byte authorization inline while the other variants are small. Box the completed authorization to keep the enum compact; existing mutable-reference coercion preserves the login API and drop behavior.

Changes are limited to two lines in `apps/desktop/runtime/src/account_login.rs`. No lint suppression or workflow changes.

Validation: `git diff --check` passed. Local Rust tooling is unavailable; the desktop runtime Clippy and tests must pass in the subsequent release run. Failure evidence: https://github.com/Dstack-TEE/private-ai-gateway/actions/runs/34646725118 .
